### PR TITLE
Add Anshelm area and adjust Vesla–Anshelm roadway to north–south

### DIFF
--- a/domain/original/area/anshelm/room1135.c
+++ b/domain/original/area/anshelm/room1135.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western Guard Post";
+    long_desc = "Western Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1136", "up",
+        "domain/original/area/anshelm/room237", "northeast",
+    });
+}

--- a/domain/original/area/anshelm/room1136.c
+++ b/domain/original/area/anshelm/room1136.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Arleg bows to you.";
+    long_desc = "Arleg bows to you.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1135", "down",
+        "domain/original/area/anshelm/room1137", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1137.c
+++ b/domain/original/area/anshelm/room1137.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Second Floor Landing";
+    long_desc = "Second Floor Landing.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1136", "down",
+        "domain/original/area/anshelm/room1142", "east",
+        "domain/original/area/anshelm/room1138", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1138.c
+++ b/domain/original/area/anshelm/room1138.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Third Floor Passage";
+    long_desc = "Third Floor Passage.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1137", "down",
+        "domain/original/area/anshelm/room1144", "east",
+        "domain/original/area/anshelm/room1139", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1139.c
+++ b/domain/original/area/anshelm/room1139.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western Spire Stairwell";
+    long_desc = "Western Spire Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1138", "down",
+        "domain/original/area/anshelm/room1140", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1140.c
+++ b/domain/original/area/anshelm/room1140.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Roof of the Western Spire";
+    long_desc = "Roof of the Western Spire.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1139", "down",
+    });
+}

--- a/domain/original/area/anshelm/room1141.c
+++ b/domain/original/area/anshelm/room1141.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western Stairwell";
+    long_desc = "Western Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1137", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1142.c
+++ b/domain/original/area/anshelm/room1142.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Killing Room";
+    long_desc = "Killing Room.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1153", "east",
+        "domain/original/area/anshelm/room1137", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1143.c
+++ b/domain/original/area/anshelm/room1143.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Anshelm Lounge";
+    long_desc = "Anshelm Lounge.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room236", "east",
+        "domain/original/area/anshelm/room1204", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1144.c
+++ b/domain/original/area/anshelm/room1144.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gatehouse Mess Hall";
+    long_desc = "Gatehouse Mess Hall.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1145", "east",
+        "domain/original/area/anshelm/room1138", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1145.c
+++ b/domain/original/area/anshelm/room1145.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gatehouse Barracks";
+    long_desc = "Gatehouse Barracks.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1146", "east",
+        "domain/original/area/anshelm/room1144", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1146.c
+++ b/domain/original/area/anshelm/room1146.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Third Floor Passage";
+    long_desc = "Third Floor Passage.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1151", "up",
+        "domain/original/area/anshelm/room1145", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1147.c
+++ b/domain/original/area/anshelm/room1147.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad at the Promenade";
+    long_desc = "Beitel Straad at the Promenade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1150", "west",
+        "domain/original/area/anshelm/room414", "east",
+        "domain/original/area/anshelm/room1169", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1148.c
+++ b/domain/original/area/anshelm/room1148.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Stairwell";
+    long_desc = "Eastern Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1149", "down",
+    });
+}

--- a/domain/original/area/anshelm/room1149.c
+++ b/domain/original/area/anshelm/room1149.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Base of the Eastern Stairwell";
+    long_desc = "Base of the Eastern Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1148", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1150.c
+++ b/domain/original/area/anshelm/room1150.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1157", "west",
+        "domain/original/area/anshelm/room1147", "east",
+        "domain/original/area/anshelm/room1168", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1151.c
+++ b/domain/original/area/anshelm/room1151.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Spire Stairwell";
+    long_desc = "Eastern Spire Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1149", "down",
+        "domain/original/area/anshelm/room1152", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1152.c
+++ b/domain/original/area/anshelm/room1152.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Roof of the Eastern Spire";
+    long_desc = "Roof of the Eastern Spire.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1151", "down",
+    });
+}

--- a/domain/original/area/anshelm/room1153.c
+++ b/domain/original/area/anshelm/room1153.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tider bows to you.";
+    long_desc = "Tider bows to you.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1142", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1154.c
+++ b/domain/original/area/anshelm/room1154.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Guard Post";
+    long_desc = "Eastern Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room237", "northwest",
+        "domain/original/area/anshelm/room1155", "east",
+    });
+}

