### PR TITLE
Add Exedoria LPC rooms and 14-room roadway connection to Vesla

### DIFF
--- a/domain/original/area/exedoria/room286.c
+++ b/domain/original/area/exedoria/room286.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Exedoria";
+    long_desc = "Entrance to Exedoria.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room287", "east",
+        "domain/original/area/roadway/room28", "exit",
+    });
+}

--- a/domain/original/area/exedoria/room287.c
+++ b/domain/original/area/exedoria/room287.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room286", "west",
+        "domain/original/area/exedoria/room288", "east",
+        "domain/original/area/exedoria/room330", "south",
+    });
+}

--- a/domain/original/area/exedoria/room288.c
+++ b/domain/original/area/exedoria/room288.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room368", "south",
+        "domain/original/area/exedoria/room287", "west",
+        "domain/original/area/exedoria/room289", "east",
+        "domain/original/area/exedoria/room367", "north",
+    });
+}

--- a/domain/original/area/exedoria/room289.c
+++ b/domain/original/area/exedoria/room289.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room288", "west",
+        "domain/original/area/exedoria/room290", "east",
+        "domain/original/area/exedoria/room366", "south",
+    });
+}

--- a/domain/original/area/exedoria/room290.c
+++ b/domain/original/area/exedoria/room290.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Monument Circle, Main Street";
+    long_desc = "Monument Circle, Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room299", "south",
+        "domain/original/area/exedoria/room289", "west",
+        "domain/original/area/exedoria/room291", "east",
+        "domain/original/area/exedoria/room369", "north",
+    });
+}

--- a/domain/original/area/exedoria/room291.c
+++ b/domain/original/area/exedoria/room291.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room298", "south",
+        "domain/original/area/exedoria/room290", "west",
+        "domain/original/area/exedoria/room292", "east",
+        "domain/original/area/exedoria/room370", "north",
+    });
+}

--- a/domain/original/area/exedoria/room292.c
+++ b/domain/original/area/exedoria/room292.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room291", "west",
+        "domain/original/area/exedoria/room293", "east",
+        "domain/original/area/exedoria/room383", "south",
+    });
+}

--- a/domain/original/area/exedoria/room293.c
+++ b/domain/original/area/exedoria/room293.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room294", "east",
+        "domain/original/area/exedoria/room292", "west",
+    });
+}

--- a/domain/original/area/exedoria/room294.c
+++ b/domain/original/area/exedoria/room294.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room295", "east",
+        "domain/original/area/exedoria/room293", "west",
+    });
+}

--- a/domain/original/area/exedoria/room295.c
+++ b/domain/original/area/exedoria/room295.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room296", "east",
+        "domain/original/area/exedoria/room294", "west",
+    });
+}

--- a/domain/original/area/exedoria/room296.c
+++ b/domain/original/area/exedoria/room296.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Main Street";
+    long_desc = "Main Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room297", "east",
+        "domain/original/area/exedoria/room295", "west",
+    });
+}

--- a/domain/original/area/exedoria/room297.c
+++ b/domain/original/area/exedoria/room297.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Corigan Court Intersection";
+    long_desc = "Corigan Court Intersection.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room296", "west",
+    });
+}

--- a/domain/original/area/exedoria/room298.c
+++ b/domain/original/area/exedoria/room298.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "City Hall";
+    long_desc = "City Hall.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room291", "north",
+    });
+}

--- a/domain/original/area/exedoria/room299.c
+++ b/domain/original/area/exedoria/room299.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eithel Sirion";
+    long_desc = "Eithel Sirion.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room300", "south",
+        "domain/original/area/exedoria/room290", "north",
+    });
+}

--- a/domain/original/area/exedoria/room300.c
+++ b/domain/original/area/exedoria/room300.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room301", "south",
+        "domain/original/area/exedoria/room302", "west",
+        "domain/original/area/exedoria/room385", "east",
+        "domain/original/area/exedoria/room299", "north",
+    });
+}

--- a/domain/original/area/exedoria/room301.c
+++ b/domain/original/area/exedoria/room301.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Frenchie's II";
+    long_desc = "Frenchie's II.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room300", "north",
+    });
+}

--- a/domain/original/area/exedoria/room302.c
+++ b/domain/original/area/exedoria/room302.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room303", "west",
+        "domain/original/area/exedoria/room300", "east",
+        "domain/original/area/exedoria/room392", "south",
+    });
+}

--- a/domain/original/area/exedoria/room303.c
+++ b/domain/original/area/exedoria/room303.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Middle of Brapnor Road";
+    long_desc = "Middle of Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room304", "west",
+        "domain/original/area/exedoria/room302", "east",
+        "domain/original/area/exedoria/room329", "south",
+    });
+}

--- a/domain/original/area/exedoria/room304.c
+++ b/domain/original/area/exedoria/room304.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room305", "west",
+        "domain/original/area/exedoria/room303", "east",
+        "domain/original/area/exedoria/room330", "north",
+    });
+}

--- a/domain/original/area/exedoria/room305.c
+++ b/domain/original/area/exedoria/room305.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room306", "west",
+        "domain/original/area/exedoria/room304", "east",
+        "domain/original/area/exedoria/room393", "north",
+    });
+}

