### PR TITLE
Remove trailing period from brief room exits

### DIFF
--- a/obj/living.c
+++ b/obj/living.c
@@ -197,7 +197,7 @@ void move_player(string dir_dest, object optional_dest_ob) {
     }
     ob = environment(this_object());
     if (brief)
-        write(ob->short() + ".\n");
+        write(ob->short() + "\n");
     else
         ob->long();
     for (i = 0, ob = first_inventory(ob); ob; ob = next_inventory(ob)) {

--- a/obj/player.c
+++ b/obj/player.c
@@ -628,7 +628,7 @@ int teleport(string dest) {
         if (!is_invis)
             say(cap_name + " " + mmsgin + ".\n");
         if (brief)
-            write(ob->short() + ".\n");
+            write(ob->short() + "\n");
         else
             ob->long();
         ob = first_inventory(ob);


### PR DESCRIPTION
### Motivation
- Brief mode output appended a literal period after the room short description, producing strings like `South Main Street (Exits: s w e n).` because callers add `".\n"` to `ob->short()`.
- The extra period is redundant when the short description already contains punctuation (for example the exit list returned by `exitsDescription(1)`), so it should be removed to avoid confusing output.
- The goal is to preserve existing short descriptions while eliminating the spurious trailing dot in brief movement/teleport output.

### Description
- Replaced `write(ob->short() + ".\n")` with `write(ob->short() + "\n")` in `obj/living.c` and `obj/player.c`.
- This prevents adding an extra `.` after short descriptions that already include punctuation such as the exit list `(Exits: ...)`.
- No other formatting or behavior changes were made to `short()` or exit rendering.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d808cf0f08327b9edabd63edd75f7)