--- a/domain/original/area/anshelm/room1155.c
+++ b/domain/original/area/anshelm/room1155.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ganran bows to you.";
+    long_desc = "Ganran bows to you.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1158", "up",
+        "domain/original/area/anshelm/room1156", "down",
+        "domain/original/area/anshelm/room1154", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1156.c
+++ b/domain/original/area/anshelm/room1156.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gatehouse Armoury";
+    long_desc = "Gatehouse Armoury.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1155", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1157.c
+++ b/domain/original/area/anshelm/room1157.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western end of Beitel Straad";
+    long_desc = "Western end of Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1150", "east",
+        "domain/original/area/anshelm/room1164", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1158.c
+++ b/domain/original/area/anshelm/room1158.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Stairwell";
+    long_desc = "Eastern Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1155", "down",
+        "domain/original/area/anshelm/room1159", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1159.c
+++ b/domain/original/area/anshelm/room1159.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Olotia bows to you.";
+    long_desc = "Olotia bows to you.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1158", "down",
+        "domain/original/area/anshelm/room1160", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1160.c
+++ b/domain/original/area/anshelm/room1160.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tiran bows to you.";
+    long_desc = "Tiran bows to you.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1159", "east",
+        "domain/original/area/anshelm/room1161", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1161.c
+++ b/domain/original/area/anshelm/room1161.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Killing Room";
+    long_desc = "Killing Room.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1160", "east",
+        "domain/original/area/anshelm/room1162", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1162.c
+++ b/domain/original/area/anshelm/room1162.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Second Floor Landing";
+    long_desc = "Second Floor Landing.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1161", "east",
+        "domain/original/area/anshelm/room1163", "down",
+    });
+}

--- a/domain/original/area/anshelm/room1163.c
+++ b/domain/original/area/anshelm/room1163.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western Stairwell";
+    long_desc = "Western Stairwell.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1135", "down",
+        "domain/original/area/anshelm/room1162", "up",
+    });
+}

--- a/domain/original/area/anshelm/room1168.c
+++ b/domain/original/area/anshelm/room1168.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Inner Bailey";
+    long_desc = "The Inner Bailey.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1150", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1185.c
+++ b/domain/original/area/anshelm/room1185.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room239", "west",
+        "domain/original/area/anshelm/room1186", "east",
+        "domain/original/area/anshelm/room1191", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1186.c
+++ b/domain/original/area/anshelm/room1186.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1185", "west",
+        "domain/original/area/anshelm/room1187", "east",
+        "domain/original/area/anshelm/room1190", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1187.c
+++ b/domain/original/area/anshelm/room1187.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1188", "east",
+        "domain/original/area/anshelm/room1186", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1188.c
+++ b/domain/original/area/anshelm/room1188.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1189", "east",
+        "domain/original/area/anshelm/room1187", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1189.c
+++ b/domain/original/area/anshelm/room1189.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern end of Beitel Straad";
+    long_desc = "Eastern end of Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1188", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1190.c
+++ b/domain/original/area/anshelm/room1190.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Banana Hammock";
+    long_desc = "The Banana Hammock.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1191", "west",
+        "domain/original/area/anshelm/room1186", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1191.c
+++ b/domain/original/area/anshelm/room1191.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Jack's Bistro";
+    long_desc = "Jack's Bistro.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1190", "east",
+        "domain/original/area/anshelm/room1185", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1192.c
+++ b/domain/original/area/anshelm/room1192.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Second Bank of Anshelm";
+    long_desc = "Second Bank of Anshelm.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room240", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1193.c
+++ b/domain/original/area/anshelm/room1193.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Anshelmish General Store";
+    long_desc = "The Anshelmish General Store.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room251", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1194.c
+++ b/domain/original/area/anshelm/room1194.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room255", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1195.c
+++ b/domain/original/area/anshelm/room1195.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Anshelmish Keep's drawbridge";
+    long_desc = "Anshelmish Keep's drawbridge.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room255", "east",
+        "domain/original/area/anshelm/room1196", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1196.c
+++ b/domain/original/area/anshelm/room1196.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1195", "east",
+    });
+}