--- a/domain/original/area/exedoria/room306.c
+++ b/domain/original/area/exedoria/room306.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room305", "east",
+        "domain/original/area/exedoria/room307", "west",
+    });
+}

--- a/domain/original/area/exedoria/room307.c
+++ b/domain/original/area/exedoria/room307.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Brapnor Road";
+    long_desc = "End of Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room306", "east",
+        "domain/original/area/exedoria/room331", "northwest",
+        "domain/original/area/exedoria/room308", "south",
+    });
+}

--- a/domain/original/area/exedoria/room308.c
+++ b/domain/original/area/exedoria/room308.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beginning of Lilu Lane";
+    long_desc = "Beginning of Lilu Lane.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room309", "south",
+        "domain/original/area/exedoria/room307", "north",
+    });
+}

--- a/domain/original/area/exedoria/room309.c
+++ b/domain/original/area/exedoria/room309.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Lilu Lane";
+    long_desc = "Lilu Lane.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room310", "south",
+        "domain/original/area/exedoria/room308", "north",
+    });
+}

--- a/domain/original/area/exedoria/room310.c
+++ b/domain/original/area/exedoria/room310.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Middle of Lilu Lane";
+    long_desc = "Middle of Lilu Lane.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room355", "west",
+        "domain/original/area/exedoria/room311", "south",
+        "domain/original/area/exedoria/room309", "north",
+    });
+}

--- a/domain/original/area/exedoria/room311.c
+++ b/domain/original/area/exedoria/room311.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Lilu Lane";
+    long_desc = "Lilu Lane.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room312", "south",
+        "domain/original/area/exedoria/room310", "north",
+    });
+}

--- a/domain/original/area/exedoria/room312.c
+++ b/domain/original/area/exedoria/room312.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Lilu Lane";
+    long_desc = "End of Lilu Lane.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room354", "west",
+        "domain/original/area/exedoria/room313", "south",
+        "domain/original/area/exedoria/room311", "north",
+    });
+}

--- a/domain/original/area/exedoria/room313.c
+++ b/domain/original/area/exedoria/room313.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beginning of Embassy Row";
+    long_desc = "Beginning of Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room314", "east",
+        "domain/original/area/exedoria/room312", "north",
+    });
+}

--- a/domain/original/area/exedoria/room314.c
+++ b/domain/original/area/exedoria/room314.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room313", "west",
+        "domain/original/area/exedoria/room315", "east",
+        "domain/original/area/exedoria/room322", "south",
+    });
+}

--- a/domain/original/area/exedoria/room315.c
+++ b/domain/original/area/exedoria/room315.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room320", "south",
+        "domain/original/area/exedoria/room314", "west",
+        "domain/original/area/exedoria/room316", "east",
+        "domain/original/area/exedoria/room321", "north",
+    });
+}

--- a/domain/original/area/exedoria/room316.c
+++ b/domain/original/area/exedoria/room316.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room318", "south",
+        "domain/original/area/exedoria/room315", "west",
+        "domain/original/area/exedoria/room317", "east",
+        "domain/original/area/exedoria/room319", "north",
+    });
+}

--- a/domain/original/area/exedoria/room317.c
+++ b/domain/original/area/exedoria/room317.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room316", "west",
+        "domain/original/area/exedoria/room323", "east",
+        "domain/original/area/exedoria/room333", "north",
+    });
+}

--- a/domain/original/area/exedoria/room318.c
+++ b/domain/original/area/exedoria/room318.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A Dark Hole in the Ground";
+    long_desc = "A Dark Hole in the Ground.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room316", "north",
+    });
+}

--- a/domain/original/area/exedoria/room319.c
+++ b/domain/original/area/exedoria/room319.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Post for Gnome Embassy";
+    long_desc = "Guard Post for Gnome Embassy.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room316", "south",
+        "domain/original/area/exedoria/room926", "north",
+    });
+}

--- a/domain/original/area/exedoria/room320.c
+++ b/domain/original/area/exedoria/room320.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before a round door";
+    long_desc = "Before a round door.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room315", "north",
+    });
+}

--- a/domain/original/area/exedoria/room321.c
+++ b/domain/original/area/exedoria/room321.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Junk yard";
+    long_desc = "Junk yard.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room315", "south",
+    });
+}

--- a/domain/original/area/exedoria/room322.c
+++ b/domain/original/area/exedoria/room322.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Elven Embassy checkpoint";
+    long_desc = "Elven Embassy checkpoint.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room314", "north",
+    });
+}

--- a/domain/original/area/exedoria/room323.c
+++ b/domain/original/area/exedoria/room323.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Embassy Row";
+    long_desc = "End of Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room317", "west",
+        "domain/original/area/exedoria/room324", "north",
+    });
+}

--- a/domain/original/area/exedoria/room324.c
+++ b/domain/original/area/exedoria/room324.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern end of alley";
+    long_desc = "Southern end of alley.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room323", "south",
+        "domain/original/area/exedoria/room325", "north",
+    });
+}

--- a/domain/original/area/exedoria/room325.c
+++ b/domain/original/area/exedoria/room325.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bend in an alley";
+    long_desc = "Bend in an alley.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room326", "west",
+        "domain/original/area/exedoria/room324", "south",
+    });
+}

