### PR TITLE
Add Indel rooms and 14-room roadway link to Vesla

### DIFF
--- a/domain/original/area/indel/room1401.c
+++ b/domain/original/area/indel/room1401.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "City of Indel, Wilderness Gate";
+    long_desc = "City of Indel, Wilderness Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1402", "south",
+        "domain/original/area/indel/room1636", "east",
+        "domain/original/area/indel/room1635", "west",
+        "domain/original/area/roadway/room55", "exit",
+    });
+}

--- a/domain/original/area/indel/room1402.c
+++ b/domain/original/area/indel/room1402.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Road";
+    long_desc = "Castle Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1401", "north",
+        "domain/original/area/indel/room1403", "south",
+        "domain/original/area/indel/room1633", "east",
+        "domain/original/area/indel/room1631", "west",
+    });
+}

--- a/domain/original/area/indel/room1403.c
+++ b/domain/original/area/indel/room1403.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Road";
+    long_desc = "Castle Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1402", "north",
+        "domain/original/area/indel/room1404", "south",
+        "domain/original/area/indel/room1630", "east",
+        "domain/original/area/indel/room1628", "west",
+    });
+}

--- a/domain/original/area/indel/room1404.c
+++ b/domain/original/area/indel/room1404.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Road Courtyard";
+    long_desc = "Castle Road Courtyard.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1403", "north",
+        "domain/original/area/indel/room1405", "south",
+        "domain/original/area/indel/room1627", "east",
+        "domain/original/area/indel/room1626", "west",
+    });
+}

--- a/domain/original/area/indel/room1405.c
+++ b/domain/original/area/indel/room1405.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Road";
+    long_desc = "Castle Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1404", "north",
+        "domain/original/area/indel/room1406", "south",
+        "domain/original/area/indel/room1625", "west",
+    });
+}

--- a/domain/original/area/indel/room1406.c
+++ b/domain/original/area/indel/room1406.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Castle Road and Merchant's Row";
+    long_desc = "Intersection of Castle Road and Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1405", "north",
+        "domain/original/area/indel/room1584", "south",
+        "domain/original/area/indel/room1508", "east",
+        "domain/original/area/indel/room1407", "west",
+    });
+}

--- a/domain/original/area/indel/room1407.c
+++ b/domain/original/area/indel/room1407.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1406", "east",
+        "domain/original/area/indel/room1408", "west",
+    });
+}

--- a/domain/original/area/indel/room1408.c
+++ b/domain/original/area/indel/room1408.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row, north of the Silver Griffin";
+    long_desc = "West Merchant's Row, north of the Silver Griffin.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1589", "south",
+        "domain/original/area/indel/room1407", "east",
+        "domain/original/area/indel/room1409", "west",
+    });
+}

--- a/domain/original/area/indel/room1409.c
+++ b/domain/original/area/indel/room1409.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row, south of Big Bob's Sign Shop";
+    long_desc = "West Merchant's Row, south of Big Bob's Sign Shop.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1590", "south",
+        "domain/original/area/indel/room1408", "east",
+        "domain/original/area/indel/room1410", "west",
+    });
+}

--- a/domain/original/area/indel/room1410.c
+++ b/domain/original/area/indel/room1410.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1409", "east",
+        "domain/original/area/indel/room1411", "west",
+    });
+}

--- a/domain/original/area/indel/room1411.c
+++ b/domain/original/area/indel/room1411.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1410", "east",
+        "domain/original/area/indel/room1412", "west",
+    });
+}

--- a/domain/original/area/indel/room1412.c
+++ b/domain/original/area/indel/room1412.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1411", "east",
+        "domain/original/area/indel/room1413", "west",
+    });
+}

--- a/domain/original/area/indel/room1413.c
+++ b/domain/original/area/indel/room1413.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row, south of Knights of Solamnia";
+    long_desc = "West Merchant's Row, south of Knights of Solamnia.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1412", "east",
+        "domain/original/area/indel/room1414", "west",
+    });
+}

--- a/domain/original/area/indel/room1414.c
+++ b/domain/original/area/indel/room1414.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1413", "east",
+        "domain/original/area/indel/room1415", "west",
+    });
+}

--- a/domain/original/area/indel/room1415.c
+++ b/domain/original/area/indel/room1415.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row, south of the Cobbler's Shop";
+    long_desc = "West Merchant's Row, south of the Cobbler's Shop.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1414", "east",
+        "domain/original/area/indel/room1416", "west",
+    });
+}

--- a/domain/original/area/indel/room1416.c
+++ b/domain/original/area/indel/room1416.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row, south of Laird's Forge";
+    long_desc = "West Merchant's Row, south of Laird's Forge.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1415", "east",
+        "domain/original/area/indel/room1417", "west",
+    });
+}

--- a/domain/original/area/indel/room1417.c
+++ b/domain/original/area/indel/room1417.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Merchant's Row";
+    long_desc = "West Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1416", "east",
+        "domain/original/area/indel/room1418", "west",
+    });
+}