--- a/domain/original/area/anshelm/room1197.c
+++ b/domain/original/area/anshelm/room1197.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Private Entry";
+    long_desc = "Private Entry.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room281", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1198.c
+++ b/domain/original/area/anshelm/room1198.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You have to turn sideways a bit to squeeze through the narrow passage.";
+    long_desc = "You have to turn sideways a bit to squeeze through the narrow passage.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room265", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1199.c
+++ b/domain/original/area/anshelm/room1199.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Armourer's Shack";
+    long_desc = "Armourer's Shack.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room270", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1200.c
+++ b/domain/original/area/anshelm/room1200.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room276", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1201.c
+++ b/domain/original/area/anshelm/room1201.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room280", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1202.c
+++ b/domain/original/area/anshelm/room1202.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room273", "southeast",
+    });
+}

--- a/domain/original/area/anshelm/room1204.c
+++ b/domain/original/area/anshelm/room1204.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
+    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1143", "east",
+    });
+}

--- a/domain/original/area/anshelm/room1326.c
+++ b/domain/original/area/anshelm/room1326.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "La Cosa Nostra";
+    long_desc = "La Cosa Nostra.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room283", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1327.c
+++ b/domain/original/area/anshelm/room1327.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Anshelm Stables";
+    long_desc = "Anshelm Stables.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room284", "south",
+    });
+}

--- a/domain/original/area/anshelm/room1328.c
+++ b/domain/original/area/anshelm/room1328.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern end of Geld Strasse";
+    long_desc = "Eastern end of Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1329", "east",
+        "domain/original/area/anshelm/room281", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1329.c
+++ b/domain/original/area/anshelm/room1329.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "With a little strain, you are able to pull open the heavy doors and enter";
+    long_desc = "With a little strain, you are able to pull open the heavy doors and enter.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1330", "east",
+        "domain/original/area/anshelm/room1328", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1330.c
+++ b/domain/original/area/anshelm/room1330.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Naive";
+    long_desc = "Naive.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1332", "south",
+        "domain/original/area/anshelm/room1329", "west",
+        "domain/original/area/anshelm/room1331", "east",
+        "domain/original/area/anshelm/room1333", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1331.c
+++ b/domain/original/area/anshelm/room1331.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Altar of the Rose";
+    long_desc = "Altar of the Rose.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1330", "west",
+    });
+}

--- a/domain/original/area/anshelm/room1332.c
+++ b/domain/original/area/anshelm/room1332.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern statuary";
+    long_desc = "Southern statuary.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1330", "north",
+    });
+}

--- a/domain/original/area/anshelm/room1333.c
+++ b/domain/original/area/anshelm/room1333.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northern statuary";
+    long_desc = "Northern statuary.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1330", "south",
+    });
+}

--- a/domain/original/area/anshelm/room235.c
+++ b/domain/original/area/anshelm/room235.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before the Anshelm Gatehouse";
+    long_desc = "Before the Anshelm Gatehouse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room236", "north",
+    });
+}

--- a/domain/original/area/anshelm/room236.c
+++ b/domain/original/area/anshelm/room236.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Under the Anshelmish Gatehouse";
+    long_desc = "Under the Anshelmish Gatehouse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1143", "west",
+        "domain/original/area/anshelm/room235", "south",
+        "domain/original/area/anshelm/room237", "north",
+    });
+}

--- a/domain/original/area/anshelm/room237.c
+++ b/domain/original/area/anshelm/room237.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern end of Rue du Nord";
+    long_desc = "Southern end of Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room1135", "southwest",
+        "domain/original/area/anshelm/room236", "south",
+        "domain/original/area/anshelm/room1154", "southeast",
+        "domain/original/area/anshelm/room238", "north",
+    });
+}

--- a/domain/original/area/anshelm/room238.c
+++ b/domain/original/area/anshelm/room238.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room413", "west",
+        "domain/original/area/anshelm/room237", "south",
+        "domain/original/area/anshelm/room239", "north",
+    });
+}

--- a/domain/original/area/anshelm/room239.c
+++ b/domain/original/area/anshelm/room239.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Rue du Nord and Beitel Straat";
+    long_desc = "Intersection of Rue du Nord and Beitel Straat.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room238", "south",
+        "domain/original/area/anshelm/room414", "west",
+        "domain/original/area/anshelm/room1185", "east",
+        "domain/original/area/anshelm/room240", "north",
+    });
+}