--- a/domain/original/area/exedoria/room326.c
+++ b/domain/original/area/exedoria/room326.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A bend in the alley";
+    long_desc = "A bend in the alley.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room325", "east",
+        "domain/original/area/exedoria/room327", "north",
+    });
+}

--- a/domain/original/area/exedoria/room327.c
+++ b/domain/original/area/exedoria/room327.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark and narrow alley";
+    long_desc = "Dark and narrow alley.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room326", "south",
+        "domain/original/area/exedoria/room328", "north",
+    });
+}

--- a/domain/original/area/exedoria/room328.c
+++ b/domain/original/area/exedoria/room328.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark alley";
+    long_desc = "Dark alley.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room327", "south",
+        "domain/original/area/exedoria/room329", "north",
+    });
+}

--- a/domain/original/area/exedoria/room329.c
+++ b/domain/original/area/exedoria/room329.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Alley entrance";
+    long_desc = "Alley entrance.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room328", "south",
+        "domain/original/area/exedoria/room303", "north",
+    });
+}

--- a/domain/original/area/exedoria/room330.c
+++ b/domain/original/area/exedoria/room330.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Excalibur, a closed guild";
+    long_desc = "The Excalibur, a closed guild.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room304", "south",
+        "domain/original/area/exedoria/room287", "north",
+    });
+}

--- a/domain/original/area/exedoria/room331.c
+++ b/domain/original/area/exedoria/room331.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Foyer of the Exedorian Inn";
+    long_desc = "Foyer of the Exedorian Inn.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room307", "southeast",
+        "domain/original/area/exedoria/room332", "west",
+    });
+}

--- a/domain/original/area/exedoria/room332.c
+++ b/domain/original/area/exedoria/room332.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Exedorian saloon";
+    long_desc = "Exedorian saloon.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room331", "east",
+    });
+}

--- a/domain/original/area/exedoria/room333.c
+++ b/domain/original/area/exedoria/room333.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before the Dwarven Embassy";
+    long_desc = "Before the Dwarven Embassy.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room317", "south",
+        "domain/original/area/exedoria/room920", "north",
+    });
+}

--- a/domain/original/area/exedoria/room334.c
+++ b/domain/original/area/exedoria/room334.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street West";
+    long_desc = "Keen Street West.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room335", "east",
+    });
+}

--- a/domain/original/area/exedoria/room335.c
+++ b/domain/original/area/exedoria/room335.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street";
+    long_desc = "Keen Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room336", "east",
+        "domain/original/area/exedoria/room334", "west",
+    });
+}

--- a/domain/original/area/exedoria/room336.c
+++ b/domain/original/area/exedoria/room336.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street";
+    long_desc = "Keen Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room335", "west",
+        "domain/original/area/exedoria/room337", "east",
+        "domain/original/area/exedoria/room602", "north",
+    });
+}

--- a/domain/original/area/exedoria/room337.c
+++ b/domain/original/area/exedoria/room337.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street";
+    long_desc = "Keen Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room336", "west",
+        "domain/original/area/exedoria/room338", "east",
+        "domain/original/area/exedoria/room603", "south",
+    });
+}

--- a/domain/original/area/exedoria/room338.c
+++ b/domain/original/area/exedoria/room338.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Keen Street Bridge";
+    long_desc = "East Keen Street Bridge.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room337", "west",
+        "domain/original/area/exedoria/room339", "east",
+        "domain/original/area/exedoria/room604", "north",
+    });
+}

--- a/domain/original/area/exedoria/room339.c
+++ b/domain/original/area/exedoria/room339.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street Bridge";
+    long_desc = "Keen Street Bridge.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room340", "east",
+        "domain/original/area/exedoria/room338", "west",
+    });
+}

--- a/domain/original/area/exedoria/room340.c
+++ b/domain/original/area/exedoria/room340.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street";
+    long_desc = "Keen Street.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room339", "west",
+        "domain/original/area/exedoria/room341", "east",
+        "domain/original/area/exedoria/room343", "south",
+    });
+}

--- a/domain/original/area/exedoria/room341.c
+++ b/domain/original/area/exedoria/room341.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keen Street East";
+    long_desc = "Keen Street East.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room340", "west",
+        "domain/original/area/exedoria/room342", "north",
+    });
+}

--- a/domain/original/area/exedoria/room342.c
+++ b/domain/original/area/exedoria/room342.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Post";
+    long_desc = "Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room341", "south",
+        "domain/original/area/exedoria/room350", "north",
+    });
+}

--- a/domain/original/area/exedoria/room343.c
+++ b/domain/original/area/exedoria/room343.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Statued lawn";
+    long_desc = "Statued lawn.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room344", "south",
+        "domain/original/area/exedoria/room340", "north",
+    });
+}

--- a/domain/original/area/exedoria/room344.c
+++ b/domain/original/area/exedoria/room344.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Statued lawn";
+    long_desc = "Statued lawn.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room345", "south",
+        "domain/original/area/exedoria/room343", "north",
+    });
+}

--- a/domain/original/area/exedoria/room345.c
+++ b/domain/original/area/exedoria/room345.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Manicured lawn";
+    long_desc = "Manicured lawn.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room346", "south",
+        "domain/original/area/exedoria/room344", "north",
+    });
+}

