### PR TITLE
Adjust include search order in master hook

### DIFF
--- a/obj/master.c
+++ b/obj/master.c
@@ -101,8 +101,9 @@ static string _include_dirs_hook (string include_name, string current_file)
 //   The full pathname of the include file.
 //   0 if no such file exists.
 //
-// If include_name can't be found as such, the function looks in /sys
-// and /room for /sys/<include_name> resp. /domain/lp-245/room/<include_name>.
+// If include_name can't be found as such, the function looks in /room,
+// /sys, and /obj (in that order) for /room/<include_name>,
+// /sys/<include_name>, and /obj/<include_name>.
 
 {
   string name, part;
@@ -110,10 +111,13 @@ static string _include_dirs_hook (string include_name, string current_file)
 
   if (file_size(ADD_SLASH(include_name)) >= 0)
     return include_name;
+  name = "room/"+include_name;
+  if (file_size(ADD_SLASH(name)) >= 0)
+    return name;
   name = "sys/"+include_name;
   if (file_size(ADD_SLASH(name)) >= 0)
     return name;
-  name = "domain/lp-245/room/"+include_name;
+  name = "obj/"+include_name;
   if (file_size(ADD_SLASH(name)) >= 0)
     return name;
   return 0;


### PR DESCRIPTION
### Motivation
- Include resolution must prefer the including file's directory, then `/room`, then `/sys`, then `/obj` to match the requested include lookup semantics.
- The previous search order missed `/room` ahead of `/sys`, causing includes located under `/room` to not be picked up.
- Avoid changing object source files to work around include lookup issues by fixing the master include hook.

### Description
- Updated the comment and logic in `obj/master.c` `_include_dirs_hook` to check `room/<include_name>` before `sys/<include_name>` and then `obj/<include_name>`.
- Preserved the initial same-directory check via `ADD_SLASH(include_name)` and return the matched path immediately when found.
- Removed the legacy `domain/lp-245/room/<include_name>` fallback and documented the new search order.
- Changes are confined to `obj/master.c`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0e3a50e48327b3de1b05a5ae3b68)