--- a/domain/original/area/anshelm/room240.c
+++ b/domain/original/area/anshelm/room240.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room239", "south",
+        "domain/original/area/anshelm/room415", "west",
+        "domain/original/area/anshelm/room1192", "east",
+        "domain/original/area/anshelm/room241", "north",
+    });
+}

--- a/domain/original/area/anshelm/room241.c
+++ b/domain/original/area/anshelm/room241.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room416", "west",
+        "domain/original/area/anshelm/room240", "south",
+        "domain/original/area/anshelm/room242", "north",
+    });
+}

--- a/domain/original/area/anshelm/room242.c
+++ b/domain/original/area/anshelm/room242.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gateway to Middle Bailey";
+    long_desc = "Gateway to Middle Bailey.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room241", "south",
+        "domain/original/area/anshelm/room243", "north",
+    });
+}

--- a/domain/original/area/anshelm/room243.c
+++ b/domain/original/area/anshelm/room243.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room242", "south",
+        "domain/original/area/anshelm/room244", "north",
+    });
+}

--- a/domain/original/area/anshelm/room244.c
+++ b/domain/original/area/anshelm/room244.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western intersection of Rue du Nord and Kirsch Lane";
+    long_desc = "Western intersection of Rue du Nord and Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room245", "west",
+        "domain/original/area/anshelm/room250", "east",
+        "domain/original/area/anshelm/room243", "south",
+    });
+}

--- a/domain/original/area/anshelm/room245.c
+++ b/domain/original/area/anshelm/room245.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kirsch Lane";
+    long_desc = "Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room244", "east",
+        "domain/original/area/anshelm/room246", "west",
+    });
+}

--- a/domain/original/area/anshelm/room246.c
+++ b/domain/original/area/anshelm/room246.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kirsch Lane";
+    long_desc = "Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room247", "west",
+        "domain/original/area/anshelm/room245", "east",
+        "domain/original/area/anshelm/room249", "south",
+    });
+}

--- a/domain/original/area/anshelm/room247.c
+++ b/domain/original/area/anshelm/room247.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western end of Kirsch Lane";
+    long_desc = "Western end of Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room246", "east",
+        "domain/original/area/anshelm/room248", "south",
+    });
+}

--- a/domain/original/area/anshelm/room248.c
+++ b/domain/original/area/anshelm/room248.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room247", "north",
+    });
+}

--- a/domain/original/area/anshelm/room249.c
+++ b/domain/original/area/anshelm/room249.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kaneohe Armory";
+    long_desc = "Kaneohe Armory.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room246", "north",
+    });
+}

--- a/domain/original/area/anshelm/room250.c
+++ b/domain/original/area/anshelm/room250.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern intersection of Rue du Nord and Kirsch Lane";
+    long_desc = "Eastern intersection of Rue du Nord and Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room244", "west",
+        "domain/original/area/anshelm/room283", "east",
+        "domain/original/area/anshelm/room251", "north",
+    });
+}

--- a/domain/original/area/anshelm/room251.c
+++ b/domain/original/area/anshelm/room251.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room250", "south",
+        "domain/original/area/anshelm/room1193", "east",
+        "domain/original/area/anshelm/room252", "north",
+    });
+}

--- a/domain/original/area/anshelm/room252.c
+++ b/domain/original/area/anshelm/room252.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room251", "south",
+        "domain/original/area/anshelm/room253", "north",
+    });
+}

--- a/domain/original/area/anshelm/room253.c
+++ b/domain/original/area/anshelm/room253.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room252", "south",
+        "domain/original/area/anshelm/room254", "north",
+    });
+}

--- a/domain/original/area/anshelm/room254.c
+++ b/domain/original/area/anshelm/room254.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room253", "south",
+        "domain/original/area/anshelm/room255", "north",
+    });
+}

--- a/domain/original/area/anshelm/room255.c
+++ b/domain/original/area/anshelm/room255.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Central Square on the Rue du Nord";
+    long_desc = "Central Square on the Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room254", "south",
+        "domain/original/area/anshelm/room1195", "west",
+        "domain/original/area/anshelm/room1194", "east",
+        "domain/original/area/anshelm/room256", "north",
+    });
+}