--- a/domain/original/area/exedoria/room346.c
+++ b/domain/original/area/exedoria/room346.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cavernous foyer";
+    long_desc = "Cavernous foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room348", "west",
+        "domain/original/area/exedoria/room347", "east",
+        "domain/original/area/exedoria/room345", "north",
+    });
+}

--- a/domain/original/area/exedoria/room347.c
+++ b/domain/original/area/exedoria/room347.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Icy room";
+    long_desc = "Icy room.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room346", "west",
+    });
+}

--- a/domain/original/area/exedoria/room348.c
+++ b/domain/original/area/exedoria/room348.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cold hallway";
+    long_desc = "Cold hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room346", "east",
+        "domain/original/area/exedoria/room349", "south",
+    });
+}

--- a/domain/original/area/exedoria/room349.c
+++ b/domain/original/area/exedoria/room349.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Snowy cave";
+    long_desc = "Snowy cave.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room348", "north",
+    });
+}

--- a/domain/original/area/exedoria/room350.c
+++ b/domain/original/area/exedoria/room350.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "With no gate guard present, you are able to enter the walled estate";
+    long_desc = "With no gate guard present, you are able to enter the walled estate.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room342", "south",
+        "domain/original/area/exedoria/room351", "north",
+    });
+}

--- a/domain/original/area/exedoria/room351.c
+++ b/domain/original/area/exedoria/room351.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Foyer";
+    long_desc = "Foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room352", "east",
+        "domain/original/area/exedoria/room350", "south",
+    });
+}

--- a/domain/original/area/exedoria/room352.c
+++ b/domain/original/area/exedoria/room352.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Wood-paneled Hallway";
+    long_desc = "Wood-paneled Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room351", "west",
+        "domain/original/area/exedoria/room353", "north",
+    });
+}

--- a/domain/original/area/exedoria/room353.c
+++ b/domain/original/area/exedoria/room353.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Busy Kitchen";
+    long_desc = "Busy Kitchen.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room352", "south",
+    });
+}

--- a/domain/original/area/exedoria/room354.c
+++ b/domain/original/area/exedoria/room354.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mom's General Store";
+    long_desc = "Mom's General Store.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room312", "east",
+    });
+}

--- a/domain/original/area/exedoria/room355.c
+++ b/domain/original/area/exedoria/room355.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Drawbridge";
+    long_desc = "Drawbridge.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room310", "east",
+        "domain/original/area/exedoria/room356", "west",
+    });
+}

--- a/domain/original/area/exedoria/room356.c
+++ b/domain/original/area/exedoria/room356.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Library's entrance";
+    long_desc = "Library's entrance.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room357", "south",
+        "domain/original/area/exedoria/room361", "west",
+        "domain/original/area/exedoria/room355", "east",
+        "domain/original/area/exedoria/room362", "north",
+    });
+}

--- a/domain/original/area/exedoria/room357.c
+++ b/domain/original/area/exedoria/room357.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cobblestoned hallway";
+    long_desc = "Cobblestoned hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room358", "south",
+        "domain/original/area/exedoria/room360", "east",
+        "domain/original/area/exedoria/room356", "north",
+    });
+}

--- a/domain/original/area/exedoria/room358.c
+++ b/domain/original/area/exedoria/room358.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A bend in the hallway";
+    long_desc = "A bend in the hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room359", "west",
+        "domain/original/area/exedoria/room357", "north",
+    });
+}

--- a/domain/original/area/exedoria/room359.c
+++ b/domain/original/area/exedoria/room359.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A monk's cell";
+    long_desc = "A monk's cell.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room358", "east",
+    });
+}

--- a/domain/original/area/exedoria/room360.c
+++ b/domain/original/area/exedoria/room360.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A monk's cell";
+    long_desc = "A monk's cell.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room357", "west",
+    });
+}

--- a/domain/original/area/exedoria/room361.c
+++ b/domain/original/area/exedoria/room361.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "With a grunt of effort, you manage to push open the heavy door, and enter";
+    long_desc = "With a grunt of effort, you manage to push open the heavy door, and enter.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room356", "east",
+    });
+}

--- a/domain/original/area/exedoria/room362.c
+++ b/domain/original/area/exedoria/room362.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cobblestoned hallway";
+    long_desc = "Cobblestoned hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room356", "south",
+        "domain/original/area/exedoria/room363", "east",
+        "domain/original/area/exedoria/room364", "north",
+    });
+}

--- a/domain/original/area/exedoria/room363.c
+++ b/domain/original/area/exedoria/room363.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A monk's cell";
+    long_desc = "A monk's cell.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room362", "west",
+    });
+}

--- a/domain/original/area/exedoria/room364.c
+++ b/domain/original/area/exedoria/room364.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A bend in the hallway";
+    long_desc = "A bend in the hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room365", "west",
+        "domain/original/area/exedoria/room362", "south",
+    });
+}

--- a/domain/original/area/exedoria/room365.c
+++ b/domain/original/area/exedoria/room365.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A monk's cell";
+    long_desc = "A monk's cell.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room364", "east",
+    });
+}

--- a/domain/original/area/exedoria/room366.c
+++ b/domain/original/area/exedoria/room366.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Cadaver Emporium";
+    long_desc = "The Cadaver Emporium.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room289", "north",
+    });
+}

--- a/domain/original/area/exedoria/room367.c
+++ b/domain/original/area/exedoria/room367.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Velvet Unicorn";
+    long_desc = "Velvet Unicorn.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room288", "south",
+    });
+}