--- a/domain/original/area/indel/room1418.c
+++ b/domain/original/area/indel/room1418.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street and Merchant's Row";
+    long_desc = "Pier Street and Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1448", "north",
+        "domain/original/area/indel/room1419", "south",
+        "domain/original/area/indel/room1417", "east",
+    });
+}

--- a/domain/original/area/indel/room1419.c
+++ b/domain/original/area/indel/room1419.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1418", "north",
+        "domain/original/area/indel/room1420", "south",
+    });
+}

--- a/domain/original/area/indel/room1420.c
+++ b/domain/original/area/indel/room1420.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1419", "north",
+        "domain/original/area/indel/room1421", "south",
+    });
+}

--- a/domain/original/area/indel/room1421.c
+++ b/domain/original/area/indel/room1421.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1420", "north",
+        "domain/original/area/indel/room1422", "south",
+    });
+}

--- a/domain/original/area/indel/room1422.c
+++ b/domain/original/area/indel/room1422.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street west of the Waterfront Gate";
+    long_desc = "Pier Street west of the Waterfront Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1421", "north",
+        "domain/original/area/indel/room1423", "south",
+    });
+}

--- a/domain/original/area/indel/room1423.c
+++ b/domain/original/area/indel/room1423.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1422", "north",
+        "domain/original/area/indel/room1424", "south",
+    });
+}

--- a/domain/original/area/indel/room1424.c
+++ b/domain/original/area/indel/room1424.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1423", "north",
+        "domain/original/area/indel/room1425", "south",
+    });
+}

--- a/domain/original/area/indel/room1425.c
+++ b/domain/original/area/indel/room1425.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1424", "north",
+        "domain/original/area/indel/room1426", "south",
+    });
+}

--- a/domain/original/area/indel/room1426.c
+++ b/domain/original/area/indel/room1426.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1425", "north",
+        "domain/original/area/indel/room1427", "south",
+    });
+}

--- a/domain/original/area/indel/room1427.c
+++ b/domain/original/area/indel/room1427.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1426", "north",
+        "domain/original/area/indel/room1428", "south",
+    });
+}

--- a/domain/original/area/indel/room1428.c
+++ b/domain/original/area/indel/room1428.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pier Street";
+    long_desc = "Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1427", "north",
+        "domain/original/area/indel/room1429", "south",
+    });
+}

--- a/domain/original/area/indel/room1429.c
+++ b/domain/original/area/indel/room1429.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1428", "north",
+        "domain/original/area/indel/room1430", "south",
+    });
+}

--- a/domain/original/area/indel/room1430.c
+++ b/domain/original/area/indel/room1430.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1429", "north",
+        "domain/original/area/indel/room1431", "south",
+    });
+}

--- a/domain/original/area/indel/room1431.c
+++ b/domain/original/area/indel/room1431.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1430", "north",
+        "domain/original/area/indel/room1432", "south",
+    });
+}

--- a/domain/original/area/indel/room1432.c
+++ b/domain/original/area/indel/room1432.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1431", "north",
+        "domain/original/area/indel/room1433", "south",
+    });
+}

--- a/domain/original/area/indel/room1433.c
+++ b/domain/original/area/indel/room1433.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1432", "north",
+        "domain/original/area/indel/room1434", "south",
+    });
+}

--- a/domain/original/area/indel/room1434.c
+++ b/domain/original/area/indel/room1434.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1433", "north",
+        "domain/original/area/indel/room1435", "south",
+        "domain/original/area/indel/room1545", "east",
+    });
+}

--- a/domain/original/area/indel/room1435.c
+++ b/domain/original/area/indel/room1435.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1434", "north",
+        "domain/original/area/indel/room1436", "south",
+    });
+}

--- a/domain/original/area/indel/room1436.c
+++ b/domain/original/area/indel/room1436.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1435", "north",
+        "domain/original/area/indel/room1437", "south",
+    });
+}

--- a/domain/original/area/indel/room1437.c
+++ b/domain/original/area/indel/room1437.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1436", "north",
+        "domain/original/area/indel/room1438", "south",
+    });
+}

--- a/domain/original/area/indel/room1438.c
+++ b/domain/original/area/indel/room1438.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Pier Street";
+    long_desc = "South Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1437", "north",
+        "domain/original/area/indel/room1439", "south",
+    });
+}

--- a/domain/original/area/indel/room1439.c
+++ b/domain/original/area/indel/room1439.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Forester's Gate";
+    long_desc = "Forester's Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1438", "north",
+    });
+}

--- a/domain/original/area/indel/room1448.c
+++ b/domain/original/area/indel/room1448.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Pier Street";
+    long_desc = "North Pier Street.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1507", "north",
+        "domain/original/area/indel/room1418", "south",
+    });
+}

--- a/domain/original/area/indel/room1507.c
+++ b/domain/original/area/indel/room1507.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cobblestone courtyard";
+    long_desc = "Cobblestone courtyard.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1448", "south",
+    });
+}