--- a/domain/original/area/anshelm/room256.c
+++ b/domain/original/area/anshelm/room256.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room255", "south",
+        "domain/original/area/anshelm/room257", "north",
+    });
+}

--- a/domain/original/area/anshelm/room257.c
+++ b/domain/original/area/anshelm/room257.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room256", "south",
+        "domain/original/area/anshelm/room258", "north",
+    });
+}

--- a/domain/original/area/anshelm/room258.c
+++ b/domain/original/area/anshelm/room258.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Rue du Nord and East Geld Strasse";
+    long_desc = "Intersection of Rue du Nord and East Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room259", "west",
+        "domain/original/area/anshelm/room281", "east",
+        "domain/original/area/anshelm/room257", "south",
+    });
+}

--- a/domain/original/area/anshelm/room259.c
+++ b/domain/original/area/anshelm/room259.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room258", "east",
+        "domain/original/area/anshelm/room260", "west",
+    });
+}

--- a/domain/original/area/anshelm/room260.c
+++ b/domain/original/area/anshelm/room260.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Rue du Nord and West Geld Strasse";
+    long_desc = "Intersection of Rue du Nord and West Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room261", "west",
+        "domain/original/area/anshelm/room259", "east",
+        "domain/original/area/anshelm/room264", "north",
+    });
+}

--- a/domain/original/area/anshelm/room261.c
+++ b/domain/original/area/anshelm/room261.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Geld Strasse";
+    long_desc = "Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room260", "east",
+        "domain/original/area/anshelm/room262", "west",
+    });
+}

--- a/domain/original/area/anshelm/room262.c
+++ b/domain/original/area/anshelm/room262.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Geld Strasse";
+    long_desc = "Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room261", "east",
+        "domain/original/area/anshelm/room263", "west",
+    });
+}

--- a/domain/original/area/anshelm/room263.c
+++ b/domain/original/area/anshelm/room263.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western end of Geld Strasse";
+    long_desc = "Western end of Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room262", "east",
+    });
+}

--- a/domain/original/area/anshelm/room264.c
+++ b/domain/original/area/anshelm/room264.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room260", "south",
+        "domain/original/area/anshelm/room265", "north",
+    });
+}

--- a/domain/original/area/anshelm/room265.c
+++ b/domain/original/area/anshelm/room265.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gateway to Upper Bailey";
+    long_desc = "Gateway to Upper Bailey.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room264", "south",
+        "domain/original/area/anshelm/room282", "west",
+        "domain/original/area/anshelm/room1198", "east",
+        "domain/original/area/anshelm/room266", "north",
+    });
+}

--- a/domain/original/area/anshelm/room266.c
+++ b/domain/original/area/anshelm/room266.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room265", "south",
+        "domain/original/area/anshelm/room267", "north",
+    });
+}

--- a/domain/original/area/anshelm/room267.c
+++ b/domain/original/area/anshelm/room267.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Rue du Nord and Kasernegade";
+    long_desc = "Intersection of Rue du Nord and Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room266", "south",
+        "domain/original/area/anshelm/room268", "west",
+        "domain/original/area/anshelm/room276", "east",
+        "domain/original/area/anshelm/room273", "north",
+    });
+}

--- a/domain/original/area/anshelm/room268.c
+++ b/domain/original/area/anshelm/room268.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room267", "east",
+        "domain/original/area/anshelm/room269", "west",
+    });
+}

--- a/domain/original/area/anshelm/room269.c
+++ b/domain/original/area/anshelm/room269.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room268", "east",
+        "domain/original/area/anshelm/room270", "west",
+    });
+}

--- a/domain/original/area/anshelm/room270.c
+++ b/domain/original/area/anshelm/room270.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room271", "west",
+        "domain/original/area/anshelm/room269", "east",
+        "domain/original/area/anshelm/room1199", "south",
+    });
+}

--- a/domain/original/area/anshelm/room271.c
+++ b/domain/original/area/anshelm/room271.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western end of Kasernegade";
+    long_desc = "Western end of Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room270", "east",
+        "domain/original/area/anshelm/room272", "north",
+    });
+}