--- a/domain/original/area/exedoria/room368.c
+++ b/domain/original/area/exedoria/room368.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eidolon Warlords";
+    long_desc = "Eidolon Warlords.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room288", "north",
+    });
+}

--- a/domain/original/area/exedoria/room369.c
+++ b/domain/original/area/exedoria/room369.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
+    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room290", "south",
+    });
+}

--- a/domain/original/area/exedoria/room370.c
+++ b/domain/original/area/exedoria/room370.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beginning of park path";
+    long_desc = "Beginning of park path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room291", "south",
+        "domain/original/area/exedoria/room371", "north",
+    });
+}

--- a/domain/original/area/exedoria/room371.c
+++ b/domain/original/area/exedoria/room371.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Park path intersection";
+    long_desc = "Park path intersection.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room370", "south",
+        "domain/original/area/exedoria/room372", "west",
+        "domain/original/area/exedoria/room378", "east",
+        "domain/original/area/exedoria/room373", "north",
+    });
+}

--- a/domain/original/area/exedoria/room372.c
+++ b/domain/original/area/exedoria/room372.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Exedoria Pet Cemetary";
+    long_desc = "Exedoria Pet Cemetary.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room371", "east",
+    });
+}

--- a/domain/original/area/exedoria/room373.c
+++ b/domain/original/area/exedoria/room373.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Park path on the hill";
+    long_desc = "Park path on the hill.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room371", "south",
+        "domain/original/area/exedoria/room374", "north",
+    });
+}

--- a/domain/original/area/exedoria/room374.c
+++ b/domain/original/area/exedoria/room374.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Elevated park path";
+    long_desc = "Elevated park path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room373", "south",
+        "domain/original/area/exedoria/room375", "north",
+    });
+}

--- a/domain/original/area/exedoria/room375.c
+++ b/domain/original/area/exedoria/room375.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of park path";
+    long_desc = "End of park path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room376", "east",
+        "domain/original/area/exedoria/room374", "south",
+    });
+}

--- a/domain/original/area/exedoria/room376.c
+++ b/domain/original/area/exedoria/room376.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple ruins";
+    long_desc = "Temple ruins.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room377", "east",
+        "domain/original/area/exedoria/room375", "west",
+    });
+}

--- a/domain/original/area/exedoria/room377.c
+++ b/domain/original/area/exedoria/room377.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple rotunda";
+    long_desc = "Temple rotunda.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room376", "west",
+    });
+}

--- a/domain/original/area/exedoria/room378.c
+++ b/domain/original/area/exedoria/room378.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gravel path to the mansion";
+    long_desc = "Gravel path to the mansion.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room379", "east",
+        "domain/original/area/exedoria/room371", "west",
+    });
+}

--- a/domain/original/area/exedoria/room379.c
+++ b/domain/original/area/exedoria/room379.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gravel path on the hill";
+    long_desc = "Gravel path on the hill.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room380", "east",
+        "domain/original/area/exedoria/room378", "west",
+    });
+}

--- a/domain/original/area/exedoria/room380.c
+++ b/domain/original/area/exedoria/room380.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection in the gravel path";
+    long_desc = "Intersection in the gravel path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room379", "west",
+        "domain/original/area/exedoria/room382", "southeast",
+        "domain/original/area/exedoria/room381", "north",
+    });
+}

--- a/domain/original/area/exedoria/room381.c
+++ b/domain/original/area/exedoria/room381.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before a white mansion";
+    long_desc = "Before a white mansion.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room380", "south",
+    });
+}

--- a/domain/original/area/exedoria/room382.c
+++ b/domain/original/area/exedoria/room382.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Outside the cemetery gate";
+    long_desc = "Outside the cemetery gate.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room380", "northwest",
+    });
+}

--- a/domain/original/area/exedoria/room383.c
+++ b/domain/original/area/exedoria/room383.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Post";
+    long_desc = "Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room384", "south",
+        "domain/original/area/exedoria/room292", "north",
+    });
+}

--- a/domain/original/area/exedoria/room384.c
+++ b/domain/original/area/exedoria/room384.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beginning of Brapnor Road";
+    long_desc = "Beginning of Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room385", "west",
+        "domain/original/area/exedoria/room386", "southeast",
+        "domain/original/area/exedoria/room383", "north",
+    });
+}

--- a/domain/original/area/exedoria/room385.c
+++ b/domain/original/area/exedoria/room385.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brapnor Road";
+    long_desc = "Brapnor Road.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room384", "east",
+        "domain/original/area/exedoria/room300", "west",
+    });
+}

--- a/domain/original/area/exedoria/room386.c
+++ b/domain/original/area/exedoria/room386.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Necrom's Gate";
+    long_desc = "Necrom's Gate.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room384", "northwest",
+        "domain/original/area/exedoria/room387", "southeast",
+    });
+}

--- a/domain/original/area/exedoria/room387.c
+++ b/domain/original/area/exedoria/room387.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Paved intersection";
+    long_desc = "Paved intersection.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room388", "east",
+        "domain/original/area/exedoria/room386", "northwest",
+        "domain/original/area/exedoria/room527", "south",
+    });
+}