--- a/domain/original/area/indel/room1508.c
+++ b/domain/original/area/indel/room1508.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1509", "east",
+        "domain/original/area/indel/room1406", "west",
+    });
+}

--- a/domain/original/area/indel/room1509.c
+++ b/domain/original/area/indel/room1509.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row, south of Saul's Formal Wear";
+    long_desc = "East Merchant's Row, south of Saul's Formal Wear.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1624", "north",
+        "domain/original/area/indel/room1510", "east",
+        "domain/original/area/indel/room1508", "west",
+    });
+}

--- a/domain/original/area/indel/room1510.c
+++ b/domain/original/area/indel/room1510.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row, south of a livestock lot";
+    long_desc = "East Merchant's Row, south of a livestock lot.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1623", "north",
+        "domain/original/area/indel/room1511", "east",
+        "domain/original/area/indel/room1509", "west",
+    });
+}

--- a/domain/original/area/indel/room1511.c
+++ b/domain/original/area/indel/room1511.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row, south of Mother Whitman's";
+    long_desc = "East Merchant's Row, south of Mother Whitman's.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1622", "north",
+        "domain/original/area/indel/room1512", "east",
+        "domain/original/area/indel/room1510", "west",
+    });
+}

--- a/domain/original/area/indel/room1512.c
+++ b/domain/original/area/indel/room1512.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1513", "east",
+        "domain/original/area/indel/room1511", "west",
+    });
+}

--- a/domain/original/area/indel/room1513.c
+++ b/domain/original/area/indel/room1513.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1514", "east",
+        "domain/original/area/indel/room1512", "west",
+    });
+}

--- a/domain/original/area/indel/room1514.c
+++ b/domain/original/area/indel/room1514.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row, south of Sithicus";
+    long_desc = "East Merchant's Row, south of Sithicus.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1621", "north",
+        "domain/original/area/indel/room1515", "east",
+        "domain/original/area/indel/room1513", "west",
+    });
+}

--- a/domain/original/area/indel/room1515.c
+++ b/domain/original/area/indel/room1515.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1516", "east",
+        "domain/original/area/indel/room1514", "west",
+    });
+}

--- a/domain/original/area/indel/room1516.c
+++ b/domain/original/area/indel/room1516.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Merchant's Row and Pensji Lane";
+    long_desc = "Merchant's Row and Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1520", "south",
+        "domain/original/area/indel/room1517", "east",
+        "domain/original/area/indel/room1515", "west",
+    });
+}

--- a/domain/original/area/indel/room1517.c
+++ b/domain/original/area/indel/room1517.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1518", "east",
+        "domain/original/area/indel/room1516", "west",
+    });
+}

--- a/domain/original/area/indel/room1518.c
+++ b/domain/original/area/indel/room1518.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Merchant's Row";
+    long_desc = "East Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1519", "east",
+        "domain/original/area/indel/room1517", "west",
+    });
+}

--- a/domain/original/area/indel/room1519.c
+++ b/domain/original/area/indel/room1519.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Merchant's Row";
+    long_desc = "End of Merchant's Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1518", "west",
+    });
+}

--- a/domain/original/area/indel/room1520.c
+++ b/domain/original/area/indel/room1520.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1516", "north",
+        "domain/original/area/indel/room1521", "south",
+    });
+}

--- a/domain/original/area/indel/room1521.c
+++ b/domain/original/area/indel/room1521.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1520", "north",
+        "domain/original/area/indel/room1522", "south",
+    });
+}

--- a/domain/original/area/indel/room1522.c
+++ b/domain/original/area/indel/room1522.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1521", "north",
+        "domain/original/area/indel/room1523", "south",
+    });
+}

--- a/domain/original/area/indel/room1523.c
+++ b/domain/original/area/indel/room1523.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1522", "north",
+        "domain/original/area/indel/room1524", "south",
+    });
+}

--- a/domain/original/area/indel/room1524.c
+++ b/domain/original/area/indel/room1524.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1523", "north",
+        "domain/original/area/indel/room1525", "south",
+    });
+}

--- a/domain/original/area/indel/room1525.c
+++ b/domain/original/area/indel/room1525.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1524", "north",
+        "domain/original/area/indel/room1526", "south",
+        "domain/original/area/indel/room1606", "east",
+    });
+}

--- a/domain/original/area/indel/room1526.c
+++ b/domain/original/area/indel/room1526.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1525", "north",
+        "domain/original/area/indel/room1527", "south",
+    });
+}

--- a/domain/original/area/indel/room1527.c
+++ b/domain/original/area/indel/room1527.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1526", "north",
+        "domain/original/area/indel/room1528", "south",
+    });
+}

--- a/domain/original/area/indel/room1528.c
+++ b/domain/original/area/indel/room1528.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1527", "north",
+        "domain/original/area/indel/room1529", "south",
+    });
+}

--- a/domain/original/area/indel/room1529.c
+++ b/domain/original/area/indel/room1529.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1528", "north",
+        "domain/original/area/indel/room1530", "south",
+    });
+}