--- a/domain/original/area/anshelm/room272.c
+++ b/domain/original/area/anshelm/room272.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Construction site";
+    long_desc = "Construction site.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room271", "south",
+    });
+}

--- a/domain/original/area/anshelm/room273.c
+++ b/domain/original/area/anshelm/room273.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rue du Nord";
+    long_desc = "Rue du Nord.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room267", "south",
+        "domain/original/area/anshelm/room1202", "northwest",
+        "domain/original/area/anshelm/room274", "north",
+    });
+}

--- a/domain/original/area/anshelm/room274.c
+++ b/domain/original/area/anshelm/room274.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Under the Town Gate";
+    long_desc = "Under the Town Gate.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room273", "south",
+        "domain/original/area/anshelm/room275", "north",
+    });
+}

--- a/domain/original/area/anshelm/room275.c
+++ b/domain/original/area/anshelm/room275.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before the Anshelm Town Gate";
+    long_desc = "Before the Anshelm Town Gate.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room274", "south",
+        "domain/original/area/roadway/room42", "exit",
+    });
+}

--- a/domain/original/area/anshelm/room276.c
+++ b/domain/original/area/anshelm/room276.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room267", "west",
+        "domain/original/area/anshelm/room277", "east",
+        "domain/original/area/anshelm/room1200", "north",
+    });
+}

--- a/domain/original/area/anshelm/room277.c
+++ b/domain/original/area/anshelm/room277.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room278", "east",
+        "domain/original/area/anshelm/room276", "west",
+    });
+}

--- a/domain/original/area/anshelm/room278.c
+++ b/domain/original/area/anshelm/room278.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room279", "east",
+        "domain/original/area/anshelm/room277", "west",
+    });
+}

--- a/domain/original/area/anshelm/room279.c
+++ b/domain/original/area/anshelm/room279.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kasernegade";
+    long_desc = "Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room280", "east",
+        "domain/original/area/anshelm/room278", "west",
+    });
+}

--- a/domain/original/area/anshelm/room280.c
+++ b/domain/original/area/anshelm/room280.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern end of Kasernegade";
+    long_desc = "Eastern end of Kasernegade.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room279", "west",
+        "domain/original/area/anshelm/room1201", "south",
+    });
+}

--- a/domain/original/area/anshelm/room281.c
+++ b/domain/original/area/anshelm/room281.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Geld Strasse";
+    long_desc = "Geld Strasse.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room258", "west",
+        "domain/original/area/anshelm/room1328", "east",
+        "domain/original/area/anshelm/room1197", "north",
+    });
+}

--- a/domain/original/area/anshelm/room282.c
+++ b/domain/original/area/anshelm/room282.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You have to turn sideways a bit to squeeze through the narrow passage.";
+    long_desc = "You have to turn sideways a bit to squeeze through the narrow passage.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room265", "east",
+    });
+}

--- a/domain/original/area/anshelm/room283.c
+++ b/domain/original/area/anshelm/room283.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kirsch Lane";
+    long_desc = "Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room250", "west",
+        "domain/original/area/anshelm/room284", "east",
+        "domain/original/area/anshelm/room1326", "north",
+    });
+}

--- a/domain/original/area/anshelm/room284.c
+++ b/domain/original/area/anshelm/room284.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kirsch Lane";
+    long_desc = "Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room283", "west",
+        "domain/original/area/anshelm/room285", "east",
+        "domain/original/area/anshelm/room1327", "north",
+    });
+}

--- a/domain/original/area/anshelm/room285.c
+++ b/domain/original/area/anshelm/room285.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern end of Kirsch Lane";
+    long_desc = "Eastern end of Kirsch Lane.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room284", "west",
+    });
+}

--- a/domain/original/area/anshelm/room413.c
+++ b/domain/original/area/anshelm/room413.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hawaiian Ryan's";
+    long_desc = "Hawaiian Ryan's.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room238", "east",
+        "domain/original/area/anshelm/room414", "north",
+    });
+}

--- a/domain/original/area/anshelm/room414.c
+++ b/domain/original/area/anshelm/room414.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Beitel Straad";
+    long_desc = "Beitel Straad.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room413", "south",
+        "domain/original/area/anshelm/room1147", "west",
+        "domain/original/area/anshelm/room239", "east",
+        "domain/original/area/anshelm/room415", "north",
+    });
+}