--- a/domain/original/area/exedoria/room388.c
+++ b/domain/original/area/exedoria/room388.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern path through the University";
+    long_desc = "Eastern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room389", "east",
+        "domain/original/area/exedoria/room387", "west",
+    });
+}

--- a/domain/original/area/exedoria/room389.c
+++ b/domain/original/area/exedoria/room389.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern path through the University";
+    long_desc = "Eastern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room390", "east",
+        "domain/original/area/exedoria/room388", "west",
+    });
+}

--- a/domain/original/area/exedoria/room390.c
+++ b/domain/original/area/exedoria/room390.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "In front of a temporary building";
+    long_desc = "In front of a temporary building.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room389", "west",
+        "domain/original/area/exedoria/room391", "east",
+        "domain/original/area/exedoria/room904", "south",
+    });
+}

--- a/domain/original/area/exedoria/room391.c
+++ b/domain/original/area/exedoria/room391.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room390", "west",
+    });
+}

--- a/domain/original/area/exedoria/room392.c
+++ b/domain/original/area/exedoria/room392.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Delilah's Deli";
+    long_desc = "Delilah's Deli.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room302", "north",
+    });
+}

--- a/domain/original/area/exedoria/room393.c
+++ b/domain/original/area/exedoria/room393.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Tower Entrance";
+    long_desc = "Guard Tower Entrance.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room305", "south",
+    });
+}

--- a/domain/original/area/exedoria/room527.c
+++ b/domain/original/area/exedoria/room527.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room528", "south",
+        "domain/original/area/exedoria/room387", "north",
+    });
+}

--- a/domain/original/area/exedoria/room528.c
+++ b/domain/original/area/exedoria/room528.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room896", "south",
+        "domain/original/area/exedoria/room894", "east",
+        "domain/original/area/exedoria/room527", "north",
+    });
+}

--- a/domain/original/area/exedoria/room602.c
+++ b/domain/original/area/exedoria/room602.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Railed entrance";
+    long_desc = "Railed entrance.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room336", "south",
+    });
+}

--- a/domain/original/area/exedoria/room603.c
+++ b/domain/original/area/exedoria/room603.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Flagstoned entry";
+    long_desc = "Flagstoned entry.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room915", "south",
+        "domain/original/area/exedoria/room337", "north",
+    });
+}

--- a/domain/original/area/exedoria/room604.c
+++ b/domain/original/area/exedoria/room604.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You rudely trespass on the private property.";
+    long_desc = "You rudely trespass on the private property.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room907", "northeast",
+        "domain/original/area/exedoria/room910", "northwest",
+        "domain/original/area/exedoria/room338", "south",
+    });
+}

--- a/domain/original/area/exedoria/room894.c
+++ b/domain/original/area/exedoria/room894.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dormitory foyer";
+    long_desc = "Dormitory foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room528", "west",
+        "domain/original/area/exedoria/room895", "south",
+        "domain/original/area/exedoria/room903", "north",
+    });
+}

--- a/domain/original/area/exedoria/room895.c
+++ b/domain/original/area/exedoria/room895.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dining commons";
+    long_desc = "Dining commons.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room894", "north",
+    });
+}

--- a/domain/original/area/exedoria/room896.c
+++ b/domain/original/area/exedoria/room896.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room897", "south",
+        "domain/original/area/exedoria/room528", "north",
+    });
+}

--- a/domain/original/area/exedoria/room897.c
+++ b/domain/original/area/exedoria/room897.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room898", "south",
+        "domain/original/area/exedoria/room896", "north",
+    });
+}

--- a/domain/original/area/exedoria/room898.c
+++ b/domain/original/area/exedoria/room898.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room899", "south",
+        "domain/original/area/exedoria/room897", "north",
+    });
+}

--- a/domain/original/area/exedoria/room899.c
+++ b/domain/original/area/exedoria/room899.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern path through the University";
+    long_desc = "Southern path through the University.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room902", "south",
+        "domain/original/area/exedoria/room900", "east",
+        "domain/original/area/exedoria/room898", "north",
+    });
+}

--- a/domain/original/area/exedoria/room900.c
+++ b/domain/original/area/exedoria/room900.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "School of Business";
+    long_desc = "School of Business.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room899", "west",
+        "domain/original/area/exedoria/room901", "north",
+    });
+}

--- a/domain/original/area/exedoria/room901.c
+++ b/domain/original/area/exedoria/room901.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dean's office";
+    long_desc = "Dean's office.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room900", "south",
+    });
+}

--- a/domain/original/area/exedoria/room902.c
+++ b/domain/original/area/exedoria/room902.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room899", "north",
+    });
+}

--- a/domain/original/area/exedoria/room903.c
+++ b/domain/original/area/exedoria/room903.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Resident Advisor's office";
+    long_desc = "Resident Advisor's office.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room894", "south",
+    });
+}

--- a/domain/original/area/exedoria/room904.c
+++ b/domain/original/area/exedoria/room904.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Science building's entry";
+    long_desc = "Science building's entry.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room905", "west",
+        "domain/original/area/exedoria/room906", "east",
+        "domain/original/area/exedoria/room390", "north",
+    });
+}

--- a/domain/original/area/exedoria/room905.c
+++ b/domain/original/area/exedoria/room905.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Science laboratory";
+    long_desc = "Science laboratory.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room904", "east",
+    });
+}