--- a/domain/original/area/indel/room1530.c
+++ b/domain/original/area/indel/room1530.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1529", "north",
+        "domain/original/area/indel/room1531", "south",
+    });
+}

--- a/domain/original/area/indel/room1531.c
+++ b/domain/original/area/indel/room1531.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1530", "north",
+        "domain/original/area/indel/room1532", "south",
+    });
+}

--- a/domain/original/area/indel/room1532.c
+++ b/domain/original/area/indel/room1532.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1531", "north",
+        "domain/original/area/indel/room1533", "south",
+    });
+}

--- a/domain/original/area/indel/room1533.c
+++ b/domain/original/area/indel/room1533.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1532", "north",
+        "domain/original/area/indel/room1534", "south",
+        "domain/original/area/indel/room1597", "east",
+    });
+}

--- a/domain/original/area/indel/room1534.c
+++ b/domain/original/area/indel/room1534.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pensji Lane";
+    long_desc = "Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1533", "north",
+        "domain/original/area/indel/room1542", "south",
+    });
+}

--- a/domain/original/area/indel/room1535.c
+++ b/domain/original/area/indel/room1535.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1536", "east",
+        "domain/original/area/indel/room1557", "west",
+    });
+}

--- a/domain/original/area/indel/room1536.c
+++ b/domain/original/area/indel/room1536.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1537", "east",
+        "domain/original/area/indel/room1535", "west",
+    });
+}

--- a/domain/original/area/indel/room1537.c
+++ b/domain/original/area/indel/room1537.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1538", "east",
+        "domain/original/area/indel/room1536", "west",
+    });
+}

--- a/domain/original/area/indel/room1538.c
+++ b/domain/original/area/indel/room1538.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "City Barracks Gate";
+    long_desc = "City Barracks Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1539", "east",
+        "domain/original/area/indel/room1537", "west",
+    });
+}

--- a/domain/original/area/indel/room1539.c
+++ b/domain/original/area/indel/room1539.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Martial Row";
+    long_desc = "West Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1540", "east",
+        "domain/original/area/indel/room1538", "west",
+    });
+}

--- a/domain/original/area/indel/room1540.c
+++ b/domain/original/area/indel/room1540.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Martial Row";
+    long_desc = "West Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1541", "east",
+        "domain/original/area/indel/room1539", "west",
+    });
+}

--- a/domain/original/area/indel/room1541.c
+++ b/domain/original/area/indel/room1541.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Martial Row";
+    long_desc = "West Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1542", "east",
+        "domain/original/area/indel/room1540", "west",
+    });
+}

--- a/domain/original/area/indel/room1542.c
+++ b/domain/original/area/indel/room1542.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Martial Row and Pensji Lane";
+    long_desc = "Intersection of Martial Row and Pensji Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1534", "north",
+        "domain/original/area/indel/room1591", "east",
+        "domain/original/area/indel/room1541", "west",
+    });
+}

--- a/domain/original/area/indel/room1543.c
+++ b/domain/original/area/indel/room1543.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1544", "north",
+        "domain/original/area/indel/room1546", "south",
+    });
+}

--- a/domain/original/area/indel/room1544.c
+++ b/domain/original/area/indel/room1544.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1558", "north",
+        "domain/original/area/indel/room1543", "south",
+    });
+}

--- a/domain/original/area/indel/room1545.c
+++ b/domain/original/area/indel/room1545.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ambassador Gate";
+    long_desc = "Ambassador Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1546", "east",
+        "domain/original/area/indel/room1434", "west",
+    });
+}

--- a/domain/original/area/indel/room1546.c
+++ b/domain/original/area/indel/room1546.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Church Road and Embassy Row";
+    long_desc = "Intersection of Church Road and Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1543", "north",
+        "domain/original/area/indel/room1547", "east",
+        "domain/original/area/indel/room1545", "west",
+    });
+}

--- a/domain/original/area/indel/room1547.c
+++ b/domain/original/area/indel/room1547.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1548", "east",
+        "domain/original/area/indel/room1546", "west",
+    });
+}

--- a/domain/original/area/indel/room1548.c
+++ b/domain/original/area/indel/room1548.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1549", "east",
+        "domain/original/area/indel/room1547", "west",
+    });
+}

--- a/domain/original/area/indel/room1549.c
+++ b/domain/original/area/indel/room1549.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1550", "east",
+        "domain/original/area/indel/room1548", "west",
+    });
+}

--- a/domain/original/area/indel/room1550.c
+++ b/domain/original/area/indel/room1550.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1551", "east",
+        "domain/original/area/indel/room1549", "west",
+    });
+}

--- a/domain/original/area/indel/room1551.c
+++ b/domain/original/area/indel/room1551.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1552", "east",
+        "domain/original/area/indel/room1550", "west",
+    });
+}

--- a/domain/original/area/indel/room1552.c
+++ b/domain/original/area/indel/room1552.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1553", "east",
+        "domain/original/area/indel/room1551", "west",
+    });
+}

--- a/domain/original/area/indel/room1553.c
+++ b/domain/original/area/indel/room1553.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1554", "east",
+        "domain/original/area/indel/room1552", "west",
+    });
+}