--- a/domain/original/area/anshelm/room415.c
+++ b/domain/original/area/anshelm/room415.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Club Femme Nu";
+    long_desc = "Club Femme Nu.\n";
+    dest_dir = ({
+        "domain/original/area/anshelm/room240", "east",
+        "domain/original/area/anshelm/room414", "south",
+    });
+}

--- a/domain/original/area/roadway/room29.c
+++ b/domain/original/area/roadway/room29.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Vesla";
+    long_desc = "Entrance to Vesla.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room30", "north",
+        "domain/original/area/vesla/room134", "city",
+    });
+}

--- a/domain/original/area/roadway/room30.c
+++ b/domain/original/area/roadway/room30.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room29", "south",
+        "domain/original/area/roadway/room31", "north",
+    });
+}

--- a/domain/original/area/roadway/room31.c
+++ b/domain/original/area/roadway/room31.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room30", "south",
+        "domain/original/area/roadway/room32", "north",
+    });
+}

--- a/domain/original/area/roadway/room32.c
+++ b/domain/original/area/roadway/room32.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room31", "south",
+        "domain/original/area/roadway/room33", "north",
+    });
+}

--- a/domain/original/area/roadway/room33.c
+++ b/domain/original/area/roadway/room33.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room32", "south",
+        "domain/original/area/roadway/room34", "north",
+    });
+}

--- a/domain/original/area/roadway/room34.c
+++ b/domain/original/area/roadway/room34.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room33", "south",
+        "domain/original/area/roadway/room35", "north",
+    });
+}

--- a/domain/original/area/roadway/room35.c
+++ b/domain/original/area/roadway/room35.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room34", "south",
+        "domain/original/area/roadway/room36", "north",
+    });
+}

--- a/domain/original/area/roadway/room36.c
+++ b/domain/original/area/roadway/room36.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room35", "south",
+        "domain/original/area/roadway/room37", "north",
+    });
+}

--- a/domain/original/area/roadway/room37.c
+++ b/domain/original/area/roadway/room37.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room36", "south",
+        "domain/original/area/roadway/room38", "north",
+    });
+}

--- a/domain/original/area/roadway/room38.c
+++ b/domain/original/area/roadway/room38.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room37", "south",
+        "domain/original/area/roadway/room39", "north",
+    });
+}

--- a/domain/original/area/roadway/room39.c
+++ b/domain/original/area/roadway/room39.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room38", "south",
+        "domain/original/area/roadway/room40", "north",
+    });
+}

--- a/domain/original/area/roadway/room40.c
+++ b/domain/original/area/roadway/room40.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room39", "south",
+        "domain/original/area/roadway/room41", "north",
+    });
+}

--- a/domain/original/area/roadway/room41.c
+++ b/domain/original/area/roadway/room41.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room40", "south",
+        "domain/original/area/roadway/room42", "north",
+    });
+}

--- a/domain/original/area/roadway/room42.c
+++ b/domain/original/area/roadway/room42.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Anshelm";
+    long_desc = "Entrance to Anshelm.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room41", "south",
+        "domain/original/area/anshelm/room275", "city",
+    });
+}

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -10,5 +10,6 @@ void reset(int arg) {
     long_desc = "Western Gate of Vesla.\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "east",
+        "domain/original/area/roadway/room29", "exit",
     });
 }


### PR DESCRIPTION
### Motivation
- Import the Anshelm map into the codebase as LPC room files so the city exists in-game.
- Provide a roadway link between Vesla and Anshelm following existing roadway patterns while correcting the orientation to north–south.

### Description
- Added numerous new room files under `domain/original/area/anshelm/` generated from the source map and wired exits to match the JSON source.
- Added a 14-room roadway chain `domain/original/area/roadway/room29.c` through `room42.c` that uses `north`/`south` exits and connects `domain/original/area/vesla/room134` to `domain/original/area/anshelm/room275`.
- Updated `domain/original/area/vesla/room134.c` to add an `exit` to `domain/original/area/roadway/room29` and updated `domain/original/area/anshelm/room275.c` to link back to `domain/original/area/roadway/room42`.
- Converted the roadway orientation from the previous northwest pattern to a north–south chain and committed the adjustments.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb45a3de08327b93b6c93687d5e24)