### PR TITLE
Add 14 east-west roadway rooms between Candera and Vesla

### DIFF
--- a/domain/original/area/roadway/room1.c
+++ b/domain/original/area/roadway/room1.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Candera";
+    long_desc = "Entrance to Candera.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room2", "east",
+    });
+}

--- a/domain/original/area/roadway/room10.c
+++ b/domain/original/area/roadway/room10.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room9", "west",
+        "domain/original/area/roadway/room11", "east",
+    });
+}

--- a/domain/original/area/roadway/room11.c
+++ b/domain/original/area/roadway/room11.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room10", "west",
+        "domain/original/area/roadway/room12", "east",
+    });
+}

--- a/domain/original/area/roadway/room12.c
+++ b/domain/original/area/roadway/room12.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room11", "west",
+        "domain/original/area/roadway/room13", "east",
+    });
+}

--- a/domain/original/area/roadway/room13.c
+++ b/domain/original/area/roadway/room13.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room12", "west",
+        "domain/original/area/roadway/room14", "east",
+    });
+}

--- a/domain/original/area/roadway/room14.c
+++ b/domain/original/area/roadway/room14.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Near Vesla City";
+    long_desc = "Near Vesla City.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room13", "west",
+    });
+}

--- a/domain/original/area/roadway/room2.c
+++ b/domain/original/area/roadway/room2.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room1", "west",
+        "domain/original/area/roadway/room3", "east",
+    });
+}

--- a/domain/original/area/roadway/room3.c
+++ b/domain/original/area/roadway/room3.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room2", "west",
+        "domain/original/area/roadway/room4", "east",
+    });
+}

--- a/domain/original/area/roadway/room4.c
+++ b/domain/original/area/roadway/room4.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room3", "west",
+        "domain/original/area/roadway/room5", "east",
+    });
+}

--- a/domain/original/area/roadway/room5.c
+++ b/domain/original/area/roadway/room5.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room4", "west",
+        "domain/original/area/roadway/room6", "east",
+    });
+}

--- a/domain/original/area/roadway/room6.c
+++ b/domain/original/area/roadway/room6.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room5", "west",
+        "domain/original/area/roadway/room7", "east",
+    });
+}

--- a/domain/original/area/roadway/room7.c
+++ b/domain/original/area/roadway/room7.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room6", "west",
+        "domain/original/area/roadway/room8", "east",
+    });
+}

--- a/domain/original/area/roadway/room8.c
+++ b/domain/original/area/roadway/room8.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room7", "west",
+        "domain/original/area/roadway/room9", "east",
+    });
+}

--- a/domain/original/area/roadway/room9.c
+++ b/domain/original/area/roadway/room9.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room8", "west",
+        "domain/original/area/roadway/room10", "east",
+    });
+}


### PR DESCRIPTION
### Motivation
- Provide a straight east-west path connecting Candera and Vesla with navigable room files.
- Populate `domain/original/area/roadway` so the area can be traversed from Candera to Vesla.
- Use descriptive endpoint names and a consistent intermediate room name for clarity.

### Description
- Create directory `domain/original/area/roadway` and add 14 LPC room files `room1.c` through `room14.c`.
- Each room file inherits `room/room`, calls `set_light(1)`, sets `short_desc` and `long_desc`, and defines a `dest_dir` linking east/west to adjacent rooms.
- The westernmost file `room1.c` has `short_desc` `Entrance to Candera` and the easternmost `room14.c` has `short_desc` `Near Vesla City` while the 12 middle rooms are `Walking on a roadway`.
- The new files were added to version control and committed together.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b271f9ae083279a534324769c89f1)