--- a/domain/original/area/indel/room1554.c
+++ b/domain/original/area/indel/room1554.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1555", "east",
+        "domain/original/area/indel/room1553", "west",
+    });
+}

--- a/domain/original/area/indel/room1555.c
+++ b/domain/original/area/indel/room1555.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1556", "east",
+        "domain/original/area/indel/room1554", "west",
+    });
+}

--- a/domain/original/area/indel/room1556.c
+++ b/domain/original/area/indel/room1556.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1557", "east",
+        "domain/original/area/indel/room1555", "west",
+    });
+}

--- a/domain/original/area/indel/room1557.c
+++ b/domain/original/area/indel/room1557.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Embassy Row";
+    long_desc = "Embassy Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1535", "east",
+        "domain/original/area/indel/room1556", "west",
+    });
+}

--- a/domain/original/area/indel/room1558.c
+++ b/domain/original/area/indel/room1558.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1559", "north",
+        "domain/original/area/indel/room1544", "south",
+    });
+}

--- a/domain/original/area/indel/room1559.c
+++ b/domain/original/area/indel/room1559.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1560", "north",
+        "domain/original/area/indel/room1558", "south",
+    });
+}

--- a/domain/original/area/indel/room1560.c
+++ b/domain/original/area/indel/room1560.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1561", "north",
+        "domain/original/area/indel/room1559", "south",
+    });
+}

--- a/domain/original/area/indel/room1561.c
+++ b/domain/original/area/indel/room1561.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1562", "north",
+        "domain/original/area/indel/room1560", "south",
+    });
+}

--- a/domain/original/area/indel/room1562.c
+++ b/domain/original/area/indel/room1562.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1563", "north",
+        "domain/original/area/indel/room1561", "south",
+    });
+}

--- a/domain/original/area/indel/room1563.c
+++ b/domain/original/area/indel/room1563.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1564", "north",
+        "domain/original/area/indel/room1562", "south",
+    });
+}

--- a/domain/original/area/indel/room1564.c
+++ b/domain/original/area/indel/room1564.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1565", "north",
+        "domain/original/area/indel/room1563", "south",
+    });
+}

--- a/domain/original/area/indel/room1565.c
+++ b/domain/original/area/indel/room1565.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1566", "north",
+        "domain/original/area/indel/room1564", "south",
+    });
+}

--- a/domain/original/area/indel/room1566.c
+++ b/domain/original/area/indel/room1566.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1567", "north",
+        "domain/original/area/indel/room1565", "south",
+    });
+}

--- a/domain/original/area/indel/room1567.c
+++ b/domain/original/area/indel/room1567.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1568", "north",
+        "domain/original/area/indel/room1566", "south",
+    });
+}

--- a/domain/original/area/indel/room1568.c
+++ b/domain/original/area/indel/room1568.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Church Road";
+    long_desc = "West Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1569", "north",
+        "domain/original/area/indel/room1567", "south",
+    });
+}

--- a/domain/original/area/indel/room1569.c
+++ b/domain/original/area/indel/room1569.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Church Road Bend";
+    long_desc = "Church Road Bend.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1568", "south",
+        "domain/original/area/indel/room1570", "east",
+    });
+}

--- a/domain/original/area/indel/room1570.c
+++ b/domain/original/area/indel/room1570.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1571", "east",
+        "domain/original/area/indel/room1569", "west",
+    });
+}

--- a/domain/original/area/indel/room1571.c
+++ b/domain/original/area/indel/room1571.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1572", "east",
+        "domain/original/area/indel/room1570", "west",
+    });
+}

--- a/domain/original/area/indel/room1572.c
+++ b/domain/original/area/indel/room1572.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1573", "east",
+        "domain/original/area/indel/room1571", "west",
+    });
+}

--- a/domain/original/area/indel/room1573.c
+++ b/domain/original/area/indel/room1573.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1574", "east",
+        "domain/original/area/indel/room1572", "west",
+    });
+}

--- a/domain/original/area/indel/room1574.c
+++ b/domain/original/area/indel/room1574.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1575", "east",
+        "domain/original/area/indel/room1573", "west",
+    });
+}

--- a/domain/original/area/indel/room1575.c
+++ b/domain/original/area/indel/room1575.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1576", "east",
+        "domain/original/area/indel/room1574", "west",
+    });
+}

--- a/domain/original/area/indel/room1576.c
+++ b/domain/original/area/indel/room1576.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1577", "east",
+        "domain/original/area/indel/room1575", "west",
+    });
+}

--- a/domain/original/area/indel/room1577.c
+++ b/domain/original/area/indel/room1577.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1578", "east",
+        "domain/original/area/indel/room1576", "west",
+    });
+}

--- a/domain/original/area/indel/room1578.c
+++ b/domain/original/area/indel/room1578.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1579", "east",
+        "domain/original/area/indel/room1577", "west",
+    });
+}