--- a/domain/original/area/exedoria/room906.c
+++ b/domain/original/area/exedoria/room906.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Science lecture hall";
+    long_desc = "Science lecture hall.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room904", "west",
+    });
+}

--- a/domain/original/area/exedoria/room907.c
+++ b/domain/original/area/exedoria/room907.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gravel Path";
+    long_desc = "Gravel Path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room908", "northwest",
+        "domain/original/area/exedoria/room604", "southwest",
+    });
+}

--- a/domain/original/area/exedoria/room908.c
+++ b/domain/original/area/exedoria/room908.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Vine-covered Entry";
+    long_desc = "Vine-covered Entry.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room910", "southwest",
+        "domain/original/area/exedoria/room907", "southeast",
+        "domain/original/area/exedoria/room909", "north",
+    });
+}

--- a/domain/original/area/exedoria/room909.c
+++ b/domain/original/area/exedoria/room909.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Grand Foyer";
+    long_desc = "Grand Foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room914", "up",
+        "domain/original/area/exedoria/room911", "west",
+        "domain/original/area/exedoria/room912", "east",
+        "domain/original/area/exedoria/room908", "south",
+    });
+}

--- a/domain/original/area/exedoria/room910.c
+++ b/domain/original/area/exedoria/room910.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gravel Path";
+    long_desc = "Gravel Path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room604", "southeast",
+        "domain/original/area/exedoria/room908", "northeast",
+    });
+}

--- a/domain/original/area/exedoria/room911.c
+++ b/domain/original/area/exedoria/room911.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Child's Den";
+    long_desc = "Child's Den.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room909", "east",
+    });
+}

--- a/domain/original/area/exedoria/room912.c
+++ b/domain/original/area/exedoria/room912.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Wooded Hallway";
+    long_desc = "Wooded Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room913", "east",
+        "domain/original/area/exedoria/room909", "west",
+    });
+}

--- a/domain/original/area/exedoria/room913.c
+++ b/domain/original/area/exedoria/room913.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Brushing aside the hanging vines, you walk east into the servants' quarters.";
+    long_desc = "Brushing aside the hanging vines, you walk east into the servants' quarters.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room912", "west",
+    });
+}

--- a/domain/original/area/exedoria/room914.c
+++ b/domain/original/area/exedoria/room914.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Treetop Bedroom";
+    long_desc = "Treetop Bedroom.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room909", "down",
+    });
+}

--- a/domain/original/area/exedoria/room915.c
+++ b/domain/original/area/exedoria/room915.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Flagstoned path";
+    long_desc = "Flagstoned path.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room916", "south",
+        "domain/original/area/exedoria/room919", "west",
+        "domain/original/area/exedoria/room918", "east",
+        "domain/original/area/exedoria/room603", "north",
+    });
+}

--- a/domain/original/area/exedoria/room916.c
+++ b/domain/original/area/exedoria/room916.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gray foyer";
+    long_desc = "Gray foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room917", "south",
+        "domain/original/area/exedoria/room915", "north",
+    });
+}

--- a/domain/original/area/exedoria/room917.c
+++ b/domain/original/area/exedoria/room917.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Trinian merchant's office";
+    long_desc = "Trinian merchant's office.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room916", "north",
+    });
+}

--- a/domain/original/area/exedoria/room918.c
+++ b/domain/original/area/exedoria/room918.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Carriage house";
+    long_desc = "Carriage house.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room915", "west",
+    });
+}

--- a/domain/original/area/exedoria/room919.c
+++ b/domain/original/area/exedoria/room919.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Slave quarters";
+    long_desc = "Slave quarters.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room915", "east",
+    });
+}

--- a/domain/original/area/exedoria/room920.c
+++ b/domain/original/area/exedoria/room920.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Embassy foyer";
+    long_desc = "Dwarven Embassy foyer.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room923", "west",
+        "domain/original/area/exedoria/room921", "up",
+        "domain/original/area/exedoria/room333", "south",
+        "domain/original/area/exedoria/room925", "east",
+        "domain/original/area/exedoria/room924", "north",
+    });
+}

--- a/domain/original/area/exedoria/room921.c
+++ b/domain/original/area/exedoria/room921.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven watchtower";
+    long_desc = "Dwarven watchtower.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room920", "down",
+        "domain/original/area/exedoria/room922", "north",
+    });
+}

--- a/domain/original/area/exedoria/room922.c
+++ b/domain/original/area/exedoria/room922.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ambassadors Suite";
+    long_desc = "Ambassadors Suite.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room921", "south",
+    });
+}

--- a/domain/original/area/exedoria/room923.c
+++ b/domain/original/area/exedoria/room923.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven brewery";
+    long_desc = "Dwarven brewery.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room920", "east",
+    });
+}

--- a/domain/original/area/exedoria/room924.c
+++ b/domain/original/area/exedoria/room924.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Ambassador's office";
+    long_desc = "Dwarven Ambassador's office.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room920", "south",
+    });
+}

--- a/domain/original/area/exedoria/room925.c
+++ b/domain/original/area/exedoria/room925.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven armoury";
+    long_desc = "Dwarven armoury.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room920", "west",
+    });
+}