--- a/domain/original/area/indel/room1579.c
+++ b/domain/original/area/indel/room1579.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Castle Road and Church Road";
+    long_desc = "Intersection of Castle Road and Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1584", "north",
+        "domain/original/area/indel/room1585", "south",
+        "domain/original/area/indel/room1580", "east",
+        "domain/original/area/indel/room1578", "west",
+    });
+}

--- a/domain/original/area/indel/room1580.c
+++ b/domain/original/area/indel/room1580.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1581", "east",
+        "domain/original/area/indel/room1579", "west",
+    });
+}

--- a/domain/original/area/indel/room1581.c
+++ b/domain/original/area/indel/room1581.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1582", "east",
+        "domain/original/area/indel/room1580", "west",
+    });
+}

--- a/domain/original/area/indel/room1582.c
+++ b/domain/original/area/indel/room1582.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1583", "east",
+        "domain/original/area/indel/room1581", "west",
+    });
+}

--- a/domain/original/area/indel/room1583.c
+++ b/domain/original/area/indel/room1583.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Church Road";
+    long_desc = "North Church Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1582", "west",
+        "domain/original/area/indel/room1653", "down",
+    });
+}

--- a/domain/original/area/indel/room1584.c
+++ b/domain/original/area/indel/room1584.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Olde City Gate";
+    long_desc = "Olde City Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1406", "north",
+        "domain/original/area/indel/room1579", "south",
+        "domain/original/area/indel/room1587", "east",
+        "domain/original/area/indel/room1588", "west",
+    });
+}

--- a/domain/original/area/indel/room1585.c
+++ b/domain/original/area/indel/room1585.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Drawbridge";
+    long_desc = "Castle Drawbridge.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1579", "north",
+        "domain/original/area/indel/room1586", "south",
+    });
+}

--- a/domain/original/area/indel/room1586.c
+++ b/domain/original/area/indel/room1586.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Castle Gatehouse";
+    long_desc = "Castle Gatehouse.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1585", "north",
+    });
+}

--- a/domain/original/area/indel/room1587.c
+++ b/domain/original/area/indel/room1587.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Krakenwater";
+    long_desc = "Krakenwater.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1584", "west",
+    });
+}

--- a/domain/original/area/indel/room1588.c
+++ b/domain/original/area/indel/room1588.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Deep Sea Thunder";
+    long_desc = "Deep Sea Thunder.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1584", "east",
+        "domain/original/area/indel/room1589", "west",
+    });
+}

--- a/domain/original/area/indel/room1589.c
+++ b/domain/original/area/indel/room1589.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Silver Griffin";
+    long_desc = "The Silver Griffin.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1408", "north",
+        "domain/original/area/indel/room1588", "east",
+        "domain/original/area/indel/room1590", "west",
+    });
+}

--- a/domain/original/area/indel/room1590.c
+++ b/domain/original/area/indel/room1590.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Horrors of the Deep";
+    long_desc = "Horrors of the Deep.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1409", "north",
+        "domain/original/area/indel/room1589", "east",
+    });
+}

--- a/domain/original/area/indel/room1591.c
+++ b/domain/original/area/indel/room1591.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Martial Row";
+    long_desc = "East Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1592", "east",
+        "domain/original/area/indel/room1542", "west",
+    });
+}

--- a/domain/original/area/indel/room1592.c
+++ b/domain/original/area/indel/room1592.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Martial Row";
+    long_desc = "East Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1593", "east",
+        "domain/original/area/indel/room1591", "west",
+    });
+}

--- a/domain/original/area/indel/room1593.c
+++ b/domain/original/area/indel/room1593.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Martial Row";
+    long_desc = "East Martial Row.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1594", "north",
+        "domain/original/area/indel/room1592", "west",
+    });
+}

--- a/domain/original/area/indel/room1594.c
+++ b/domain/original/area/indel/room1594.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Army Encampment Gate";
+    long_desc = "Army Encampment Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1593", "south",
+        "domain/original/area/indel/room1595", "west",
+    });
+}

--- a/domain/original/area/indel/room1595.c
+++ b/domain/original/area/indel/room1595.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Punishment Grounds";
+    long_desc = "Punishment Grounds.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1594", "east",
+        "domain/original/area/indel/room1596", "west",
+    });
+}

--- a/domain/original/area/indel/room1596.c
+++ b/domain/original/area/indel/room1596.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Parade Grounds";
+    long_desc = "Parade Grounds.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1597", "north",
+        "domain/original/area/indel/room1595", "east",
+    });
+}

--- a/domain/original/area/indel/room1597.c
+++ b/domain/original/area/indel/room1597.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cavalry Gate";
+    long_desc = "Cavalry Gate.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1598", "north",
+        "domain/original/area/indel/room1596", "south",
+        "domain/original/area/indel/room1533", "west",
+    });
+}

--- a/domain/original/area/indel/room1598.c
+++ b/domain/original/area/indel/room1598.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Training Grounds";
+    long_desc = "Training Grounds.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1599", "north",
+        "domain/original/area/indel/room1597", "south",
+        "domain/original/area/indel/room1600", "east",
+    });
+}