--- a/domain/original/area/exedoria/room926.c
+++ b/domain/original/area/exedoria/room926.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ground Floor of the Windmill";
+    long_desc = "Ground Floor of the Windmill.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room929", "up",
+        "domain/original/area/exedoria/room927", "west",
+        "domain/original/area/exedoria/room928", "east",
+        "domain/original/area/exedoria/room319", "south",
+    });
+}

--- a/domain/original/area/exedoria/room927.c
+++ b/domain/original/area/exedoria/room927.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Garden of Machines";
+    long_desc = "Garden of Machines.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room926", "east",
+    });
+}

--- a/domain/original/area/exedoria/room928.c
+++ b/domain/original/area/exedoria/room928.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cemetery";
+    long_desc = "Cemetery.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room926", "west",
+    });
+}

--- a/domain/original/area/exedoria/room929.c
+++ b/domain/original/area/exedoria/room929.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gnome Laboratory";
+    long_desc = "Gnome Laboratory.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room926", "down",
+        "domain/original/area/exedoria/room930", "up",
+    });
+}

--- a/domain/original/area/exedoria/room930.c
+++ b/domain/original/area/exedoria/room930.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Machinery Room";
+    long_desc = "Machinery Room.\n";
+    dest_dir = ({
+        "domain/original/area/exedoria/room929", "down",
+    });
+}

--- a/domain/original/area/roadway/room15.c
+++ b/domain/original/area/roadway/room15.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Near Vesla City";
+    long_desc = "Near Vesla City.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room16", "east",
+        "domain/original/area/vesla/room115", "city",
+    });
+}

--- a/domain/original/area/roadway/room16.c
+++ b/domain/original/area/roadway/room16.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room15", "west",
+        "domain/original/area/roadway/room17", "east",
+    });
+}

--- a/domain/original/area/roadway/room17.c
+++ b/domain/original/area/roadway/room17.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room16", "west",
+        "domain/original/area/roadway/room18", "east",
+    });
+}

--- a/domain/original/area/roadway/room18.c
+++ b/domain/original/area/roadway/room18.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room17", "west",
+        "domain/original/area/roadway/room19", "east",
+    });
+}

--- a/domain/original/area/roadway/room19.c
+++ b/domain/original/area/roadway/room19.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room18", "west",
+        "domain/original/area/roadway/room20", "east",
+    });
+}

--- a/domain/original/area/roadway/room20.c
+++ b/domain/original/area/roadway/room20.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room19", "west",
+        "domain/original/area/roadway/room21", "east",
+    });
+}

--- a/domain/original/area/roadway/room21.c
+++ b/domain/original/area/roadway/room21.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room20", "west",
+        "domain/original/area/roadway/room22", "east",
+    });
+}

--- a/domain/original/area/roadway/room22.c
+++ b/domain/original/area/roadway/room22.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room21", "west",
+        "domain/original/area/roadway/room23", "east",
+    });
+}

--- a/domain/original/area/roadway/room23.c
+++ b/domain/original/area/roadway/room23.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room22", "west",
+        "domain/original/area/roadway/room24", "east",
+    });
+}

--- a/domain/original/area/roadway/room24.c
+++ b/domain/original/area/roadway/room24.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room23", "west",
+        "domain/original/area/roadway/room25", "east",
+    });
+}

--- a/domain/original/area/roadway/room25.c
+++ b/domain/original/area/roadway/room25.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room24", "west",
+        "domain/original/area/roadway/room26", "east",
+    });
+}

--- a/domain/original/area/roadway/room26.c
+++ b/domain/original/area/roadway/room26.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room25", "west",
+        "domain/original/area/roadway/room27", "east",
+    });
+}

--- a/domain/original/area/roadway/room27.c
+++ b/domain/original/area/roadway/room27.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room26", "west",
+        "domain/original/area/roadway/room28", "east",
+    });
+}

--- a/domain/original/area/roadway/room28.c
+++ b/domain/original/area/roadway/room28.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Exedoria";
+    long_desc = "Entrance to Exedoria.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room27", "west",
+        "domain/original/area/exedoria/room286", "city",
+    });
+}


### PR DESCRIPTION
### Motivation
- Populate the codebase with LPC room files for the Exedoria area so the exported map is represented in-game.
- Provide a continuous east-west roadway to connect Vesla and Exedoria so players can travel between the cities.
- Ensure the city/exit linkage is symmetrical so the roadway `city` leads into Exedoria and the Exedoria entrance has an `exit` back to the roadway.
- Keep new room code consistent with existing style found in `domain/original/area/vesla/room228.c`.

### Description
- Added LPC room files under `domain/original/area/exedoria/room{ID}.c` for each room defined in `maps/exedoria.json`, each using `inherit "room/room"` and setting `short_desc`, `long_desc`, and `dest_dir`.
- Created a 14-room roadway segment as `domain/original/area/roadway/room15.c` through `room28.c` with linear west/east exits and `city` connections to Vesla and Exedoria.
- Connected the roadway and Exedoria entrance so `domain/original/area/roadway/room28` has `city` -> `domain/original/area/exedoria/room286` and `domain/original/area/exedoria/room286` has an `exit` -> `domain/original/area/roadway/room28`.
- Normalized `long_desc` (ensured terminating punctuation and trailing newline) and escaped strings when writing files programmatically to match LPC source formatting.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb33e5c708327aa86d741623e6aca)