--- a/domain/original/area/indel/room1599.c
+++ b/domain/original/area/indel/room1599.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Combat Training";
+    long_desc = "Combat Training.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1598", "south",
+    });
+}

--- a/domain/original/area/indel/room1600.c
+++ b/domain/original/area/indel/room1600.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Post Exchange";
+    long_desc = "Post Exchange.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1603", "north",
+        "domain/original/area/indel/room1602", "south",
+        "domain/original/area/indel/room1601", "east",
+        "domain/original/area/indel/room1598", "west",
+    });
+}

--- a/domain/original/area/indel/room1601.c
+++ b/domain/original/area/indel/room1601.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Stockade";
+    long_desc = "Stockade.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1600", "west",
+    });
+}

--- a/domain/original/area/indel/room1602.c
+++ b/domain/original/area/indel/room1602.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Infirmary";
+    long_desc = "Infirmary.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1600", "north",
+        "domain/original/area/indel/room1605", "east",
+    });
+}

--- a/domain/original/area/indel/room1603.c
+++ b/domain/original/area/indel/room1603.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Soldiers' Tent";
+    long_desc = "Soldiers' Tent.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1600", "south",
+        "domain/original/area/indel/room1604", "east",
+    });
+}

--- a/domain/original/area/indel/room1604.c
+++ b/domain/original/area/indel/room1604.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Soldiers' Tent";
+    long_desc = "Soldiers' Tent.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1603", "west",
+    });
+}

--- a/domain/original/area/indel/room1605.c
+++ b/domain/original/area/indel/room1605.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You move the partition to the side and walk into the back of the tent.";
+    long_desc = "You move the partition to the side and walk into the back of the tent..\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1602", "west",
+    });
+}

--- a/domain/original/area/indel/room1621.c
+++ b/domain/original/area/indel/room1621.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Sithicus";
+    long_desc = "Sithicus.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1514", "south",
+    });
+}

--- a/domain/original/area/indel/room1622.c
+++ b/domain/original/area/indel/room1622.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mother Whitman's Confections Shop";
+    long_desc = "Mother Whitman's Confections Shop.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1511", "south",
+    });
+}

--- a/domain/original/area/indel/room1623.c
+++ b/domain/original/area/indel/room1623.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Livestock Lot";
+    long_desc = "Livestock Lot.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1643", "north",
+        "domain/original/area/indel/room1510", "south",
+    });
+}

--- a/domain/original/area/indel/room1624.c
+++ b/domain/original/area/indel/room1624.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Saul's formal wear";
+    long_desc = "Saul's formal wear.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1509", "south",
+    });
+}

--- a/domain/original/area/indel/room1625.c
+++ b/domain/original/area/indel/room1625.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Quicksilver Delivery Service";
+    long_desc = "Quicksilver Delivery Service.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1405", "east",
+    });
+}

--- a/domain/original/area/indel/room1626.c
+++ b/domain/original/area/indel/room1626.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Jusonah's Pawn and Polearms";
+    long_desc = "Jusonah's Pawn and Polearms.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1404", "east",
+    });
+}

--- a/domain/original/area/indel/room1627.c
+++ b/domain/original/area/indel/room1627.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible for";
+    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible for.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1637", "south",
+        "domain/original/area/indel/room1404", "west",
+    });
+}

--- a/domain/original/area/indel/room1628.c
+++ b/domain/original/area/indel/room1628.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Zomar's Dry Goods";
+    long_desc = "Zomar's Dry Goods.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1403", "east",
+        "domain/original/area/indel/room1629", "down",
+    });
+}

--- a/domain/original/area/indel/room1629.c
+++ b/domain/original/area/indel/room1629.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Art of Darkness";
+    long_desc = "The Art of Darkness.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1628", "up",
+    });
+}

--- a/domain/original/area/indel/room1630.c
+++ b/domain/original/area/indel/room1630.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Burrow's Map Shop";
+    long_desc = "Burrow's Map Shop.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1403", "west",
+    });
+}

--- a/domain/original/area/indel/room1631.c
+++ b/domain/original/area/indel/room1631.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Muddy Lane";
+    long_desc = "Muddy Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1402", "east",
+        "domain/original/area/indel/room1632", "west",
+    });
+}

--- a/domain/original/area/indel/room1632.c
+++ b/domain/original/area/indel/room1632.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Muddy Lane";
+    long_desc = "Muddy Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1631", "east",
+    });
+}

--- a/domain/original/area/indel/room1633.c
+++ b/domain/original/area/indel/room1633.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Muddy Lane";
+    long_desc = "Muddy Lane.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1634", "east",
+        "domain/original/area/indel/room1402", "west",
+    });
+}

--- a/domain/original/area/indel/room1634.c
+++ b/domain/original/area/indel/room1634.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Farm Road";
+    long_desc = "Farm Road.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1633", "west",
+    });
+}

--- a/domain/original/area/indel/room1635.c
+++ b/domain/original/area/indel/room1635.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Ready Room";
+    long_desc = "West Ready Room.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1401", "east",
+    });
+}

--- a/domain/original/area/indel/room1636.c
+++ b/domain/original/area/indel/room1636.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Ready Room";
+    long_desc = "East Ready Room.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1401", "west",
+    });
+}

--- a/domain/original/area/indel/room1637.c
+++ b/domain/original/area/indel/room1637.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Player Appreciation Week Discussions";
+    long_desc = "Player Appreciation Week Discussions.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1627", "north",
+    });
+}

--- a/domain/original/area/indel/room1653.c
+++ b/domain/original/area/indel/room1653.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mudball Arena Entrance";
+    long_desc = "Mudball Arena Entrance.\n";
+    dest_dir = ({
+        "domain/original/area/indel/room1583", "up",
+    });
+}

--- a/domain/original/area/roadway/room14.c
+++ b/domain/original/area/roadway/room14.c
@@ -10,6 +10,7 @@ void reset(int arg) {
     long_desc = "Near Vesla City.\n";
     dest_dir = ({
         "domain/original/area/roadway/room30", "north",
+        "domain/original/area/roadway/room43", "south",
         "domain/original/area/roadway/room13", "west",
         "domain/original/area/roadway/room16", "east",
 	"domain/original/area/vesla/room115", "city",

--- a/domain/original/area/roadway/room43.c
+++ b/domain/original/area/roadway/room43.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room14", "north",
+        "domain/original/area/roadway/room44", "south",
+    });
+}

--- a/domain/original/area/roadway/room44.c
+++ b/domain/original/area/roadway/room44.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room43", "north",
+        "domain/original/area/roadway/room45", "south",
+    });
+}

--- a/domain/original/area/roadway/room45.c
+++ b/domain/original/area/roadway/room45.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room44", "north",
+        "domain/original/area/roadway/room46", "south",
+    });
+}

--- a/domain/original/area/roadway/room46.c
+++ b/domain/original/area/roadway/room46.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room45", "north",
+        "domain/original/area/roadway/room47", "south",
+    });
+}

--- a/domain/original/area/roadway/room47.c
+++ b/domain/original/area/roadway/room47.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room46", "north",
+        "domain/original/area/roadway/room48", "south",
+    });
+}

--- a/domain/original/area/roadway/room48.c
+++ b/domain/original/area/roadway/room48.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room47", "north",
+        "domain/original/area/roadway/room49", "south",
+    });
+}

--- a/domain/original/area/roadway/room49.c
+++ b/domain/original/area/roadway/room49.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room48", "north",
+        "domain/original/area/roadway/room50", "south",
+    });
+}

--- a/domain/original/area/roadway/room50.c
+++ b/domain/original/area/roadway/room50.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room49", "north",
+        "domain/original/area/roadway/room51", "south",
+    });
+}

--- a/domain/original/area/roadway/room51.c
+++ b/domain/original/area/roadway/room51.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room50", "north",
+        "domain/original/area/roadway/room52", "south",
+    });
+}

--- a/domain/original/area/roadway/room52.c
+++ b/domain/original/area/roadway/room52.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room51", "north",
+        "domain/original/area/roadway/room53", "south",
+    });
+}

--- a/domain/original/area/roadway/room53.c
+++ b/domain/original/area/roadway/room53.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room52", "north",
+        "domain/original/area/roadway/room54", "south",
+    });
+}

--- a/domain/original/area/roadway/room54.c
+++ b/domain/original/area/roadway/room54.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Walking on a roadway";
+    long_desc = "Walking on a roadway.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room53", "north",
+        "domain/original/area/roadway/room55", "south",
+    });
+}

--- a/domain/original/area/roadway/room55.c
+++ b/domain/original/area/roadway/room55.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Near Indel City";
+    long_desc = "Near Indel City.\n";
+    dest_dir = ({
+        "domain/original/area/roadway/room54", "north",
+        "domain/original/area/indel/room1401", "city",
+    });
+}


### PR DESCRIPTION
### Motivation
- Generate LPC room files from `maps/indel.json` so the Indel area is available in-game.  
- Preserve the room coding/style used by `domain/original/area/vesla/room228.c` for consistency.  
- Provide a continuous north–south roadway to connect Vesla and Indel so players can travel between cities.  
- Ensure `indel/room1401` and the roadway endpoint interlink with `city`/`exit` directions for bidirectional access.  

### Description
- Created the directory `domain/original/area/indel/` and added LPC room files for each room entry in `maps/indel.json` using `inherit "room/room"` and the `reset` layout.  
- Added roadway rooms `domain/original/area/roadway/room43.c` through `room55.c` forming a 14-room north/south chain that links `roadway/room14.c` (updated) to the new segment.  
- Wired the city/roadway connection so `indel/room1401.c` includes an `exit` to `domain/original/area/roadway/room55` and `domain/original/area/roadway/room55.c` includes a `city` exit back to `indel/room1401`.  
- Staged and committed the generated files as a single change set.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bbbcfbb64832790779fc64a774d2e)