### PR TITLE
Remove default "environment": -1 and "weight": 1 entries from exported map JSON files

### DIFF
--- a/maps/anshelm.json
+++ b/maps/anshelm.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Before the Anshelm Gatehouse",
-      "environment": -1,
       "exits": {
         "north": 236
       },
-      "weight": 1,
       "id": 235,
       "area": {
         "id": 3
@@ -17,13 +15,11 @@
     },
     {
       "name": "Under the Anshelmish Gatehouse",
-      "environment": -1,
       "exits": {
         "west": 1143,
         "south": 235,
         "north": 237
       },
-      "weight": 1,
       "id": 236,
       "area": {
         "id": 3
@@ -31,14 +27,12 @@
     },
     {
       "name": "Southern end of Rue du Nord",
-      "environment": -1,
       "exits": {
         "southwest": 1135,
         "south": 236,
         "southeast": 1154,
         "north": 238
       },
-      "weight": 1,
       "id": 237,
       "area": {
         "id": 3
@@ -46,13 +40,11 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "west": 413,
         "south": 237,
         "north": 239
       },
-      "weight": 1,
       "id": 238,
       "area": {
         "id": 3
@@ -60,14 +52,12 @@
     },
     {
       "name": "Intersection of Rue du Nord and Beitel Straat",
-      "environment": -1,
       "exits": {
         "south": 238,
         "west": 414,
         "east": 1185,
         "north": 240
       },
-      "weight": 1,
       "id": 239,
       "area": {
         "id": 3
@@ -75,14 +65,12 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 239,
         "west": 415,
         "east": 1192,
         "north": 241
       },
-      "weight": 1,
       "id": 240,
       "area": {
         "id": 3
@@ -90,13 +78,11 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "west": 416,
         "south": 240,
         "north": 242
       },
-      "weight": 1,
       "id": 241,
       "area": {
         "id": 3
@@ -104,12 +90,10 @@
     },
     {
       "name": "Gateway to Middle Bailey",
-      "environment": -1,
       "exits": {
         "south": 241,
         "north": 243
       },
-      "weight": 1,
       "id": 242,
       "area": {
         "id": 3
@@ -117,12 +101,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 242,
         "north": 244
       },
-      "weight": 1,
       "id": 243,
       "area": {
         "id": 3
@@ -130,13 +112,11 @@
     },
     {
       "name": "Western intersection of Rue du Nord and Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 245,
         "east": 250,
         "south": 243
       },
-      "weight": 1,
       "id": 244,
       "area": {
         "id": 3
@@ -144,12 +124,10 @@
     },
     {
       "name": "Kirsch Lane",
-      "environment": -1,
       "exits": {
         "east": 244,
         "west": 246
       },
-      "weight": 1,
       "id": 245,
       "area": {
         "id": 3
@@ -157,13 +135,11 @@
     },
     {
       "name": "Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 247,
         "east": 245,
         "south": 249
       },
-      "weight": 1,
       "id": 246,
       "area": {
         "id": 3
@@ -171,12 +147,10 @@
     },
     {
       "name": "Western end of Kirsch Lane",
-      "environment": -1,
       "exits": {
         "east": 246,
         "south": 248
       },
-      "weight": 1,
       "id": 247,
       "area": {
         "id": 3
@@ -184,11 +158,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "north": 247
       },
-      "weight": 1,
       "id": 248,
       "area": {
         "id": 3
@@ -196,11 +168,9 @@
     },
     {
       "name": "Kaneohe Armory",
-      "environment": -1,
       "exits": {
         "north": 246
       },
-      "weight": 1,
       "id": 249,
       "area": {
         "id": 3
@@ -208,13 +178,11 @@
     },
     {
       "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 244,
         "east": 283,
         "north": 251
       },
-      "weight": 1,
       "id": 250,
       "area": {
         "id": 3
@@ -222,13 +190,11 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 250,
         "east": 1193,
         "north": 252
       },
-      "weight": 1,
       "id": 251,
       "area": {
         "id": 3
@@ -236,12 +202,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 251,
         "north": 253
       },
-      "weight": 1,
       "id": 252,
       "area": {
         "id": 3
@@ -249,12 +213,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 252,
         "north": 254
       },
-      "weight": 1,
       "id": 253,
       "area": {
         "id": 3
@@ -262,12 +224,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 253,
         "north": 255
       },
-      "weight": 1,
       "id": 254,
       "area": {
         "id": 3
@@ -275,14 +235,12 @@
     },
     {
       "name": "Central Square on the Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 254,
         "west": 1195,
         "east": 1194,
         "north": 256
       },
-      "weight": 1,
       "id": 255,
       "area": {
         "id": 3
@@ -290,12 +248,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 255,
         "north": 257
       },
-      "weight": 1,
       "id": 256,
       "area": {
         "id": 3
@@ -303,12 +259,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 256,
         "north": 258
       },
-      "weight": 1,
       "id": 257,
       "area": {
         "id": 3
@@ -316,13 +270,11 @@
     },
     {
       "name": "Intersection of Rue du Nord and East Geld Strasse",
-      "environment": -1,
       "exits": {
         "west": 259,
         "east": 281,
         "south": 257
       },
-      "weight": 1,
       "id": 258,
       "area": {
         "id": 3
@@ -330,12 +282,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "east": 258,
         "west": 260
       },
-      "weight": 1,
       "id": 259,
       "area": {
         "id": 3
@@ -343,13 +293,11 @@
     },
     {
       "name": "Intersection of Rue du Nord and West Geld Strasse",
-      "environment": -1,
       "exits": {
         "west": 261,
         "east": 259,
         "north": 264
       },
-      "weight": 1,
       "id": 260,
       "area": {
         "id": 3
@@ -357,12 +305,10 @@
     },
     {
       "name": "Geld Strasse",
-      "environment": -1,
       "exits": {
         "east": 260,
         "west": 262
       },
-      "weight": 1,
       "id": 261,
       "area": {
         "id": 3
@@ -370,12 +316,10 @@
     },
     {
       "name": "Geld Strasse",
-      "environment": -1,
       "exits": {
         "east": 261,
         "west": 263
       },
-      "weight": 1,
       "id": 262,
       "area": {
         "id": 3
@@ -383,11 +327,9 @@
     },
     {
       "name": "Western end of Geld Strasse",
-      "environment": -1,
       "exits": {
         "east": 262
       },
-      "weight": 1,
       "id": 263,
       "area": {
         "id": 3
@@ -395,12 +337,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 260,
         "north": 265
       },
-      "weight": 1,
       "id": 264,
       "area": {
         "id": 3
@@ -408,14 +348,12 @@
     },
     {
       "name": "Gateway to Upper Bailey",
-      "environment": -1,
       "exits": {
         "south": 264,
         "west": 282,
         "east": 1198,
         "north": 266
       },
-      "weight": 1,
       "id": 265,
       "area": {
         "id": 3
@@ -423,12 +361,10 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 265,
         "north": 267
       },
-      "weight": 1,
       "id": 266,
       "area": {
         "id": 3
@@ -436,14 +372,12 @@
     },
     {
       "name": "Intersection of Rue du Nord and Kasernegade",
-      "environment": -1,
       "exits": {
         "south": 266,
         "west": 268,
         "east": 276,
         "north": 273
       },
-      "weight": 1,
       "id": 267,
       "area": {
         "id": 3
@@ -451,12 +385,10 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 267,
         "west": 269
       },
-      "weight": 1,
       "id": 268,
       "area": {
         "id": 3
@@ -464,12 +396,10 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 268,
         "west": 270
       },
-      "weight": 1,
       "id": 269,
       "area": {
         "id": 3
@@ -477,13 +407,11 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "west": 271,
         "east": 269,
         "south": 1199
       },
-      "weight": 1,
       "id": 270,
       "area": {
         "id": 3
@@ -491,12 +419,10 @@
     },
     {
       "name": "Western end of Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 270,
         "north": 272
       },
-      "weight": 1,
       "id": 271,
       "area": {
         "id": 3
@@ -504,11 +430,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "south": 271
       },
-      "weight": 1,
       "id": 272,
       "area": {
         "id": 3
@@ -516,13 +440,11 @@
     },
     {
       "name": "Rue du Nord",
-      "environment": -1,
       "exits": {
         "south": 267,
         "northwest": 1202,
         "north": 274
       },
-      "weight": 1,
       "id": 273,
       "area": {
         "id": 3
@@ -530,12 +452,10 @@
     },
     {
       "name": "Under the Town Gate",
-      "environment": -1,
       "exits": {
         "south": 273,
         "north": 275
       },
-      "weight": 1,
       "id": 274,
       "area": {
         "id": 3
@@ -543,11 +463,9 @@
     },
     {
       "name": "Before the Anshelm Town Gate",
-      "environment": -1,
       "exits": {
         "south": 274
       },
-      "weight": 1,
       "id": 275,
       "area": {
         "id": 3
@@ -555,13 +473,11 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "west": 267,
         "east": 277,
         "north": 1200
       },
-      "weight": 1,
       "id": 276,
       "area": {
         "id": 3
@@ -569,12 +485,10 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 278,
         "west": 276
       },
-      "weight": 1,
       "id": 277,
       "area": {
         "id": 3
@@ -582,12 +496,10 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 279,
         "west": 277
       },
-      "weight": 1,
       "id": 278,
       "area": {
         "id": 3
@@ -595,12 +507,10 @@
     },
     {
       "name": "Kasernegade",
-      "environment": -1,
       "exits": {
         "east": 280,
         "west": 278
       },
-      "weight": 1,
       "id": 279,
       "area": {
         "id": 3
@@ -608,12 +518,10 @@
     },
     {
       "name": "Eastern end of Kasernegade",
-      "environment": -1,
       "exits": {
         "west": 279,
         "south": 1201
       },
-      "weight": 1,
       "id": 280,
       "area": {
         "id": 3
@@ -621,13 +529,11 @@
     },
     {
       "name": "Geld Strasse",
-      "environment": -1,
       "exits": {
         "west": 258,
         "east": 1328,
         "north": 1197
       },
-      "weight": 1,
       "id": 281,
       "area": {
         "id": 3
@@ -635,11 +541,9 @@
     },
     {
       "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
-      "environment": -1,
       "exits": {
         "east": 265
       },
-      "weight": 1,
       "id": 282,
       "area": {
         "id": 3
@@ -647,13 +551,11 @@
     },
     {
       "name": "Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 250,
         "east": 284,
         "north": 1326
       },
-      "weight": 1,
       "id": 283,
       "area": {
         "id": 3
@@ -661,13 +563,11 @@
     },
     {
       "name": "Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 283,
         "east": 285,
         "north": 1327
       },
-      "weight": 1,
       "id": 284,
       "area": {
         "id": 3
@@ -675,11 +575,9 @@
     },
     {
       "name": "Eastern end of Kirsch Lane",
-      "environment": -1,
       "exits": {
         "west": 284
       },
-      "weight": 1,
       "id": 285,
       "area": {
         "id": 3
@@ -687,12 +585,10 @@
     },
     {
       "name": "Hawaiian Ryan's",
-      "environment": -1,
       "exits": {
         "east": 238,
         "north": 414
       },
-      "weight": 1,
       "id": 413,
       "area": {
         "id": 3
@@ -700,14 +596,12 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "south": 413,
         "west": 1147,
         "east": 239,
         "north": 415
       },
-      "weight": 1,
       "id": 414,
       "area": {
         "id": 3
@@ -715,12 +609,10 @@
     },
     {
       "name": "Club Femme Nu",
-      "environment": -1,
       "exits": {
         "east": 240,
         "south": 414
       },
-      "weight": 1,
       "id": 415,
       "area": {
         "id": 3
@@ -728,12 +620,10 @@
     },
     {
       "name": "Western Guard Post",
-      "environment": -1,
       "exits": {
         "up": 1136,
         "northeast": 237
       },
-      "weight": 1,
       "id": 1135,
       "area": {
         "id": 3
@@ -741,12 +631,10 @@
     },
     {
       "name": "Arleg bows to you.",
-      "environment": -1,
       "exits": {
         "down": 1135,
         "up": 1137
       },
-      "weight": 1,
       "id": 1136,
       "area": {
         "id": 3
@@ -754,13 +642,11 @@
     },
     {
       "name": "Second Floor Landing",
-      "environment": -1,
       "exits": {
         "down": 1136,
         "east": 1142,
         "up": 1138
       },
-      "weight": 1,
       "id": 1137,
       "area": {
         "id": 3
@@ -768,13 +654,11 @@
     },
     {
       "name": "Third Floor Passage",
-      "environment": -1,
       "exits": {
         "down": 1137,
         "east": 1144,
         "up": 1139
       },
-      "weight": 1,
       "id": 1138,
       "area": {
         "id": 3
@@ -782,12 +666,10 @@
     },
     {
       "name": "Western Spire Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1138,
         "up": 1140
       },
-      "weight": 1,
       "id": 1139,
       "area": {
         "id": 3
@@ -795,11 +677,9 @@
     },
     {
       "name": "Roof of the Western Spire",
-      "environment": -1,
       "exits": {
         "down": 1139
       },
-      "weight": 1,
       "id": 1140,
       "area": {
         "id": 3
@@ -807,11 +687,9 @@
     },
     {
       "name": "Western Stairwell",
-      "environment": -1,
       "exits": {
         "up": 1137
       },
-      "weight": 1,
       "id": 1141,
       "area": {
         "id": 3
@@ -819,12 +697,10 @@
     },
     {
       "name": "Killing Room",
-      "environment": -1,
       "exits": {
         "east": 1153,
         "west": 1137
       },
-      "weight": 1,
       "id": 1142,
       "area": {
         "id": 3
@@ -832,12 +708,10 @@
     },
     {
       "name": "Anshelm Lounge",
-      "environment": -1,
       "exits": {
         "east": 236,
         "west": 1204
       },
-      "weight": 1,
       "id": 1143,
       "area": {
         "id": 3
@@ -845,12 +719,10 @@
     },
     {
       "name": "Gatehouse Mess Hall",
-      "environment": -1,
       "exits": {
         "east": 1145,
         "west": 1138
       },
-      "weight": 1,
       "id": 1144,
       "area": {
         "id": 3
@@ -858,12 +730,10 @@
     },
     {
       "name": "Gatehouse Barracks",
-      "environment": -1,
       "exits": {
         "east": 1146,
         "west": 1144
       },
-      "weight": 1,
       "id": 1145,
       "area": {
         "id": 3
@@ -871,12 +741,10 @@
     },
     {
       "name": "Third Floor Passage",
-      "environment": -1,
       "exits": {
         "up": 1151,
         "west": 1145
       },
-      "weight": 1,
       "id": 1146,
       "area": {
         "id": 3
@@ -884,13 +752,11 @@
     },
     {
       "name": "Beitel Straad at the Promenade",
-      "environment": -1,
       "exits": {
         "west": 1150,
         "east": 414,
         "north": 1169
       },
-      "weight": 1,
       "id": 1147,
       "area": {
         "id": 3
@@ -898,11 +764,9 @@
     },
     {
       "name": "Eastern Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1149
       },
-      "weight": 1,
       "id": 1148,
       "area": {
         "id": 3
@@ -910,11 +774,9 @@
     },
     {
       "name": "Base of the Eastern Stairwell",
-      "environment": -1,
       "exits": {
         "up": 1148
       },
-      "weight": 1,
       "id": 1149,
       "area": {
         "id": 3
@@ -922,13 +784,11 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "west": 1157,
         "east": 1147,
         "south": 1168
       },
-      "weight": 1,
       "id": 1150,
       "area": {
         "id": 3
@@ -936,12 +796,10 @@
     },
     {
       "name": "Eastern Spire Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1149,
         "up": 1152
       },
-      "weight": 1,
       "id": 1151,
       "area": {
         "id": 3
@@ -949,11 +807,9 @@
     },
     {
       "name": "Roof of the Eastern Spire",
-      "environment": -1,
       "exits": {
         "down": 1151
       },
-      "weight": 1,
       "id": 1152,
       "area": {
         "id": 3
@@ -961,11 +817,9 @@
     },
     {
       "name": "Tider bows to you.",
-      "environment": -1,
       "exits": {
         "west": 1142
       },
-      "weight": 1,
       "id": 1153,
       "area": {
         "id": 3
@@ -973,12 +827,10 @@
     },
     {
       "name": "Eastern Guard Post",
-      "environment": -1,
       "exits": {
         "northwest": 237,
         "east": 1155
       },
-      "weight": 1,
       "id": 1154,
       "area": {
         "id": 3
@@ -986,13 +838,11 @@
     },
     {
       "name": "Ganran bows to you.",
-      "environment": -1,
       "exits": {
         "up": 1158,
         "down": 1156,
         "west": 1154
       },
-      "weight": 1,
       "id": 1155,
       "area": {
         "id": 3
@@ -1000,11 +850,9 @@
     },
     {
       "name": "Gatehouse Armoury",
-      "environment": -1,
       "exits": {
         "up": 1155
       },
-      "weight": 1,
       "id": 1156,
       "area": {
         "id": 3
@@ -1012,12 +860,10 @@
     },
     {
       "name": "Western end of Beitel Straad",
-      "environment": -1,
       "exits": {
         "east": 1150,
         "north": 1164
       },
-      "weight": 1,
       "id": 1157,
       "area": {
         "id": 3
@@ -1025,12 +871,10 @@
     },
     {
       "name": "Eastern Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1155,
         "up": 1159
       },
-      "weight": 1,
       "id": 1158,
       "area": {
         "id": 3
@@ -1038,12 +882,10 @@
     },
     {
       "name": "Olotia bows to you.",
-      "environment": -1,
       "exits": {
         "down": 1158,
         "west": 1160
       },
-      "weight": 1,
       "id": 1159,
       "area": {
         "id": 3
@@ -1051,12 +893,10 @@
     },
     {
       "name": "Tiran bows to you.",
-      "environment": -1,
       "exits": {
         "east": 1159,
         "west": 1161
       },
-      "weight": 1,
       "id": 1160,
       "area": {
         "id": 3
@@ -1064,12 +904,10 @@
     },
     {
       "name": "Killing Room",
-      "environment": -1,
       "exits": {
         "east": 1160,
         "west": 1162
       },
-      "weight": 1,
       "id": 1161,
       "area": {
         "id": 3
@@ -1077,12 +915,10 @@
     },
     {
       "name": "Second Floor Landing",
-      "environment": -1,
       "exits": {
         "east": 1161,
         "down": 1163
       },
-      "weight": 1,
       "id": 1162,
       "area": {
         "id": 3
@@ -1090,12 +926,10 @@
     },
     {
       "name": "Western Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1135,
         "up": 1162
       },
-      "weight": 1,
       "id": 1163,
       "area": {
         "id": 3
@@ -1103,11 +937,9 @@
     },
     {
       "name": "The Inner Bailey",
-      "environment": -1,
       "exits": {
         "north": 1150
       },
-      "weight": 1,
       "id": 1168,
       "area": {
         "id": 3
@@ -1115,13 +947,11 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "west": 239,
         "east": 1186,
         "north": 1191
       },
-      "weight": 1,
       "id": 1185,
       "area": {
         "id": 3
@@ -1129,13 +959,11 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "west": 1185,
         "east": 1187,
         "north": 1190
       },
-      "weight": 1,
       "id": 1186,
       "area": {
         "id": 3
@@ -1143,12 +971,10 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "east": 1188,
         "west": 1186
       },
-      "weight": 1,
       "id": 1187,
       "area": {
         "id": 3
@@ -1156,12 +982,10 @@
     },
     {
       "name": "Beitel Straad",
-      "environment": -1,
       "exits": {
         "east": 1189,
         "west": 1187
       },
-      "weight": 1,
       "id": 1188,
       "area": {
         "id": 3
@@ -1169,11 +993,9 @@
     },
     {
       "name": "Eastern end of Beitel Straad",
-      "environment": -1,
       "exits": {
         "west": 1188
       },
-      "weight": 1,
       "id": 1189,
       "area": {
         "id": 3
@@ -1181,12 +1003,10 @@
     },
     {
       "name": "The Banana Hammock",
-      "environment": -1,
       "exits": {
         "west": 1191,
         "south": 1186
       },
-      "weight": 1,
       "id": 1190,
       "area": {
         "id": 3
@@ -1194,12 +1014,10 @@
     },
     {
       "name": "Jack's Bistro",
-      "environment": -1,
       "exits": {
         "east": 1190,
         "south": 1185
       },
-      "weight": 1,
       "id": 1191,
       "area": {
         "id": 3
@@ -1207,11 +1025,9 @@
     },
     {
       "name": "Second Bank of Anshelm",
-      "environment": -1,
       "exits": {
         "west": 240
       },
-      "weight": 1,
       "id": 1192,
       "area": {
         "id": 3
@@ -1219,11 +1035,9 @@
     },
     {
       "name": "The Anshelmish General Store",
-      "environment": -1,
       "exits": {
         "west": 251
       },
-      "weight": 1,
       "id": 1193,
       "area": {
         "id": 3
@@ -1231,11 +1045,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "west": 255
       },
-      "weight": 1,
       "id": 1194,
       "area": {
         "id": 3
@@ -1243,12 +1055,10 @@
     },
     {
       "name": "Anshelmish Keep's drawbridge",
-      "environment": -1,
       "exits": {
         "east": 255,
         "west": 1196
       },
-      "weight": 1,
       "id": 1195,
       "area": {
         "id": 3
@@ -1256,11 +1066,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "east": 1195
       },
-      "weight": 1,
       "id": 1196,
       "area": {
         "id": 3
@@ -1268,11 +1076,9 @@
     },
     {
       "name": "Private Entry",
-      "environment": -1,
       "exits": {
         "south": 281
       },
-      "weight": 1,
       "id": 1197,
       "area": {
         "id": 3
@@ -1280,11 +1086,9 @@
     },
     {
       "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
-      "environment": -1,
       "exits": {
         "west": 265
       },
-      "weight": 1,
       "id": 1198,
       "area": {
         "id": 3
@@ -1292,11 +1096,9 @@
     },
     {
       "name": "Armourer's Shack",
-      "environment": -1,
       "exits": {
         "north": 270
       },
-      "weight": 1,
       "id": 1199,
       "area": {
         "id": 3
@@ -1304,11 +1106,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "south": 276
       },
-      "weight": 1,
       "id": 1200,
       "area": {
         "id": 3
@@ -1316,11 +1116,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "north": 280
       },
-      "weight": 1,
       "id": 1201,
       "area": {
         "id": 3
@@ -1328,11 +1126,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "southeast": 273
       },
-      "weight": 1,
       "id": 1202,
       "area": {
         "id": 3
@@ -1340,11 +1136,9 @@
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "environment": -1,
       "exits": {
         "east": 1143
       },
-      "weight": 1,
       "id": 1204,
       "area": {
         "id": 3
@@ -1352,11 +1146,9 @@
     },
     {
       "name": "La Cosa Nostra",
-      "environment": -1,
       "exits": {
         "south": 283
       },
-      "weight": 1,
       "id": 1326,
       "area": {
         "id": 3
@@ -1364,11 +1156,9 @@
     },
     {
       "name": "Anshelm Stables",
-      "environment": -1,
       "exits": {
         "south": 284
       },
-      "weight": 1,
       "id": 1327,
       "area": {
         "id": 3
@@ -1376,12 +1166,10 @@
     },
     {
       "name": "Eastern end of Geld Strasse",
-      "environment": -1,
       "exits": {
         "east": 1329,
         "west": 281
       },
-      "weight": 1,
       "id": 1328,
       "area": {
         "id": 3
@@ -1389,12 +1177,10 @@
     },
     {
       "name": "With a little strain, you are able to pull open the heavy doors and enter",
-      "environment": -1,
       "exits": {
         "east": 1330,
         "west": 1328
       },
-      "weight": 1,
       "id": 1329,
       "area": {
         "id": 3
@@ -1402,14 +1188,12 @@
     },
     {
       "name": "Naive",
-      "environment": -1,
       "exits": {
         "south": 1332,
         "west": 1329,
         "east": 1331,
         "north": 1333
       },
-      "weight": 1,
       "id": 1330,
       "area": {
         "id": 3
@@ -1417,11 +1201,9 @@
     },
     {
       "name": "Altar of the Rose",
-      "environment": -1,
       "exits": {
         "west": 1330
       },
-      "weight": 1,
       "id": 1331,
       "area": {
         "id": 3
@@ -1429,11 +1211,9 @@
     },
     {
       "name": "Southern statuary",
-      "environment": -1,
       "exits": {
         "north": 1330
       },
-      "weight": 1,
       "id": 1332,
       "area": {
         "id": 3
@@ -1441,11 +1221,9 @@
     },
     {
       "name": "Northern statuary",
-      "environment": -1,
       "exits": {
         "south": 1330
       },
-      "weight": 1,
       "id": 1333,
       "area": {
         "id": 3

--- a/maps/anthill.json
+++ b/maps/anthill.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Inside the Anthill",
-      "environment": -1,
       "exits": {
         "up": 1806,
         "down": 1744,
         "north": 1740
       },
-      "weight": 1,
       "id": 1723,
       "area": {
         "id": 34
@@ -19,13 +17,11 @@
     },
     {
       "name": "Inside the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1741,
         "southeast": 1743,
         "south": 1723
       },
-      "weight": 1,
       "id": 1740,
       "area": {
         "id": 34
@@ -33,12 +29,10 @@
     },
     {
       "name": "Inside the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1742,
         "northeast": 1740
       },
-      "weight": 1,
       "id": 1741,
       "area": {
         "id": 34
@@ -46,12 +40,10 @@
     },
     {
       "name": "Inside the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1741,
         "northeast": 1743
       },
-      "weight": 1,
       "id": 1742,
       "area": {
         "id": 34
@@ -59,12 +51,10 @@
     },
     {
       "name": "Inside the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1740,
         "southwest": 1742
       },
-      "weight": 1,
       "id": 1743,
       "area": {
         "id": 34
@@ -72,7 +62,6 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1751,
         "up": 1723,
@@ -81,7 +70,6 @@
         "down": 1754,
         "northwest": 1747
       },
-      "weight": 1,
       "id": 1744,
       "area": {
         "id": 34
@@ -89,12 +77,10 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1744,
         "south": 1746
       },
-      "weight": 1,
       "id": 1745,
       "area": {
         "id": 34
@@ -102,11 +88,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "north": 1745
       },
-      "weight": 1,
       "id": 1746,
       "area": {
         "id": 34
@@ -114,13 +98,11 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1749,
         "northeast": 1748,
         "southeast": 1744
       },
-      "weight": 1,
       "id": 1747,
       "area": {
         "id": 34
@@ -128,11 +110,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1747
       },
-      "weight": 1,
       "id": 1748,
       "area": {
         "id": 34
@@ -140,11 +120,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1747
       },
-      "weight": 1,
       "id": 1749,
       "area": {
         "id": 34
@@ -152,11 +130,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1744
       },
-      "weight": 1,
       "id": 1750,
       "area": {
         "id": 34
@@ -164,13 +140,11 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1753,
         "northeast": 1752,
         "northwest": 1744
       },
-      "weight": 1,
       "id": 1751,
       "area": {
         "id": 34
@@ -178,11 +152,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1751
       },
-      "weight": 1,
       "id": 1752,
       "area": {
         "id": 34
@@ -190,11 +162,9 @@
     },
     {
       "name": "In the Heart of the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1751
       },
-      "weight": 1,
       "id": 1753,
       "area": {
         "id": 34
@@ -202,13 +172,11 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "up": 1744,
         "east": 1758,
         "south": 1755
       },
-      "weight": 1,
       "id": 1754,
       "area": {
         "id": 34
@@ -216,12 +184,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1756,
         "north": 1754
       },
-      "weight": 1,
       "id": 1755,
       "area": {
         "id": 34
@@ -229,12 +195,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1755,
         "southwest": 1757
       },
-      "weight": 1,
       "id": 1756,
       "area": {
         "id": 34
@@ -242,11 +206,9 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1756
       },
-      "weight": 1,
       "id": 1757,
       "area": {
         "id": 34
@@ -254,14 +216,12 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1763,
         "northeast": 1759,
         "northwest": 1762,
         "west": 1754
       },
-      "weight": 1,
       "id": 1758,
       "area": {
         "id": 34
@@ -269,12 +229,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1760,
         "southwest": 1758
       },
-      "weight": 1,
       "id": 1759,
       "area": {
         "id": 34
@@ -282,13 +240,11 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1762,
         "northwest": 1761,
         "southeast": 1759
       },
-      "weight": 1,
       "id": 1760,
       "area": {
         "id": 34
@@ -296,11 +252,9 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1760
       },
-      "weight": 1,
       "id": 1761,
       "area": {
         "id": 34
@@ -308,13 +262,11 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1765,
         "northeast": 1760,
         "southeast": 1758
       },
-      "weight": 1,
       "id": 1762,
       "area": {
         "id": 34
@@ -322,12 +274,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1758,
         "northeast": 1764
       },
-      "weight": 1,
       "id": 1763,
       "area": {
         "id": 34
@@ -335,11 +285,9 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1763
       },
-      "weight": 1,
       "id": 1764,
       "area": {
         "id": 34
@@ -347,12 +295,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1766,
         "northeast": 1762
       },
-      "weight": 1,
       "id": 1765,
       "area": {
         "id": 34
@@ -360,13 +306,11 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1767,
         "northeast": 1770,
         "southeast": 1765
       },
-      "weight": 1,
       "id": 1766,
       "area": {
         "id": 34
@@ -374,12 +318,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southeast": 1768,
         "northeast": 1766
       },
-      "weight": 1,
       "id": 1767,
       "area": {
         "id": 34
@@ -387,12 +329,10 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1767,
         "southeast": 1769
       },
-      "weight": 1,
       "id": 1768,
       "area": {
         "id": 34
@@ -400,11 +340,9 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1768
       },
-      "weight": 1,
       "id": 1769,
       "area": {
         "id": 34
@@ -412,11 +350,9 @@
     },
     {
       "name": "At the Base of the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1766
       },
-      "weight": 1,
       "id": 1770,
       "area": {
         "id": 34
@@ -424,14 +360,12 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "south": 1798,
         "west": 1772,
         "east": 1782,
         "north": 1797
       },
-      "weight": 1,
       "id": 1771,
       "area": {
         "id": 34
@@ -439,12 +373,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1773,
         "east": 1771
       },
-      "weight": 1,
       "id": 1772,
       "area": {
         "id": 34
@@ -452,13 +384,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "east": 1774,
         "southeast": 1772,
         "south": 1791
       },
-      "weight": 1,
       "id": 1773,
       "area": {
         "id": 34
@@ -466,13 +396,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1775,
         "west": 1773,
         "north": 1783
       },
-      "weight": 1,
       "id": 1774,
       "area": {
         "id": 34
@@ -480,12 +408,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1774,
         "east": 1776
       },
-      "weight": 1,
       "id": 1775,
       "area": {
         "id": 34
@@ -493,12 +419,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1775,
         "south": 1777
       },
-      "weight": 1,
       "id": 1776,
       "area": {
         "id": 34
@@ -506,7 +430,6 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "south": 1782,
         "west": 1797,
@@ -514,7 +437,6 @@
         "east": 1799,
         "north": 1776
       },
-      "weight": 1,
       "id": 1777,
       "area": {
         "id": 34
@@ -522,12 +444,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1777,
         "east": 1779
       },
-      "weight": 1,
       "id": 1778,
       "area": {
         "id": 34
@@ -535,12 +455,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1778,
         "south": 1780
       },
-      "weight": 1,
       "id": 1779,
       "area": {
         "id": 34
@@ -548,13 +466,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1781,
         "south": 1803,
         "north": 1779
       },
-      "weight": 1,
       "id": 1780,
       "area": {
         "id": 34
@@ -562,13 +478,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1780,
         "west": 1782,
         "south": 1800
       },
-      "weight": 1,
       "id": 1781,
       "area": {
         "id": 34
@@ -576,13 +490,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1771,
         "east": 1781,
         "north": 1777
       },
-      "weight": 1,
       "id": 1782,
       "area": {
         "id": 34
@@ -590,12 +502,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1784,
         "south": 1774
       },
-      "weight": 1,
       "id": 1783,
       "area": {
         "id": 34
@@ -603,12 +513,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1785,
         "east": 1783
       },
-      "weight": 1,
       "id": 1784,
       "area": {
         "id": 34
@@ -616,12 +524,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1786,
         "northeast": 1784
       },
-      "weight": 1,
       "id": 1785,
       "area": {
         "id": 34
@@ -629,12 +535,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "east": 1785,
         "south": 1787
       },
-      "weight": 1,
       "id": 1786,
       "area": {
         "id": 34
@@ -642,12 +546,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1788,
         "north": 1786
       },
-      "weight": 1,
       "id": 1787,
       "area": {
         "id": 34
@@ -655,12 +557,10 @@
     },
     {
       "name": "Near the Queen's Lair",
-      "environment": -1,
       "exits": {
         "northeast": 1787,
         "north": 1789
       },
-      "weight": 1,
       "id": 1788,
       "area": {
         "id": 34
@@ -668,12 +568,10 @@
     },
     {
       "name": "Near the Queen's Lair",
-      "environment": -1,
       "exits": {
         "south": 1788,
         "north": 1790
       },
-      "weight": 1,
       "id": 1789,
       "area": {
         "id": 34
@@ -681,11 +579,9 @@
     },
     {
       "name": "The Ant Lair",
-      "environment": -1,
       "exits": {
         "south": 1789
       },
-      "weight": 1,
       "id": 1790,
       "area": {
         "id": 34
@@ -693,13 +589,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "south": 1792,
         "southeast": 1796,
         "north": 1773
       },
-      "weight": 1,
       "id": 1791,
       "area": {
         "id": 34
@@ -707,13 +601,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1793,
         "east": 1796,
         "north": 1791
       },
-      "weight": 1,
       "id": 1792,
       "area": {
         "id": 34
@@ -721,12 +613,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "east": 1792,
         "north": 1794
       },
-      "weight": 1,
       "id": 1793,
       "area": {
         "id": 34
@@ -734,12 +624,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "southwest": 1795,
         "south": 1793
       },
-      "weight": 1,
       "id": 1794,
       "area": {
         "id": 34
@@ -747,11 +635,9 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "northeast": 1794
       },
-      "weight": 1,
       "id": 1795,
       "area": {
         "id": 34
@@ -759,12 +645,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "northwest": 1791,
         "west": 1792
       },
-      "weight": 1,
       "id": 1796,
       "area": {
         "id": 34
@@ -772,12 +656,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "east": 1777,
         "south": 1771
       },
-      "weight": 1,
       "id": 1797,
       "area": {
         "id": 34
@@ -785,11 +667,9 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "north": 1771
       },
-      "weight": 1,
       "id": 1798,
       "area": {
         "id": 34
@@ -797,11 +677,9 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1777
       },
-      "weight": 1,
       "id": 1799,
       "area": {
         "id": 34
@@ -809,13 +687,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1801,
         "east": 1802,
         "north": 1781
       },
-      "weight": 1,
       "id": 1800,
       "area": {
         "id": 34
@@ -823,11 +699,9 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "east": 1800
       },
-      "weight": 1,
       "id": 1801,
       "area": {
         "id": 34
@@ -835,12 +709,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1800,
         "north": 1803
       },
-      "weight": 1,
       "id": 1802,
       "area": {
         "id": 34
@@ -848,13 +720,11 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "south": 1802,
         "east": 1804,
         "north": 1780
       },
-      "weight": 1,
       "id": 1803,
       "area": {
         "id": 34
@@ -862,12 +732,10 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "west": 1803,
         "north": 1805
       },
-      "weight": 1,
       "id": 1804,
       "area": {
         "id": 34
@@ -875,11 +743,9 @@
     },
     {
       "name": "Beneath the Anthill",
-      "environment": -1,
       "exits": {
         "south": 1804
       },
-      "weight": 1,
       "id": 1805,
       "area": {
         "id": 34
@@ -887,9 +753,7 @@
     },
     {
       "name": "At the top of the anthill.",
-      "environment": -1,
       "id": 1806,
-      "weight": 1,
       "area": {
         "id": 34
       }

--- a/maps/area10.json
+++ b/maps/area10.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Entryway",
-      "environment": -1,
       "exits": {
         "south": 201,
         "north": 932
       },
-      "weight": 1,
       "id": 931,
       "area": {
         "id": 10
@@ -18,14 +16,12 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 931,
         "west": 933,
         "east": 934,
         "north": 937
       },
-      "weight": 1,
       "id": 932,
       "area": {
         "id": 10
@@ -33,12 +29,10 @@
     },
     {
       "name": "Corner",
-      "environment": -1,
       "exits": {
         "east": 932,
         "north": 939
       },
-      "weight": 1,
       "id": 933,
       "area": {
         "id": 10
@@ -46,12 +40,10 @@
     },
     {
       "name": "Corner",
-      "environment": -1,
       "exits": {
         "west": 932,
         "north": 935
       },
-      "weight": 1,
       "id": 934,
       "area": {
         "id": 10
@@ -59,13 +51,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 934,
         "east": 945,
         "north": 936
       },
-      "weight": 1,
       "id": 935,
       "area": {
         "id": 10
@@ -73,13 +63,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 935,
         "east": 946,
         "north": 947
       },
-      "weight": 1,
       "id": 936,
       "area": {
         "id": 10
@@ -87,12 +75,10 @@
     },
     {
       "name": "Courtyard",
-      "environment": -1,
       "exits": {
         "south": 932,
         "north": 938
       },
-      "weight": 1,
       "id": 937,
       "area": {
         "id": 10
@@ -100,12 +86,10 @@
     },
     {
       "name": "Courtyard",
-      "environment": -1,
       "exits": {
         "south": 937,
         "north": 941
       },
-      "weight": 1,
       "id": 938,
       "area": {
         "id": 10
@@ -113,13 +97,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 942,
         "south": 933,
         "north": 940
       },
-      "weight": 1,
       "id": 939,
       "area": {
         "id": 10
@@ -127,13 +109,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 943,
         "south": 939,
         "north": 944
       },
-      "weight": 1,
       "id": 940,
       "area": {
         "id": 10
@@ -141,14 +121,12 @@
     },
     {
       "name": "Archway",
-      "environment": -1,
       "exits": {
         "south": 938,
         "west": 944,
         "east": 947,
         "north": 948
       },
-      "weight": 1,
       "id": 941,
       "area": {
         "id": 10
@@ -156,11 +134,9 @@
     },
     {
       "name": "Quarters",
-      "environment": -1,
       "exits": {
         "east": 939
       },
-      "weight": 1,
       "id": 942,
       "area": {
         "id": 10
@@ -168,11 +144,9 @@
     },
     {
       "name": "Quarters",
-      "environment": -1,
       "exits": {
         "east": 940
       },
-      "weight": 1,
       "id": 943,
       "area": {
         "id": 10
@@ -180,12 +154,10 @@
     },
     {
       "name": "Corner",
-      "environment": -1,
       "exits": {
         "east": 941,
         "south": 940
       },
-      "weight": 1,
       "id": 944,
       "area": {
         "id": 10
@@ -193,11 +165,9 @@
     },
     {
       "name": "Quarters",
-      "environment": -1,
       "exits": {
         "west": 935
       },
-      "weight": 1,
       "id": 945,
       "area": {
         "id": 10
@@ -205,11 +175,9 @@
     },
     {
       "name": "Quarters",
-      "environment": -1,
       "exits": {
         "west": 936
       },
-      "weight": 1,
       "id": 946,
       "area": {
         "id": 10
@@ -217,12 +185,10 @@
     },
     {
       "name": "Corner",
-      "environment": -1,
       "exits": {
         "west": 941,
         "south": 936
       },
-      "weight": 1,
       "id": 947,
       "area": {
         "id": 10
@@ -230,14 +196,12 @@
     },
     {
       "name": "Temple Chamber",
-      "environment": -1,
       "exits": {
         "south": 941,
         "west": 951,
         "east": 952,
         "north": 949
       },
-      "weight": 1,
       "id": 948,
       "area": {
         "id": 10
@@ -245,12 +209,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 948,
         "north": 950
       },
-      "weight": 1,
       "id": 949,
       "area": {
         "id": 10
@@ -258,11 +220,9 @@
     },
     {
       "name": "Library",
-      "environment": -1,
       "exits": {
         "south": 949
       },
-      "weight": 1,
       "id": 950,
       "area": {
         "id": 10
@@ -270,11 +230,9 @@
     },
     {
       "name": "Kitchen",
-      "environment": -1,
       "exits": {
         "east": 948
       },
-      "weight": 1,
       "id": 951,
       "area": {
         "id": 10
@@ -282,11 +240,9 @@
     },
     {
       "name": "Storage",
-      "environment": -1,
       "exits": {
         "west": 948
       },
-      "weight": 1,
       "id": 952,
       "area": {
         "id": 10

--- a/maps/area11.json
+++ b/maps/area11.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Entrance of a village",
-      "environment": -1,
       "exits": {
         "west": 859,
         "east": 877,
         "south": 131
       },
-      "weight": 1,
       "id": 858,
       "area": {
         "id": 11
@@ -19,13 +17,11 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "east": 858,
         "northwest": 860,
         "north": 864
       },
-      "weight": 1,
       "id": 859,
       "area": {
         "id": 11
@@ -33,13 +29,11 @@
     },
     {
       "name": "A living room made of glass",
-      "environment": -1,
       "exits": {
         "southwest": 863,
         "northwest": 861,
         "southeast": 859
       },
-      "weight": 1,
       "id": 860,
       "area": {
         "id": 11
@@ -47,12 +41,10 @@
     },
     {
       "name": "A kitchen made of glass",
-      "environment": -1,
       "exits": {
         "southwest": 862,
         "southeast": 860
       },
-      "weight": 1,
       "id": 861,
       "area": {
         "id": 11
@@ -60,12 +52,10 @@
     },
     {
       "name": "Sylvia's workroom",
-      "environment": -1,
       "exits": {
         "southeast": 863,
         "northeast": 861
       },
-      "weight": 1,
       "id": 862,
       "area": {
         "id": 11
@@ -73,12 +63,10 @@
     },
     {
       "name": "A bedroom made of glass",
-      "environment": -1,
       "exits": {
         "northwest": 862,
         "northeast": 860
       },
-      "weight": 1,
       "id": 863,
       "area": {
         "id": 11
@@ -86,12 +74,10 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "south": 859,
         "north": 865
       },
-      "weight": 1,
       "id": 864,
       "area": {
         "id": 11
@@ -99,13 +85,11 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "east": 868,
         "northwest": 866,
         "south": 864
       },
-      "weight": 1,
       "id": 865,
       "area": {
         "id": 11
@@ -113,12 +97,10 @@
     },
     {
       "name": "Inside a small home",
-      "environment": -1,
       "exits": {
         "southeast": 865,
         "west": 867
       },
-      "weight": 1,
       "id": 866,
       "area": {
         "id": 11
@@ -126,11 +108,9 @@
     },
     {
       "name": "A large kitchen",
-      "environment": -1,
       "exits": {
         "east": 866
       },
-      "weight": 1,
       "id": 867,
       "area": {
         "id": 11
@@ -138,13 +118,11 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "west": 865,
         "east": 875,
         "north": 869
       },
-      "weight": 1,
       "id": 868,
       "area": {
         "id": 11
@@ -152,12 +130,10 @@
     },
     {
       "name": "Bottom floor of the silo",
-      "environment": -1,
       "exits": {
         "up": 870,
         "south": 868
       },
-      "weight": 1,
       "id": 869,
       "area": {
         "id": 11
@@ -165,12 +141,10 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "west": 868,
         "south": 876
       },
-      "weight": 1,
       "id": 875,
       "area": {
         "id": 11
@@ -178,13 +152,11 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "south": 877,
         "east": 953,
         "north": 875
       },
-      "weight": 1,
       "id": 876,
       "area": {
         "id": 11
@@ -192,12 +164,10 @@
     },
     {
       "name": "On a dusty path",
-      "environment": -1,
       "exits": {
         "west": 858,
         "north": 876
       },
-      "weight": 1,
       "id": 877,
       "area": {
         "id": 11
@@ -205,12 +175,10 @@
     },
     {
       "name": "On the porch",
-      "environment": -1,
       "exits": {
         "east": 954,
         "west": 876
       },
-      "weight": 1,
       "id": 953,
       "area": {
         "id": 11
@@ -218,13 +186,11 @@
     },
     {
       "name": "In the sitting room",
-      "environment": -1,
       "exits": {
         "west": 953,
         "east": 955,
         "south": 958
       },
-      "weight": 1,
       "id": 954,
       "area": {
         "id": 11
@@ -232,12 +198,10 @@
     },
     {
       "name": "In the kitchen",
-      "environment": -1,
       "exits": {
         "west": 954,
         "south": 956
       },
-      "weight": 1,
       "id": 955,
       "area": {
         "id": 11
@@ -245,13 +209,11 @@
     },
     {
       "name": "In the dining room",
-      "environment": -1,
       "exits": {
         "west": 958,
         "east": 957,
         "north": 955
       },
-      "weight": 1,
       "id": 956,
       "area": {
         "id": 11
@@ -259,12 +221,10 @@
     },
     {
       "name": "You leave the farmhouse and enter the backyard.",
-      "environment": -1,
       "exits": {
         "east": 959,
         "west": 956
       },
-      "weight": 1,
       "id": 957,
       "area": {
         "id": 11
@@ -272,12 +232,10 @@
     },
     {
       "name": "In the study",
-      "environment": -1,
       "exits": {
         "east": 956,
         "north": 954
       },
-      "weight": 1,
       "id": 958,
       "area": {
         "id": 11
@@ -285,12 +243,10 @@
     },
     {
       "name": "In a shed",
-      "environment": -1,
       "exits": {
         "up": 960,
         "west": 957
       },
-      "weight": 1,
       "id": 959,
       "area": {
         "id": 11
@@ -298,11 +254,9 @@
     },
     {
       "name": "Above the shed",
-      "environment": -1,
       "exits": {
         "down": 959
       },
-      "weight": 1,
       "id": 960,
       "area": {
         "id": 11

--- a/maps/area12.json
+++ b/maps/area12.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Cemetery Lane.",
-      "environment": -1,
       "exits": {
         "south": 128,
         "north": 882
       },
-      "weight": 1,
       "id": 881,
       "area": {
         "id": 12
@@ -18,12 +16,10 @@
     },
     {
       "name": "Cemetery Lane.",
-      "environment": -1,
       "exits": {
         "south": 881,
         "north": 883
       },
-      "weight": 1,
       "id": 882,
       "area": {
         "id": 12
@@ -31,12 +27,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "east": 884,
         "south": 882
       },
-      "weight": 1,
       "id": 883,
       "area": {
         "id": 12
@@ -44,12 +38,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "west": 883,
         "north": 885
       },
-      "weight": 1,
       "id": 884,
       "area": {
         "id": 12
@@ -57,12 +49,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "west": 886,
         "south": 884
       },
-      "weight": 1,
       "id": 885,
       "area": {
         "id": 12
@@ -70,12 +60,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "east": 885,
         "north": 887
       },
-      "weight": 1,
       "id": 886,
       "area": {
         "id": 12
@@ -83,14 +71,12 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "south": 886,
         "west": 889,
         "east": 892,
         "north": 888
       },
-      "weight": 1,
       "id": 887,
       "area": {
         "id": 12
@@ -98,11 +84,9 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "south": 887
       },
-      "weight": 1,
       "id": 888,
       "area": {
         "id": 12
@@ -110,12 +94,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "east": 887,
         "south": 890
       },
-      "weight": 1,
       "id": 889,
       "area": {
         "id": 12
@@ -123,12 +105,10 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "south": 891,
         "north": 889
       },
-      "weight": 1,
       "id": 890,
       "area": {
         "id": 12
@@ -136,11 +116,9 @@
     },
     {
       "name": "Thieves Guild",
-      "environment": -1,
       "exits": {
         "north": 890
       },
-      "weight": 1,
       "id": 891,
       "area": {
         "id": 12
@@ -148,11 +126,9 @@
     },
     {
       "name": "A cemetery.",
-      "environment": -1,
       "exits": {
         "west": 887
       },
-      "weight": 1,
       "id": 892,
       "area": {
         "id": 12

--- a/maps/area13.json
+++ b/maps/area13.json
@@ -5,7 +5,6 @@
   "rooms": [
     {
       "name": "Foyer",
-      "environment": -1,
       "exits": {
         "west": 98,
         "up": 1011,
@@ -13,7 +12,6 @@
         "east": 1001,
         "north": 1009
       },
-      "weight": 1,
       "id": 1000,
       "area": {
         "id": 13
@@ -21,13 +19,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "northeast": 1008,
         "east": 1002,
         "west": 1000
       },
-      "weight": 1,
       "id": 1001,
       "area": {
         "id": 13
@@ -35,14 +31,12 @@
     },
     {
       "name": "Ballroom",
-      "environment": -1,
       "exits": {
         "south": 1007,
         "west": 1001,
         "east": 1003,
         "north": 1014
       },
-      "weight": 1,
       "id": 1002,
       "area": {
         "id": 13
@@ -50,13 +44,11 @@
     },
     {
       "name": "Dance Floor",
-      "environment": -1,
       "exits": {
         "west": 1002,
         "east": 1004,
         "south": 1006
       },
-      "weight": 1,
       "id": 1003,
       "area": {
         "id": 13
@@ -64,13 +56,11 @@
     },
     {
       "name": "Gaston's table",
-      "environment": -1,
       "exits": {
         "west": 1003,
         "south": 1005,
         "north": 1013
       },
-      "weight": 1,
       "id": 1004,
       "area": {
         "id": 13
@@ -78,13 +68,11 @@
     },
     {
       "name": "Dance Floor",
-      "environment": -1,
       "exits": {
         "west": 1006,
         "south": 1012,
         "north": 1004
       },
-      "weight": 1,
       "id": 1005,
       "area": {
         "id": 13
@@ -92,13 +80,11 @@
     },
     {
       "name": "Dance Floor",
-      "environment": -1,
       "exits": {
         "west": 1007,
         "east": 1005,
         "north": 1003
       },
-      "weight": 1,
       "id": 1006,
       "area": {
         "id": 13
@@ -106,12 +92,10 @@
     },
     {
       "name": "Buffet table",
-      "environment": -1,
       "exits": {
         "east": 1006,
         "north": 1002
       },
-      "weight": 1,
       "id": 1007,
       "area": {
         "id": 13
@@ -119,11 +103,9 @@
     },
     {
       "name": "Kitchen",
-      "environment": -1,
       "exits": {
         "southwest": 1001
       },
-      "weight": 1,
       "id": 1008,
       "area": {
         "id": 13
@@ -131,11 +113,9 @@
     },
     {
       "name": "Library",
-      "environment": -1,
       "exits": {
         "south": 1000
       },
-      "weight": 1,
       "id": 1009,
       "area": {
         "id": 13
@@ -143,11 +123,9 @@
     },
     {
       "name": "Map Room",
-      "environment": -1,
       "exits": {
         "north": 1000
       },
-      "weight": 1,
       "id": 1010,
       "area": {
         "id": 13
@@ -155,11 +133,9 @@
     },
     {
       "name": "House of Clan Lord Gaston",
-      "environment": -1,
       "exits": {
         "down": 1000
       },
-      "weight": 1,
       "id": 1011,
       "area": {
         "id": 13
@@ -167,11 +143,9 @@
     },
     {
       "name": "Deck",
-      "environment": -1,
       "exits": {
         "north": 1005
       },
-      "weight": 1,
       "id": 1012,
       "area": {
         "id": 13
@@ -179,12 +153,10 @@
     },
     {
       "name": "Bandstand",
-      "environment": -1,
       "exits": {
         "west": 1014,
         "south": 1004
       },
-      "weight": 1,
       "id": 1013,
       "area": {
         "id": 13
@@ -192,12 +164,10 @@
     },
     {
       "name": "Dark corner",
-      "environment": -1,
       "exits": {
         "east": 1013,
         "south": 1002
       },
-      "weight": 1,
       "id": 1014,
       "area": {
         "id": 13

--- a/maps/area14.json
+++ b/maps/area14.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Headquarter Entrance",
-      "environment": -1,
       "exits": {
         "south": 74,
         "east": 1017,
         "north": 1020
       },
-      "weight": 1,
       "id": 1018,
       "area": {
         "id": 14
@@ -19,12 +17,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1018,
         "north": 1021
       },
-      "weight": 1,
       "id": 1020,
       "area": {
         "id": 14
@@ -32,13 +28,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1020,
         "east": 1022,
         "north": 1024
       },
-      "weight": 1,
       "id": 1021,
       "area": {
         "id": 14
@@ -46,12 +40,10 @@
     },
     {
       "name": "Bunk Area",
-      "environment": -1,
       "exits": {
         "west": 1021,
         "south": 1023
       },
-      "weight": 1,
       "id": 1022,
       "area": {
         "id": 14
@@ -59,11 +51,9 @@
     },
     {
       "name": "Banquet Hall",
-      "environment": -1,
       "exits": {
         "north": 1022
       },
-      "weight": 1,
       "id": 1023,
       "area": {
         "id": 14
@@ -71,13 +61,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1021,
         "east": 1029,
         "north": 1025
       },
-      "weight": 1,
       "id": 1024,
       "area": {
         "id": 14
@@ -85,13 +73,11 @@
     },
     {
       "name": "Ready Room",
-      "environment": -1,
       "exits": {
         "south": 1024,
         "east": 1028,
         "north": 1026
       },
-      "weight": 1,
       "id": 1025,
       "area": {
         "id": 14
@@ -99,12 +85,10 @@
     },
     {
       "name": "Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 1027,
         "south": 1025
       },
-      "weight": 1,
       "id": 1026,
       "area": {
         "id": 14
@@ -112,12 +96,10 @@
     },
     {
       "name": "Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 963,
         "west": 1026
       },
-      "weight": 1,
       "id": 1027,
       "area": {
         "id": 14
@@ -125,11 +107,9 @@
     },
     {
       "name": "Armoury",
-      "environment": -1,
       "exits": {
         "west": 1025
       },
-      "weight": 1,
       "id": 1028,
       "area": {
         "id": 14
@@ -137,11 +117,9 @@
     },
     {
       "name": "Strategist's Room",
-      "environment": -1,
       "exits": {
         "west": 1024
       },
-      "weight": 1,
       "id": 1029,
       "area": {
         "id": 14

--- a/maps/area16.json
+++ b/maps/area16.json
@@ -5,29 +5,23 @@
   "rooms": [
     {
       "name": "Southwest Tower",
-      "environment": -1,
       "id": 1036,
-      "weight": 1,
       "area": {
         "id": 16
       }
     },
     {
       "name": "Empty Closet",
-      "environment": -1,
       "id": 1037,
-      "weight": 1,
       "area": {
         "id": 16
       }
     },
     {
       "name": "Thief Hideout Entrance",
-      "environment": -1,
       "exits": {
         "up": 1037
       },
-      "weight": 1,
       "id": 1038,
       "area": {
         "id": 16

--- a/maps/area17.json
+++ b/maps/area17.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "east": 1049,
         "north": 1040
       },
-      "weight": 1,
       "id": 1039,
       "area": {
         "id": 17
@@ -18,12 +16,10 @@
     },
     {
       "name": "A bend in the hallway",
-      "environment": -1,
       "exits": {
         "east": 1041,
         "south": 1039
       },
-      "weight": 1,
       "id": 1040,
       "area": {
         "id": 17
@@ -31,12 +27,10 @@
     },
     {
       "name": "Cobwebs brush against the left side of your face as you walk through them.",
-      "environment": -1,
       "exits": {
         "east": 1042,
         "west": 1040
       },
-      "weight": 1,
       "id": 1041,
       "area": {
         "id": 17
@@ -44,12 +38,10 @@
     },
     {
       "name": "The Great Hall",
-      "environment": -1,
       "exits": {
         "east": 1043,
         "west": 1041
       },
-      "weight": 1,
       "id": 1042,
       "area": {
         "id": 17
@@ -57,12 +49,10 @@
     },
     {
       "name": "A bend in the hallway",
-      "environment": -1,
       "exits": {
         "west": 1042,
         "south": 1044
       },
-      "weight": 1,
       "id": 1043,
       "area": {
         "id": 17
@@ -70,13 +60,11 @@
     },
     {
       "name": "Barrack",
-      "environment": -1,
       "exits": {
         "west": 1045,
         "south": 1046,
         "north": 1043
       },
-      "weight": 1,
       "id": 1044,
       "area": {
         "id": 17
@@ -84,12 +72,10 @@
     },
     {
       "name": "First floor landing",
-      "environment": -1,
       "exits": {
         "east": 1044,
         "up": 1050
       },
-      "weight": 1,
       "id": 1045,
       "area": {
         "id": 17
@@ -97,12 +83,10 @@
     },
     {
       "name": "Barrack",
-      "environment": -1,
       "exits": {
         "south": 1047,
         "north": 1044
       },
-      "weight": 1,
       "id": 1046,
       "area": {
         "id": 17
@@ -110,12 +94,10 @@
     },
     {
       "name": "Staging Room",
-      "environment": -1,
       "exits": {
         "west": 1048,
         "north": 1046
       },
-      "weight": 1,
       "id": 1047,
       "area": {
         "id": 17
@@ -123,11 +105,9 @@
     },
     {
       "name": "Sally Port",
-      "environment": -1,
       "exits": {
         "east": 1047
       },
-      "weight": 1,
       "id": 1048,
       "area": {
         "id": 17
@@ -135,11 +115,9 @@
     },
     {
       "name": "An office",
-      "environment": -1,
       "exits": {
         "west": 1039
       },
-      "weight": 1,
       "id": 1049,
       "area": {
         "id": 17
@@ -147,13 +125,11 @@
     },
     {
       "name": "Second floor landing",
-      "environment": -1,
       "exits": {
         "up": 1051,
         "down": 1045,
         "north": 1069
       },
-      "weight": 1,
       "id": 1050,
       "area": {
         "id": 17
@@ -161,14 +137,12 @@
     },
     {
       "name": "Third floor landing",
-      "environment": -1,
       "exits": {
         "down": 1050,
         "up": 1052,
         "east": 1065,
         "north": 1064
       },
-      "weight": 1,
       "id": 1051,
       "area": {
         "id": 17
@@ -176,7 +150,6 @@
     },
     {
       "name": "Stairwell",
-      "environment": -1,
       "exits": {
         "west": 1060,
         "down": 1051,
@@ -184,7 +157,6 @@
         "east": 1059,
         "north": 1057
       },
-      "weight": 1,
       "id": 1052,
       "area": {
         "id": 17
@@ -192,13 +164,11 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "south": 1054,
         "east": 1056,
         "north": 1052
       },
-      "weight": 1,
       "id": 1053,
       "area": {
         "id": 17
@@ -206,12 +176,10 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "east": 1055,
         "north": 1053
       },
-      "weight": 1,
       "id": 1054,
       "area": {
         "id": 17
@@ -219,12 +187,10 @@
     },
     {
       "name": "Southeast corner of roof",
-      "environment": -1,
       "exits": {
         "west": 1054,
         "north": 1056
       },
-      "weight": 1,
       "id": 1055,
       "area": {
         "id": 17
@@ -232,13 +198,11 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "west": 1053,
         "south": 1055,
         "north": 1059
       },
-      "weight": 1,
       "id": 1056,
       "area": {
         "id": 17
@@ -246,12 +210,10 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "east": 1058,
         "south": 1052
       },
-      "weight": 1,
       "id": 1057,
       "area": {
         "id": 17
@@ -259,12 +221,10 @@
     },
     {
       "name": "Northeast corner of roof",
-      "environment": -1,
       "exits": {
         "west": 1057,
         "south": 1059
       },
-      "weight": 1,
       "id": 1058,
       "area": {
         "id": 17
@@ -272,13 +232,11 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "west": 1052,
         "south": 1056,
         "north": 1058
       },
-      "weight": 1,
       "id": 1059,
       "area": {
         "id": 17
@@ -286,13 +244,11 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "west": 1063,
         "east": 1052,
         "north": 1061
       },
-      "weight": 1,
       "id": 1060,
       "area": {
         "id": 17
@@ -300,12 +256,10 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "west": 1062,
         "south": 1060
       },
-      "weight": 1,
       "id": 1061,
       "area": {
         "id": 17
@@ -313,12 +267,10 @@
     },
     {
       "name": "Northwest corner of roof",
-      "environment": -1,
       "exits": {
         "east": 1061,
         "south": 1063
       },
-      "weight": 1,
       "id": 1062,
       "area": {
         "id": 17
@@ -326,12 +278,10 @@
     },
     {
       "name": "Northeast Tower Roof",
-      "environment": -1,
       "exits": {
         "east": 1060,
         "north": 1062
       },
-      "weight": 1,
       "id": 1063,
       "area": {
         "id": 17
@@ -339,11 +289,9 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "south": 1051
       },
-      "weight": 1,
       "id": 1064,
       "area": {
         "id": 17
@@ -351,12 +299,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 1051,
         "south": 1066
       },
-      "weight": 1,
       "id": 1065,
       "area": {
         "id": 17
@@ -364,12 +310,10 @@
     },
     {
       "name": "Hall",
-      "environment": -1,
       "exits": {
         "south": 1067,
         "north": 1065
       },
-      "weight": 1,
       "id": 1066,
       "area": {
         "id": 17
@@ -377,12 +321,10 @@
     },
     {
       "name": "War Room",
-      "environment": -1,
       "exits": {
         "west": 1068,
         "north": 1066
       },
-      "weight": 1,
       "id": 1067,
       "area": {
         "id": 17
@@ -390,11 +332,9 @@
     },
     {
       "name": "Portal Chamber",
-      "environment": -1,
       "exits": {
         "east": 1067
       },
-      "weight": 1,
       "id": 1068,
       "area": {
         "id": 17
@@ -402,13 +342,11 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "west": 1070,
         "east": 1072,
         "south": 1050
       },
-      "weight": 1,
       "id": 1069,
       "area": {
         "id": 17
@@ -416,13 +354,11 @@
     },
     {
       "name": "Prison Wing",
-      "environment": -1,
       "exits": {
         "west": 1071,
         "east": 1069,
         "south": 1077
       },
-      "weight": 1,
       "id": 1070,
       "area": {
         "id": 17
@@ -430,11 +366,9 @@
     },
     {
       "name": "Prison cell",
-      "environment": -1,
       "exits": {
         "east": 1070
       },
-      "weight": 1,
       "id": 1071,
       "area": {
         "id": 17
@@ -442,12 +376,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 1069,
         "south": 1073
       },
-      "weight": 1,
       "id": 1072,
       "area": {
         "id": 17
@@ -455,12 +387,10 @@
     },
     {
       "name": "An alarm sounds as you pass the threshold of the magic barrier.",
-      "environment": -1,
       "exits": {
         "south": 1074,
         "north": 1072
       },
-      "weight": 1,
       "id": 1073,
       "area": {
         "id": 17
@@ -468,13 +398,11 @@
     },
     {
       "name": "Witch's Workroom",
-      "environment": -1,
       "exits": {
         "west": 1075,
         "south": 1076,
         "north": 1073
       },
-      "weight": 1,
       "id": 1074,
       "area": {
         "id": 17
@@ -482,11 +410,9 @@
     },
     {
       "name": "Library",
-      "environment": -1,
       "exits": {
         "east": 1074
       },
-      "weight": 1,
       "id": 1075,
       "area": {
         "id": 17
@@ -494,11 +420,9 @@
     },
     {
       "name": "Morgue",
-      "environment": -1,
       "exits": {
         "north": 1074
       },
-      "weight": 1,
       "id": 1076,
       "area": {
         "id": 17
@@ -506,11 +430,9 @@
     },
     {
       "name": "Prison cell",
-      "environment": -1,
       "exits": {
         "north": 1070
       },
-      "weight": 1,
       "id": 1077,
       "area": {
         "id": 17

--- a/maps/area18.json
+++ b/maps/area18.json
@@ -5,7 +5,6 @@
   "rooms": [
     {
       "name": "House of Clan Lord Bracknar",
-      "environment": -1,
       "exits": {
         "west": 1080,
         "up": 1081,
@@ -13,7 +12,6 @@
         "east": 76,
         "north": 1078
       },
-      "weight": 1,
       "id": 77,
       "area": {
         "id": 18
@@ -21,11 +19,9 @@
     },
     {
       "name": "Lord's Stable",
-      "environment": -1,
       "exits": {
         "south": 77
       },
-      "weight": 1,
       "id": 1078,
       "area": {
         "id": 18
@@ -33,11 +29,9 @@
     },
     {
       "name": "Kitchen",
-      "environment": -1,
       "exits": {
         "north": 77
       },
-      "weight": 1,
       "id": 1079,
       "area": {
         "id": 18
@@ -45,11 +39,9 @@
     },
     {
       "name": "Bracknar's Garden",
-      "environment": -1,
       "exits": {
         "east": 77
       },
-      "weight": 1,
       "id": 1080,
       "area": {
         "id": 18
@@ -57,11 +49,9 @@
     },
     {
       "name": "House of Clan Lord Bracknar",
-      "environment": -1,
       "exits": {
         "down": 77
       },
-      "weight": 1,
       "id": 1081,
       "area": {
         "id": 18

--- a/maps/area19.json
+++ b/maps/area19.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Gatehouse",
-      "environment": -1,
       "exits": {
         "up": 1083,
         "east": 87,
         "west": 1084
       },
-      "weight": 1,
       "id": 1082,
       "area": {
         "id": 19
@@ -19,11 +17,9 @@
     },
     {
       "name": "Blockhouse",
-      "environment": -1,
       "exits": {
         "down": 1082
       },
-      "weight": 1,
       "id": 1083,
       "area": {
         "id": 19
@@ -31,14 +27,12 @@
     },
     {
       "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
-      "environment": -1,
       "exits": {
         "south": 1087,
         "west": 1085,
         "east": 1082,
         "north": 1092
       },
-      "weight": 1,
       "id": 1084,
       "area": {
         "id": 19
@@ -46,12 +40,10 @@
     },
     {
       "name": "Eastern bailey",
-      "environment": -1,
       "exits": {
         "east": 1084,
         "west": 1086
       },
-      "weight": 1,
       "id": 1085,
       "area": {
         "id": 19
@@ -59,13 +51,11 @@
     },
     {
       "name": "Western bailey",
-      "environment": -1,
       "exits": {
         "south": 1871,
         "east": 1085,
         "north": 1870
       },
-      "weight": 1,
       "id": 1086,
       "area": {
         "id": 19
@@ -73,13 +63,11 @@
     },
     {
       "name": "Long hallway",
-      "environment": -1,
       "exits": {
         "west": 1089,
         "south": 1088,
         "north": 1084
       },
-      "weight": 1,
       "id": 1087,
       "area": {
         "id": 19
@@ -87,12 +75,10 @@
     },
     {
       "name": "Passage",
-      "environment": -1,
       "exits": {
         "up": 1090,
         "north": 1087
       },
-      "weight": 1,
       "id": 1088,
       "area": {
         "id": 19
@@ -100,11 +86,9 @@
     },
     {
       "name": "Sun Court",
-      "environment": -1,
       "exits": {
         "east": 1087
       },
-      "weight": 1,
       "id": 1089,
       "area": {
         "id": 19
@@ -112,12 +96,10 @@
     },
     {
       "name": "Stairwell",
-      "environment": -1,
       "exits": {
         "down": 1088,
         "up": 1091
       },
-      "weight": 1,
       "id": 1090,
       "area": {
         "id": 19
@@ -125,11 +107,9 @@
     },
     {
       "name": "Southeast Watchtower",
-      "environment": -1,
       "exits": {
         "down": 1090
       },
-      "weight": 1,
       "id": 1091,
       "area": {
         "id": 19
@@ -137,11 +117,9 @@
     },
     {
       "name": "Long hallway",
-      "environment": -1,
       "exits": {
         "south": 1084
       },
-      "weight": 1,
       "id": 1092,
       "area": {
         "id": 19
@@ -149,11 +127,9 @@
     },
     {
       "name": "Armoury",
-      "environment": -1,
       "exits": {
         "south": 1086
       },
-      "weight": 1,
       "id": 1870,
       "area": {
         "id": 19
@@ -161,11 +137,9 @@
     },
     {
       "name": "Stables",
-      "environment": -1,
       "exits": {
         "north": 1086
       },
-      "weight": 1,
       "id": 1871,
       "area": {
         "id": 19

--- a/maps/area20.json
+++ b/maps/area20.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "up": 1098,
         "east": 1100,
         "south": 1101
       },
-      "weight": 1,
       "id": 1099,
       "area": {
         "id": 20
@@ -19,13 +17,11 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "northeast": 1103,
         "southeast": 1102,
         "west": 1099
       },
-      "weight": 1,
       "id": 1100,
       "area": {
         "id": 20
@@ -33,11 +29,9 @@
     },
     {
       "name": "Crypt of the Honored Dead.",
-      "environment": -1,
       "exits": {
         "north": 1099
       },
-      "weight": 1,
       "id": 1101,
       "area": {
         "id": 20
@@ -45,12 +39,10 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "northwest": 1100,
         "southeast": 1115
       },
-      "weight": 1,
       "id": 1102,
       "area": {
         "id": 20
@@ -58,12 +50,10 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "southwest": 1100,
         "northeast": 1104
       },
-      "weight": 1,
       "id": 1103,
       "area": {
         "id": 20
@@ -71,12 +61,10 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "southwest": 1103,
         "east": 1105
       },
-      "weight": 1,
       "id": 1104,
       "area": {
         "id": 20
@@ -84,14 +72,12 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1108,
         "west": 1104,
         "east": 1106,
         "north": 1107
       },
-      "weight": 1,
       "id": 1105,
       "area": {
         "id": 20
@@ -99,14 +85,12 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1111,
         "west": 1105,
         "east": 1110,
         "north": 1109
       },
-      "weight": 1,
       "id": 1106,
       "area": {
         "id": 20
@@ -114,11 +98,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1105
       },
-      "weight": 1,
       "id": 1107,
       "area": {
         "id": 20
@@ -126,11 +108,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "north": 1105
       },
-      "weight": 1,
       "id": 1108,
       "area": {
         "id": 20
@@ -138,11 +118,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1106
       },
-      "weight": 1,
       "id": 1109,
       "area": {
         "id": 20
@@ -150,14 +128,12 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1113,
         "west": 1106,
         "east": 1114,
         "north": 1112
       },
-      "weight": 1,
       "id": 1110,
       "area": {
         "id": 20
@@ -165,11 +141,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "north": 1106
       },
-      "weight": 1,
       "id": 1111,
       "area": {
         "id": 20
@@ -177,11 +151,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "south": 1110
       },
-      "weight": 1,
       "id": 1112,
       "area": {
         "id": 20
@@ -189,11 +161,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "north": 1110
       },
-      "weight": 1,
       "id": 1113,
       "area": {
         "id": 20
@@ -201,11 +171,9 @@
     },
     {
       "name": "Battle of the Sand Gargoyles",
-      "environment": -1,
       "exits": {
         "west": 1110
       },
-      "weight": 1,
       "id": 1114,
       "area": {
         "id": 20
@@ -213,12 +181,10 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "northwest": 1102,
         "east": 1116
       },
-      "weight": 1,
       "id": 1115,
       "area": {
         "id": 20
@@ -226,14 +192,12 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "south": 1123,
         "west": 1115,
         "east": 1117,
         "north": 1124
       },
-      "weight": 1,
       "id": 1116,
       "area": {
         "id": 20
@@ -241,14 +205,12 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "south": 1121,
         "west": 1116,
         "east": 1118,
         "north": 1122
       },
-      "weight": 1,
       "id": 1117,
       "area": {
         "id": 20
@@ -256,13 +218,11 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "west": 1117,
         "south": 1119,
         "north": 1120
       },
-      "weight": 1,
       "id": 1118,
       "area": {
         "id": 20
@@ -270,11 +230,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "north": 1118
       },
-      "weight": 1,
       "id": 1119,
       "area": {
         "id": 20
@@ -282,11 +240,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "south": 1118
       },
-      "weight": 1,
       "id": 1120,
       "area": {
         "id": 20
@@ -294,11 +250,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "north": 1117
       },
-      "weight": 1,
       "id": 1121,
       "area": {
         "id": 20
@@ -306,11 +260,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "south": 1117
       },
-      "weight": 1,
       "id": 1122,
       "area": {
         "id": 20
@@ -318,11 +270,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "north": 1116
       },
-      "weight": 1,
       "id": 1123,
       "area": {
         "id": 20
@@ -330,11 +280,9 @@
     },
     {
       "name": "Battle of Maiden's Kiss",
-      "environment": -1,
       "exits": {
         "south": 1116
       },
-      "weight": 1,
       "id": 1124,
       "area": {
         "id": 20

--- a/maps/area21.json
+++ b/maps/area21.json
@@ -5,14 +5,12 @@
   "rooms": [
     {
       "name": "Living room",
-      "environment": -1,
       "exits": {
         "south": 1157,
         "northeast": 1167,
         "northwest": 1165,
         "north": 1166
       },
-      "weight": 1,
       "id": 1164,
       "area": {
         "id": 21
@@ -20,11 +18,9 @@
     },
     {
       "name": "You brush aside the blanket and duck to pass through the small door.",
-      "environment": -1,
       "exits": {
         "southeast": 1164
       },
-      "weight": 1,
       "id": 1165,
       "area": {
         "id": 21
@@ -32,11 +28,9 @@
     },
     {
       "name": "You feel strange walking into the kitchen - that's where women belong.",
-      "environment": -1,
       "exits": {
         "south": 1164
       },
-      "weight": 1,
       "id": 1166,
       "area": {
         "id": 21
@@ -44,11 +38,9 @@
     },
     {
       "name": "You brush aside the blanket and duck to pass through the small door.",
-      "environment": -1,
       "exits": {
         "southwest": 1164
       },
-      "weight": 1,
       "id": 1167,
       "area": {
         "id": 21

--- a/maps/area23.json
+++ b/maps/area23.json
@@ -5,14 +5,12 @@
   "rooms": [
     {
       "name": "City Unemployment Office",
-      "environment": -1,
       "exits": {
         "south": 1203,
         "west": 417,
         "east": 241,
         "north": 418
       },
-      "weight": 1,
       "id": 416,
       "area": {
         "id": 23
@@ -20,11 +18,9 @@
     },
     {
       "name": "City Unemployment Office",
-      "environment": -1,
       "exits": {
         "east": 416
       },
-      "weight": 1,
       "id": 417,
       "area": {
         "id": 23
@@ -32,11 +28,9 @@
     },
     {
       "name": "City Unemployment Office",
-      "environment": -1,
       "exits": {
         "south": 416
       },
-      "weight": 1,
       "id": 418,
       "area": {
         "id": 23
@@ -44,11 +38,9 @@
     },
     {
       "name": "City Unemployment Office",
-      "environment": -1,
       "exits": {
         "north": 416
       },
-      "weight": 1,
       "id": 1203,
       "area": {
         "id": 23

--- a/maps/area25.json
+++ b/maps/area25.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "A short entryway",
-      "environment": -1,
       "exits": {
         "north": 1263
       },
-      "weight": 1,
       "id": 1223,
       "area": {
         "id": 25
@@ -17,14 +15,12 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1223,
         "west": 1276,
         "east": 1278,
         "north": 1264
       },
-      "weight": 1,
       "id": 1263,
       "area": {
         "id": 25
@@ -32,12 +28,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1263,
         "north": 1265
       },
-      "weight": 1,
       "id": 1264,
       "area": {
         "id": 25
@@ -45,13 +39,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1264,
         "east": 1275,
         "north": 1266
       },
-      "weight": 1,
       "id": 1265,
       "area": {
         "id": 25
@@ -59,14 +51,12 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 1265,
         "west": 1271,
         "east": 1273,
         "north": 1267
       },
-      "weight": 1,
       "id": 1266,
       "area": {
         "id": 25
@@ -74,13 +64,11 @@
     },
     {
       "name": "End of Hallway",
-      "environment": -1,
       "exits": {
         "west": 1268,
         "east": 1269,
         "south": 1266
       },
-      "weight": 1,
       "id": 1267,
       "area": {
         "id": 25
@@ -88,11 +76,9 @@
     },
     {
       "name": "Munchkin Romper Room",
-      "environment": -1,
       "exits": {
         "east": 1267
       },
-      "weight": 1,
       "id": 1268,
       "area": {
         "id": 25
@@ -100,12 +86,10 @@
     },
     {
       "name": "Mages' Barracks",
-      "environment": -1,
       "exits": {
         "east": 1270,
         "west": 1267
       },
-      "weight": 1,
       "id": 1269,
       "area": {
         "id": 25
@@ -113,11 +97,9 @@
     },
     {
       "name": "Munchkin Library",
-      "environment": -1,
       "exits": {
         "west": 1269
       },
-      "weight": 1,
       "id": 1270,
       "area": {
         "id": 25
@@ -125,12 +107,10 @@
     },
     {
       "name": "Munchkin Mess Hall",
-      "environment": -1,
       "exits": {
         "east": 1266,
         "west": 1272
       },
-      "weight": 1,
       "id": 1271,
       "area": {
         "id": 25
@@ -138,11 +118,9 @@
     },
     {
       "name": "Kitchen",
-      "environment": -1,
       "exits": {
         "east": 1271
       },
-      "weight": 1,
       "id": 1272,
       "area": {
         "id": 25
@@ -150,12 +128,10 @@
     },
     {
       "name": "Fighters' Barracks",
-      "environment": -1,
       "exits": {
         "east": 1274,
         "west": 1266
       },
-      "weight": 1,
       "id": 1273,
       "area": {
         "id": 25
@@ -163,12 +139,10 @@
     },
     {
       "name": "Fighters' Barracks",
-      "environment": -1,
       "exits": {
         "west": 1273,
         "south": 1288
       },
-      "weight": 1,
       "id": 1274,
       "area": {
         "id": 25
@@ -176,11 +150,9 @@
     },
     {
       "name": "Munchkin Smithy",
-      "environment": -1,
       "exits": {
         "west": 1265
       },
-      "weight": 1,
       "id": 1275,
       "area": {
         "id": 25
@@ -188,12 +160,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "east": 1263,
         "west": 1277
       },
-      "weight": 1,
       "id": 1276,
       "area": {
         "id": 25
@@ -201,13 +171,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 1281,
         "east": 1276,
         "south": 1280
       },
-      "weight": 1,
       "id": 1277,
       "area": {
         "id": 25
@@ -215,13 +183,11 @@
     },
     {
       "name": "Narrow Hallway",
-      "environment": -1,
       "exits": {
         "west": 1263,
         "east": 1279,
         "north": 1286
       },
-      "weight": 1,
       "id": 1278,
       "area": {
         "id": 25
@@ -229,12 +195,10 @@
     },
     {
       "name": "End of Narrow Hallway",
-      "environment": -1,
       "exits": {
         "west": 1278,
         "north": 1287
       },
-      "weight": 1,
       "id": 1279,
       "area": {
         "id": 25
@@ -242,12 +206,10 @@
     },
     {
       "name": "A Dark Tunnel",
-      "environment": -1,
       "exits": {
         "south": 1284,
         "north": 1277
       },
-      "weight": 1,
       "id": 1280,
       "area": {
         "id": 25
@@ -255,13 +217,11 @@
     },
     {
       "name": "End of Hallway",
-      "environment": -1,
       "exits": {
         "south": 1282,
         "east": 1277,
         "north": 1283
       },
-      "weight": 1,
       "id": 1281,
       "area": {
         "id": 25
@@ -269,11 +229,9 @@
     },
     {
       "name": "Munchkin Leader's Quarters",
-      "environment": -1,
       "exits": {
         "north": 1281
       },
-      "weight": 1,
       "id": 1282,
       "area": {
         "id": 25
@@ -281,11 +239,9 @@
     },
     {
       "name": "Munchkin Leader's Harem",
-      "environment": -1,
       "exits": {
         "south": 1281
       },
-      "weight": 1,
       "id": 1283,
       "area": {
         "id": 25
@@ -293,12 +249,10 @@
     },
     {
       "name": "A Dark Tunnel",
-      "environment": -1,
       "exits": {
         "northeast": 1285,
         "north": 1280
       },
-      "weight": 1,
       "id": 1284,
       "area": {
         "id": 25
@@ -306,11 +260,9 @@
     },
     {
       "name": "A Dark Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1284
       },
-      "weight": 1,
       "id": 1285,
       "area": {
         "id": 25
@@ -318,11 +270,9 @@
     },
     {
       "name": "Dank Cell",
-      "environment": -1,
       "exits": {
         "south": 1278
       },
-      "weight": 1,
       "id": 1286,
       "area": {
         "id": 25
@@ -330,11 +280,9 @@
     },
     {
       "name": "Dank Cell",
-      "environment": -1,
       "exits": {
         "south": 1279
       },
-      "weight": 1,
       "id": 1287,
       "area": {
         "id": 25
@@ -342,11 +290,9 @@
     },
     {
       "name": "The Lollipop Guild",
-      "environment": -1,
       "exits": {
         "north": 1274
       },
-      "weight": 1,
       "id": 1288,
       "area": {
         "id": 25

--- a/maps/area27.json
+++ b/maps/area27.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Tiled Entryway",
-      "environment": -1,
       "exits": {
         "west": 1336,
         "south": 1335
       },
-      "weight": 1,
       "id": 1334,
       "area": {
         "id": 27
@@ -18,12 +16,10 @@
     },
     {
       "name": "Inside of Bracknar Gate",
-      "environment": -1,
       "exits": {
         "south": 261,
         "north": 1334
       },
-      "weight": 1,
       "id": 1335,
       "area": {
         "id": 27
@@ -31,12 +27,10 @@
     },
     {
       "name": "Sitting Room",
-      "environment": -1,
       "exits": {
         "east": 1334,
         "north": 1337
       },
-      "weight": 1,
       "id": 1336,
       "area": {
         "id": 27
@@ -44,12 +38,10 @@
     },
     {
       "name": "Guarded hallway",
-      "environment": -1,
       "exits": {
         "south": 1336,
         "north": 1361
       },
-      "weight": 1,
       "id": 1337,
       "area": {
         "id": 27
@@ -57,11 +49,9 @@
     },
     {
       "name": "Clan Lord's Private Chambers",
-      "environment": -1,
       "exits": {
         "south": 1337
       },
-      "weight": 1,
       "id": 1361,
       "area": {
         "id": 27

--- a/maps/area29.json
+++ b/maps/area29.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1492,
         "east": 1496,
         "south": 1441
       },
-      "weight": 1,
       "id": 1440,
       "area": {
         "id": 29
@@ -19,14 +17,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1442,
         "west": 1493,
         "east": 1495,
         "north": 1440
       },
-      "weight": 1,
       "id": 1441,
       "area": {
         "id": 29
@@ -34,14 +30,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1475,
         "west": 1494,
         "east": 1443,
         "north": 1441
       },
-      "weight": 1,
       "id": 1442,
       "area": {
         "id": 29
@@ -49,14 +43,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1476,
         "west": 1442,
         "east": 1444,
         "north": 1495
       },
-      "weight": 1,
       "id": 1443,
       "area": {
         "id": 29
@@ -64,14 +56,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1477,
         "west": 1443,
         "east": 1445,
         "north": 1498
       },
-      "weight": 1,
       "id": 1444,
       "area": {
         "id": 29
@@ -79,13 +69,11 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1444,
         "east": 1446,
         "south": 1460
       },
-      "weight": 1,
       "id": 1445,
       "area": {
         "id": 29
@@ -93,13 +81,11 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "west": 1445,
         "east": 1447,
         "south": 1459
       },
-      "weight": 1,
       "id": 1446,
       "area": {
         "id": 29
@@ -107,13 +93,11 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "west": 1446,
         "east": 1449,
         "south": 1452
       },
-      "weight": 1,
       "id": 1447,
       "area": {
         "id": 29
@@ -121,12 +105,10 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "east": 1450,
         "west": 1447
       },
-      "weight": 1,
       "id": 1449,
       "area": {
         "id": 29
@@ -134,12 +116,10 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "east": 1451,
         "west": 1449
       },
-      "weight": 1,
       "id": 1450,
       "area": {
         "id": 29
@@ -147,11 +127,9 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1450
       },
-      "weight": 1,
       "id": 1451,
       "area": {
         "id": 29
@@ -159,13 +137,11 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1459,
         "south": 1453,
         "north": 1447
       },
-      "weight": 1,
       "id": 1452,
       "area": {
         "id": 29
@@ -173,13 +149,11 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1458,
         "south": 1454,
         "north": 1452
       },
-      "weight": 1,
       "id": 1453,
       "area": {
         "id": 29
@@ -187,13 +161,11 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "west": 1457,
         "south": 1455,
         "north": 1453
       },
-      "weight": 1,
       "id": 1454,
       "area": {
         "id": 29
@@ -201,12 +173,10 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1456,
         "north": 1454
       },
-      "weight": 1,
       "id": 1455,
       "area": {
         "id": 29
@@ -214,14 +184,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1499,
         "west": 1463,
         "east": 1455,
         "north": 1457
       },
-      "weight": 1,
       "id": 1456,
       "area": {
         "id": 29
@@ -229,14 +197,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1456,
         "west": 1462,
         "east": 1454,
         "north": 1458
       },
-      "weight": 1,
       "id": 1457,
       "area": {
         "id": 29
@@ -244,14 +210,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1457,
         "west": 1461,
         "east": 1453,
         "north": 1459
       },
-      "weight": 1,
       "id": 1458,
       "area": {
         "id": 29
@@ -259,14 +223,12 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "south": 1458,
         "west": 1460,
         "east": 1452,
         "north": 1446
       },
-      "weight": 1,
       "id": 1459,
       "area": {
         "id": 29
@@ -274,14 +236,12 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "south": 1461,
         "west": 1477,
         "east": 1459,
         "north": 1445
       },
-      "weight": 1,
       "id": 1460,
       "area": {
         "id": 29
@@ -289,14 +249,12 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "south": 1462,
         "west": 1478,
         "east": 1458,
         "north": 1460
       },
-      "weight": 1,
       "id": 1461,
       "area": {
         "id": 29
@@ -304,14 +262,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1463,
         "west": 1479,
         "east": 1457,
         "north": 1461
       },
-      "weight": 1,
       "id": 1462,
       "area": {
         "id": 29
@@ -319,14 +275,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1464,
         "west": 1480,
         "east": 1456,
         "north": 1462
       },
-      "weight": 1,
       "id": 1463,
       "area": {
         "id": 29
@@ -334,13 +288,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "west": 1465,
         "east": 1499,
         "north": 1463
       },
-      "weight": 1,
       "id": 1464,
       "area": {
         "id": 29
@@ -348,13 +300,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "west": 1466,
         "east": 1464,
         "north": 1480
       },
-      "weight": 1,
       "id": 1465,
       "area": {
         "id": 29
@@ -362,13 +312,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "west": 1467,
         "east": 1465,
         "north": 1481
       },
-      "weight": 1,
       "id": 1466,
       "area": {
         "id": 29
@@ -376,13 +324,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "west": 1468,
         "east": 1466,
         "north": 1482
       },
-      "weight": 1,
       "id": 1467,
       "area": {
         "id": 29
@@ -390,12 +336,10 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "east": 1467,
         "west": 1469
       },
-      "weight": 1,
       "id": 1468,
       "area": {
         "id": 29
@@ -403,12 +347,10 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "east": 1468,
         "north": 1470
       },
-      "weight": 1,
       "id": 1469,
       "area": {
         "id": 29
@@ -416,12 +358,10 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1469,
         "north": 1471
       },
-      "weight": 1,
       "id": 1470,
       "area": {
         "id": 29
@@ -429,13 +369,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1470,
         "east": 1484,
         "north": 1472
       },
-      "weight": 1,
       "id": 1471,
       "area": {
         "id": 29
@@ -443,13 +381,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1471,
         "east": 1485,
         "north": 1473
       },
-      "weight": 1,
       "id": 1472,
       "area": {
         "id": 29
@@ -457,13 +393,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1472,
         "east": 1474,
         "north": 1489
       },
-      "weight": 1,
       "id": 1473,
       "area": {
         "id": 29
@@ -471,14 +405,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1485,
         "west": 1473,
         "east": 1475,
         "north": 1494
       },
-      "weight": 1,
       "id": 1474,
       "area": {
         "id": 29
@@ -486,14 +418,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1486,
         "west": 1474,
         "east": 1476,
         "north": 1442
       },
-      "weight": 1,
       "id": 1475,
       "area": {
         "id": 29
@@ -501,14 +431,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1487,
         "west": 1475,
         "east": 1477,
         "north": 1443
       },
-      "weight": 1,
       "id": 1476,
       "area": {
         "id": 29
@@ -516,14 +444,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1478,
         "west": 1476,
         "east": 1460,
         "north": 1444
       },
-      "weight": 1,
       "id": 1477,
       "area": {
         "id": 29
@@ -531,14 +457,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1479,
         "west": 1487,
         "east": 1461,
         "north": 1477
       },
-      "weight": 1,
       "id": 1478,
       "area": {
         "id": 29
@@ -546,14 +470,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1480,
         "west": 1488,
         "east": 1462,
         "north": 1478
       },
-      "weight": 1,
       "id": 1479,
       "area": {
         "id": 29
@@ -561,14 +483,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1465,
         "west": 1481,
         "east": 1463,
         "north": 1479
       },
-      "weight": 1,
       "id": 1480,
       "area": {
         "id": 29
@@ -576,14 +496,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1466,
         "west": 1482,
         "east": 1480,
         "north": 1488
       },
-      "weight": 1,
       "id": 1481,
       "area": {
         "id": 29
@@ -591,13 +509,11 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1467,
         "east": 1481,
         "north": 1483
       },
-      "weight": 1,
       "id": 1482,
       "area": {
         "id": 29
@@ -605,14 +521,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1482,
         "west": 1484,
         "east": 1488,
         "north": 1486
       },
-      "weight": 1,
       "id": 1483,
       "area": {
         "id": 29
@@ -620,13 +534,11 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "west": 1471,
         "east": 1483,
         "north": 1485
       },
-      "weight": 1,
       "id": 1484,
       "area": {
         "id": 29
@@ -634,14 +546,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1484,
         "west": 1472,
         "east": 1486,
         "north": 1474
       },
-      "weight": 1,
       "id": 1485,
       "area": {
         "id": 29
@@ -649,14 +559,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1483,
         "west": 1485,
         "east": 1487,
         "north": 1475
       },
-      "weight": 1,
       "id": 1486,
       "area": {
         "id": 29
@@ -664,14 +572,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1488,
         "west": 1486,
         "east": 1478,
         "north": 1476
       },
-      "weight": 1,
       "id": 1487,
       "area": {
         "id": 29
@@ -679,14 +585,12 @@
     },
     {
       "name": "Dense forest",
-      "environment": -1,
       "exits": {
         "south": 1481,
         "west": 1483,
         "east": 1479,
         "north": 1487
       },
-      "weight": 1,
       "id": 1488,
       "area": {
         "id": 29
@@ -694,13 +598,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1473,
         "east": 1494,
         "north": 1490
       },
-      "weight": 1,
       "id": 1489,
       "area": {
         "id": 29
@@ -708,13 +610,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "south": 1489,
         "east": 1493,
         "north": 1491
       },
-      "weight": 1,
       "id": 1490,
       "area": {
         "id": 29
@@ -722,13 +622,11 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "down": 1506,
         "east": 1492,
         "south": 1490
       },
-      "weight": 1,
       "id": 1491,
       "area": {
         "id": 29
@@ -736,13 +634,11 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "west": 1491,
         "east": 1440,
         "south": 1493
       },
-      "weight": 1,
       "id": 1492,
       "area": {
         "id": 29
@@ -750,14 +646,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1494,
         "west": 1490,
         "east": 1441,
         "north": 1492
       },
-      "weight": 1,
       "id": 1493,
       "area": {
         "id": 29
@@ -765,14 +659,12 @@
     },
     {
       "name": "The Valley",
-      "environment": -1,
       "exits": {
         "south": 1474,
         "west": 1489,
         "east": 1442,
         "north": 1493
       },
-      "weight": 1,
       "id": 1494,
       "area": {
         "id": 29
@@ -780,14 +672,12 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "south": 1443,
         "west": 1441,
         "east": 1498,
         "north": 1496
       },
-      "weight": 1,
       "id": 1495,
       "area": {
         "id": 29
@@ -795,13 +685,11 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1440,
         "east": 1497,
         "south": 1495
       },
-      "weight": 1,
       "id": 1496,
       "area": {
         "id": 29
@@ -809,12 +697,10 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1496,
         "south": 1498
       },
-      "weight": 1,
       "id": 1497,
       "area": {
         "id": 29
@@ -822,13 +708,11 @@
     },
     {
       "name": "Light forest",
-      "environment": -1,
       "exits": {
         "west": 1495,
         "south": 1444,
         "north": 1497
       },
-      "weight": 1,
       "id": 1498,
       "area": {
         "id": 29
@@ -836,13 +720,11 @@
     },
     {
       "name": "Meadow",
-      "environment": -1,
       "exits": {
         "west": 1464,
         "south": 1505,
         "north": 1456
       },
-      "weight": 1,
       "id": 1499,
       "area": {
         "id": 29
@@ -850,14 +732,12 @@
     },
     {
       "name": "Path",
-      "environment": -1,
       "exits": {
         "south": 1501,
         "west": 1503,
         "east": 1473,
         "north": 1504
       },
-      "weight": 1,
       "id": 1500,
       "area": {
         "id": 29
@@ -865,12 +745,10 @@
     },
     {
       "name": "Forest",
-      "environment": -1,
       "exits": {
         "west": 1502,
         "north": 1500
       },
-      "weight": 1,
       "id": 1501,
       "area": {
         "id": 29
@@ -878,12 +756,10 @@
     },
     {
       "name": "Beach",
-      "environment": -1,
       "exits": {
         "east": 1501,
         "north": 1503
       },
-      "weight": 1,
       "id": 1502,
       "area": {
         "id": 29
@@ -891,12 +767,10 @@
     },
     {
       "name": "Beach",
-      "environment": -1,
       "exits": {
         "east": 1500,
         "south": 1502
       },
-      "weight": 1,
       "id": 1503,
       "area": {
         "id": 29
@@ -904,11 +778,9 @@
     },
     {
       "name": "Lighthouse Base",
-      "environment": -1,
       "exits": {
         "south": 1500
       },
-      "weight": 1,
       "id": 1504,
       "area": {
         "id": 29
@@ -916,11 +788,9 @@
     },
     {
       "name": "Mountain Range",
-      "environment": -1,
       "exits": {
         "north": 1499
       },
-      "weight": 1,
       "id": 1505,
       "area": {
         "id": 29
@@ -928,11 +798,9 @@
     },
     {
       "name": "Mine Entrance",
-      "environment": -1,
       "exits": {
         "up": 1491
       },
-      "weight": 1,
       "id": 1506,
       "area": {
         "id": 29

--- a/maps/area32.json
+++ b/maps/area32.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1651,
         "west": 1673
       },
-      "weight": 1,
       "id": 1650,
       "area": {
         "id": 32
@@ -18,12 +16,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1652,
         "west": 1650
       },
-      "weight": 1,
       "id": 1651,
       "area": {
         "id": 32
@@ -31,12 +27,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1654,
         "west": 1651
       },
-      "weight": 1,
       "id": 1652,
       "area": {
         "id": 32
@@ -44,12 +38,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "west": 1652,
         "south": 1655
       },
-      "weight": 1,
       "id": 1654,
       "area": {
         "id": 32
@@ -57,12 +49,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1656,
         "north": 1654
       },
-      "weight": 1,
       "id": 1655,
       "area": {
         "id": 32
@@ -70,12 +60,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1657,
         "north": 1655
       },
-      "weight": 1,
       "id": 1656,
       "area": {
         "id": 32
@@ -83,12 +71,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1658,
         "north": 1656
       },
-      "weight": 1,
       "id": 1657,
       "area": {
         "id": 32
@@ -96,12 +82,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1659,
         "north": 1657
       },
-      "weight": 1,
       "id": 1658,
       "area": {
         "id": 32
@@ -109,12 +93,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1660,
         "north": 1658
       },
-      "weight": 1,
       "id": 1659,
       "area": {
         "id": 32
@@ -122,12 +104,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1661,
         "north": 1659
       },
-      "weight": 1,
       "id": 1660,
       "area": {
         "id": 32
@@ -135,12 +115,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1662,
         "north": 1660
       },
-      "weight": 1,
       "id": 1661,
       "area": {
         "id": 32
@@ -148,12 +126,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1663,
         "north": 1661
       },
-      "weight": 1,
       "id": 1662,
       "area": {
         "id": 32
@@ -161,12 +137,10 @@
     },
     {
       "name": "East Moat",
-      "environment": -1,
       "exits": {
         "south": 1664,
         "north": 1662
       },
-      "weight": 1,
       "id": 1663,
       "area": {
         "id": 32
@@ -174,12 +148,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "west": 1665,
         "north": 1663
       },
-      "weight": 1,
       "id": 1664,
       "area": {
         "id": 32
@@ -187,12 +159,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1664,
         "west": 1666
       },
-      "weight": 1,
       "id": 1665,
       "area": {
         "id": 32
@@ -200,12 +170,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1665,
         "west": 1667
       },
-      "weight": 1,
       "id": 1666,
       "area": {
         "id": 32
@@ -213,12 +181,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1666,
         "west": 1668
       },
-      "weight": 1,
       "id": 1667,
       "area": {
         "id": 32
@@ -226,12 +192,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1667,
         "west": 1669
       },
-      "weight": 1,
       "id": 1668,
       "area": {
         "id": 32
@@ -239,12 +203,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1668,
         "west": 1670
       },
-      "weight": 1,
       "id": 1669,
       "area": {
         "id": 32
@@ -252,12 +214,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1669,
         "west": 1671
       },
-      "weight": 1,
       "id": 1670,
       "area": {
         "id": 32
@@ -265,12 +225,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1670,
         "west": 1672
       },
-      "weight": 1,
       "id": 1671,
       "area": {
         "id": 32
@@ -278,12 +236,10 @@
     },
     {
       "name": "South Moat",
-      "environment": -1,
       "exits": {
         "east": 1671,
         "north": 1686
       },
-      "weight": 1,
       "id": 1672,
       "area": {
         "id": 32
@@ -291,12 +247,10 @@
     },
     {
       "name": "North Moat - Under Draw Bridge",
-      "environment": -1,
       "exits": {
         "east": 1650,
         "west": 1674
       },
-      "weight": 1,
       "id": 1673,
       "area": {
         "id": 32
@@ -304,12 +258,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1673,
         "west": 1675
       },
-      "weight": 1,
       "id": 1674,
       "area": {
         "id": 32
@@ -317,12 +269,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1674,
         "west": 1676
       },
-      "weight": 1,
       "id": 1675,
       "area": {
         "id": 32
@@ -330,12 +280,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1675,
         "west": 1677
       },
-      "weight": 1,
       "id": 1676,
       "area": {
         "id": 32
@@ -343,12 +291,10 @@
     },
     {
       "name": "North Moat",
-      "environment": -1,
       "exits": {
         "east": 1676,
         "south": 1678
       },
-      "weight": 1,
       "id": 1677,
       "area": {
         "id": 32
@@ -356,12 +302,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1679,
         "north": 1677
       },
-      "weight": 1,
       "id": 1678,
       "area": {
         "id": 32
@@ -369,12 +313,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1680,
         "north": 1678
       },
-      "weight": 1,
       "id": 1679,
       "area": {
         "id": 32
@@ -382,12 +324,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1681,
         "north": 1679
       },
-      "weight": 1,
       "id": 1680,
       "area": {
         "id": 32
@@ -395,12 +335,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1682,
         "north": 1680
       },
-      "weight": 1,
       "id": 1681,
       "area": {
         "id": 32
@@ -408,12 +346,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1683,
         "north": 1681
       },
-      "weight": 1,
       "id": 1682,
       "area": {
         "id": 32
@@ -421,12 +357,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1684,
         "north": 1682
       },
-      "weight": 1,
       "id": 1683,
       "area": {
         "id": 32
@@ -434,12 +368,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1685,
         "north": 1683
       },
-      "weight": 1,
       "id": 1684,
       "area": {
         "id": 32
@@ -447,12 +379,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1686,
         "north": 1684
       },
-      "weight": 1,
       "id": 1685,
       "area": {
         "id": 32
@@ -460,12 +390,10 @@
     },
     {
       "name": "West Moat",
-      "environment": -1,
       "exits": {
         "south": 1672,
         "north": 1685
       },
-      "weight": 1,
       "id": 1686,
       "area": {
         "id": 32

--- a/maps/area33.json
+++ b/maps/area33.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Oak Treehouse landing",
-      "environment": -1,
       "exits": {
         "southwest": 1725,
         "northeast": 1726,
         "southeast": 1724
       },
-      "weight": 1,
       "id": 990,
       "area": {
         "id": 33
@@ -19,12 +17,10 @@
     },
     {
       "name": "Gate to the Village Green",
-      "environment": -1,
       "exits": {
         "east": 1693,
         "south": 1688
       },
-      "weight": 1,
       "id": 1687,
       "area": {
         "id": 33
@@ -32,13 +28,11 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1689,
         "east": 1694,
         "north": 1687
       },
-      "weight": 1,
       "id": 1688,
       "area": {
         "id": 33
@@ -46,13 +40,11 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1699,
         "east": 1690,
         "north": 1688
       },
-      "weight": 1,
       "id": 1689,
       "area": {
         "id": 33
@@ -60,14 +52,12 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1700,
         "west": 1689,
         "east": 1691,
         "north": 1694
       },
-      "weight": 1,
       "id": 1690,
       "area": {
         "id": 33
@@ -75,14 +65,12 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1701,
         "west": 1690,
         "east": 1692,
         "north": 1704
       },
-      "weight": 1,
       "id": 1691,
       "area": {
         "id": 33
@@ -90,14 +78,12 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "south": 1702,
         "west": 1691,
         "east": 1706,
         "north": 1703
       },
-      "weight": 1,
       "id": 1692,
       "area": {
         "id": 33
@@ -105,13 +91,11 @@
     },
     {
       "name": "Northwestern Green",
-      "environment": -1,
       "exits": {
         "west": 1687,
         "east": 1695,
         "south": 1694
       },
-      "weight": 1,
       "id": 1693,
       "area": {
         "id": 33
@@ -119,14 +103,12 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1690,
         "west": 1688,
         "east": 1704,
         "north": 1693
       },
-      "weight": 1,
       "id": 1694,
       "area": {
         "id": 33
@@ -134,13 +116,11 @@
     },
     {
       "name": "Northwestern Green",
-      "environment": -1,
       "exits": {
         "west": 1693,
         "east": 1696,
         "south": 1704
       },
-      "weight": 1,
       "id": 1695,
       "area": {
         "id": 33
@@ -148,13 +128,11 @@
     },
     {
       "name": "Northeastern Green",
-      "environment": -1,
       "exits": {
         "west": 1695,
         "east": 1697,
         "south": 1703
       },
-      "weight": 1,
       "id": 1696,
       "area": {
         "id": 33
@@ -162,13 +140,11 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "west": 1696,
         "east": 1698,
         "south": 1705
       },
-      "weight": 1,
       "id": 1697,
       "area": {
         "id": 33
@@ -176,12 +152,10 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "west": 1697,
         "south": 1710
       },
-      "weight": 1,
       "id": 1698,
       "area": {
         "id": 33
@@ -189,13 +163,11 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1713,
         "east": 1700,
         "north": 1689
       },
-      "weight": 1,
       "id": 1699,
       "area": {
         "id": 33
@@ -203,14 +175,12 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1712,
         "west": 1699,
         "east": 1701,
         "north": 1690
       },
-      "weight": 1,
       "id": 1700,
       "area": {
         "id": 33
@@ -218,14 +188,12 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1711,
         "west": 1700,
         "east": 1702,
         "north": 1691
       },
-      "weight": 1,
       "id": 1701,
       "area": {
         "id": 33
@@ -233,14 +201,12 @@
     },
     {
       "name": "Southeast Green",
-      "environment": -1,
       "exits": {
         "south": 1714,
         "west": 1701,
         "east": 1707,
         "north": 1692
       },
-      "weight": 1,
       "id": 1702,
       "area": {
         "id": 33
@@ -248,14 +214,12 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "south": 1692,
         "west": 1704,
         "east": 1705,
         "north": 1696
       },
-      "weight": 1,
       "id": 1703,
       "area": {
         "id": 33
@@ -263,14 +227,12 @@
     },
     {
       "name": "Northwest Green",
-      "environment": -1,
       "exits": {
         "south": 1691,
         "west": 1694,
         "east": 1703,
         "north": 1695
       },
-      "weight": 1,
       "id": 1704,
       "area": {
         "id": 33
@@ -278,14 +240,12 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "south": 1706,
         "west": 1703,
         "east": 1710,
         "north": 1697
       },
-      "weight": 1,
       "id": 1705,
       "area": {
         "id": 33
@@ -293,14 +253,12 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "south": 1707,
         "west": 1692,
         "east": 1709,
         "north": 1705
       },
-      "weight": 1,
       "id": 1706,
       "area": {
         "id": 33
@@ -308,14 +266,12 @@
     },
     {
       "name": "Ruins in the Southeast Green",
-      "environment": -1,
       "exits": {
         "south": 1715,
         "west": 1702,
         "east": 1708,
         "north": 1706
       },
-      "weight": 1,
       "id": 1707,
       "area": {
         "id": 33
@@ -323,13 +279,11 @@
     },
     {
       "name": "Ruins in the Southeast Green",
-      "environment": -1,
       "exits": {
         "west": 1707,
         "south": 1716,
         "north": 1709
       },
-      "weight": 1,
       "id": 1708,
       "area": {
         "id": 33
@@ -337,13 +291,11 @@
     },
     {
       "name": "Northeastern Green",
-      "environment": -1,
       "exits": {
         "west": 1706,
         "south": 1708,
         "north": 1710
       },
-      "weight": 1,
       "id": 1709,
       "area": {
         "id": 33
@@ -351,14 +303,12 @@
     },
     {
       "name": "Northeast Green",
-      "environment": -1,
       "exits": {
         "south": 1709,
         "west": 1705,
         "east": 1722,
         "north": 1698
       },
-      "weight": 1,
       "id": 1710,
       "area": {
         "id": 33
@@ -366,14 +316,12 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1717,
         "west": 1712,
         "east": 1714,
         "north": 1701
       },
-      "weight": 1,
       "id": 1711,
       "area": {
         "id": 33
@@ -381,14 +329,12 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1718,
         "west": 1713,
         "east": 1711,
         "north": 1700
       },
-      "weight": 1,
       "id": 1712,
       "area": {
         "id": 33
@@ -396,13 +342,11 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1719,
         "east": 1712,
         "north": 1699
       },
-      "weight": 1,
       "id": 1713,
       "area": {
         "id": 33
@@ -410,13 +354,11 @@
     },
     {
       "name": "Southeast Green",
-      "environment": -1,
       "exits": {
         "west": 1711,
         "east": 1715,
         "north": 1702
       },
-      "weight": 1,
       "id": 1714,
       "area": {
         "id": 33
@@ -424,13 +366,11 @@
     },
     {
       "name": "Southeast Green",
-      "environment": -1,
       "exits": {
         "west": 1714,
         "east": 1716,
         "north": 1707
       },
-      "weight": 1,
       "id": 1715,
       "area": {
         "id": 33
@@ -438,12 +378,10 @@
     },
     {
       "name": "Southeast Green",
-      "environment": -1,
       "exits": {
         "west": 1715,
         "north": 1708
       },
-      "weight": 1,
       "id": 1716,
       "area": {
         "id": 33
@@ -451,12 +389,10 @@
     },
     {
       "name": "Southwest Green",
-      "environment": -1,
       "exits": {
         "west": 1718,
         "north": 1711
       },
-      "weight": 1,
       "id": 1717,
       "area": {
         "id": 33
@@ -464,14 +400,12 @@
     },
     {
       "name": "Dark Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1721,
         "west": 1719,
         "east": 1717,
         "north": 1712
       },
-      "weight": 1,
       "id": 1718,
       "area": {
         "id": 33
@@ -479,13 +413,11 @@
     },
     {
       "name": "Dark Southwest Green",
-      "environment": -1,
       "exits": {
         "south": 1720,
         "east": 1718,
         "north": 1713
       },
-      "weight": 1,
       "id": 1719,
       "area": {
         "id": 33
@@ -493,12 +425,10 @@
     },
     {
       "name": "Dark Southwest Green",
-      "environment": -1,
       "exits": {
         "east": 1721,
         "north": 1719
       },
-      "weight": 1,
       "id": 1720,
       "area": {
         "id": 33
@@ -506,12 +436,10 @@
     },
     {
       "name": "Dark Southwest Green",
-      "environment": -1,
       "exits": {
         "west": 1720,
         "north": 1718
       },
-      "weight": 1,
       "id": 1721,
       "area": {
         "id": 33
@@ -519,11 +447,9 @@
     },
     {
       "name": "The Herb Exchange",
-      "environment": -1,
       "exits": {
         "west": 1710
       },
-      "weight": 1,
       "id": 1722,
       "area": {
         "id": 33
@@ -531,12 +457,10 @@
     },
     {
       "name": "Oak Treehouse Rope Bridge",
-      "environment": -1,
       "exits": {
         "northwest": 990,
         "southeast": 1729
       },
-      "weight": 1,
       "id": 1724,
       "area": {
         "id": 33
@@ -544,12 +468,10 @@
     },
     {
       "name": "Oak Treehouse Rope Bridge",
-      "environment": -1,
       "exits": {
         "southwest": 1728,
         "northeast": 990
       },
-      "weight": 1,
       "id": 1725,
       "area": {
         "id": 33
@@ -557,12 +479,10 @@
     },
     {
       "name": "Oak Treehouse Rope Bridge",
-      "environment": -1,
       "exits": {
         "southwest": 990,
         "northeast": 1727
       },
-      "weight": 1,
       "id": 1726,
       "area": {
         "id": 33
@@ -570,11 +490,9 @@
     },
     {
       "name": "Living Quarters in the Oak",
-      "environment": -1,
       "exits": {
         "southwest": 1726
       },
-      "weight": 1,
       "id": 1727,
       "area": {
         "id": 33
@@ -582,11 +500,9 @@
     },
     {
       "name": "Living Quarters in the Oak",
-      "environment": -1,
       "exits": {
         "northeast": 1725
       },
-      "weight": 1,
       "id": 1728,
       "area": {
         "id": 33
@@ -594,12 +510,10 @@
     },
     {
       "name": "Oak Treehouse Gazebo",
-      "environment": -1,
       "exits": {
         "northwest": 1724,
         "east": 1730
       },
-      "weight": 1,
       "id": 1729,
       "area": {
         "id": 33
@@ -607,12 +521,10 @@
     },
     {
       "name": "Long Rope Bridge",
-      "environment": -1,
       "exits": {
         "east": 1731,
         "west": 1729
       },
-      "weight": 1,
       "id": 1730,
       "area": {
         "id": 33
@@ -620,14 +532,12 @@
     },
     {
       "name": "The rope bridge sways underfoot, but you maintain your balance.",
-      "environment": -1,
       "exits": {
         "west": 1730,
         "northeast": 1732,
         "east": 1733,
         "south": 1734
       },
-      "weight": 1,
       "id": 1731,
       "area": {
         "id": 33
@@ -635,11 +545,9 @@
     },
     {
       "name": "You push open the door and proceed northeast into the large room.",
-      "environment": -1,
       "exits": {
         "southwest": 1731
       },
-      "weight": 1,
       "id": 1732,
       "area": {
         "id": 33
@@ -647,11 +555,9 @@
     },
     {
       "name": "You push open the door to the private quarters.",
-      "environment": -1,
       "exits": {
         "west": 1731
       },
-      "weight": 1,
       "id": 1733,
       "area": {
         "id": 33
@@ -659,12 +565,10 @@
     },
     {
       "name": "Gingerly, you step out onto the taunt rope bridge.",
-      "environment": -1,
       "exits": {
         "south": 1735,
         "north": 1731
       },
-      "weight": 1,
       "id": 1734,
       "area": {
         "id": 33
@@ -672,12 +576,10 @@
     },
     {
       "name": "You scurry across the swinging rope bridge.",
-      "environment": -1,
       "exits": {
         "southeast": 1736,
         "north": 1734
       },
-      "weight": 1,
       "id": 1735,
       "area": {
         "id": 33
@@ -685,13 +587,11 @@
     },
     {
       "name": "Tel'Quesir Throne Room",
-      "environment": -1,
       "exits": {
         "northeast": 1738,
         "northwest": 1735,
         "southeast": 1737
       },
-      "weight": 1,
       "id": 1736,
       "area": {
         "id": 33
@@ -699,12 +599,10 @@
     },
     {
       "name": "White Chapel",
-      "environment": -1,
       "exits": {
         "northwest": 1736,
         "north": 1738
       },
-      "weight": 1,
       "id": 1737,
       "area": {
         "id": 33
@@ -712,12 +610,10 @@
     },
     {
       "name": "Hall of Ministers",
-      "environment": -1,
       "exits": {
         "southwest": 1736,
         "south": 1737
       },
-      "weight": 1,
       "id": 1738,
       "area": {
         "id": 33

--- a/maps/area36.json
+++ b/maps/area36.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "You are just inside the entrace to a large cave",
-      "environment": -1,
       "exits": {
         "east": 1825
       },
-      "weight": 1,
       "id": 1824,
       "area": {
         "id": 36
@@ -17,13 +15,11 @@
     },
     {
       "name": "A wide tunnel",
-      "environment": -1,
       "exits": {
         "west": 1824,
         "south": 1826,
         "north": 1827
       },
-      "weight": 1,
       "id": 1825,
       "area": {
         "id": 36
@@ -31,11 +27,9 @@
     },
     {
       "name": "A den",
-      "environment": -1,
       "exits": {
         "north": 1825
       },
-      "weight": 1,
       "id": 1826,
       "area": {
         "id": 36
@@ -43,12 +37,10 @@
     },
     {
       "name": "A tunnel",
-      "environment": -1,
       "exits": {
         "south": 1825,
         "north": 1828
       },
-      "weight": 1,
       "id": 1827,
       "area": {
         "id": 36
@@ -56,12 +48,10 @@
     },
     {
       "name": "A bend in the tunnel",
-      "environment": -1,
       "exits": {
         "east": 1829,
         "south": 1827
       },
-      "weight": 1,
       "id": 1828,
       "area": {
         "id": 36
@@ -69,12 +59,10 @@
     },
     {
       "name": "A tunnel",
-      "environment": -1,
       "exits": {
         "east": 1830,
         "west": 1828
       },
-      "weight": 1,
       "id": 1829,
       "area": {
         "id": 36
@@ -82,13 +70,11 @@
     },
     {
       "name": "T-intersection",
-      "environment": -1,
       "exits": {
         "west": 1829,
         "south": 1831,
         "north": 1833
       },
-      "weight": 1,
       "id": 1830,
       "area": {
         "id": 36
@@ -96,12 +82,10 @@
     },
     {
       "name": "The widening tunnel",
-      "environment": -1,
       "exits": {
         "east": 1832,
         "north": 1830
       },
-      "weight": 1,
       "id": 1831,
       "area": {
         "id": 36
@@ -109,11 +93,9 @@
     },
     {
       "name": "A large chamber",
-      "environment": -1,
       "exits": {
         "west": 1831
       },
-      "weight": 1,
       "id": 1832,
       "area": {
         "id": 36
@@ -121,11 +103,9 @@
     },
     {
       "name": "A small chamber",
-      "environment": -1,
       "exits": {
         "south": 1830
       },
-      "weight": 1,
       "id": 1833,
       "area": {
         "id": 36

--- a/maps/area38.json
+++ b/maps/area38.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "You cross the sharply arching bridge.",
-      "environment": -1,
       "exits": {
         "south": 1861,
         "north": 1864
       },
-      "weight": 1,
       "id": 1863,
       "area": {
         "id": 38
@@ -18,12 +16,10 @@
     },
     {
       "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
-      "environment": -1,
       "exits": {
         "south": 1863,
         "north": 1865
       },
-      "weight": 1,
       "id": 1864,
       "area": {
         "id": 38
@@ -31,12 +27,10 @@
     },
     {
       "name": "You step down into the sandy courtyard.",
-      "environment": -1,
       "exits": {
         "south": 1864,
         "north": 1866
       },
-      "weight": 1,
       "id": 1865,
       "area": {
         "id": 38
@@ -44,12 +38,10 @@
     },
     {
       "name": "Northwest Training Yard",
-      "environment": -1,
       "exits": {
         "south": 1865,
         "north": 1867
       },
-      "weight": 1,
       "id": 1866,
       "area": {
         "id": 38
@@ -57,12 +49,10 @@
     },
     {
       "name": "You step up onto the boardwalk that rings the practice yard.",
-      "environment": -1,
       "exits": {
         "south": 1866,
         "north": 1868
       },
-      "weight": 1,
       "id": 1867,
       "area": {
         "id": 38
@@ -70,11 +60,9 @@
     },
     {
       "name": "You slide back the fusumi with a flick of your hand.",
-      "environment": -1,
       "exits": {
         "south": 1867
       },
-      "weight": 1,
       "id": 1868,
       "area": {
         "id": 38

--- a/maps/area6.json
+++ b/maps/area6.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Entrance to Gorge",
-      "environment": -1,
       "exits": {
         "north": 507
       },
-      "weight": 1,
       "id": 506,
       "area": {
         "id": 6
@@ -17,12 +15,10 @@
     },
     {
       "name": "Narrow Gorge",
-      "environment": -1,
       "exits": {
         "west": 508,
         "south": 506
       },
-      "weight": 1,
       "id": 507,
       "area": {
         "id": 6
@@ -30,11 +26,9 @@
     },
     {
       "name": "Old Guard Room",
-      "environment": -1,
       "exits": {
         "east": 507
       },
-      "weight": 1,
       "id": 508,
       "area": {
         "id": 6

--- a/maps/area7.json
+++ b/maps/area7.json
@@ -5,20 +5,16 @@
   "rooms": [
     {
       "name": "",
-      "environment": -1,
       "id": 509,
-      "weight": 1,
       "area": {
         "id": 7
       }
     },
     {
       "name": "Barbarian Clearing",
-      "environment": -1,
       "exits": {
         "north": 511
       },
-      "weight": 1,
       "id": 510,
       "area": {
         "id": 7
@@ -26,13 +22,11 @@
     },
     {
       "name": "Underground Pond",
-      "environment": -1,
       "exits": {
         "southwest": 512,
         "west": 518,
         "south": 510
       },
-      "weight": 1,
       "id": 511,
       "area": {
         "id": 7
@@ -40,12 +34,10 @@
     },
     {
       "name": "Cave Passage",
-      "environment": -1,
       "exits": {
         "south": 513,
         "northeast": 511
       },
-      "weight": 1,
       "id": 512,
       "area": {
         "id": 7
@@ -53,12 +45,10 @@
     },
     {
       "name": "Cave Passage",
-      "environment": -1,
       "exits": {
         "south": 515,
         "north": 512
       },
-      "weight": 1,
       "id": 513,
       "area": {
         "id": 7
@@ -66,21 +56,17 @@
     },
     {
       "name": "You begin to climb into the pit, and the descent seems simple enough.",
-      "environment": -1,
       "id": 514,
-      "weight": 1,
       "area": {
         "id": 7
       }
     },
     {
       "name": "Bottom of a Deep Dark Pit",
-      "environment": -1,
       "exits": {
         "east": 516,
         "north": 513
       },
-      "weight": 1,
       "id": 515,
       "area": {
         "id": 7
@@ -88,12 +74,10 @@
     },
     {
       "name": "Dark Barricade",
-      "environment": -1,
       "exits": {
         "east": 517,
         "west": 515
       },
-      "weight": 1,
       "id": 516,
       "area": {
         "id": 7
@@ -101,12 +85,10 @@
     },
     {
       "name": "Corridor",
-      "environment": -1,
       "exits": {
         "east": 519,
         "west": 516
       },
-      "weight": 1,
       "id": 517,
       "area": {
         "id": 7
@@ -114,12 +96,10 @@
     },
     {
       "name": "Cave Passage",
-      "environment": -1,
       "exits": {
         "southwest": 1292,
         "east": 511
       },
-      "weight": 1,
       "id": 518,
       "area": {
         "id": 7
@@ -127,14 +107,12 @@
     },
     {
       "name": "Passage Way",
-      "environment": -1,
       "exits": {
         "south": 520,
         "west": 517,
         "east": 523,
         "north": 521
       },
-      "weight": 1,
       "id": 519,
       "area": {
         "id": 7
@@ -142,11 +120,9 @@
     },
     {
       "name": "Barracks",
-      "environment": -1,
       "exits": {
         "north": 519
       },
-      "weight": 1,
       "id": 520,
       "area": {
         "id": 7
@@ -154,12 +130,10 @@
     },
     {
       "name": "Mess Hall",
-      "environment": -1,
       "exits": {
         "south": 519,
         "north": 522
       },
-      "weight": 1,
       "id": 521,
       "area": {
         "id": 7
@@ -167,11 +141,9 @@
     },
     {
       "name": "Kitchen",
-      "environment": -1,
       "exits": {
         "south": 521
       },
-      "weight": 1,
       "id": 522,
       "area": {
         "id": 7
@@ -179,14 +151,12 @@
     },
     {
       "name": "Passage Way",
-      "environment": -1,
       "exits": {
         "south": 524,
         "west": 519,
         "east": 1295,
         "north": 1294
       },
-      "weight": 1,
       "id": 523,
       "area": {
         "id": 7
@@ -194,12 +164,10 @@
     },
     {
       "name": "Passage Way",
-      "environment": -1,
       "exits": {
         "south": 525,
         "north": 523
       },
-      "weight": 1,
       "id": 524,
       "area": {
         "id": 7
@@ -207,13 +175,11 @@
     },
     {
       "name": "Passage Way",
-      "environment": -1,
       "exits": {
         "west": 1293,
         "south": 526,
         "north": 524
       },
-      "weight": 1,
       "id": 525,
       "area": {
         "id": 7
@@ -221,11 +187,9 @@
     },
     {
       "name": "Circular room",
-      "environment": -1,
       "exits": {
         "north": 525
       },
-      "weight": 1,
       "id": 526,
       "area": {
         "id": 7
@@ -233,11 +197,9 @@
     },
     {
       "name": "Cave Waterfall",
-      "environment": -1,
       "exits": {
         "northeast": 518
       },
-      "weight": 1,
       "id": 1292,
       "area": {
         "id": 7
@@ -245,11 +207,9 @@
     },
     {
       "name": "Throne Room",
-      "environment": -1,
       "exits": {
         "east": 525
       },
-      "weight": 1,
       "id": 1293,
       "area": {
         "id": 7
@@ -257,11 +217,9 @@
     },
     {
       "name": "Mess Hall",
-      "environment": -1,
       "exits": {
         "south": 523
       },
-      "weight": 1,
       "id": 1294,
       "area": {
         "id": 7
@@ -269,12 +227,10 @@
     },
     {
       "name": "New Tunnel",
-      "environment": -1,
       "exits": {
         "east": 1296,
         "west": 523
       },
-      "weight": 1,
       "id": 1295,
       "area": {
         "id": 7
@@ -282,11 +238,9 @@
     },
     {
       "name": "New Tunnel",
-      "environment": -1,
       "exits": {
         "west": 1295
       },
-      "weight": 1,
       "id": 1296,
       "area": {
         "id": 7
@@ -294,14 +248,12 @@
     },
     {
       "name": "New Tunnel",
-      "environment": -1,
       "exits": {
         "south": 1299,
         "west": 1298,
         "east": 1301,
         "north": 1300
       },
-      "weight": 1,
       "id": 1297,
       "area": {
         "id": 7
@@ -309,11 +261,9 @@
     },
     {
       "name": "You pass through the door and it closes and locks behind you.",
-      "environment": -1,
       "exits": {
         "east": 1297
       },
-      "weight": 1,
       "id": 1298,
       "area": {
         "id": 7
@@ -321,11 +271,9 @@
     },
     {
       "name": "Nursery",
-      "environment": -1,
       "exits": {
         "north": 1297
       },
-      "weight": 1,
       "id": 1299,
       "area": {
         "id": 7
@@ -333,11 +281,9 @@
     },
     {
       "name": "Barracks",
-      "environment": -1,
       "exits": {
         "south": 1297
       },
-      "weight": 1,
       "id": 1300,
       "area": {
         "id": 7
@@ -345,12 +291,10 @@
     },
     {
       "name": "New Tunnel: Checkpoint",
-      "environment": -1,
       "exits": {
         "east": 1302,
         "west": 1297
       },
-      "weight": 1,
       "id": 1301,
       "area": {
         "id": 7
@@ -358,12 +302,10 @@
     },
     {
       "name": "Top of the mine shaft",
-      "environment": -1,
       "exits": {
         "down": 1303,
         "west": 1301
       },
-      "weight": 1,
       "id": 1302,
       "area": {
         "id": 7
@@ -371,12 +313,10 @@
     },
     {
       "name": "You let up on the ropes, and the counterweight slowly glides you down the",
-      "environment": -1,
       "exits": {
         "down": 1304,
         "up": 1302
       },
-      "weight": 1,
       "id": 1303,
       "area": {
         "id": 7
@@ -384,14 +324,12 @@
     },
     {
       "name": "You let up on the ropes, and the counterweight slowly glides you down the",
-      "environment": -1,
       "exits": {
         "southwest": 1305,
         "up": 1303,
         "east": 1320,
         "north": 1311
       },
-      "weight": 1,
       "id": 1304,
       "area": {
         "id": 7
@@ -399,13 +337,11 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1306,
         "northeast": 1304,
         "southeast": 1309
       },
-      "weight": 1,
       "id": 1305,
       "area": {
         "id": 7
@@ -413,13 +349,11 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northeast": 1305,
         "northwest": 1308,
         "southeast": 1307
       },
-      "weight": 1,
       "id": 1306,
       "area": {
         "id": 7
@@ -427,11 +361,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northwest": 1306
       },
-      "weight": 1,
       "id": 1307,
       "area": {
         "id": 7
@@ -439,11 +371,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southeast": 1306
       },
-      "weight": 1,
       "id": 1308,
       "area": {
         "id": 7
@@ -451,12 +381,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northwest": 1305,
         "northeast": 1310
       },
-      "weight": 1,
       "id": 1309,
       "area": {
         "id": 7
@@ -464,11 +392,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1309
       },
-      "weight": 1,
       "id": 1310,
       "area": {
         "id": 7
@@ -476,12 +402,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "south": 1304,
         "northeast": 1312
       },
-      "weight": 1,
       "id": 1311,
       "area": {
         "id": 7
@@ -489,12 +413,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1311,
         "north": 1313
       },
-      "weight": 1,
       "id": 1312,
       "area": {
         "id": 7
@@ -502,13 +424,11 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "east": 1314,
         "northwest": 1316,
         "south": 1312
       },
-      "weight": 1,
       "id": 1313,
       "area": {
         "id": 7
@@ -516,12 +436,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southeast": 1315,
         "west": 1313
       },
-      "weight": 1,
       "id": 1314,
       "area": {
         "id": 7
@@ -529,11 +447,9 @@
     },
     {
       "name": "Your left arm is now in full health.",
-      "environment": -1,
       "exits": {
         "northwest": 1314
       },
-      "weight": 1,
       "id": 1315,
       "area": {
         "id": 7
@@ -541,13 +457,11 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northeast": 1319,
         "southeast": 1313,
         "north": 1317
       },
-      "weight": 1,
       "id": 1316,
       "area": {
         "id": 7
@@ -555,12 +469,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northwest": 1318,
         "south": 1316
       },
-      "weight": 1,
       "id": 1317,
       "area": {
         "id": 7
@@ -568,11 +480,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southeast": 1317
       },
-      "weight": 1,
       "id": 1318,
       "area": {
         "id": 7
@@ -580,11 +490,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1316
       },
-      "weight": 1,
       "id": 1319,
       "area": {
         "id": 7
@@ -592,12 +500,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "west": 1304,
         "northeast": 1321
       },
-      "weight": 1,
       "id": 1320,
       "area": {
         "id": 7
@@ -605,14 +511,12 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "southwest": 1320,
         "west": 1325,
         "southeast": 1322,
         "north": 1324
       },
-      "weight": 1,
       "id": 1321,
       "area": {
         "id": 7
@@ -620,12 +524,10 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "northwest": 1321,
         "east": 1323
       },
-      "weight": 1,
       "id": 1322,
       "area": {
         "id": 7
@@ -633,11 +535,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "west": 1322
       },
-      "weight": 1,
       "id": 1323,
       "area": {
         "id": 7
@@ -645,11 +545,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "south": 1321
       },
-      "weight": 1,
       "id": 1324,
       "area": {
         "id": 7
@@ -657,11 +555,9 @@
     },
     {
       "name": "Twisting Tunnel",
-      "environment": -1,
       "exits": {
         "east": 1321
       },
-      "weight": 1,
       "id": 1325,
       "area": {
         "id": 7

--- a/maps/area8.json
+++ b/maps/area8.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "The start of a forest path",
-      "environment": -1,
       "exits": {
         "northeast": 530
       },
-      "weight": 1,
       "id": 529,
       "area": {
         "id": 8
@@ -17,13 +15,11 @@
     },
     {
       "name": "The start of a forest path",
-      "environment": -1,
       "exits": {
         "southwest": 529,
         "northeast": 531,
         "northwest": 532
       },
-      "weight": 1,
       "id": 530,
       "area": {
         "id": 8
@@ -31,13 +27,11 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 530,
         "northeast": 539,
         "east": 551
       },
-      "weight": 1,
       "id": 531,
       "area": {
         "id": 8
@@ -45,14 +39,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 535,
         "northeast": 578,
         "southeast": 530,
         "north": 533
       },
-      "weight": 1,
       "id": 532,
       "area": {
         "id": 8
@@ -60,7 +52,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 534,
         "south": 532,
@@ -69,7 +60,6 @@
         "east": 578,
         "north": 591
       },
-      "weight": 1,
       "id": 533,
       "area": {
         "id": 8
@@ -77,7 +67,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "south": 535,
         "west": 536,
@@ -85,7 +74,6 @@
         "east": 533,
         "north": 592
       },
-      "weight": 1,
       "id": 534,
       "area": {
         "id": 8
@@ -93,13 +81,11 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "northeast": 533,
         "east": 532,
         "north": 534
       },
-      "weight": 1,
       "id": 535,
       "area": {
         "id": 8
@@ -107,13 +93,11 @@
     },
     {
       "name": "River Bank",
-      "environment": -1,
       "exits": {
         "southwest": 537,
         "northeast": 592,
         "east": 534
       },
-      "weight": 1,
       "id": 536,
       "area": {
         "id": 8
@@ -121,12 +105,10 @@
     },
     {
       "name": "River Bank",
-      "environment": -1,
       "exits": {
         "southwest": 538,
         "northeast": 536
       },
-      "weight": 1,
       "id": 537,
       "area": {
         "id": 8
@@ -134,11 +116,9 @@
     },
     {
       "name": "Gryphon Nest",
-      "environment": -1,
       "exits": {
         "northeast": 537
       },
-      "weight": 1,
       "id": 538,
       "area": {
         "id": 8
@@ -146,14 +126,12 @@
     },
     {
       "name": "A clearing in the forest",
-      "environment": -1,
       "exits": {
         "southwest": 531,
         "northeast": 540,
         "east": 550,
         "south": 551
       },
-      "weight": 1,
       "id": 539,
       "area": {
         "id": 8
@@ -161,14 +139,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 539,
         "northeast": 541,
         "east": 549,
         "south": 550
       },
-      "weight": 1,
       "id": 540,
       "area": {
         "id": 8
@@ -176,7 +152,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "south": 549,
         "southwest": 540,
@@ -184,7 +159,6 @@
         "east": 548,
         "west": 575
       },
-      "weight": 1,
       "id": 541,
       "area": {
         "id": 8
@@ -192,14 +166,12 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "southwest": 541,
         "northeast": 543,
         "east": 547,
         "south": 548
       },
-      "weight": 1,
       "id": 542,
       "area": {
         "id": 8
@@ -207,14 +179,12 @@
     },
     {
       "name": "A dark forest",
-      "environment": -1,
       "exits": {
         "southwest": 542,
         "northeast": 544,
         "east": 546,
         "south": 547
       },
-      "weight": 1,
       "id": 543,
       "area": {
         "id": 8
@@ -222,13 +192,11 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "southwest": 543,
         "east": 545,
         "south": 546
       },
-      "weight": 1,
       "id": 544,
       "area": {
         "id": 8
@@ -236,14 +204,12 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "southwest": 546,
         "west": 544,
         "east": 558,
         "south": 557
       },
-      "weight": 1,
       "id": 545,
       "area": {
         "id": 8
@@ -251,7 +217,6 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "west": 543,
         "south": 556,
@@ -260,7 +225,6 @@
         "east": 557,
         "north": 544
       },
-      "weight": 1,
       "id": 546,
       "area": {
         "id": 8
@@ -268,7 +232,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 542,
         "south": 555,
@@ -277,7 +240,6 @@
         "east": 556,
         "north": 543
       },
-      "weight": 1,
       "id": 547,
       "area": {
         "id": 8
@@ -285,7 +247,6 @@
     },
     {
       "name": "A path in the forest",
-      "environment": -1,
       "exits": {
         "west": 541,
         "south": 554,
@@ -294,7 +255,6 @@
         "east": 555,
         "north": 542
       },
-      "weight": 1,
       "id": 548,
       "area": {
         "id": 8
@@ -302,7 +262,6 @@
     },
     {
       "name": "A clearing in the forest",
-      "environment": -1,
       "exits": {
         "west": 540,
         "south": 553,
@@ -311,7 +270,6 @@
         "east": 554,
         "north": 541
       },
-      "weight": 1,
       "id": 549,
       "area": {
         "id": 8
@@ -319,7 +277,6 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "west": 539,
         "south": 552,
@@ -328,7 +285,6 @@
         "east": 553,
         "north": 540
       },
-      "weight": 1,
       "id": 550,
       "area": {
         "id": 8
@@ -336,7 +292,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "south": 576,
         "west": 531,
@@ -344,7 +299,6 @@
         "east": 552,
         "north": 539
       },
-      "weight": 1,
       "id": 551,
       "area": {
         "id": 8
@@ -352,14 +306,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 551,
         "northeast": 553,
         "east": 565,
         "north": 550
       },
-      "weight": 1,
       "id": 552,
       "area": {
         "id": 8
@@ -367,7 +319,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 550,
         "south": 565,
@@ -376,7 +327,6 @@
         "east": 564,
         "north": 549
       },
-      "weight": 1,
       "id": 553,
       "area": {
         "id": 8
@@ -384,7 +334,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 549,
         "south": 564,
@@ -393,7 +342,6 @@
         "east": 563,
         "north": 548
       },
-      "weight": 1,
       "id": 554,
       "area": {
         "id": 8
@@ -401,7 +349,6 @@
     },
     {
       "name": "A path through the forest",
-      "environment": -1,
       "exits": {
         "west": 548,
         "south": 563,
@@ -410,7 +357,6 @@
         "east": 562,
         "north": 547
       },
-      "weight": 1,
       "id": 555,
       "area": {
         "id": 8
@@ -418,7 +364,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 547,
         "south": 562,
@@ -427,7 +372,6 @@
         "east": 561,
         "north": 546
       },
-      "weight": 1,
       "id": 556,
       "area": {
         "id": 8
@@ -435,7 +379,6 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "west": 546,
         "south": 561,
@@ -444,7 +387,6 @@
         "east": 560,
         "north": 545
       },
-      "weight": 1,
       "id": 557,
       "area": {
         "id": 8
@@ -452,14 +394,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 557,
         "west": 545,
         "east": 559,
         "south": 560
       },
-      "weight": 1,
       "id": 558,
       "area": {
         "id": 8
@@ -467,13 +407,11 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 560,
         "west": 558,
         "south": 573
       },
-      "weight": 1,
       "id": 559,
       "area": {
         "id": 8
@@ -481,7 +419,6 @@
     },
     {
       "name": "A path in the forest",
-      "environment": -1,
       "exits": {
         "west": 557,
         "south": 572,
@@ -490,7 +427,6 @@
         "east": 573,
         "north": 558
       },
-      "weight": 1,
       "id": 560,
       "area": {
         "id": 8
@@ -498,7 +434,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 556,
         "south": 571,
@@ -507,7 +442,6 @@
         "east": 572,
         "north": 557
       },
-      "weight": 1,
       "id": 561,
       "area": {
         "id": 8
@@ -515,7 +449,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 555,
         "south": 570,
@@ -524,7 +457,6 @@
         "east": 571,
         "north": 556
       },
-      "weight": 1,
       "id": 562,
       "area": {
         "id": 8
@@ -532,7 +464,6 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "west": 554,
         "south": 569,
@@ -541,7 +472,6 @@
         "east": 570,
         "north": 555
       },
-      "weight": 1,
       "id": 563,
       "area": {
         "id": 8
@@ -549,7 +479,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 553,
         "south": 568,
@@ -558,7 +487,6 @@
         "east": 569,
         "north": 554
       },
-      "weight": 1,
       "id": 564,
       "area": {
         "id": 8
@@ -566,7 +494,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 552,
         "south": 574,
@@ -575,7 +502,6 @@
         "east": 568,
         "north": 553
       },
-      "weight": 1,
       "id": 565,
       "area": {
         "id": 8
@@ -583,12 +509,10 @@
     },
     {
       "name": "A dark forest glade",
-      "environment": -1,
       "exits": {
         "southwest": 567,
         "northeast": 565
       },
-      "weight": 1,
       "id": 566,
       "area": {
         "id": 8
@@ -596,12 +520,10 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 601,
         "northeast": 566
       },
-      "weight": 1,
       "id": 567,
       "area": {
         "id": 8
@@ -609,14 +531,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 574,
         "northeast": 569,
         "west": 565,
         "north": 564
       },
-      "weight": 1,
       "id": 568,
       "area": {
         "id": 8
@@ -624,14 +544,12 @@
     },
     {
       "name": "A path through the forest",
-      "environment": -1,
       "exits": {
         "southwest": 568,
         "northeast": 570,
         "west": 564,
         "north": 563
       },
-      "weight": 1,
       "id": 569,
       "area": {
         "id": 8
@@ -639,14 +557,12 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "southwest": 569,
         "northeast": 571,
         "west": 563,
         "north": 562
       },
-      "weight": 1,
       "id": 570,
       "area": {
         "id": 8
@@ -654,14 +570,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 570,
         "northeast": 572,
         "west": 562,
         "north": 561
       },
-      "weight": 1,
       "id": 571,
       "area": {
         "id": 8
@@ -669,14 +583,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 571,
         "northeast": 573,
         "west": 561,
         "north": 560
       },
-      "weight": 1,
       "id": 572,
       "area": {
         "id": 8
@@ -684,13 +596,11 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 572,
         "west": 560,
         "north": 559
       },
-      "weight": 1,
       "id": 573,
       "area": {
         "id": 8
@@ -698,12 +608,10 @@
     },
     {
       "name": "Forest Glade",
-      "environment": -1,
       "exits": {
         "northeast": 568,
         "north": 565
       },
-      "weight": 1,
       "id": 574,
       "area": {
         "id": 8
@@ -711,11 +619,9 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "east": 541
       },
-      "weight": 1,
       "id": 575,
       "area": {
         "id": 8
@@ -723,12 +629,10 @@
     },
     {
       "name": "The start of a forest path",
-      "environment": -1,
       "exits": {
         "southwest": 577,
         "north": 551
       },
-      "weight": 1,
       "id": 576,
       "area": {
         "id": 8
@@ -736,11 +640,9 @@
     },
     {
       "name": "The start of a forest path",
-      "environment": -1,
       "exits": {
         "northeast": 576
       },
-      "weight": 1,
       "id": 577,
       "area": {
         "id": 8
@@ -748,7 +650,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 533,
         "southwest": 532,
@@ -756,7 +657,6 @@
         "east": 600,
         "north": 596
       },
-      "weight": 1,
       "id": 578,
       "area": {
         "id": 8
@@ -764,14 +664,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 578,
         "northeast": 580,
         "west": 596,
         "north": 597
       },
-      "weight": 1,
       "id": 579,
       "area": {
         "id": 8
@@ -779,14 +677,12 @@
     },
     {
       "name": "A clearing in the forest",
-      "environment": -1,
       "exits": {
         "southwest": 579,
         "northeast": 581,
         "west": 597,
         "north": 598
       },
-      "weight": 1,
       "id": 580,
       "area": {
         "id": 8
@@ -794,14 +690,12 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 580,
         "northeast": 582,
         "west": 598,
         "north": 585
       },
-      "weight": 1,
       "id": 581,
       "area": {
         "id": 8
@@ -809,7 +703,6 @@
     },
     {
       "name": "Forest Mound",
-      "environment": -1,
       "exits": {
         "west": 585,
         "southwest": 581,
@@ -817,7 +710,6 @@
         "east": 599,
         "north": 584
       },
-      "weight": 1,
       "id": 582,
       "area": {
         "id": 8
@@ -825,12 +717,10 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "southwest": 582,
         "west": 584
       },
-      "weight": 1,
       "id": 583,
       "area": {
         "id": 8
@@ -838,14 +728,12 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "southwest": 585,
         "west": 586,
         "east": 583,
         "south": 582
       },
-      "weight": 1,
       "id": 584,
       "area": {
         "id": 8
@@ -853,7 +741,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "south": 581,
         "west": 595,
@@ -861,7 +748,6 @@
         "east": 582,
         "north": 586
       },
-      "weight": 1,
       "id": 585,
       "area": {
         "id": 8
@@ -869,14 +755,12 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "southwest": 588,
         "west": 587,
         "east": 584,
         "south": 585
       },
-      "weight": 1,
       "id": 586,
       "area": {
         "id": 8
@@ -884,13 +768,11 @@
     },
     {
       "name": "A river bank",
-      "environment": -1,
       "exits": {
         "southwest": 595,
         "east": 586,
         "south": 588
       },
-      "weight": 1,
       "id": 587,
       "area": {
         "id": 8
@@ -898,7 +780,6 @@
     },
     {
       "name": "A dark forest glade",
-      "environment": -1,
       "exits": {
         "west": 595,
         "south": 598,
@@ -907,7 +788,6 @@
         "east": 589,
         "north": 587
       },
-      "weight": 1,
       "id": 588,
       "area": {
         "id": 8
@@ -915,7 +795,6 @@
     },
     {
       "name": "A forest glade",
-      "environment": -1,
       "exits": {
         "west": 594,
         "south": 597,
@@ -924,7 +803,6 @@
         "east": 598,
         "north": 595
       },
-      "weight": 1,
       "id": 589,
       "area": {
         "id": 8
@@ -932,7 +810,6 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "west": 593,
         "south": 596,
@@ -941,7 +818,6 @@
         "east": 597,
         "north": 594
       },
-      "weight": 1,
       "id": 590,
       "area": {
         "id": 8
@@ -949,7 +825,6 @@
     },
     {
       "name": "A forest",
-      "environment": -1,
       "exits": {
         "west": 592,
         "south": 533,
@@ -958,7 +833,6 @@
         "east": 596,
         "north": 593
       },
-      "weight": 1,
       "id": 591,
       "area": {
         "id": 8
@@ -966,14 +840,12 @@
     },
     {
       "name": "A river bank",
-      "environment": -1,
       "exits": {
         "southwest": 536,
         "northeast": 593,
         "east": 591,
         "south": 534
       },
-      "weight": 1,
       "id": 592,
       "area": {
         "id": 8
@@ -981,14 +853,12 @@
     },
     {
       "name": "A river bank",
-      "environment": -1,
       "exits": {
         "southwest": 592,
         "northeast": 594,
         "east": 590,
         "south": 591
       },
-      "weight": 1,
       "id": 593,
       "area": {
         "id": 8
@@ -996,14 +866,12 @@
     },
     {
       "name": "A riverbank",
-      "environment": -1,
       "exits": {
         "southwest": 593,
         "northeast": 595,
         "east": 589,
         "south": 590
       },
-      "weight": 1,
       "id": 594,
       "area": {
         "id": 8
@@ -1011,14 +879,12 @@
     },
     {
       "name": "A river bank",
-      "environment": -1,
       "exits": {
         "southwest": 594,
         "northeast": 587,
         "east": 585,
         "south": 589
       },
-      "weight": 1,
       "id": 595,
       "area": {
         "id": 8
@@ -1026,7 +892,6 @@
     },
     {
       "name": "A path through the forest",
-      "environment": -1,
       "exits": {
         "west": 591,
         "south": 578,
@@ -1035,7 +900,6 @@
         "east": 579,
         "north": 590
       },
-      "weight": 1,
       "id": 596,
       "area": {
         "id": 8
@@ -1043,7 +907,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 590,
         "south": 579,
@@ -1052,7 +915,6 @@
         "east": 580,
         "north": 589
       },
-      "weight": 1,
       "id": 597,
       "area": {
         "id": 8
@@ -1060,7 +922,6 @@
     },
     {
       "name": "A forest path",
-      "environment": -1,
       "exits": {
         "west": 589,
         "south": 580,
@@ -1069,7 +930,6 @@
         "east": 581,
         "north": 588
       },
-      "weight": 1,
       "id": 598,
       "area": {
         "id": 8
@@ -1077,11 +937,9 @@
     },
     {
       "name": "A small clearing",
-      "environment": -1,
       "exits": {
         "west": 582
       },
-      "weight": 1,
       "id": 599,
       "area": {
         "id": 8
@@ -1089,11 +947,9 @@
     },
     {
       "name": "Druids Guild",
-      "environment": -1,
       "exits": {
         "west": 578
       },
-      "weight": 1,
       "id": 600,
       "area": {
         "id": 8
@@ -1101,11 +957,9 @@
     },
     {
       "name": "Large home",
-      "environment": -1,
       "exits": {
         "east": 567
       },
-      "weight": 1,
       "id": 601,
       "area": {
         "id": 8

--- a/maps/balin.json
+++ b/maps/balin.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Ocean before Beachhead",
-      "environment": -1,
       "exits": {
         "north": 606
       },
-      "weight": 1,
       "id": 605,
       "area": {
         "id": 9
@@ -17,14 +15,12 @@
     },
     {
       "name": "A sandy beachhead",
-      "environment": -1,
       "exits": {
         "south": 605,
         "west": 623,
         "east": 626,
         "north": 607
       },
-      "weight": 1,
       "id": 606,
       "area": {
         "id": 9
@@ -32,13 +28,11 @@
     },
     {
       "name": "A narrow path between the dunes",
-      "environment": -1,
       "exits": {
         "south": 606,
         "east": 628,
         "north": 608
       },
-      "weight": 1,
       "id": 607,
       "area": {
         "id": 9
@@ -46,12 +40,10 @@
     },
     {
       "name": "A Dune Path",
-      "environment": -1,
       "exits": {
         "south": 607,
         "north": 609
       },
-      "weight": 1,
       "id": 608,
       "area": {
         "id": 9
@@ -59,14 +51,12 @@
     },
     {
       "name": "The City Gate",
-      "environment": -1,
       "exits": {
         "south": 608,
         "west": 631,
         "east": 634,
         "north": 610
       },
-      "weight": 1,
       "id": 609,
       "area": {
         "id": 9
@@ -74,14 +64,12 @@
     },
     {
       "name": "Intersection of Silver Street and Balin Road",
-      "environment": -1,
       "exits": {
         "south": 609,
         "west": 635,
         "east": 660,
         "north": 611
       },
-      "weight": 1,
       "id": 610,
       "area": {
         "id": 9
@@ -89,13 +77,11 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "south": 610,
         "east": 713,
         "north": 612
       },
-      "weight": 1,
       "id": 611,
       "area": {
         "id": 9
@@ -103,13 +89,11 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "south": 611,
         "east": 674,
         "north": 613
       },
-      "weight": 1,
       "id": 612,
       "area": {
         "id": 9
@@ -117,14 +101,12 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "south": 612,
         "west": 675,
         "east": 676,
         "north": 614
       },
-      "weight": 1,
       "id": 613,
       "area": {
         "id": 9
@@ -132,14 +114,12 @@
     },
     {
       "name": "A Grand Plaza",
-      "environment": -1,
       "exits": {
         "south": 613,
         "west": 678,
         "east": 677,
         "north": 615
       },
-      "weight": 1,
       "id": 614,
       "area": {
         "id": 9
@@ -147,13 +127,11 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "west": 688,
         "south": 614,
         "north": 616
       },
-      "weight": 1,
       "id": 615,
       "area": {
         "id": 9
@@ -161,13 +139,11 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "south": 615,
         "east": 689,
         "north": 617
       },
-      "weight": 1,
       "id": 616,
       "area": {
         "id": 9
@@ -175,13 +151,11 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "west": 690,
         "south": 616,
         "north": 618
       },
-      "weight": 1,
       "id": 617,
       "area": {
         "id": 9
@@ -189,14 +163,12 @@
     },
     {
       "name": "Silver Street",
-      "environment": -1,
       "exits": {
         "south": 617,
         "west": 622,
         "east": 691,
         "north": 619
       },
-      "weight": 1,
       "id": 618,
       "area": {
         "id": 9
@@ -204,12 +176,10 @@
     },
     {
       "name": "End of Silver Street",
-      "environment": -1,
       "exits": {
         "east": 620,
         "south": 618
       },
-      "weight": 1,
       "id": 619,
       "area": {
         "id": 9
@@ -217,12 +187,10 @@
     },
     {
       "name": "Island smeltery",
-      "environment": -1,
       "exits": {
         "east": 621,
         "west": 619
       },
-      "weight": 1,
       "id": 620,
       "area": {
         "id": 9
@@ -230,11 +198,9 @@
     },
     {
       "name": "Repair Shop",
-      "environment": -1,
       "exits": {
         "west": 620
       },
-      "weight": 1,
       "id": 621,
       "area": {
         "id": 9
@@ -242,21 +208,17 @@
     },
     {
       "name": "A Bloody Arena.",
-      "environment": -1,
       "id": 622,
-      "weight": 1,
       "area": {
         "id": 9
       }
     },
     {
       "name": "Western Part of Beach",
-      "environment": -1,
       "exits": {
         "east": 606,
         "west": 624
       },
-      "weight": 1,
       "id": 623,
       "area": {
         "id": 9
@@ -264,12 +226,10 @@
     },
     {
       "name": "East of the waterfall",
-      "environment": -1,
       "exits": {
         "east": 623,
         "west": 625
       },
-      "weight": 1,
       "id": 624,
       "area": {
         "id": 9
@@ -277,11 +237,9 @@
     },
     {
       "name": "The base of a waterfall",
-      "environment": -1,
       "exits": {
         "east": 624
       },
-      "weight": 1,
       "id": 625,
       "area": {
         "id": 9
@@ -289,12 +247,10 @@
     },
     {
       "name": "Ruins",
-      "environment": -1,
       "exits": {
         "east": 627,
         "west": 606
       },
-      "weight": 1,
       "id": 626,
       "area": {
         "id": 9
@@ -302,11 +258,9 @@
     },
     {
       "name": "Eastern Beach",
-      "environment": -1,
       "exits": {
         "west": 626
       },
-      "weight": 1,
       "id": 627,
       "area": {
         "id": 9
@@ -314,12 +268,10 @@
     },
     {
       "name": "A valley between two large dunes",
-      "environment": -1,
       "exits": {
         "east": 629,
         "west": 607
       },
-      "weight": 1,
       "id": 628,
       "area": {
         "id": 9
@@ -327,12 +279,10 @@
     },
     {
       "name": "A desert plain",
-      "environment": -1,
       "exits": {
         "west": 628,
         "north": 630
       },
-      "weight": 1,
       "id": 629,
       "area": {
         "id": 9
@@ -340,11 +290,9 @@
     },
     {
       "name": "A dead end",
-      "environment": -1,
       "exits": {
         "south": 629
       },
-      "weight": 1,
       "id": 630,
       "area": {
         "id": 9
@@ -352,12 +300,10 @@
     },
     {
       "name": "Guard Room",
-      "environment": -1,
       "exits": {
         "east": 609,
         "west": 632
       },
-      "weight": 1,
       "id": 631,
       "area": {
         "id": 9
@@ -365,12 +311,10 @@
     },
     {
       "name": "Armoury",
-      "environment": -1,
       "exits": {
         "east": 631,
         "west": 633
       },
-      "weight": 1,
       "id": 632,
       "area": {
         "id": 9
@@ -378,11 +322,9 @@
     },
     {
       "name": "Elderoak's Quarters",
-      "environment": -1,
       "exits": {
         "east": 632
       },
-      "weight": 1,
       "id": 633,
       "area": {
         "id": 9
@@ -390,11 +332,9 @@
     },
     {
       "name": "A guard house",
-      "environment": -1,
       "exits": {
         "west": 609
       },
-      "weight": 1,
       "id": 634,
       "area": {
         "id": 9
@@ -402,7 +342,6 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "northwest": 719,
         "south": 717,
@@ -410,7 +349,6 @@
         "east": 610,
         "west": 636
       },
-      "weight": 1,
       "id": 635,
       "area": {
         "id": 9
@@ -418,14 +356,12 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "southwest": 722,
         "east": 635,
         "southeast": 721,
         "west": 637
       },
-      "weight": 1,
       "id": 636,
       "area": {
         "id": 9
@@ -433,14 +369,12 @@
     },
     {
       "name": "West End of Balin Road",
-      "environment": -1,
       "exits": {
         "west": 638,
         "northeast": 720,
         "east": 636,
         "south": 723
       },
-      "weight": 1,
       "id": 637,
       "area": {
         "id": 9
@@ -448,12 +382,10 @@
     },
     {
       "name": "Tunnel Under Canal",
-      "environment": -1,
       "exits": {
         "east": 637,
         "west": 639
       },
-      "weight": 1,
       "id": 638,
       "area": {
         "id": 9
@@ -461,12 +393,10 @@
     },
     {
       "name": "South End of Highland Avenue",
-      "environment": -1,
       "exits": {
         "east": 638,
         "west": 640
       },
-      "weight": 1,
       "id": 639,
       "area": {
         "id": 9
@@ -474,13 +404,11 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 657,
         "east": 639,
         "north": 641
       },
-      "weight": 1,
       "id": 640,
       "area": {
         "id": 9
@@ -488,12 +416,10 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 640,
         "north": 642
       },
-      "weight": 1,
       "id": 641,
       "area": {
         "id": 9
@@ -501,12 +427,10 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "west": 643,
         "south": 641
       },
-      "weight": 1,
       "id": 642,
       "area": {
         "id": 9
@@ -514,13 +438,11 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 647,
         "east": 642,
         "north": 644
       },
-      "weight": 1,
       "id": 643,
       "area": {
         "id": 9
@@ -528,14 +450,12 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 643,
         "west": 646,
         "east": 648,
         "north": 645
       },
-      "weight": 1,
       "id": 644,
       "area": {
         "id": 9
@@ -543,11 +463,9 @@
     },
     {
       "name": "Dwarven Hut",
-      "environment": -1,
       "exits": {
         "south": 644
       },
-      "weight": 1,
       "id": 645,
       "area": {
         "id": 9
@@ -555,11 +473,9 @@
     },
     {
       "name": "You trundle past the facade and arrive on a beautiful street.",
-      "environment": -1,
       "exits": {
         "east": 644
       },
-      "weight": 1,
       "id": 646,
       "area": {
         "id": 9
@@ -567,11 +483,9 @@
     },
     {
       "name": "Gnome Hut",
-      "environment": -1,
       "exits": {
         "north": 643
       },
-      "weight": 1,
       "id": 647,
       "area": {
         "id": 9
@@ -579,14 +493,12 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 651,
         "west": 644,
         "east": 649,
         "north": 650
       },
-      "weight": 1,
       "id": 648,
       "area": {
         "id": 9
@@ -594,11 +506,9 @@
     },
     {
       "name": "Dwarven Home",
-      "environment": -1,
       "exits": {
         "west": 648
       },
-      "weight": 1,
       "id": 649,
       "area": {
         "id": 9
@@ -606,12 +516,10 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "west": 652,
         "south": 648
       },
-      "weight": 1,
       "id": 650,
       "area": {
         "id": 9
@@ -619,11 +527,9 @@
     },
     {
       "name": "Dwarven Shack",
-      "environment": -1,
       "exits": {
         "north": 648
       },
-      "weight": 1,
       "id": 651,
       "area": {
         "id": 9
@@ -631,13 +537,11 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "west": 653,
         "east": 650,
         "north": 654
       },
-      "weight": 1,
       "id": 652,
       "area": {
         "id": 9
@@ -645,12 +549,10 @@
     },
     {
       "name": "Dwarven Home",
-      "environment": -1,
       "exits": {
         "east": 652,
         "south": 656
       },
-      "weight": 1,
       "id": 653,
       "area": {
         "id": 9
@@ -658,12 +560,10 @@
     },
     {
       "name": "Highland Avenue",
-      "environment": -1,
       "exits": {
         "south": 652,
         "north": 655
       },
-      "weight": 1,
       "id": 654,
       "area": {
         "id": 9
@@ -671,12 +571,10 @@
     },
     {
       "name": "House of Balin",
-      "environment": -1,
       "exits": {
         "west": 712,
         "south": 654
       },
-      "weight": 1,
       "id": 655,
       "area": {
         "id": 9
@@ -684,11 +582,9 @@
     },
     {
       "name": "Dwarven Home",
-      "environment": -1,
       "exits": {
         "north": 653
       },
-      "weight": 1,
       "id": 656,
       "area": {
         "id": 9
@@ -696,13 +592,11 @@
     },
     {
       "name": "Keep Of Alcibiades",
-      "environment": -1,
       "exits": {
         "west": 659,
         "east": 658,
         "north": 640
       },
-      "weight": 1,
       "id": 657,
       "area": {
         "id": 9
@@ -710,11 +604,9 @@
     },
     {
       "name": "Study",
-      "environment": -1,
       "exits": {
         "west": 657
       },
-      "weight": 1,
       "id": 658,
       "area": {
         "id": 9
@@ -722,11 +614,9 @@
     },
     {
       "name": "Bedroom:",
-      "environment": -1,
       "exits": {
         "east": 657
       },
-      "weight": 1,
       "id": 659,
       "area": {
         "id": 9
@@ -734,12 +624,10 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "east": 661,
         "west": 610
       },
-      "weight": 1,
       "id": 660,
       "area": {
         "id": 9
@@ -747,13 +635,11 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "west": 660,
         "east": 662,
         "south": 673
       },
-      "weight": 1,
       "id": 661,
       "area": {
         "id": 9
@@ -761,13 +647,11 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "west": 661,
         "east": 663,
         "north": 672
       },
-      "weight": 1,
       "id": 662,
       "area": {
         "id": 9
@@ -775,14 +659,12 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "south": 670,
         "west": 662,
         "east": 664,
         "north": 671
       },
-      "weight": 1,
       "id": 663,
       "area": {
         "id": 9
@@ -790,14 +672,12 @@
     },
     {
       "name": "Balin Road",
-      "environment": -1,
       "exits": {
         "south": 667,
         "west": 663,
         "east": 665,
         "north": 668
       },
-      "weight": 1,
       "id": 664,
       "area": {
         "id": 9
@@ -805,12 +685,10 @@
     },
     {
       "name": "East End of Balin Road",
-      "environment": -1,
       "exits": {
         "west": 664,
         "south": 666
       },
-      "weight": 1,
       "id": 665,
       "area": {
         "id": 9
@@ -818,11 +696,9 @@
     },
     {
       "name": "Arched Gates",
-      "environment": -1,
       "exits": {
         "north": 665
       },
-      "weight": 1,
       "id": 666,
       "area": {
         "id": 9
@@ -830,11 +706,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "north": 664
       },
-      "weight": 1,
       "id": 667,
       "area": {
         "id": 9
@@ -842,12 +716,10 @@
     },
     {
       "name": "Island Historical Society",
-      "environment": -1,
       "exits": {
         "south": 664,
         "north": 669
       },
-      "weight": 1,
       "id": 668,
       "area": {
         "id": 9
@@ -855,11 +727,9 @@
     },
     {
       "name": "Office",
-      "environment": -1,
       "exits": {
         "south": 668
       },
-      "weight": 1,
       "id": 669,
       "area": {
         "id": 9
@@ -867,11 +737,9 @@
     },
     {
       "name": "Elven Mercantile",
-      "environment": -1,
       "exits": {
         "north": 663
       },
-      "weight": 1,
       "id": 670,
       "area": {
         "id": 9
@@ -879,12 +747,10 @@
     },
     {
       "name": "Temple Shop",
-      "environment": -1,
       "exits": {
         "west": 672,
         "south": 663
       },
-      "weight": 1,
       "id": 671,
       "area": {
         "id": 9
@@ -892,13 +758,11 @@
     },
     {
       "name": "Temple Plaza",
-      "environment": -1,
       "exits": {
         "west": 715,
         "east": 671,
         "south": 662
       },
-      "weight": 1,
       "id": 672,
       "area": {
         "id": 9
@@ -906,11 +770,9 @@
     },
     {
       "name": "Seed Shop",
-      "environment": -1,
       "exits": {
         "north": 661
       },
-      "weight": 1,
       "id": 673,
       "area": {
         "id": 9
@@ -918,11 +780,9 @@
     },
     {
       "name": "City Pastry Shop",
-      "environment": -1,
       "exits": {
         "west": 612
       },
-      "weight": 1,
       "id": 674,
       "area": {
         "id": 9
@@ -930,11 +790,9 @@
     },
     {
       "name": "Soylent Green",
-      "environment": -1,
       "exits": {
         "east": 613
       },
-      "weight": 1,
       "id": 675,
       "area": {
         "id": 9
@@ -942,12 +800,10 @@
     },
     {
       "name": "Mariner's Revenge",
-      "environment": -1,
       "exits": {
         "west": 613,
         "north": 677
       },
-      "weight": 1,
       "id": 676,
       "area": {
         "id": 9
@@ -955,14 +811,12 @@
     },
     {
       "name": "Gate House",
-      "environment": -1,
       "exits": {
         "south": 676,
         "west": 614,
         "east": 693,
         "north": 686
       },
-      "weight": 1,
       "id": 677,
       "area": {
         "id": 9
@@ -970,12 +824,10 @@
     },
     {
       "name": "Gate House",
-      "environment": -1,
       "exits": {
         "east": 614,
         "west": 679
       },
-      "weight": 1,
       "id": 678,
       "area": {
         "id": 9
@@ -983,13 +835,11 @@
     },
     {
       "name": "Foyer",
-      "environment": -1,
       "exits": {
         "south": 684,
         "east": 678,
         "north": 680
       },
-      "weight": 1,
       "id": 679,
       "area": {
         "id": 9
@@ -997,12 +847,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 679,
         "north": 681
       },
-      "weight": 1,
       "id": 680,
       "area": {
         "id": 9
@@ -1010,12 +858,10 @@
     },
     {
       "name": "Audience Hall",
-      "environment": -1,
       "exits": {
         "west": 682,
         "south": 680
       },
-      "weight": 1,
       "id": 681,
       "area": {
         "id": 9
@@ -1023,12 +869,10 @@
     },
     {
       "name": "Council Chamber",
-      "environment": -1,
       "exits": {
         "east": 681,
         "west": 683
       },
-      "weight": 1,
       "id": 682,
       "area": {
         "id": 9
@@ -1036,11 +880,9 @@
     },
     {
       "name": "Trophy Room",
-      "environment": -1,
       "exits": {
         "east": 682
       },
-      "weight": 1,
       "id": 683,
       "area": {
         "id": 9
@@ -1048,12 +890,10 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "south": 685,
         "north": 679
       },
-      "weight": 1,
       "id": 684,
       "area": {
         "id": 9
@@ -1061,11 +901,9 @@
     },
     {
       "name": "Lady Roland's Bedroom",
-      "environment": -1,
       "exits": {
         "north": 684
       },
-      "weight": 1,
       "id": 685,
       "area": {
         "id": 9
@@ -1073,12 +911,10 @@
     },
     {
       "name": "RIIS",
-      "environment": -1,
       "exits": {
         "down": 687,
         "south": 677
       },
-      "weight": 1,
       "id": 686,
       "area": {
         "id": 9
@@ -1086,11 +922,9 @@
     },
     {
       "name": "Crack of Doom",
-      "environment": -1,
       "exits": {
         "up": 686
       },
-      "weight": 1,
       "id": 687,
       "area": {
         "id": 9
@@ -1098,11 +932,9 @@
     },
     {
       "name": "Rhian's Potion Shop",
-      "environment": -1,
       "exits": {
         "east": 615
       },
-      "weight": 1,
       "id": 688,
       "area": {
         "id": 9
@@ -1110,11 +942,9 @@
     },
     {
       "name": "Alchemist Shop",
-      "environment": -1,
       "exits": {
         "west": 616
       },
-      "weight": 1,
       "id": 689,
       "area": {
         "id": 9
@@ -1122,11 +952,9 @@
     },
     {
       "name": "Entrance to the Hall of Records",
-      "environment": -1,
       "exits": {
         "east": 617
       },
-      "weight": 1,
       "id": 690,
       "area": {
         "id": 9
@@ -1134,12 +962,10 @@
     },
     {
       "name": "Power System Generator",
-      "environment": -1,
       "exits": {
         "east": 692,
         "west": 618
       },
-      "weight": 1,
       "id": 691,
       "area": {
         "id": 9
@@ -1147,11 +973,9 @@
     },
     {
       "name": "Power System Internals",
-      "environment": -1,
       "exits": {
         "west": 691
       },
-      "weight": 1,
       "id": 692,
       "area": {
         "id": 9
@@ -1159,13 +983,11 @@
     },
     {
       "name": "Entryway",
-      "environment": -1,
       "exits": {
         "west": 677,
         "south": 694,
         "north": 696
       },
-      "weight": 1,
       "id": 693,
       "area": {
         "id": 9
@@ -1173,12 +995,10 @@
     },
     {
       "name": "South Corridor",
-      "environment": -1,
       "exits": {
         "south": 695,
         "north": 693
       },
-      "weight": 1,
       "id": 694,
       "area": {
         "id": 9
@@ -1186,11 +1006,9 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "north": 694
       },
-      "weight": 1,
       "id": 695,
       "area": {
         "id": 9
@@ -1198,12 +1016,10 @@
     },
     {
       "name": "North Corridor",
-      "environment": -1,
       "exits": {
         "south": 693,
         "north": 697
       },
-      "weight": 1,
       "id": 696,
       "area": {
         "id": 9
@@ -1211,12 +1027,10 @@
     },
     {
       "name": "Guard Room",
-      "environment": -1,
       "exits": {
         "east": 698,
         "south": 696
       },
-      "weight": 1,
       "id": 697,
       "area": {
         "id": 9
@@ -1224,12 +1038,10 @@
     },
     {
       "name": "West Harem",
-      "environment": -1,
       "exits": {
         "east": 699,
         "west": 697
       },
-      "weight": 1,
       "id": 698,
       "area": {
         "id": 9
@@ -1237,12 +1049,10 @@
     },
     {
       "name": "East Harem",
-      "environment": -1,
       "exits": {
         "east": 700,
         "west": 698
       },
-      "weight": 1,
       "id": 699,
       "area": {
         "id": 9
@@ -1250,12 +1060,10 @@
     },
     {
       "name": "Bedchamber",
-      "environment": -1,
       "exits": {
         "east": 701,
         "west": 699
       },
-      "weight": 1,
       "id": 700,
       "area": {
         "id": 9
@@ -1263,12 +1071,10 @@
     },
     {
       "name": "Entryway",
-      "environment": -1,
       "exits": {
         "west": 700,
         "south": 702
       },
-      "weight": 1,
       "id": 701,
       "area": {
         "id": 9
@@ -1276,13 +1082,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "south": 703,
         "east": 708,
         "north": 701
       },
-      "weight": 1,
       "id": 702,
       "area": {
         "id": 9
@@ -1290,13 +1094,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "south": 704,
         "east": 707,
         "north": 702
       },
-      "weight": 1,
       "id": 703,
       "area": {
         "id": 9
@@ -1304,13 +1106,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "south": 705,
         "east": 706,
         "north": 703
       },
-      "weight": 1,
       "id": 704,
       "area": {
         "id": 9
@@ -1318,11 +1118,9 @@
     },
     {
       "name": "South Entryway",
-      "environment": -1,
       "exits": {
         "north": 704
       },
-      "weight": 1,
       "id": 705,
       "area": {
         "id": 9
@@ -1330,13 +1128,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "west": 704,
         "south": 710,
         "north": 707
       },
-      "weight": 1,
       "id": 706,
       "area": {
         "id": 9
@@ -1344,13 +1140,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "west": 703,
         "south": 706,
         "north": 708
       },
-      "weight": 1,
       "id": 707,
       "area": {
         "id": 9
@@ -1358,13 +1152,11 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "west": 702,
         "south": 707,
         "north": 709
       },
-      "weight": 1,
       "id": 708,
       "area": {
         "id": 9
@@ -1372,11 +1164,9 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "south": 708
       },
-      "weight": 1,
       "id": 709,
       "area": {
         "id": 9
@@ -1384,11 +1174,9 @@
     },
     {
       "name": "Turkish Bath",
-      "environment": -1,
       "exits": {
         "north": 706
       },
-      "weight": 1,
       "id": 710,
       "area": {
         "id": 9
@@ -1396,20 +1184,16 @@
     },
     {
       "name": "The hermit says: Is there anything you would like to talk about?",
-      "environment": -1,
       "id": 711,
-      "weight": 1,
       "area": {
         "id": 9
       }
     },
     {
       "name": "Hermit's Chamber",
-      "environment": -1,
       "exits": {
         "east": 655
       },
-      "weight": 1,
       "id": 712,
       "area": {
         "id": 9
@@ -1417,13 +1201,11 @@
     },
     {
       "name": "Temple",
-      "environment": -1,
       "exits": {
         "west": 611,
         "east": 714,
         "north": 716
       },
-      "weight": 1,
       "id": 713,
       "area": {
         "id": 9
@@ -1431,12 +1213,10 @@
     },
     {
       "name": "Central Chamber",
-      "environment": -1,
       "exits": {
         "east": 715,
         "west": 713
       },
-      "weight": 1,
       "id": 714,
       "area": {
         "id": 9
@@ -1444,12 +1224,10 @@
     },
     {
       "name": "Eastern Chamber",
-      "environment": -1,
       "exits": {
         "east": 672,
         "west": 714
       },
-      "weight": 1,
       "id": 715,
       "area": {
         "id": 9
@@ -1457,11 +1235,9 @@
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "environment": -1,
       "exits": {
         "south": 713
       },
-      "weight": 1,
       "id": 716,
       "area": {
         "id": 9
@@ -1469,11 +1245,9 @@
     },
     {
       "name": "Poison Shop",
-      "environment": -1,
       "exits": {
         "north": 635
       },
-      "weight": 1,
       "id": 717,
       "area": {
         "id": 9
@@ -1481,11 +1255,9 @@
     },
     {
       "name": "Taxidermist",
-      "environment": -1,
       "exits": {
         "southwest": 635
       },
-      "weight": 1,
       "id": 718,
       "area": {
         "id": 9
@@ -1493,11 +1265,9 @@
     },
     {
       "name": "Weaver's",
-      "environment": -1,
       "exits": {
         "southeast": 635
       },
-      "weight": 1,
       "id": 719,
       "area": {
         "id": 9
@@ -1505,11 +1275,9 @@
     },
     {
       "name": "Foyer of House of Ill Repute",
-      "environment": -1,
       "exits": {
         "southwest": 637
       },
-      "weight": 1,
       "id": 720,
       "area": {
         "id": 9
@@ -1517,11 +1285,9 @@
     },
     {
       "name": "Balin Road Pub",
-      "environment": -1,
       "exits": {
         "northwest": 636
       },
-      "weight": 1,
       "id": 721,
       "area": {
         "id": 9
@@ -1529,11 +1295,9 @@
     },
     {
       "name": "Wheelwright",
-      "environment": -1,
       "exits": {
         "northeast": 636
       },
-      "weight": 1,
       "id": 722,
       "area": {
         "id": 9
@@ -1541,12 +1305,10 @@
     },
     {
       "name": "Crowded Thoroughfare",
-      "environment": -1,
       "exits": {
         "south": 724,
         "north": 637
       },
-      "weight": 1,
       "id": 723,
       "area": {
         "id": 9
@@ -1554,12 +1316,10 @@
     },
     {
       "name": "Archway of Servitude",
-      "environment": -1,
       "exits": {
         "south": 725,
         "north": 723
       },
-      "weight": 1,
       "id": 724,
       "area": {
         "id": 9
@@ -1567,13 +1327,11 @@
     },
     {
       "name": "Bazaar Crossroad",
-      "environment": -1,
       "exits": {
         "west": 726,
         "east": 729,
         "north": 724
       },
-      "weight": 1,
       "id": 725,
       "area": {
         "id": 9
@@ -1581,12 +1339,10 @@
     },
     {
       "name": "Western District",
-      "environment": -1,
       "exits": {
         "east": 725,
         "south": 727
       },
-      "weight": 1,
       "id": 726,
       "area": {
         "id": 9
@@ -1594,12 +1350,10 @@
     },
     {
       "name": "Western District",
-      "environment": -1,
       "exits": {
         "south": 728,
         "north": 726
       },
-      "weight": 1,
       "id": 727,
       "area": {
         "id": 9
@@ -1607,12 +1361,10 @@
     },
     {
       "name": "Western slave bazaar",
-      "environment": -1,
       "exits": {
         "east": 732,
         "north": 727
       },
-      "weight": 1,
       "id": 728,
       "area": {
         "id": 9
@@ -1620,12 +1372,10 @@
     },
     {
       "name": "Eastern District",
-      "environment": -1,
       "exits": {
         "west": 725,
         "south": 730
       },
-      "weight": 1,
       "id": 729,
       "area": {
         "id": 9
@@ -1633,12 +1383,10 @@
     },
     {
       "name": "Eastern District",
-      "environment": -1,
       "exits": {
         "south": 731,
         "north": 729
       },
-      "weight": 1,
       "id": 730,
       "area": {
         "id": 9
@@ -1646,12 +1394,10 @@
     },
     {
       "name": "Eastern slave bazaar",
-      "environment": -1,
       "exits": {
         "west": 732,
         "north": 730
       },
-      "weight": 1,
       "id": 731,
       "area": {
         "id": 9
@@ -1659,13 +1405,11 @@
     },
     {
       "name": "Central slave bazaar",
-      "environment": -1,
       "exits": {
         "west": 728,
         "east": 731,
         "south": 733
       },
-      "weight": 1,
       "id": 732,
       "area": {
         "id": 9
@@ -1673,11 +1417,9 @@
     },
     {
       "name": "Administrative hallway",
-      "environment": -1,
       "exits": {
         "north": 732
       },
-      "weight": 1,
       "id": 733,
       "area": {
         "id": 9

--- a/maps/candera.json
+++ b/maps/candera.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "North Gate",
-      "environment": -1,
       "exits": {
         "west": 56,
         "east": 2,
         "south": 57
       },
-      "weight": 1,
       "id": 1,
       "area": {
         "id": 1
@@ -19,12 +17,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 3,
         "west": 1
       },
-      "weight": 1,
       "id": 2,
       "area": {
         "id": 1
@@ -32,12 +28,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 4,
         "west": 2
       },
-      "weight": 1,
       "id": 3,
       "area": {
         "id": 1
@@ -45,12 +39,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 5,
         "west": 3
       },
-      "weight": 1,
       "id": 4,
       "area": {
         "id": 1
@@ -58,12 +50,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 6,
         "west": 4
       },
-      "weight": 1,
       "id": 5,
       "area": {
         "id": 1
@@ -71,12 +61,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 7,
         "west": 5
       },
-      "weight": 1,
       "id": 6,
       "area": {
         "id": 1
@@ -84,12 +72,10 @@
     },
     {
       "name": "Entrance to the Northeast Tower",
-      "environment": -1,
       "exits": {
         "east": 8,
         "west": 6
       },
-      "weight": 1,
       "id": 7,
       "area": {
         "id": 1
@@ -97,12 +83,10 @@
     },
     {
       "name": "Northeast Corner",
-      "environment": -1,
       "exits": {
         "west": 7,
         "south": 9
       },
-      "weight": 1,
       "id": 8,
       "area": {
         "id": 1
@@ -110,12 +94,10 @@
     },
     {
       "name": "Entrance to the Northeast Tower",
-      "environment": -1,
       "exits": {
         "south": 10,
         "north": 8
       },
-      "weight": 1,
       "id": 9,
       "area": {
         "id": 1
@@ -123,12 +105,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 11,
         "north": 9
       },
-      "weight": 1,
       "id": 10,
       "area": {
         "id": 1
@@ -136,12 +116,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 12,
         "north": 10
       },
-      "weight": 1,
       "id": 11,
       "area": {
         "id": 1
@@ -149,12 +127,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 13,
         "north": 11
       },
-      "weight": 1,
       "id": 12,
       "area": {
         "id": 1
@@ -162,12 +138,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 14,
         "north": 12
       },
-      "weight": 1,
       "id": 13,
       "area": {
         "id": 1
@@ -175,12 +149,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 15,
         "north": 13
       },
-      "weight": 1,
       "id": 14,
       "area": {
         "id": 1
@@ -188,13 +160,11 @@
     },
     {
       "name": "East Wall Guard Station",
-      "environment": -1,
       "exits": {
         "south": 16,
         "east": 973,
         "north": 14
       },
-      "weight": 1,
       "id": 15,
       "area": {
         "id": 1
@@ -202,12 +172,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 17,
         "north": 15
       },
-      "weight": 1,
       "id": 16,
       "area": {
         "id": 1
@@ -215,12 +183,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 18,
         "north": 16
       },
-      "weight": 1,
       "id": 17,
       "area": {
         "id": 1
@@ -228,12 +194,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 19,
         "north": 17
       },
-      "weight": 1,
       "id": 18,
       "area": {
         "id": 1
@@ -241,12 +205,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 20,
         "north": 18
       },
-      "weight": 1,
       "id": 19,
       "area": {
         "id": 1
@@ -254,12 +216,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 21,
         "north": 19
       },
-      "weight": 1,
       "id": 20,
       "area": {
         "id": 1
@@ -267,12 +227,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 22,
         "north": 20
       },
-      "weight": 1,
       "id": 21,
       "area": {
         "id": 1
@@ -280,12 +238,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "west": 23,
         "north": 21
       },
-      "weight": 1,
       "id": 22,
       "area": {
         "id": 1
@@ -293,12 +249,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 22,
         "west": 24
       },
-      "weight": 1,
       "id": 23,
       "area": {
         "id": 1
@@ -306,12 +260,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 23,
         "west": 25
       },
-      "weight": 1,
       "id": 24,
       "area": {
         "id": 1
@@ -319,12 +271,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 24,
         "west": 26
       },
-      "weight": 1,
       "id": 25,
       "area": {
         "id": 1
@@ -332,12 +282,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 25,
         "west": 27
       },
-      "weight": 1,
       "id": 26,
       "area": {
         "id": 1
@@ -345,12 +293,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 26,
         "west": 28
       },
-      "weight": 1,
       "id": 27,
       "area": {
         "id": 1
@@ -358,12 +304,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 27,
         "west": 29
       },
-      "weight": 1,
       "id": 28,
       "area": {
         "id": 1
@@ -371,13 +315,11 @@
     },
     {
       "name": "South Wall Guard Station",
-      "environment": -1,
       "exits": {
         "west": 30,
         "east": 28,
         "south": 1030
       },
-      "weight": 1,
       "id": 29,
       "area": {
         "id": 1
@@ -385,12 +327,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 29,
         "west": 31
       },
-      "weight": 1,
       "id": 30,
       "area": {
         "id": 1
@@ -398,12 +338,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 30,
         "west": 32
       },
-      "weight": 1,
       "id": 31,
       "area": {
         "id": 1
@@ -411,12 +349,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 31,
         "west": 33
       },
-      "weight": 1,
       "id": 32,
       "area": {
         "id": 1
@@ -424,12 +360,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 32,
         "west": 34
       },
-      "weight": 1,
       "id": 33,
       "area": {
         "id": 1
@@ -437,12 +371,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 33,
         "west": 35
       },
-      "weight": 1,
       "id": 34,
       "area": {
         "id": 1
@@ -450,12 +382,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 34,
         "west": 36
       },
-      "weight": 1,
       "id": 35,
       "area": {
         "id": 1
@@ -463,12 +393,10 @@
     },
     {
       "name": "Southwest Corner",
-      "environment": -1,
       "exits": {
         "east": 35,
         "north": 37
       },
-      "weight": 1,
       "id": 36,
       "area": {
         "id": 1
@@ -476,12 +404,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 36,
         "north": 38
       },
-      "weight": 1,
       "id": 37,
       "area": {
         "id": 1
@@ -489,12 +415,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 37,
         "north": 39
       },
-      "weight": 1,
       "id": 38,
       "area": {
         "id": 1
@@ -502,12 +426,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 38,
         "north": 40
       },
-      "weight": 1,
       "id": 39,
       "area": {
         "id": 1
@@ -515,12 +437,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 39,
         "north": 41
       },
-      "weight": 1,
       "id": 40,
       "area": {
         "id": 1
@@ -528,12 +448,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 40,
         "north": 42
       },
-      "weight": 1,
       "id": 41,
       "area": {
         "id": 1
@@ -541,12 +459,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 41,
         "north": 43
       },
-      "weight": 1,
       "id": 42,
       "area": {
         "id": 1
@@ -554,13 +470,11 @@
     },
     {
       "name": "West Wall Guard Station",
-      "environment": -1,
       "exits": {
         "west": 1033,
         "south": 42,
         "north": 44
       },
-      "weight": 1,
       "id": 43,
       "area": {
         "id": 1
@@ -568,12 +482,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 43,
         "north": 45
       },
-      "weight": 1,
       "id": 44,
       "area": {
         "id": 1
@@ -581,12 +493,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 44,
         "north": 46
       },
-      "weight": 1,
       "id": 45,
       "area": {
         "id": 1
@@ -594,12 +504,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 45,
         "north": 47
       },
-      "weight": 1,
       "id": 46,
       "area": {
         "id": 1
@@ -607,12 +515,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 46,
         "north": 48
       },
-      "weight": 1,
       "id": 47,
       "area": {
         "id": 1
@@ -620,12 +526,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "south": 47,
         "north": 49
       },
-      "weight": 1,
       "id": 48,
       "area": {
         "id": 1
@@ -633,12 +537,10 @@
     },
     {
       "name": "Entrance to the Northwest Tower",
-      "environment": -1,
       "exits": {
         "south": 48,
         "north": 50
       },
-      "weight": 1,
       "id": 49,
       "area": {
         "id": 1
@@ -646,12 +548,10 @@
     },
     {
       "name": "Northwest Corner",
-      "environment": -1,
       "exits": {
         "east": 51,
         "south": 49
       },
-      "weight": 1,
       "id": 50,
       "area": {
         "id": 1
@@ -659,12 +559,10 @@
     },
     {
       "name": "Entrance to the Northwest Tower",
-      "environment": -1,
       "exits": {
         "east": 52,
         "west": 50
       },
-      "weight": 1,
       "id": 51,
       "area": {
         "id": 1
@@ -672,12 +570,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 53,
         "west": 51
       },
-      "weight": 1,
       "id": 52,
       "area": {
         "id": 1
@@ -685,12 +581,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 54,
         "west": 52
       },
-      "weight": 1,
       "id": 53,
       "area": {
         "id": 1
@@ -698,12 +592,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 55,
         "west": 53
       },
-      "weight": 1,
       "id": 54,
       "area": {
         "id": 1
@@ -711,12 +603,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 56,
         "west": 54
       },
-      "weight": 1,
       "id": 55,
       "area": {
         "id": 1
@@ -724,12 +614,10 @@
     },
     {
       "name": "New Outer Wall",
-      "environment": -1,
       "exits": {
         "east": 1,
         "west": 55
       },
-      "weight": 1,
       "id": 56,
       "area": {
         "id": 1
@@ -737,14 +625,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 58,
         "west": 963,
         "east": 964,
         "north": 1
       },
-      "weight": 1,
       "id": 57,
       "area": {
         "id": 1
@@ -752,14 +638,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 59,
         "west": 965,
         "east": 966,
         "north": 57
       },
-      "weight": 1,
       "id": 58,
       "area": {
         "id": 1
@@ -767,13 +651,11 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "west": 967,
         "south": 60,
         "north": 58
       },
-      "weight": 1,
       "id": 59,
       "area": {
         "id": 1
@@ -781,14 +663,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 61,
         "west": 968,
         "east": 969,
         "north": 59
       },
-      "weight": 1,
       "id": 60,
       "area": {
         "id": 1
@@ -796,13 +676,11 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "west": 970,
         "south": 62,
         "north": 60
       },
-      "weight": 1,
       "id": 61,
       "area": {
         "id": 1
@@ -810,14 +688,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 63,
         "west": 971,
         "east": 972,
         "north": 61
       },
-      "weight": 1,
       "id": 62,
       "area": {
         "id": 1
@@ -825,14 +701,12 @@
     },
     {
       "name": "Canderan Well",
-      "environment": -1,
       "exits": {
         "south": 64,
         "west": 72,
         "east": 94,
         "north": 62
       },
-      "weight": 1,
       "id": 63,
       "area": {
         "id": 1
@@ -840,14 +714,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 65,
         "west": 429,
         "east": 427,
         "north": 63
       },
-      "weight": 1,
       "id": 64,
       "area": {
         "id": 1
@@ -855,14 +727,12 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 66,
         "west": 430,
         "east": 1015,
         "north": 64
       },
-      "weight": 1,
       "id": 65,
       "area": {
         "id": 1
@@ -870,12 +740,10 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 67,
         "north": 65
       },
-      "weight": 1,
       "id": 66,
       "area": {
         "id": 1
@@ -883,12 +751,10 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 68,
         "north": 66
       },
-      "weight": 1,
       "id": 67,
       "area": {
         "id": 1
@@ -896,13 +762,11 @@
     },
     {
       "name": "Warrior's Walk",
-      "environment": -1,
       "exits": {
         "south": 69,
         "east": 431,
         "north": 67
       },
-      "weight": 1,
       "id": 68,
       "area": {
         "id": 1
@@ -910,14 +774,12 @@
     },
     {
       "name": "House of Lord Candera",
-      "environment": -1,
       "exits": {
         "up": 1134,
         "west": 70,
         "east": 71,
         "north": 68
       },
-      "weight": 1,
       "id": 69,
       "area": {
         "id": 1
@@ -925,11 +787,9 @@
     },
     {
       "name": "House of Lord Candera",
-      "environment": -1,
       "exits": {
         "east": 69
       },
-      "weight": 1,
       "id": 70,
       "area": {
         "id": 1
@@ -937,11 +797,9 @@
     },
     {
       "name": "House of Lord Candera",
-      "environment": -1,
       "exits": {
         "west": 69
       },
-      "weight": 1,
       "id": 71,
       "area": {
         "id": 1
@@ -949,13 +807,11 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "west": 73,
         "east": 63,
         "south": 429
       },
-      "weight": 1,
       "id": 72,
       "area": {
         "id": 1
@@ -963,14 +819,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 1016,
         "west": 74,
         "east": 72,
         "north": 1017
       },
-      "weight": 1,
       "id": 73,
       "area": {
         "id": 1
@@ -978,14 +832,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 1019,
         "west": 75,
         "east": 73,
         "north": 1018
       },
-      "weight": 1,
       "id": 74,
       "area": {
         "id": 1
@@ -993,13 +845,11 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "west": 76,
         "east": 74,
         "south": 1095
       },
-      "weight": 1,
       "id": 75,
       "area": {
         "id": 1
@@ -1007,14 +857,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 78,
         "west": 77,
         "east": 75,
         "north": 86
       },
-      "weight": 1,
       "id": 76,
       "area": {
         "id": 1
@@ -1022,12 +870,10 @@
     },
     {
       "name": "Zoman's Flat",
-      "environment": -1,
       "exits": {
         "south": 79,
         "north": 76
       },
-      "weight": 1,
       "id": 78,
       "area": {
         "id": 1
@@ -1035,13 +881,11 @@
     },
     {
       "name": "Zoman's Flat",
-      "environment": -1,
       "exits": {
         "south": 80,
         "east": 1096,
         "north": 78
       },
-      "weight": 1,
       "id": 79,
       "area": {
         "id": 1
@@ -1049,12 +893,10 @@
     },
     {
       "name": "Zoman's Flat",
-      "environment": -1,
       "exits": {
         "south": 81,
         "north": 79
       },
-      "weight": 1,
       "id": 80,
       "area": {
         "id": 1
@@ -1062,12 +904,10 @@
     },
     {
       "name": "Zoman's Flat",
-      "environment": -1,
       "exits": {
         "south": 82,
         "north": 80
       },
-      "weight": 1,
       "id": 81,
       "area": {
         "id": 1
@@ -1075,14 +915,12 @@
     },
     {
       "name": "Zoman's Flat",
-      "environment": -1,
       "exits": {
         "south": 83,
         "west": 1097,
         "east": 1098,
         "north": 81
       },
-      "weight": 1,
       "id": 82,
       "area": {
         "id": 1
@@ -1090,13 +928,11 @@
     },
     {
       "name": "Temple of Air",
-      "environment": -1,
       "exits": {
         "west": 84,
         "east": 85,
         "north": 82
       },
-      "weight": 1,
       "id": 83,
       "area": {
         "id": 1
@@ -1104,12 +940,10 @@
     },
     {
       "name": "Temple of Air",
-      "environment": -1,
       "exits": {
         "east": 83,
         "up": 1130
       },
-      "weight": 1,
       "id": 84,
       "area": {
         "id": 1
@@ -1117,12 +951,10 @@
     },
     {
       "name": "Temple of Air",
-      "environment": -1,
       "exits": {
         "up": 1131,
         "west": 83
       },
-      "weight": 1,
       "id": 85,
       "area": {
         "id": 1
@@ -1130,12 +962,10 @@
     },
     {
       "name": "Suran's Flat",
-      "environment": -1,
       "exits": {
         "south": 76,
         "north": 87
       },
-      "weight": 1,
       "id": 86,
       "area": {
         "id": 1
@@ -1143,13 +973,11 @@
     },
     {
       "name": "Suran's Flat",
-      "environment": -1,
       "exits": {
         "west": 1082,
         "south": 86,
         "north": 88
       },
-      "weight": 1,
       "id": 87,
       "area": {
         "id": 1
@@ -1157,12 +985,10 @@
     },
     {
       "name": "Suran's Flat",
-      "environment": -1,
       "exits": {
         "south": 87,
         "north": 89
       },
-      "weight": 1,
       "id": 88,
       "area": {
         "id": 1
@@ -1170,12 +996,10 @@
     },
     {
       "name": "Suran's Flat",
-      "environment": -1,
       "exits": {
         "south": 88,
         "north": 90
       },
-      "weight": 1,
       "id": 89,
       "area": {
         "id": 1
@@ -1183,14 +1007,12 @@
     },
     {
       "name": "Suran's Flat",
-      "environment": -1,
       "exits": {
         "south": 89,
         "west": 1093,
         "east": 1094,
         "north": 91
       },
-      "weight": 1,
       "id": 90,
       "area": {
         "id": 1
@@ -1198,13 +1020,11 @@
     },
     {
       "name": "Temple of Water",
-      "environment": -1,
       "exits": {
         "west": 92,
         "east": 93,
         "south": 90
       },
-      "weight": 1,
       "id": 91,
       "area": {
         "id": 1
@@ -1212,12 +1032,10 @@
     },
     {
       "name": "Temple of Water",
-      "environment": -1,
       "exits": {
         "east": 91,
         "up": 1132
       },
-      "weight": 1,
       "id": 92,
       "area": {
         "id": 1
@@ -1225,12 +1043,10 @@
     },
     {
       "name": "Temple of Water",
-      "environment": -1,
       "exits": {
         "up": 1133,
         "west": 91
       },
-      "weight": 1,
       "id": 93,
       "area": {
         "id": 1
@@ -1238,14 +1054,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 427,
         "west": 63,
         "east": 95,
         "north": 972
       },
-      "weight": 1,
       "id": 94,
       "area": {
         "id": 1
@@ -1253,13 +1067,11 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "west": 94,
         "east": 96,
         "south": 975
       },
-      "weight": 1,
       "id": 95,
       "area": {
         "id": 1
@@ -1267,14 +1079,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 976,
         "west": 95,
         "east": 97,
         "north": 977
       },
-      "weight": 1,
       "id": 96,
       "area": {
         "id": 1
@@ -1282,13 +1092,11 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "west": 96,
         "east": 98,
         "north": 428
       },
-      "weight": 1,
       "id": 97,
       "area": {
         "id": 1
@@ -1296,14 +1104,12 @@
     },
     {
       "name": "Clansmen Way",
-      "environment": -1,
       "exits": {
         "south": 99,
         "west": 97,
         "east": 1000,
         "north": 107
       },
-      "weight": 1,
       "id": 98,
       "area": {
         "id": 1
@@ -1311,12 +1117,10 @@
     },
     {
       "name": "Fallah's Flat:",
-      "environment": -1,
       "exits": {
         "south": 100,
         "north": 98
       },
-      "weight": 1,
       "id": 99,
       "area": {
         "id": 1
@@ -1324,14 +1128,12 @@
     },
     {
       "name": "Fallah's Flat:",
-      "environment": -1,
       "exits": {
         "south": 101,
         "west": 505,
         "east": 997,
         "north": 99
       },
-      "weight": 1,
       "id": 100,
       "area": {
         "id": 1
@@ -1339,12 +1141,10 @@
     },
     {
       "name": "Fallah's Flat",
-      "environment": -1,
       "exits": {
         "south": 102,
         "north": 100
       },
-      "weight": 1,
       "id": 101,
       "area": {
         "id": 1
@@ -1352,12 +1152,10 @@
     },
     {
       "name": "Fallah's Flat",
-      "environment": -1,
       "exits": {
         "south": 103,
         "north": 101
       },
-      "weight": 1,
       "id": 102,
       "area": {
         "id": 1
@@ -1365,14 +1163,12 @@
     },
     {
       "name": "Fallah's Flat:",
-      "environment": -1,
       "exits": {
         "south": 104,
         "west": 998,
         "east": 999,
         "north": 102
       },
-      "weight": 1,
       "id": 103,
       "area": {
         "id": 1
@@ -1380,13 +1176,11 @@
     },
     {
       "name": "Temple of Earth",
-      "environment": -1,
       "exits": {
         "west": 105,
         "east": 106,
         "north": 103
       },
-      "weight": 1,
       "id": 104,
       "area": {
         "id": 1
@@ -1394,12 +1188,10 @@
     },
     {
       "name": "Temple of Earth",
-      "environment": -1,
       "exits": {
         "east": 104,
         "up": 1127
       },
-      "weight": 1,
       "id": 105,
       "area": {
         "id": 1
@@ -1407,12 +1199,10 @@
     },
     {
       "name": "Temple of Earth",
-      "environment": -1,
       "exits": {
         "up": 1126,
         "west": 104
       },
-      "weight": 1,
       "id": 106,
       "area": {
         "id": 1
@@ -1420,12 +1210,10 @@
     },
     {
       "name": "Phaekads Flat:",
-      "environment": -1,
       "exits": {
         "south": 98,
         "north": 108
       },
-      "weight": 1,
       "id": 107,
       "area": {
         "id": 1
@@ -1433,12 +1221,10 @@
     },
     {
       "name": "Phaekads Flat:",
-      "environment": -1,
       "exits": {
         "south": 107,
         "north": 109
       },
-      "weight": 1,
       "id": 108,
       "area": {
         "id": 1
@@ -1446,12 +1232,10 @@
     },
     {
       "name": "Phaekads Flat",
-      "environment": -1,
       "exits": {
         "south": 108,
         "north": 110
       },
-      "weight": 1,
       "id": 109,
       "area": {
         "id": 1
@@ -1459,12 +1243,10 @@
     },
     {
       "name": "Phaekads Flat",
-      "environment": -1,
       "exits": {
         "south": 109,
         "north": 111
       },
-      "weight": 1,
       "id": 110,
       "area": {
         "id": 1
@@ -1472,13 +1254,11 @@
     },
     {
       "name": "Phaekads Flat:",
-      "environment": -1,
       "exits": {
         "south": 110,
         "east": 996,
         "north": 112
       },
-      "weight": 1,
       "id": 111,
       "area": {
         "id": 1
@@ -1486,13 +1266,11 @@
     },
     {
       "name": "Temple of Fire",
-      "environment": -1,
       "exits": {
         "west": 113,
         "east": 114,
         "south": 111
       },
-      "weight": 1,
       "id": 112,
       "area": {
         "id": 1
@@ -1500,12 +1278,10 @@
     },
     {
       "name": "Temple of Fire",
-      "environment": -1,
       "exits": {
         "east": 112,
         "up": 1129
       },
-      "weight": 1,
       "id": 113,
       "area": {
         "id": 1
@@ -1513,12 +1289,10 @@
     },
     {
       "name": "Temple of Fire",
-      "environment": -1,
       "exits": {
         "up": 1128,
         "west": 112
       },
-      "weight": 1,
       "id": 114,
       "area": {
         "id": 1
@@ -1526,12 +1300,10 @@
     },
     {
       "name": "The Rabbit's Hole",
-      "environment": -1,
       "exits": {
         "west": 64,
         "north": 94
       },
-      "weight": 1,
       "id": 427,
       "area": {
         "id": 1
@@ -1539,12 +1311,10 @@
     },
     {
       "name": "6 Feet Under",
-      "environment": -1,
       "exits": {
         "west": 977,
         "south": 97
       },
-      "weight": 1,
       "id": 428,
       "area": {
         "id": 1
@@ -1552,12 +1322,10 @@
     },
     {
       "name": "Morbid Curiosity",
-      "environment": -1,
       "exits": {
         "east": 64,
         "north": 72
       },
-      "weight": 1,
       "id": 429,
       "area": {
         "id": 1
@@ -1565,11 +1333,9 @@
     },
     {
       "name": "Scribe",
-      "environment": -1,
       "exits": {
         "east": 65
       },
-      "weight": 1,
       "id": 430,
       "area": {
         "id": 1
@@ -1577,11 +1343,9 @@
     },
     {
       "name": "Servants Quarters",
-      "environment": -1,
       "exits": {
         "west": 68
       },
-      "weight": 1,
       "id": 431,
       "area": {
         "id": 1
@@ -1589,11 +1353,9 @@
     },
     {
       "name": "Slave Auction:",
-      "environment": -1,
       "exits": {
         "east": 100
       },
-      "weight": 1,
       "id": 505,
       "area": {
         "id": 1
@@ -1601,12 +1363,10 @@
     },
     {
       "name": "Eastern Entrance",
-      "environment": -1,
       "exits": {
         "east": 57,
         "west": 1027
       },
-      "weight": 1,
       "id": 963,
       "area": {
         "id": 1
@@ -1614,11 +1374,9 @@
     },
     {
       "name": "Widow's House",
-      "environment": -1,
       "exits": {
         "west": 57
       },
-      "weight": 1,
       "id": 964,
       "area": {
         "id": 1
@@ -1626,11 +1384,9 @@
     },
     {
       "name": "A Jeweler's Shop",
-      "environment": -1,
       "exits": {
         "east": 58
       },
-      "weight": 1,
       "id": 965,
       "area": {
         "id": 1
@@ -1638,12 +1394,10 @@
     },
     {
       "name": "Farmer's Smith",
-      "environment": -1,
       "exits": {
         "east": 989,
         "west": 58
       },
-      "weight": 1,
       "id": 966,
       "area": {
         "id": 1
@@ -1651,12 +1405,10 @@
     },
     {
       "name": "Candera Information Bureau",
-      "environment": -1,
       "exits": {
         "east": 59,
         "north": 1125
       },
-      "weight": 1,
       "id": 967,
       "area": {
         "id": 1
@@ -1664,11 +1416,9 @@
     },
     {
       "name": "Lizard Skin Trader",
-      "environment": -1,
       "exits": {
         "east": 60
       },
-      "weight": 1,
       "id": 968,
       "area": {
         "id": 1
@@ -1676,11 +1426,9 @@
     },
     {
       "name": "Shaman's Shack",
-      "environment": -1,
       "exits": {
         "west": 60
       },
-      "weight": 1,
       "id": 969,
       "area": {
         "id": 1
@@ -1688,11 +1436,9 @@
     },
     {
       "name": "Silk Shop",
-      "environment": -1,
       "exits": {
         "east": 61
       },
-      "weight": 1,
       "id": 970,
       "area": {
         "id": 1
@@ -1700,11 +1446,9 @@
     },
     {
       "name": "Barbarian's Guild",
-      "environment": -1,
       "exits": {
         "east": 62
       },
-      "weight": 1,
       "id": 971,
       "area": {
         "id": 1
@@ -1712,12 +1456,10 @@
     },
     {
       "name": "Trader's Shack",
-      "environment": -1,
       "exits": {
         "west": 62,
         "south": 94
       },
-      "weight": 1,
       "id": 972,
       "area": {
         "id": 1
@@ -1725,13 +1467,11 @@
     },
     {
       "name": "East Wall Guard Station",
-      "environment": -1,
       "exits": {
         "west": 15,
         "south": 974,
         "north": 986
       },
-      "weight": 1,
       "id": 973,
       "area": {
         "id": 1
@@ -1739,11 +1479,9 @@
     },
     {
       "name": "Living Quarters",
-      "environment": -1,
       "exits": {
         "north": 973
       },
-      "weight": 1,
       "id": 974,
       "area": {
         "id": 1
@@ -1751,11 +1489,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "north": 95
       },
-      "weight": 1,
       "id": 975,
       "area": {
         "id": 1
@@ -1763,11 +1499,9 @@
     },
     {
       "name": "Back Alley",
-      "environment": -1,
       "exits": {
         "north": 96
       },
-      "weight": 1,
       "id": 976,
       "area": {
         "id": 1
@@ -1775,11 +1509,9 @@
     },
     {
       "name": "Sleeping Quarters",
-      "environment": -1,
       "exits": {
         "south": 973
       },
-      "weight": 1,
       "id": 986,
       "area": {
         "id": 1
@@ -1787,11 +1519,9 @@
     },
     {
       "name": "Candera Priest's Hut",
-      "environment": -1,
       "exits": {
         "west": 111
       },
-      "weight": 1,
       "id": 996,
       "area": {
         "id": 1
@@ -1799,11 +1529,9 @@
     },
     {
       "name": "Pillow Shop:",
-      "environment": -1,
       "exits": {
         "west": 100
       },
-      "weight": 1,
       "id": 997,
       "area": {
         "id": 1
@@ -1811,11 +1539,9 @@
     },
     {
       "name": "Relic Shop:",
-      "environment": -1,
       "exits": {
         "east": 103
       },
-      "weight": 1,
       "id": 998,
       "area": {
         "id": 1
@@ -1823,11 +1549,9 @@
     },
     {
       "name": "Butcher Shop:",
-      "environment": -1,
       "exits": {
         "west": 103
       },
-      "weight": 1,
       "id": 999,
       "area": {
         "id": 1
@@ -1835,11 +1559,9 @@
     },
     {
       "name": "Snake Charmer",
-      "environment": -1,
       "exits": {
         "west": 65
       },
-      "weight": 1,
       "id": 1015,
       "area": {
         "id": 1
@@ -1847,11 +1569,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "north": 73
       },
-      "weight": 1,
       "id": 1016,
       "area": {
         "id": 1
@@ -1859,12 +1579,10 @@
     },
     {
       "name": "Kaimuki Q's",
-      "environment": -1,
       "exits": {
         "west": 1018,
         "south": 73
       },
-      "weight": 1,
       "id": 1017,
       "area": {
         "id": 1
@@ -1872,11 +1590,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "north": 74
       },
-      "weight": 1,
       "id": 1019,
       "area": {
         "id": 1
@@ -1884,13 +1600,11 @@
     },
     {
       "name": "South Wall Guard Station",
-      "environment": -1,
       "exits": {
         "west": 1031,
         "east": 1032,
         "north": 29
       },
-      "weight": 1,
       "id": 1030,
       "area": {
         "id": 1
@@ -1898,11 +1612,9 @@
     },
     {
       "name": "Living Quarters",
-      "environment": -1,
       "exits": {
         "east": 1030
       },
-      "weight": 1,
       "id": 1031,
       "area": {
         "id": 1
@@ -1910,11 +1622,9 @@
     },
     {
       "name": "Sleeping Quarters",
-      "environment": -1,
       "exits": {
         "west": 1030
       },
-      "weight": 1,
       "id": 1032,
       "area": {
         "id": 1
@@ -1922,13 +1632,11 @@
     },
     {
       "name": "West Wall Guard Station",
-      "environment": -1,
       "exits": {
         "south": 1034,
         "east": 43,
         "north": 1035
       },
-      "weight": 1,
       "id": 1033,
       "area": {
         "id": 1
@@ -1936,11 +1644,9 @@
     },
     {
       "name": "Living Quarters",
-      "environment": -1,
       "exits": {
         "north": 1033
       },
-      "weight": 1,
       "id": 1034,
       "area": {
         "id": 1
@@ -1948,11 +1654,9 @@
     },
     {
       "name": "Sleeping Quarters",
-      "environment": -1,
       "exits": {
         "south": 1033
       },
-      "weight": 1,
       "id": 1035,
       "area": {
         "id": 1
@@ -1960,11 +1664,9 @@
     },
     {
       "name": "Goondala's Flowers",
-      "environment": -1,
       "exits": {
         "east": 90
       },
-      "weight": 1,
       "id": 1093,
       "area": {
         "id": 1
@@ -1972,11 +1674,9 @@
     },
     {
       "name": "Weapon Master's Shop",
-      "environment": -1,
       "exits": {
         "west": 90
       },
-      "weight": 1,
       "id": 1094,
       "area": {
         "id": 1
@@ -1984,11 +1684,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "north": 75
       },
-      "weight": 1,
       "id": 1095,
       "area": {
         "id": 1
@@ -1996,11 +1694,9 @@
     },
     {
       "name": "Alchemist's Shop",
-      "environment": -1,
       "exits": {
         "west": 79
       },
-      "weight": 1,
       "id": 1096,
       "area": {
         "id": 1
@@ -2008,11 +1704,9 @@
     },
     {
       "name": "Canderan Guard House",
-      "environment": -1,
       "exits": {
         "east": 82
       },
-      "weight": 1,
       "id": 1097,
       "area": {
         "id": 1
@@ -2020,12 +1714,10 @@
     },
     {
       "name": "Crypt of the Honored Dead",
-      "environment": -1,
       "exits": {
         "down": 1099,
         "west": 82
       },
-      "weight": 1,
       "id": 1098,
       "area": {
         "id": 1
@@ -2033,11 +1725,9 @@
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "environment": -1,
       "exits": {
         "south": 967
       },
-      "weight": 1,
       "id": 1125,
       "area": {
         "id": 1
@@ -2045,11 +1735,9 @@
     },
     {
       "name": "Temple of Earth",
-      "environment": -1,
       "exits": {
         "down": 106
       },
-      "weight": 1,
       "id": 1126,
       "area": {
         "id": 1
@@ -2057,11 +1745,9 @@
     },
     {
       "name": "Temple of Earth",
-      "environment": -1,
       "exits": {
         "down": 105
       },
-      "weight": 1,
       "id": 1127,
       "area": {
         "id": 1
@@ -2069,11 +1755,9 @@
     },
     {
       "name": "Temple of Fire",
-      "environment": -1,
       "exits": {
         "down": 114
       },
-      "weight": 1,
       "id": 1128,
       "area": {
         "id": 1
@@ -2081,11 +1765,9 @@
     },
     {
       "name": "Temple of Fire",
-      "environment": -1,
       "exits": {
         "down": 113
       },
-      "weight": 1,
       "id": 1129,
       "area": {
         "id": 1
@@ -2093,11 +1775,9 @@
     },
     {
       "name": "Temple of Air",
-      "environment": -1,
       "exits": {
         "down": 84
       },
-      "weight": 1,
       "id": 1130,
       "area": {
         "id": 1
@@ -2105,11 +1785,9 @@
     },
     {
       "name": "Temple of Air",
-      "environment": -1,
       "exits": {
         "down": 85
       },
-      "weight": 1,
       "id": 1131,
       "area": {
         "id": 1
@@ -2117,11 +1795,9 @@
     },
     {
       "name": "Temple of Water",
-      "environment": -1,
       "exits": {
         "down": 92
       },
-      "weight": 1,
       "id": 1132,
       "area": {
         "id": 1
@@ -2129,11 +1805,9 @@
     },
     {
       "name": "Temple of Water",
-      "environment": -1,
       "exits": {
         "down": 93
       },
-      "weight": 1,
       "id": 1133,
       "area": {
         "id": 1
@@ -2141,11 +1815,9 @@
     },
     {
       "name": "House of Lord Candera",
-      "environment": -1,
       "exits": {
         "down": 69
       },
-      "weight": 1,
       "id": 1134,
       "area": {
         "id": 1

--- a/maps/chikurin-forest.json
+++ b/maps/chikurin-forest.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "northeast": 1858,
         "northwest": 1835,
         "north": 1856
       },
-      "weight": 1,
       "id": 1834,
       "area": {
         "id": 37
@@ -19,14 +17,12 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "east": 1856,
         "northeast": 1857,
         "southeast": 1834,
         "north": 1836
       },
-      "weight": 1,
       "id": 1835,
       "area": {
         "id": 37
@@ -34,7 +30,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "northwest": 1837,
         "south": 1835,
@@ -42,7 +37,6 @@
         "east": 1857,
         "north": 1855
       },
-      "weight": 1,
       "id": 1836,
       "area": {
         "id": 37
@@ -50,14 +44,12 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "east": 1855,
         "northeast": 1851,
         "southeast": 1836,
         "north": 1838
       },
-      "weight": 1,
       "id": 1837,
       "area": {
         "id": 37
@@ -65,7 +57,6 @@
     },
     {
       "name": "Calm Clearing in the Bamboo Forest",
-      "environment": -1,
       "exits": {
         "southeast": 1855,
         "south": 1837,
@@ -73,7 +64,6 @@
         "east": 1851,
         "north": 1839
       },
-      "weight": 1,
       "id": 1838,
       "area": {
         "id": 37
@@ -81,14 +71,12 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "east": 1850,
         "northeast": 1840,
         "southeast": 1851,
         "south": 1838
       },
-      "weight": 1,
       "id": 1839,
       "area": {
         "id": 37
@@ -96,7 +84,6 @@
     },
     {
       "name": "Bamboo Forest, Near a Pond",
-      "environment": -1,
       "exits": {
         "southeast": 1849,
         "south": 1850,
@@ -105,7 +92,6 @@
         "east": 1846,
         "north": 1841
       },
-      "weight": 1,
       "id": 1840,
       "area": {
         "id": 37
@@ -113,13 +99,11 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "east": 1842,
         "southeast": 1846,
         "south": 1840
       },
-      "weight": 1,
       "id": 1841,
       "area": {
         "id": 37
@@ -127,14 +111,12 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "south": 1846,
         "west": 1841,
         "east": 1845,
         "north": 1843
       },
-      "weight": 1,
       "id": 1842,
       "area": {
         "id": 37
@@ -142,12 +124,10 @@
     },
     {
       "name": "Chikurin Path, south of Semai Pass",
-      "environment": -1,
       "exits": {
         "south": 1842,
         "north": 1844
       },
-      "weight": 1,
       "id": 1843,
       "area": {
         "id": 37
@@ -155,11 +135,9 @@
     },
     {
       "name": "Heading north, you enter the narrow Semai Pass.",
-      "environment": -1,
       "exits": {
         "south": 1843
       },
-      "weight": 1,
       "id": 1844,
       "area": {
         "id": 37
@@ -167,13 +145,11 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "southwest": 1846,
         "west": 1842,
         "south": 1848
       },
-      "weight": 1,
       "id": 1845,
       "area": {
         "id": 37
@@ -181,7 +157,6 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "southeast": 1847,
         "west": 1840,
@@ -192,7 +167,6 @@
         "east": 1848,
         "north": 1842
       },
-      "weight": 1,
       "id": 1846,
       "area": {
         "id": 37
@@ -200,7 +174,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "northwest": 1846,
         "south": 1853,
@@ -208,7 +181,6 @@
         "east": 1852,
         "north": 1848
       },
-      "weight": 1,
       "id": 1847,
       "area": {
         "id": 37
@@ -216,7 +188,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "northwest": 1842,
         "south": 1847,
@@ -225,7 +196,6 @@
         "southeast": 1852,
         "north": 1845
       },
-      "weight": 1,
       "id": 1848,
       "area": {
         "id": 37
@@ -233,7 +203,6 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "southeast": 1853,
         "south": 1854,
@@ -241,7 +210,6 @@
         "west": 1850,
         "north": 1846
       },
-      "weight": 1,
       "id": 1849,
       "area": {
         "id": 37
@@ -249,7 +217,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "west": 1839,
         "south": 1851,
@@ -258,7 +225,6 @@
         "east": 1849,
         "north": 1840
       },
-      "weight": 1,
       "id": 1850,
       "area": {
         "id": 37
@@ -266,7 +232,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "southeast": 1862,
         "west": 1838,
@@ -277,7 +242,6 @@
         "east": 1854,
         "north": 1850
       },
-      "weight": 1,
       "id": 1851,
       "area": {
         "id": 37
@@ -285,12 +249,10 @@
     },
     {
       "name": "Bamboo Forest, North of a Monastery",
-      "environment": -1,
       "exits": {
         "northwest": 1848,
         "west": 1847
       },
-      "weight": 1,
       "id": 1852,
       "area": {
         "id": 37
@@ -298,7 +260,6 @@
     },
     {
       "name": "Bamboo Forest, West of a Monastery",
-      "environment": -1,
       "exits": {
         "northwest": 1849,
         "south": 1860,
@@ -306,7 +267,6 @@
         "west": 1854,
         "north": 1847
       },
-      "weight": 1,
       "id": 1853,
       "area": {
         "id": 37
@@ -314,7 +274,6 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "south": 1862,
         "southwest": 1855,
@@ -322,7 +281,6 @@
         "east": 1853,
         "north": 1849
       },
-      "weight": 1,
       "id": 1854,
       "area": {
         "id": 37
@@ -330,7 +288,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "southeast": 1857,
         "northwest": 1838,
@@ -340,7 +297,6 @@
         "east": 1862,
         "north": 1851
       },
-      "weight": 1,
       "id": 1855,
       "area": {
         "id": 37
@@ -348,14 +304,12 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "south": 1834,
         "west": 1835,
         "east": 1858,
         "north": 1857
       },
-      "weight": 1,
       "id": 1856,
       "area": {
         "id": 37
@@ -363,11 +317,9 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "north": 1862
       },
-      "weight": 1,
       "id": 1857,
       "area": {
         "id": 37
@@ -375,14 +327,12 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "southwest": 1834,
         "west": 1856,
         "northwest": 1857,
         "north": 1859
       },
-      "weight": 1,
       "id": 1858,
       "area": {
         "id": 37
@@ -390,14 +340,12 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "west": 1857,
         "south": 1858,
         "northwest": 1862,
         "north": 1860
       },
-      "weight": 1,
       "id": 1859,
       "area": {
         "id": 37
@@ -405,7 +353,6 @@
     },
     {
       "name": "Bamboo Forest",
-      "environment": -1,
       "exits": {
         "south": 1859,
         "southwest": 1857,
@@ -413,7 +360,6 @@
         "east": 1861,
         "north": 1853
       },
-      "weight": 1,
       "id": 1860,
       "area": {
         "id": 37
@@ -421,13 +367,11 @@
     },
     {
       "name": "Bamboo Forest, South of a Monastery",
-      "environment": -1,
       "exits": {
         "southwest": 1859,
         "west": 1860,
         "north": 1863
       },
-      "weight": 1,
       "id": 1861,
       "area": {
         "id": 37
@@ -435,11 +379,9 @@
     },
     {
       "name": "Chikurin Forest Path",
-      "environment": -1,
       "exits": {
         "south": 1857
       },
-      "weight": 1,
       "id": 1862,
       "area": {
         "id": 37

--- a/maps/crimsonaxe-mine.json
+++ b/maps/crimsonaxe-mine.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Moist cavern",
-      "environment": -1,
       "exits": {
         "down": 1809,
         "up": 1808
       },
-      "weight": 1,
       "id": 1807,
       "area": {
         "id": 35
@@ -18,11 +16,9 @@
     },
     {
       "name": "Crack in the mountainside",
-      "environment": -1,
       "exits": {
         "down": 1807
       },
-      "weight": 1,
       "id": 1808,
       "area": {
         "id": 35
@@ -30,12 +26,10 @@
     },
     {
       "name": "Giant cavern",
-      "environment": -1,
       "exits": {
         "up": 1807,
         "west": 1810
       },
-      "weight": 1,
       "id": 1809,
       "area": {
         "id": 35
@@ -43,11 +37,9 @@
     },
     {
       "name": "Bright niche",
-      "environment": -1,
       "exits": {
         "east": 1809
       },
-      "weight": 1,
       "id": 1810,
       "area": {
         "id": 35
@@ -55,11 +47,9 @@
     },
     {
       "name": "The ore lift",
-      "environment": -1,
       "exits": {
         "south": 1812
       },
-      "weight": 1,
       "id": 1811,
       "area": {
         "id": 35
@@ -67,13 +57,11 @@
     },
     {
       "name": "The Crimsonaxe mine",
-      "environment": -1,
       "exits": {
         "west": 1813,
         "south": 1815,
         "north": 1811
       },
-      "weight": 1,
       "id": 1812,
       "area": {
         "id": 35
@@ -81,13 +69,11 @@
     },
     {
       "name": "A guard point",
-      "environment": -1,
       "exits": {
         "south": 1814,
         "east": 1812,
         "north": 1823
       },
-      "weight": 1,
       "id": 1813,
       "area": {
         "id": 35
@@ -95,11 +81,9 @@
     },
     {
       "name": "The immense stone slab moves suprisingly easily.",
-      "environment": -1,
       "exits": {
         "north": 1813
       },
-      "weight": 1,
       "id": 1814,
       "area": {
         "id": 35
@@ -107,13 +91,11 @@
     },
     {
       "name": "The Crimsonaxe mine",
-      "environment": -1,
       "exits": {
         "south": 1816,
         "east": 1821,
         "north": 1812
       },
-      "weight": 1,
       "id": 1815,
       "area": {
         "id": 35
@@ -121,12 +103,10 @@
     },
     {
       "name": "A bend in the tunnel.",
-      "environment": -1,
       "exits": {
         "southeast": 1817,
         "north": 1815
       },
-      "weight": 1,
       "id": 1816,
       "area": {
         "id": 35
@@ -134,13 +114,11 @@
     },
     {
       "name": "A mine shaft.",
-      "environment": -1,
       "exits": {
         "northwest": 1816,
         "east": 1818,
         "up": 1820
       },
-      "weight": 1,
       "id": 1817,
       "area": {
         "id": 35
@@ -148,12 +126,10 @@
     },
     {
       "name": "A guard house.",
-      "environment": -1,
       "exits": {
         "up": 1819,
         "west": 1817
       },
-      "weight": 1,
       "id": 1818,
       "area": {
         "id": 35
@@ -161,11 +137,9 @@
     },
     {
       "name": "A sentry room",
-      "environment": -1,
       "exits": {
         "down": 1818
       },
-      "weight": 1,
       "id": 1819,
       "area": {
         "id": 35
@@ -173,11 +147,9 @@
     },
     {
       "name": "A darkened entrance.",
-      "environment": -1,
       "exits": {
         "down": 1817
       },
-      "weight": 1,
       "id": 1820,
       "area": {
         "id": 35
@@ -185,12 +157,10 @@
     },
     {
       "name": "Mine catering",
-      "environment": -1,
       "exits": {
         "west": 1815,
         "north": 1822
       },
-      "weight": 1,
       "id": 1821,
       "area": {
         "id": 35
@@ -198,11 +168,9 @@
     },
     {
       "name": "A smelly crevice.",
-      "environment": -1,
       "exits": {
         "south": 1821
       },
-      "weight": 1,
       "id": 1822,
       "area": {
         "id": 35
@@ -210,11 +178,9 @@
     },
     {
       "name": "The immense stone slab moves suprisingly easily.",
-      "environment": -1,
       "exits": {
         "south": 1813
       },
-      "weight": 1,
       "id": 1823,
       "area": {
         "id": 35

--- a/maps/exedoria.json
+++ b/maps/exedoria.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Entrance to Exedoria",
-      "environment": -1,
       "exits": {
         "east": 287
       },
-      "weight": 1,
       "id": 286,
       "area": {
         "id": 4
@@ -17,13 +15,11 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "west": 286,
         "east": 288,
         "south": 330
       },
-      "weight": 1,
       "id": 287,
       "area": {
         "id": 4
@@ -31,14 +27,12 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "south": 368,
         "west": 287,
         "east": 289,
         "north": 367
       },
-      "weight": 1,
       "id": 288,
       "area": {
         "id": 4
@@ -46,13 +40,11 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "west": 288,
         "east": 290,
         "south": 366
       },
-      "weight": 1,
       "id": 289,
       "area": {
         "id": 4
@@ -60,14 +52,12 @@
     },
     {
       "name": "Monument Circle, Main Street",
-      "environment": -1,
       "exits": {
         "south": 299,
         "west": 289,
         "east": 291,
         "north": 369
       },
-      "weight": 1,
       "id": 290,
       "area": {
         "id": 4
@@ -75,14 +65,12 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "south": 298,
         "west": 290,
         "east": 292,
         "north": 370
       },
-      "weight": 1,
       "id": 291,
       "area": {
         "id": 4
@@ -90,13 +78,11 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "west": 291,
         "east": 293,
         "south": 383
       },
-      "weight": 1,
       "id": 292,
       "area": {
         "id": 4
@@ -104,12 +90,10 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "east": 294,
         "west": 292
       },
-      "weight": 1,
       "id": 293,
       "area": {
         "id": 4
@@ -117,12 +101,10 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "east": 295,
         "west": 293
       },
-      "weight": 1,
       "id": 294,
       "area": {
         "id": 4
@@ -130,12 +112,10 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "east": 296,
         "west": 294
       },
-      "weight": 1,
       "id": 295,
       "area": {
         "id": 4
@@ -143,12 +123,10 @@
     },
     {
       "name": "Main Street",
-      "environment": -1,
       "exits": {
         "east": 297,
         "west": 295
       },
-      "weight": 1,
       "id": 296,
       "area": {
         "id": 4
@@ -156,11 +134,9 @@
     },
     {
       "name": "Corigan Court Intersection",
-      "environment": -1,
       "exits": {
         "west": 296
       },
-      "weight": 1,
       "id": 297,
       "area": {
         "id": 4
@@ -168,11 +144,9 @@
     },
     {
       "name": "City Hall",
-      "environment": -1,
       "exits": {
         "north": 291
       },
-      "weight": 1,
       "id": 298,
       "area": {
         "id": 4
@@ -180,12 +154,10 @@
     },
     {
       "name": "Eithel Sirion",
-      "environment": -1,
       "exits": {
         "south": 300,
         "north": 290
       },
-      "weight": 1,
       "id": 299,
       "area": {
         "id": 4
@@ -193,14 +165,12 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "south": 301,
         "west": 302,
         "east": 385,
         "north": 299
       },
-      "weight": 1,
       "id": 300,
       "area": {
         "id": 4
@@ -208,11 +178,9 @@
     },
     {
       "name": "Frenchie's II",
-      "environment": -1,
       "exits": {
         "north": 300
       },
-      "weight": 1,
       "id": 301,
       "area": {
         "id": 4
@@ -220,13 +188,11 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "west": 303,
         "east": 300,
         "south": 392
       },
-      "weight": 1,
       "id": 302,
       "area": {
         "id": 4
@@ -234,13 +200,11 @@
     },
     {
       "name": "Middle of Brapnor Road",
-      "environment": -1,
       "exits": {
         "west": 304,
         "east": 302,
         "south": 329
       },
-      "weight": 1,
       "id": 303,
       "area": {
         "id": 4
@@ -248,13 +212,11 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "west": 305,
         "east": 303,
         "north": 330
       },
-      "weight": 1,
       "id": 304,
       "area": {
         "id": 4
@@ -262,13 +224,11 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "west": 306,
         "east": 304,
         "north": 393
       },
-      "weight": 1,
       "id": 305,
       "area": {
         "id": 4
@@ -276,12 +236,10 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "east": 305,
         "west": 307
       },
-      "weight": 1,
       "id": 306,
       "area": {
         "id": 4
@@ -289,13 +247,11 @@
     },
     {
       "name": "End of Brapnor Road",
-      "environment": -1,
       "exits": {
         "east": 306,
         "northwest": 331,
         "south": 308
       },
-      "weight": 1,
       "id": 307,
       "area": {
         "id": 4
@@ -303,12 +259,10 @@
     },
     {
       "name": "Beginning of Lilu Lane",
-      "environment": -1,
       "exits": {
         "south": 309,
         "north": 307
       },
-      "weight": 1,
       "id": 308,
       "area": {
         "id": 4
@@ -316,12 +270,10 @@
     },
     {
       "name": "Lilu Lane",
-      "environment": -1,
       "exits": {
         "south": 310,
         "north": 308
       },
-      "weight": 1,
       "id": 309,
       "area": {
         "id": 4
@@ -329,13 +281,11 @@
     },
     {
       "name": "Middle of Lilu Lane",
-      "environment": -1,
       "exits": {
         "west": 355,
         "south": 311,
         "north": 309
       },
-      "weight": 1,
       "id": 310,
       "area": {
         "id": 4
@@ -343,12 +293,10 @@
     },
     {
       "name": "Lilu Lane",
-      "environment": -1,
       "exits": {
         "south": 312,
         "north": 310
       },
-      "weight": 1,
       "id": 311,
       "area": {
         "id": 4
@@ -356,13 +304,11 @@
     },
     {
       "name": "End of Lilu Lane",
-      "environment": -1,
       "exits": {
         "west": 354,
         "south": 313,
         "north": 311
       },
-      "weight": 1,
       "id": 312,
       "area": {
         "id": 4
@@ -370,12 +316,10 @@
     },
     {
       "name": "Beginning of Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 314,
         "north": 312
       },
-      "weight": 1,
       "id": 313,
       "area": {
         "id": 4
@@ -383,13 +327,11 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "west": 313,
         "east": 315,
         "south": 322
       },
-      "weight": 1,
       "id": 314,
       "area": {
         "id": 4
@@ -397,14 +339,12 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "south": 320,
         "west": 314,
         "east": 316,
         "north": 321
       },
-      "weight": 1,
       "id": 315,
       "area": {
         "id": 4
@@ -412,14 +352,12 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "south": 318,
         "west": 315,
         "east": 317,
         "north": 319
       },
-      "weight": 1,
       "id": 316,
       "area": {
         "id": 4
@@ -427,13 +365,11 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "west": 316,
         "east": 323,
         "north": 333
       },
-      "weight": 1,
       "id": 317,
       "area": {
         "id": 4
@@ -441,11 +377,9 @@
     },
     {
       "name": "A Dark Hole in the Ground",
-      "environment": -1,
       "exits": {
         "north": 316
       },
-      "weight": 1,
       "id": 318,
       "area": {
         "id": 4
@@ -453,12 +387,10 @@
     },
     {
       "name": "Guard Post for Gnome Embassy",
-      "environment": -1,
       "exits": {
         "south": 316,
         "north": 926
       },
-      "weight": 1,
       "id": 319,
       "area": {
         "id": 4
@@ -466,11 +398,9 @@
     },
     {
       "name": "Before a round door",
-      "environment": -1,
       "exits": {
         "north": 315
       },
-      "weight": 1,
       "id": 320,
       "area": {
         "id": 4
@@ -478,11 +408,9 @@
     },
     {
       "name": "Junk yard",
-      "environment": -1,
       "exits": {
         "south": 315
       },
-      "weight": 1,
       "id": 321,
       "area": {
         "id": 4
@@ -490,11 +418,9 @@
     },
     {
       "name": "Elven Embassy checkpoint",
-      "environment": -1,
       "exits": {
         "north": 314
       },
-      "weight": 1,
       "id": 322,
       "area": {
         "id": 4
@@ -502,12 +428,10 @@
     },
     {
       "name": "End of Embassy Row",
-      "environment": -1,
       "exits": {
         "west": 317,
         "north": 324
       },
-      "weight": 1,
       "id": 323,
       "area": {
         "id": 4
@@ -515,12 +439,10 @@
     },
     {
       "name": "Southern end of alley",
-      "environment": -1,
       "exits": {
         "south": 323,
         "north": 325
       },
-      "weight": 1,
       "id": 324,
       "area": {
         "id": 4
@@ -528,12 +450,10 @@
     },
     {
       "name": "Bend in an alley",
-      "environment": -1,
       "exits": {
         "west": 326,
         "south": 324
       },
-      "weight": 1,
       "id": 325,
       "area": {
         "id": 4
@@ -541,12 +461,10 @@
     },
     {
       "name": "A bend in the alley",
-      "environment": -1,
       "exits": {
         "east": 325,
         "north": 327
       },
-      "weight": 1,
       "id": 326,
       "area": {
         "id": 4
@@ -554,12 +472,10 @@
     },
     {
       "name": "Dark and narrow alley",
-      "environment": -1,
       "exits": {
         "south": 326,
         "north": 328
       },
-      "weight": 1,
       "id": 327,
       "area": {
         "id": 4
@@ -567,12 +483,10 @@
     },
     {
       "name": "Dark alley",
-      "environment": -1,
       "exits": {
         "south": 327,
         "north": 329
       },
-      "weight": 1,
       "id": 328,
       "area": {
         "id": 4
@@ -580,12 +494,10 @@
     },
     {
       "name": "Alley entrance",
-      "environment": -1,
       "exits": {
         "south": 328,
         "north": 303
       },
-      "weight": 1,
       "id": 329,
       "area": {
         "id": 4
@@ -593,12 +505,10 @@
     },
     {
       "name": "The Excalibur, a closed guild",
-      "environment": -1,
       "exits": {
         "south": 304,
         "north": 287
       },
-      "weight": 1,
       "id": 330,
       "area": {
         "id": 4
@@ -606,12 +516,10 @@
     },
     {
       "name": "Foyer of the Exedorian Inn",
-      "environment": -1,
       "exits": {
         "southeast": 307,
         "west": 332
       },
-      "weight": 1,
       "id": 331,
       "area": {
         "id": 4
@@ -619,11 +527,9 @@
     },
     {
       "name": "Exedorian saloon",
-      "environment": -1,
       "exits": {
         "east": 331
       },
-      "weight": 1,
       "id": 332,
       "area": {
         "id": 4
@@ -631,12 +537,10 @@
     },
     {
       "name": "Before the Dwarven Embassy",
-      "environment": -1,
       "exits": {
         "south": 317,
         "north": 920
       },
-      "weight": 1,
       "id": 333,
       "area": {
         "id": 4
@@ -644,11 +548,9 @@
     },
     {
       "name": "Keen Street West",
-      "environment": -1,
       "exits": {
         "east": 335
       },
-      "weight": 1,
       "id": 334,
       "area": {
         "id": 4
@@ -656,12 +558,10 @@
     },
     {
       "name": "Keen Street",
-      "environment": -1,
       "exits": {
         "east": 336,
         "west": 334
       },
-      "weight": 1,
       "id": 335,
       "area": {
         "id": 4
@@ -669,13 +569,11 @@
     },
     {
       "name": "Keen Street",
-      "environment": -1,
       "exits": {
         "west": 335,
         "east": 337,
         "north": 602
       },
-      "weight": 1,
       "id": 336,
       "area": {
         "id": 4
@@ -683,13 +581,11 @@
     },
     {
       "name": "Keen Street",
-      "environment": -1,
       "exits": {
         "west": 336,
         "east": 338,
         "south": 603
       },
-      "weight": 1,
       "id": 337,
       "area": {
         "id": 4
@@ -697,13 +593,11 @@
     },
     {
       "name": "East Keen Street Bridge",
-      "environment": -1,
       "exits": {
         "west": 337,
         "east": 339,
         "north": 604
       },
-      "weight": 1,
       "id": 338,
       "area": {
         "id": 4
@@ -711,12 +605,10 @@
     },
     {
       "name": "Keen Street Bridge",
-      "environment": -1,
       "exits": {
         "east": 340,
         "west": 338
       },
-      "weight": 1,
       "id": 339,
       "area": {
         "id": 4
@@ -724,13 +616,11 @@
     },
     {
       "name": "Keen Street",
-      "environment": -1,
       "exits": {
         "west": 339,
         "east": 341,
         "south": 343
       },
-      "weight": 1,
       "id": 340,
       "area": {
         "id": 4
@@ -738,12 +628,10 @@
     },
     {
       "name": "Keen Street East",
-      "environment": -1,
       "exits": {
         "west": 340,
         "north": 342
       },
-      "weight": 1,
       "id": 341,
       "area": {
         "id": 4
@@ -751,12 +639,10 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "south": 341,
         "north": 350
       },
-      "weight": 1,
       "id": 342,
       "area": {
         "id": 4
@@ -764,12 +650,10 @@
     },
     {
       "name": "Statued lawn",
-      "environment": -1,
       "exits": {
         "south": 344,
         "north": 340
       },
-      "weight": 1,
       "id": 343,
       "area": {
         "id": 4
@@ -777,12 +661,10 @@
     },
     {
       "name": "Statued lawn",
-      "environment": -1,
       "exits": {
         "south": 345,
         "north": 343
       },
-      "weight": 1,
       "id": 344,
       "area": {
         "id": 4
@@ -790,12 +672,10 @@
     },
     {
       "name": "Manicured lawn",
-      "environment": -1,
       "exits": {
         "south": 346,
         "north": 344
       },
-      "weight": 1,
       "id": 345,
       "area": {
         "id": 4
@@ -803,13 +683,11 @@
     },
     {
       "name": "Cavernous foyer",
-      "environment": -1,
       "exits": {
         "west": 348,
         "east": 347,
         "north": 345
       },
-      "weight": 1,
       "id": 346,
       "area": {
         "id": 4
@@ -817,11 +695,9 @@
     },
     {
       "name": "Icy room",
-      "environment": -1,
       "exits": {
         "west": 346
       },
-      "weight": 1,
       "id": 347,
       "area": {
         "id": 4
@@ -829,12 +705,10 @@
     },
     {
       "name": "Cold hallway",
-      "environment": -1,
       "exits": {
         "east": 346,
         "south": 349
       },
-      "weight": 1,
       "id": 348,
       "area": {
         "id": 4
@@ -842,11 +716,9 @@
     },
     {
       "name": "Snowy cave",
-      "environment": -1,
       "exits": {
         "north": 348
       },
-      "weight": 1,
       "id": 349,
       "area": {
         "id": 4
@@ -854,12 +726,10 @@
     },
     {
       "name": "With no gate guard present, you are able to enter the walled estate",
-      "environment": -1,
       "exits": {
         "south": 342,
         "north": 351
       },
-      "weight": 1,
       "id": 350,
       "area": {
         "id": 4
@@ -867,12 +737,10 @@
     },
     {
       "name": "Foyer",
-      "environment": -1,
       "exits": {
         "east": 352,
         "south": 350
       },
-      "weight": 1,
       "id": 351,
       "area": {
         "id": 4
@@ -880,12 +748,10 @@
     },
     {
       "name": "Wood-paneled Hallway",
-      "environment": -1,
       "exits": {
         "west": 351,
         "north": 353
       },
-      "weight": 1,
       "id": 352,
       "area": {
         "id": 4
@@ -893,11 +759,9 @@
     },
     {
       "name": "Busy Kitchen",
-      "environment": -1,
       "exits": {
         "south": 352
       },
-      "weight": 1,
       "id": 353,
       "area": {
         "id": 4
@@ -905,11 +769,9 @@
     },
     {
       "name": "Mom's General Store",
-      "environment": -1,
       "exits": {
         "east": 312
       },
-      "weight": 1,
       "id": 354,
       "area": {
         "id": 4
@@ -917,12 +779,10 @@
     },
     {
       "name": "Drawbridge",
-      "environment": -1,
       "exits": {
         "east": 310,
         "west": 356
       },
-      "weight": 1,
       "id": 355,
       "area": {
         "id": 4
@@ -930,14 +790,12 @@
     },
     {
       "name": "Library's entrance",
-      "environment": -1,
       "exits": {
         "south": 357,
         "west": 361,
         "east": 355,
         "north": 362
       },
-      "weight": 1,
       "id": 356,
       "area": {
         "id": 4
@@ -945,13 +803,11 @@
     },
     {
       "name": "Cobblestoned hallway",
-      "environment": -1,
       "exits": {
         "south": 358,
         "east": 360,
         "north": 356
       },
-      "weight": 1,
       "id": 357,
       "area": {
         "id": 4
@@ -959,12 +815,10 @@
     },
     {
       "name": "A bend in the hallway",
-      "environment": -1,
       "exits": {
         "west": 359,
         "north": 357
       },
-      "weight": 1,
       "id": 358,
       "area": {
         "id": 4
@@ -972,11 +826,9 @@
     },
     {
       "name": "A monk's cell",
-      "environment": -1,
       "exits": {
         "east": 358
       },
-      "weight": 1,
       "id": 359,
       "area": {
         "id": 4
@@ -984,11 +836,9 @@
     },
     {
       "name": "A monk's cell",
-      "environment": -1,
       "exits": {
         "west": 357
       },
-      "weight": 1,
       "id": 360,
       "area": {
         "id": 4
@@ -996,11 +846,9 @@
     },
     {
       "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
-      "environment": -1,
       "exits": {
         "east": 356
       },
-      "weight": 1,
       "id": 361,
       "area": {
         "id": 4
@@ -1008,13 +856,11 @@
     },
     {
       "name": "Cobblestoned hallway",
-      "environment": -1,
       "exits": {
         "south": 356,
         "east": 363,
         "north": 364
       },
-      "weight": 1,
       "id": 362,
       "area": {
         "id": 4
@@ -1022,11 +868,9 @@
     },
     {
       "name": "A monk's cell",
-      "environment": -1,
       "exits": {
         "west": 362
       },
-      "weight": 1,
       "id": 363,
       "area": {
         "id": 4
@@ -1034,12 +878,10 @@
     },
     {
       "name": "A bend in the hallway",
-      "environment": -1,
       "exits": {
         "west": 365,
         "south": 362
       },
-      "weight": 1,
       "id": 364,
       "area": {
         "id": 4
@@ -1047,11 +889,9 @@
     },
     {
       "name": "A monk's cell",
-      "environment": -1,
       "exits": {
         "east": 364
       },
-      "weight": 1,
       "id": 365,
       "area": {
         "id": 4
@@ -1059,11 +899,9 @@
     },
     {
       "name": "The Cadaver Emporium",
-      "environment": -1,
       "exits": {
         "north": 289
       },
-      "weight": 1,
       "id": 366,
       "area": {
         "id": 4
@@ -1071,11 +909,9 @@
     },
     {
       "name": "Velvet Unicorn",
-      "environment": -1,
       "exits": {
         "south": 288
       },
-      "weight": 1,
       "id": 367,
       "area": {
         "id": 4
@@ -1083,11 +919,9 @@
     },
     {
       "name": "Eidolon Warlords",
-      "environment": -1,
       "exits": {
         "north": 288
       },
-      "weight": 1,
       "id": 368,
       "area": {
         "id": 4
@@ -1095,11 +929,9 @@
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "environment": -1,
       "exits": {
         "south": 290
       },
-      "weight": 1,
       "id": 369,
       "area": {
         "id": 4
@@ -1107,12 +939,10 @@
     },
     {
       "name": "Beginning of park path",
-      "environment": -1,
       "exits": {
         "south": 291,
         "north": 371
       },
-      "weight": 1,
       "id": 370,
       "area": {
         "id": 4
@@ -1120,14 +950,12 @@
     },
     {
       "name": "Park path intersection",
-      "environment": -1,
       "exits": {
         "south": 370,
         "west": 372,
         "east": 378,
         "north": 373
       },
-      "weight": 1,
       "id": 371,
       "area": {
         "id": 4
@@ -1135,11 +963,9 @@
     },
     {
       "name": "Exedoria Pet Cemetary",
-      "environment": -1,
       "exits": {
         "east": 371
       },
-      "weight": 1,
       "id": 372,
       "area": {
         "id": 4
@@ -1147,12 +973,10 @@
     },
     {
       "name": "Park path on the hill",
-      "environment": -1,
       "exits": {
         "south": 371,
         "north": 374
       },
-      "weight": 1,
       "id": 373,
       "area": {
         "id": 4
@@ -1160,12 +984,10 @@
     },
     {
       "name": "Elevated park path",
-      "environment": -1,
       "exits": {
         "south": 373,
         "north": 375
       },
-      "weight": 1,
       "id": 374,
       "area": {
         "id": 4
@@ -1173,12 +995,10 @@
     },
     {
       "name": "End of park path",
-      "environment": -1,
       "exits": {
         "east": 376,
         "south": 374
       },
-      "weight": 1,
       "id": 375,
       "area": {
         "id": 4
@@ -1186,12 +1006,10 @@
     },
     {
       "name": "Temple ruins",
-      "environment": -1,
       "exits": {
         "east": 377,
         "west": 375
       },
-      "weight": 1,
       "id": 376,
       "area": {
         "id": 4
@@ -1199,11 +1017,9 @@
     },
     {
       "name": "Temple rotunda",
-      "environment": -1,
       "exits": {
         "west": 376
       },
-      "weight": 1,
       "id": 377,
       "area": {
         "id": 4
@@ -1211,12 +1027,10 @@
     },
     {
       "name": "Gravel path to the mansion",
-      "environment": -1,
       "exits": {
         "east": 379,
         "west": 371
       },
-      "weight": 1,
       "id": 378,
       "area": {
         "id": 4
@@ -1224,12 +1038,10 @@
     },
     {
       "name": "Gravel path on the hill",
-      "environment": -1,
       "exits": {
         "east": 380,
         "west": 378
       },
-      "weight": 1,
       "id": 379,
       "area": {
         "id": 4
@@ -1237,13 +1049,11 @@
     },
     {
       "name": "Intersection in the gravel path",
-      "environment": -1,
       "exits": {
         "west": 379,
         "southeast": 382,
         "north": 381
       },
-      "weight": 1,
       "id": 380,
       "area": {
         "id": 4
@@ -1251,11 +1061,9 @@
     },
     {
       "name": "Before a white mansion",
-      "environment": -1,
       "exits": {
         "south": 380
       },
-      "weight": 1,
       "id": 381,
       "area": {
         "id": 4
@@ -1263,11 +1071,9 @@
     },
     {
       "name": "Outside the cemetery gate",
-      "environment": -1,
       "exits": {
         "northwest": 380
       },
-      "weight": 1,
       "id": 382,
       "area": {
         "id": 4
@@ -1275,12 +1081,10 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "south": 384,
         "north": 292
       },
-      "weight": 1,
       "id": 383,
       "area": {
         "id": 4
@@ -1288,13 +1092,11 @@
     },
     {
       "name": "Beginning of Brapnor Road",
-      "environment": -1,
       "exits": {
         "west": 385,
         "southeast": 386,
         "north": 383
       },
-      "weight": 1,
       "id": 384,
       "area": {
         "id": 4
@@ -1302,12 +1104,10 @@
     },
     {
       "name": "Brapnor Road",
-      "environment": -1,
       "exits": {
         "east": 384,
         "west": 300
       },
-      "weight": 1,
       "id": 385,
       "area": {
         "id": 4
@@ -1315,12 +1115,10 @@
     },
     {
       "name": "Necrom's Gate",
-      "environment": -1,
       "exits": {
         "northwest": 384,
         "southeast": 387
       },
-      "weight": 1,
       "id": 386,
       "area": {
         "id": 4
@@ -1328,13 +1126,11 @@
     },
     {
       "name": "Paved intersection",
-      "environment": -1,
       "exits": {
         "east": 388,
         "northwest": 386,
         "south": 527
       },
-      "weight": 1,
       "id": 387,
       "area": {
         "id": 4
@@ -1342,12 +1138,10 @@
     },
     {
       "name": "Eastern path through the University",
-      "environment": -1,
       "exits": {
         "east": 389,
         "west": 387
       },
-      "weight": 1,
       "id": 388,
       "area": {
         "id": 4
@@ -1355,12 +1149,10 @@
     },
     {
       "name": "Eastern path through the University",
-      "environment": -1,
       "exits": {
         "east": 390,
         "west": 388
       },
-      "weight": 1,
       "id": 389,
       "area": {
         "id": 4
@@ -1368,13 +1160,11 @@
     },
     {
       "name": "In front of a temporary building",
-      "environment": -1,
       "exits": {
         "west": 389,
         "east": 391,
         "south": 904
       },
-      "weight": 1,
       "id": 390,
       "area": {
         "id": 4
@@ -1382,11 +1172,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "west": 390
       },
-      "weight": 1,
       "id": 391,
       "area": {
         "id": 4
@@ -1394,11 +1182,9 @@
     },
     {
       "name": "Delilah's Deli",
-      "environment": -1,
       "exits": {
         "north": 302
       },
-      "weight": 1,
       "id": 392,
       "area": {
         "id": 4
@@ -1406,11 +1192,9 @@
     },
     {
       "name": "Guard Tower Entrance",
-      "environment": -1,
       "exits": {
         "south": 305
       },
-      "weight": 1,
       "id": 393,
       "area": {
         "id": 4
@@ -1418,12 +1202,10 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 528,
         "north": 387
       },
-      "weight": 1,
       "id": 527,
       "area": {
         "id": 4
@@ -1431,13 +1213,11 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 896,
         "east": 894,
         "north": 527
       },
-      "weight": 1,
       "id": 528,
       "area": {
         "id": 4
@@ -1445,11 +1225,9 @@
     },
     {
       "name": "Railed entrance",
-      "environment": -1,
       "exits": {
         "south": 336
       },
-      "weight": 1,
       "id": 602,
       "area": {
         "id": 4
@@ -1457,12 +1235,10 @@
     },
     {
       "name": "Flagstoned entry",
-      "environment": -1,
       "exits": {
         "south": 915,
         "north": 337
       },
-      "weight": 1,
       "id": 603,
       "area": {
         "id": 4
@@ -1470,13 +1246,11 @@
     },
     {
       "name": "You rudely trespass on the private property.",
-      "environment": -1,
       "exits": {
         "northeast": 907,
         "northwest": 910,
         "south": 338
       },
-      "weight": 1,
       "id": 604,
       "area": {
         "id": 4
@@ -1484,13 +1258,11 @@
     },
     {
       "name": "Dormitory foyer",
-      "environment": -1,
       "exits": {
         "west": 528,
         "south": 895,
         "north": 903
       },
-      "weight": 1,
       "id": 894,
       "area": {
         "id": 4
@@ -1498,11 +1270,9 @@
     },
     {
       "name": "Dining commons",
-      "environment": -1,
       "exits": {
         "north": 894
       },
-      "weight": 1,
       "id": 895,
       "area": {
         "id": 4
@@ -1510,12 +1280,10 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 897,
         "north": 528
       },
-      "weight": 1,
       "id": 896,
       "area": {
         "id": 4
@@ -1523,12 +1291,10 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 898,
         "north": 896
       },
-      "weight": 1,
       "id": 897,
       "area": {
         "id": 4
@@ -1536,12 +1302,10 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 899,
         "north": 897
       },
-      "weight": 1,
       "id": 898,
       "area": {
         "id": 4
@@ -1549,13 +1313,11 @@
     },
     {
       "name": "Southern path through the University",
-      "environment": -1,
       "exits": {
         "south": 902,
         "east": 900,
         "north": 898
       },
-      "weight": 1,
       "id": 899,
       "area": {
         "id": 4
@@ -1563,12 +1325,10 @@
     },
     {
       "name": "School of Business",
-      "environment": -1,
       "exits": {
         "west": 899,
         "north": 901
       },
-      "weight": 1,
       "id": 900,
       "area": {
         "id": 4
@@ -1576,11 +1336,9 @@
     },
     {
       "name": "Dean's office",
-      "environment": -1,
       "exits": {
         "south": 900
       },
-      "weight": 1,
       "id": 901,
       "area": {
         "id": 4
@@ -1588,11 +1346,9 @@
     },
     {
       "name": "Construction site",
-      "environment": -1,
       "exits": {
         "north": 899
       },
-      "weight": 1,
       "id": 902,
       "area": {
         "id": 4
@@ -1600,11 +1356,9 @@
     },
     {
       "name": "Resident Advisor's office",
-      "environment": -1,
       "exits": {
         "south": 894
       },
-      "weight": 1,
       "id": 903,
       "area": {
         "id": 4
@@ -1612,13 +1366,11 @@
     },
     {
       "name": "Science building's entry",
-      "environment": -1,
       "exits": {
         "west": 905,
         "east": 906,
         "north": 390
       },
-      "weight": 1,
       "id": 904,
       "area": {
         "id": 4
@@ -1626,11 +1378,9 @@
     },
     {
       "name": "Science laboratory",
-      "environment": -1,
       "exits": {
         "east": 904
       },
-      "weight": 1,
       "id": 905,
       "area": {
         "id": 4
@@ -1638,11 +1388,9 @@
     },
     {
       "name": "Science lecture hall",
-      "environment": -1,
       "exits": {
         "west": 904
       },
-      "weight": 1,
       "id": 906,
       "area": {
         "id": 4
@@ -1650,12 +1398,10 @@
     },
     {
       "name": "Gravel Path",
-      "environment": -1,
       "exits": {
         "northwest": 908,
         "southwest": 604
       },
-      "weight": 1,
       "id": 907,
       "area": {
         "id": 4
@@ -1663,13 +1409,11 @@
     },
     {
       "name": "Vine-covered Entry",
-      "environment": -1,
       "exits": {
         "southwest": 910,
         "southeast": 907,
         "north": 909
       },
-      "weight": 1,
       "id": 908,
       "area": {
         "id": 4
@@ -1677,14 +1421,12 @@
     },
     {
       "name": "Grand Foyer",
-      "environment": -1,
       "exits": {
         "up": 914,
         "west": 911,
         "east": 912,
         "south": 908
       },
-      "weight": 1,
       "id": 909,
       "area": {
         "id": 4
@@ -1692,12 +1434,10 @@
     },
     {
       "name": "Gravel Path",
-      "environment": -1,
       "exits": {
         "southeast": 604,
         "northeast": 908
       },
-      "weight": 1,
       "id": 910,
       "area": {
         "id": 4
@@ -1705,11 +1445,9 @@
     },
     {
       "name": "Child's Den",
-      "environment": -1,
       "exits": {
         "east": 909
       },
-      "weight": 1,
       "id": 911,
       "area": {
         "id": 4
@@ -1717,12 +1455,10 @@
     },
     {
       "name": "Wooded Hallway",
-      "environment": -1,
       "exits": {
         "east": 913,
         "west": 909
       },
-      "weight": 1,
       "id": 912,
       "area": {
         "id": 4
@@ -1730,11 +1466,9 @@
     },
     {
       "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
-      "environment": -1,
       "exits": {
         "west": 912
       },
-      "weight": 1,
       "id": 913,
       "area": {
         "id": 4
@@ -1742,11 +1476,9 @@
     },
     {
       "name": "Treetop Bedroom",
-      "environment": -1,
       "exits": {
         "down": 909
       },
-      "weight": 1,
       "id": 914,
       "area": {
         "id": 4
@@ -1754,14 +1486,12 @@
     },
     {
       "name": "Flagstoned path",
-      "environment": -1,
       "exits": {
         "south": 916,
         "west": 919,
         "east": 918,
         "north": 603
       },
-      "weight": 1,
       "id": 915,
       "area": {
         "id": 4
@@ -1769,12 +1499,10 @@
     },
     {
       "name": "Gray foyer",
-      "environment": -1,
       "exits": {
         "south": 917,
         "north": 915
       },
-      "weight": 1,
       "id": 916,
       "area": {
         "id": 4
@@ -1782,11 +1510,9 @@
     },
     {
       "name": "Trinian merchant's office",
-      "environment": -1,
       "exits": {
         "north": 916
       },
-      "weight": 1,
       "id": 917,
       "area": {
         "id": 4
@@ -1794,11 +1520,9 @@
     },
     {
       "name": "Carriage house",
-      "environment": -1,
       "exits": {
         "west": 915
       },
-      "weight": 1,
       "id": 918,
       "area": {
         "id": 4
@@ -1806,11 +1530,9 @@
     },
     {
       "name": "Slave quarters",
-      "environment": -1,
       "exits": {
         "east": 915
       },
-      "weight": 1,
       "id": 919,
       "area": {
         "id": 4
@@ -1818,7 +1540,6 @@
     },
     {
       "name": "Dwarven Embassy foyer",
-      "environment": -1,
       "exits": {
         "west": 923,
         "up": 921,
@@ -1826,7 +1547,6 @@
         "east": 925,
         "north": 924
       },
-      "weight": 1,
       "id": 920,
       "area": {
         "id": 4
@@ -1834,12 +1554,10 @@
     },
     {
       "name": "Dwarven watchtower",
-      "environment": -1,
       "exits": {
         "down": 920,
         "north": 922
       },
-      "weight": 1,
       "id": 921,
       "area": {
         "id": 4
@@ -1847,11 +1565,9 @@
     },
     {
       "name": "Ambassadors Suite",
-      "environment": -1,
       "exits": {
         "south": 921
       },
-      "weight": 1,
       "id": 922,
       "area": {
         "id": 4
@@ -1859,11 +1575,9 @@
     },
     {
       "name": "Dwarven brewery",
-      "environment": -1,
       "exits": {
         "east": 920
       },
-      "weight": 1,
       "id": 923,
       "area": {
         "id": 4
@@ -1871,11 +1585,9 @@
     },
     {
       "name": "Dwarven Ambassador's office",
-      "environment": -1,
       "exits": {
         "south": 920
       },
-      "weight": 1,
       "id": 924,
       "area": {
         "id": 4
@@ -1883,11 +1595,9 @@
     },
     {
       "name": "Dwarven armoury",
-      "environment": -1,
       "exits": {
         "west": 920
       },
-      "weight": 1,
       "id": 925,
       "area": {
         "id": 4
@@ -1895,14 +1605,12 @@
     },
     {
       "name": "Ground Floor of the Windmill",
-      "environment": -1,
       "exits": {
         "up": 929,
         "west": 927,
         "east": 928,
         "south": 319
       },
-      "weight": 1,
       "id": 926,
       "area": {
         "id": 4
@@ -1910,11 +1618,9 @@
     },
     {
       "name": "Garden of Machines",
-      "environment": -1,
       "exits": {
         "east": 926
       },
-      "weight": 1,
       "id": 927,
       "area": {
         "id": 4
@@ -1922,11 +1628,9 @@
     },
     {
       "name": "Cemetery",
-      "environment": -1,
       "exits": {
         "west": 926
       },
-      "weight": 1,
       "id": 928,
       "area": {
         "id": 4
@@ -1934,12 +1638,10 @@
     },
     {
       "name": "Gnome Laboratory",
-      "environment": -1,
       "exits": {
         "down": 926,
         "up": 930
       },
-      "weight": 1,
       "id": 929,
       "area": {
         "id": 4
@@ -1947,11 +1649,9 @@
     },
     {
       "name": "Machinery Room",
-      "environment": -1,
       "exits": {
         "down": 929
       },
-      "weight": 1,
       "id": 930,
       "area": {
         "id": 4

--- a/maps/great-bazaar-of-candera.json
+++ b/maps/great-bazaar-of-candera.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 96,
         "east": 428,
         "north": 995
       },
-      "weight": 1,
       "id": 977,
       "area": {
         "id": 15
@@ -19,11 +17,9 @@
     },
     {
       "name": "Nut Shop",
-      "environment": -1,
       "exits": {
         "south": 989
       },
-      "weight": 1,
       "id": 978,
       "area": {
         "id": 15
@@ -31,14 +27,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 980,
         "west": 984,
         "east": 991,
         "north": 989
       },
-      "weight": 1,
       "id": 979,
       "area": {
         "id": 15
@@ -46,14 +40,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 981,
         "west": 983,
         "east": 993,
         "north": 979
       },
-      "weight": 1,
       "id": 980,
       "area": {
         "id": 15
@@ -61,13 +53,11 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "west": 982,
         "east": 995,
         "north": 980
       },
-      "weight": 1,
       "id": 981,
       "area": {
         "id": 15
@@ -75,11 +65,9 @@
     },
     {
       "name": "Shader's Scales",
-      "environment": -1,
       "exits": {
         "east": 981
       },
-      "weight": 1,
       "id": 982,
       "area": {
         "id": 15
@@ -87,11 +75,9 @@
     },
     {
       "name": "Omars' Oil:",
-      "environment": -1,
       "exits": {
         "east": 980
       },
-      "weight": 1,
       "id": 983,
       "area": {
         "id": 15
@@ -99,11 +85,9 @@
     },
     {
       "name": "Smithy",
-      "environment": -1,
       "exits": {
         "east": 979
       },
-      "weight": 1,
       "id": 984,
       "area": {
         "id": 15
@@ -111,14 +95,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 991,
         "west": 989,
         "east": 987,
         "north": 988
       },
-      "weight": 1,
       "id": 985,
       "area": {
         "id": 15
@@ -126,11 +108,9 @@
     },
     {
       "name": "Lord Candera's Lottery",
-      "environment": -1,
       "exits": {
         "west": 985
       },
-      "weight": 1,
       "id": 987,
       "area": {
         "id": 15
@@ -138,11 +118,9 @@
     },
     {
       "name": "Empty Tent",
-      "environment": -1,
       "exits": {
         "south": 985
       },
-      "weight": 1,
       "id": 988,
       "area": {
         "id": 15
@@ -150,14 +128,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 979,
         "west": 966,
         "east": 985,
         "north": 978
       },
-      "weight": 1,
       "id": 989,
       "area": {
         "id": 15
@@ -165,14 +141,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 993,
         "west": 979,
         "east": 992,
         "north": 985
       },
-      "weight": 1,
       "id": 991,
       "area": {
         "id": 15
@@ -180,11 +154,9 @@
     },
     {
       "name": "Kamal's Camel Lot:",
-      "environment": -1,
       "exits": {
         "west": 991
       },
-      "weight": 1,
       "id": 992,
       "area": {
         "id": 15
@@ -192,14 +164,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 995,
         "west": 980,
         "east": 994,
         "north": 991
       },
-      "weight": 1,
       "id": 993,
       "area": {
         "id": 15
@@ -207,11 +177,9 @@
     },
     {
       "name": "Perfume Tent:",
-      "environment": -1,
       "exits": {
         "west": 993
       },
-      "weight": 1,
       "id": 994,
       "area": {
         "id": 15
@@ -219,14 +187,12 @@
     },
     {
       "name": "Great Bazaar of Candera",
-      "environment": -1,
       "exits": {
         "south": 977,
         "west": 981,
         "east": 1739,
         "north": 993
       },
-      "weight": 1,
       "id": 995,
       "area": {
         "id": 15
@@ -234,11 +200,9 @@
     },
     {
       "name": "Landak's Hut:",
-      "environment": -1,
       "exits": {
         "west": 995
       },
-      "weight": 1,
       "id": 1739,
       "area": {
         "id": 15

--- a/maps/ice-dragons-den.json
+++ b/maps/ice-dragons-den.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Ice Dragon's Den",
-      "environment": -1,
       "exits": {
         "down": 1339
       },
-      "weight": 1,
       "id": 1338,
       "area": {
         "id": 26
@@ -17,12 +15,10 @@
     },
     {
       "name": "Near a Frozen Waterfall",
-      "environment": -1,
       "exits": {
         "northwest": 1340,
         "east": 1342
       },
-      "weight": 1,
       "id": 1339,
       "area": {
         "id": 26
@@ -30,12 +26,10 @@
     },
     {
       "name": "By an Icy Gate",
-      "environment": -1,
       "exits": {
         "southeast": 1339,
         "east": 1341
       },
-      "weight": 1,
       "id": 1340,
       "area": {
         "id": 26
@@ -43,11 +37,9 @@
     },
     {
       "name": "Edge of an Icy Cliff",
-      "environment": -1,
       "exits": {
         "west": 1340
       },
-      "weight": 1,
       "id": 1341,
       "area": {
         "id": 26
@@ -55,12 +47,10 @@
     },
     {
       "name": "On Top of a Frozen River",
-      "environment": -1,
       "exits": {
         "west": 1339,
         "north": 1343
       },
-      "weight": 1,
       "id": 1342,
       "area": {
         "id": 26
@@ -68,12 +58,10 @@
     },
     {
       "name": "On Top of a Frozen River",
-      "environment": -1,
       "exits": {
         "south": 1342,
         "north": 1344
       },
-      "weight": 1,
       "id": 1343,
       "area": {
         "id": 26
@@ -81,12 +69,10 @@
     },
     {
       "name": "Under a Snowy Overhang",
-      "environment": -1,
       "exits": {
         "northwest": 1345,
         "south": 1343
       },
-      "weight": 1,
       "id": 1344,
       "area": {
         "id": 26
@@ -94,12 +80,10 @@
     },
     {
       "name": "On Top of an Icy Stream",
-      "environment": -1,
       "exits": {
         "southeast": 1344,
         "west": 1346
       },
-      "weight": 1,
       "id": 1345,
       "area": {
         "id": 26
@@ -107,14 +91,12 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "east": 1345,
         "northwest": 1347,
         "southeast": 1360,
         "west": 1358
       },
-      "weight": 1,
       "id": 1346,
       "area": {
         "id": 26
@@ -122,14 +104,12 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "west": 1351,
         "northeast": 1348,
         "southeast": 1346,
         "south": 1358
       },
-      "weight": 1,
       "id": 1347,
       "area": {
         "id": 26
@@ -137,12 +117,10 @@
     },
     {
       "name": "Entrance to a Frozen Cavern",
-      "environment": -1,
       "exits": {
         "southwest": 1347,
         "southeast": 1349
       },
-      "weight": 1,
       "id": 1348,
       "area": {
         "id": 26
@@ -150,12 +128,10 @@
     },
     {
       "name": "Frozen Cavern",
-      "environment": -1,
       "exits": {
         "northwest": 1348,
         "east": 1350
       },
-      "weight": 1,
       "id": 1349,
       "area": {
         "id": 26
@@ -163,11 +139,9 @@
     },
     {
       "name": "End of a Frozen Cavern",
-      "environment": -1,
       "exits": {
         "west": 1349
       },
-      "weight": 1,
       "id": 1350,
       "area": {
         "id": 26
@@ -175,13 +149,11 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "west": 1352,
         "east": 1347,
         "south": 1356
       },
-      "weight": 1,
       "id": 1351,
       "area": {
         "id": 26
@@ -189,13 +161,11 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "east": 1351,
         "northwest": 1359,
         "south": 1353
       },
-      "weight": 1,
       "id": 1352,
       "area": {
         "id": 26
@@ -203,13 +173,11 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "southwest": 1354,
         "east": 1356,
         "north": 1352
       },
-      "weight": 1,
       "id": 1353,
       "area": {
         "id": 26
@@ -217,12 +185,10 @@
     },
     {
       "name": "Ice Cave Entrance",
-      "environment": -1,
       "exits": {
         "east": 1355,
         "northeast": 1353
       },
-      "weight": 1,
       "id": 1354,
       "area": {
         "id": 26
@@ -230,11 +196,9 @@
     },
     {
       "name": "Inside an Ice Cave",
-      "environment": -1,
       "exits": {
         "west": 1354
       },
-      "weight": 1,
       "id": 1355,
       "area": {
         "id": 26
@@ -242,14 +206,12 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "south": 1357,
         "west": 1353,
         "east": 1358,
         "north": 1351
       },
-      "weight": 1,
       "id": 1356,
       "area": {
         "id": 26
@@ -257,11 +219,9 @@
     },
     {
       "name": "Isolated Icy Area",
-      "environment": -1,
       "exits": {
         "north": 1356
       },
-      "weight": 1,
       "id": 1357,
       "area": {
         "id": 26
@@ -269,13 +229,11 @@
     },
     {
       "name": "On Top of an Icy Lake",
-      "environment": -1,
       "exits": {
         "west": 1356,
         "east": 1346,
         "north": 1347
       },
-      "weight": 1,
       "id": 1358,
       "area": {
         "id": 26
@@ -283,11 +241,9 @@
     },
     {
       "name": "Northern Shore of an Icy Lake",
-      "environment": -1,
       "exits": {
         "southeast": 1352
       },
-      "weight": 1,
       "id": 1359,
       "area": {
         "id": 26
@@ -295,11 +251,9 @@
     },
     {
       "name": "Snowy Overhang",
-      "environment": -1,
       "exits": {
         "northwest": 1346
       },
-      "weight": 1,
       "id": 1360,
       "area": {
         "id": 26
@@ -307,11 +261,9 @@
     },
     {
       "name": "down the waterfall.",
-      "environment": -1,
       "exits": {
         "down": 1339
       },
-      "weight": 1,
       "id": 1869,
       "area": {
         "id": 26

--- a/maps/indel-city-park.json
+++ b/maps/indel-city-park.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1525,
         "east": 1607,
         "north": 1608
       },
-      "weight": 1,
       "id": 1606,
       "area": {
         "id": 30
@@ -19,13 +17,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1606,
         "east": 1613,
         "north": 1609
       },
-      "weight": 1,
       "id": 1607,
       "area": {
         "id": 30
@@ -33,13 +29,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1606,
         "east": 1609,
         "north": 1611
       },
-      "weight": 1,
       "id": 1608,
       "area": {
         "id": 30
@@ -47,14 +41,12 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1607,
         "west": 1608,
         "east": 1610,
         "north": 1612
       },
-      "weight": 1,
       "id": 1609,
       "area": {
         "id": 30
@@ -62,13 +54,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1609,
         "south": 1613,
         "north": 1614
       },
-      "weight": 1,
       "id": 1610,
       "area": {
         "id": 30
@@ -76,13 +66,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1608,
         "east": 1612,
         "north": 1615
       },
-      "weight": 1,
       "id": 1611,
       "area": {
         "id": 30
@@ -90,14 +78,12 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1609,
         "west": 1611,
         "east": 1614,
         "north": 1616
       },
-      "weight": 1,
       "id": 1612,
       "area": {
         "id": 30
@@ -105,12 +91,10 @@
     },
     {
       "name": "Gazebo in the Park",
-      "environment": -1,
       "exits": {
         "west": 1607,
         "north": 1610
       },
-      "weight": 1,
       "id": 1613,
       "area": {
         "id": 30
@@ -118,13 +102,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1612,
         "south": 1610,
         "north": 1617
       },
-      "weight": 1,
       "id": 1614,
       "area": {
         "id": 30
@@ -132,13 +114,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1611,
         "east": 1616,
         "north": 1619
       },
-      "weight": 1,
       "id": 1615,
       "area": {
         "id": 30
@@ -146,14 +126,12 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "south": 1612,
         "west": 1615,
         "east": 1617,
         "north": 1618
       },
-      "weight": 1,
       "id": 1616,
       "area": {
         "id": 30
@@ -161,13 +139,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1616,
         "south": 1614,
         "north": 1620
       },
-      "weight": 1,
       "id": 1617,
       "area": {
         "id": 30
@@ -175,13 +151,11 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1619,
         "east": 1620,
         "south": 1616
       },
-      "weight": 1,
       "id": 1618,
       "area": {
         "id": 30
@@ -189,12 +163,10 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "east": 1618,
         "south": 1615
       },
-      "weight": 1,
       "id": 1619,
       "area": {
         "id": 30
@@ -202,12 +174,10 @@
     },
     {
       "name": "Indel City Park",
-      "environment": -1,
       "exits": {
         "west": 1618,
         "south": 1617
       },
-      "weight": 1,
       "id": 1620,
       "area": {
         "id": 30

--- a/maps/indel.json
+++ b/maps/indel.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "City of Indel, Wilderness Gate",
-      "environment": -1,
       "exits": {
         "west": 1635,
         "east": 1636,
         "south": 1402
       },
-      "weight": 1,
       "id": 1401,
       "area": {
         "id": 28
@@ -19,14 +17,12 @@
     },
     {
       "name": "Castle Road",
-      "environment": -1,
       "exits": {
         "south": 1403,
         "west": 1631,
         "east": 1633,
         "north": 1401
       },
-      "weight": 1,
       "id": 1402,
       "area": {
         "id": 28
@@ -34,14 +30,12 @@
     },
     {
       "name": "Castle Road",
-      "environment": -1,
       "exits": {
         "south": 1404,
         "west": 1628,
         "east": 1630,
         "north": 1402
       },
-      "weight": 1,
       "id": 1403,
       "area": {
         "id": 28
@@ -49,14 +43,12 @@
     },
     {
       "name": "Castle Road Courtyard",
-      "environment": -1,
       "exits": {
         "south": 1405,
         "west": 1626,
         "east": 1627,
         "north": 1403
       },
-      "weight": 1,
       "id": 1404,
       "area": {
         "id": 28
@@ -64,13 +56,11 @@
     },
     {
       "name": "Castle Road",
-      "environment": -1,
       "exits": {
         "west": 1625,
         "south": 1406,
         "north": 1404
       },
-      "weight": 1,
       "id": 1405,
       "area": {
         "id": 28
@@ -78,14 +68,12 @@
     },
     {
       "name": "Intersection of Castle Road and Merchant's Row",
-      "environment": -1,
       "exits": {
         "south": 1584,
         "west": 1407,
         "east": 1508,
         "north": 1405
       },
-      "weight": 1,
       "id": 1406,
       "area": {
         "id": 28
@@ -93,12 +81,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1406,
         "west": 1408
       },
-      "weight": 1,
       "id": 1407,
       "area": {
         "id": 28
@@ -106,13 +92,11 @@
     },
     {
       "name": "West Merchant's Row, north of the Silver Griffin",
-      "environment": -1,
       "exits": {
         "west": 1409,
         "east": 1407,
         "south": 1589
       },
-      "weight": 1,
       "id": 1408,
       "area": {
         "id": 28
@@ -120,13 +104,11 @@
     },
     {
       "name": "West Merchant's Row, south of Big Bob's Sign Shop",
-      "environment": -1,
       "exits": {
         "west": 1410,
         "east": 1408,
         "south": 1590
       },
-      "weight": 1,
       "id": 1409,
       "area": {
         "id": 28
@@ -134,12 +116,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1409,
         "west": 1411
       },
-      "weight": 1,
       "id": 1410,
       "area": {
         "id": 28
@@ -147,12 +127,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1410,
         "west": 1412
       },
-      "weight": 1,
       "id": 1411,
       "area": {
         "id": 28
@@ -160,12 +138,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1411,
         "west": 1413
       },
-      "weight": 1,
       "id": 1412,
       "area": {
         "id": 28
@@ -173,12 +149,10 @@
     },
     {
       "name": "West Merchant's Row, south of Knights of Solamnia",
-      "environment": -1,
       "exits": {
         "east": 1412,
         "west": 1414
       },
-      "weight": 1,
       "id": 1413,
       "area": {
         "id": 28
@@ -186,12 +160,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1413,
         "west": 1415
       },
-      "weight": 1,
       "id": 1414,
       "area": {
         "id": 28
@@ -199,12 +171,10 @@
     },
     {
       "name": "West Merchant's Row, south of the Cobbler's Shop",
-      "environment": -1,
       "exits": {
         "east": 1414,
         "west": 1416
       },
-      "weight": 1,
       "id": 1415,
       "area": {
         "id": 28
@@ -212,12 +182,10 @@
     },
     {
       "name": "West Merchant's Row, south of Laird's Forge",
-      "environment": -1,
       "exits": {
         "east": 1415,
         "west": 1417
       },
-      "weight": 1,
       "id": 1416,
       "area": {
         "id": 28
@@ -225,12 +193,10 @@
     },
     {
       "name": "West Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1416,
         "west": 1418
       },
-      "weight": 1,
       "id": 1417,
       "area": {
         "id": 28
@@ -238,13 +204,11 @@
     },
     {
       "name": "Pier Street and Merchant's Row",
-      "environment": -1,
       "exits": {
         "south": 1419,
         "east": 1417,
         "north": 1448
       },
-      "weight": 1,
       "id": 1418,
       "area": {
         "id": 28
@@ -252,12 +216,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1420,
         "north": 1418
       },
-      "weight": 1,
       "id": 1419,
       "area": {
         "id": 28
@@ -265,12 +227,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1421,
         "north": 1419
       },
-      "weight": 1,
       "id": 1420,
       "area": {
         "id": 28
@@ -278,12 +238,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1422,
         "north": 1420
       },
-      "weight": 1,
       "id": 1421,
       "area": {
         "id": 28
@@ -291,12 +249,10 @@
     },
     {
       "name": "Pier Street west of the Waterfront Gate",
-      "environment": -1,
       "exits": {
         "south": 1423,
         "north": 1421
       },
-      "weight": 1,
       "id": 1422,
       "area": {
         "id": 28
@@ -304,12 +260,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1424,
         "north": 1422
       },
-      "weight": 1,
       "id": 1423,
       "area": {
         "id": 28
@@ -317,12 +271,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1425,
         "north": 1423
       },
-      "weight": 1,
       "id": 1424,
       "area": {
         "id": 28
@@ -330,12 +282,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1426,
         "north": 1424
       },
-      "weight": 1,
       "id": 1425,
       "area": {
         "id": 28
@@ -343,12 +293,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1427,
         "north": 1425
       },
-      "weight": 1,
       "id": 1426,
       "area": {
         "id": 28
@@ -356,12 +304,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1428,
         "north": 1426
       },
-      "weight": 1,
       "id": 1427,
       "area": {
         "id": 28
@@ -369,12 +315,10 @@
     },
     {
       "name": "Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1429,
         "north": 1427
       },
-      "weight": 1,
       "id": 1428,
       "area": {
         "id": 28
@@ -382,12 +326,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1430,
         "north": 1428
       },
-      "weight": 1,
       "id": 1429,
       "area": {
         "id": 28
@@ -395,12 +337,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1431,
         "north": 1429
       },
-      "weight": 1,
       "id": 1430,
       "area": {
         "id": 28
@@ -408,12 +348,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1432,
         "north": 1430
       },
-      "weight": 1,
       "id": 1431,
       "area": {
         "id": 28
@@ -421,12 +359,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1433,
         "north": 1431
       },
-      "weight": 1,
       "id": 1432,
       "area": {
         "id": 28
@@ -434,12 +370,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1434,
         "north": 1432
       },
-      "weight": 1,
       "id": 1433,
       "area": {
         "id": 28
@@ -447,13 +381,11 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1435,
         "east": 1545,
         "north": 1433
       },
-      "weight": 1,
       "id": 1434,
       "area": {
         "id": 28
@@ -461,12 +393,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1436,
         "north": 1434
       },
-      "weight": 1,
       "id": 1435,
       "area": {
         "id": 28
@@ -474,12 +404,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1437,
         "north": 1435
       },
-      "weight": 1,
       "id": 1436,
       "area": {
         "id": 28
@@ -487,12 +415,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1438,
         "north": 1436
       },
-      "weight": 1,
       "id": 1437,
       "area": {
         "id": 28
@@ -500,12 +426,10 @@
     },
     {
       "name": "South Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1439,
         "north": 1437
       },
-      "weight": 1,
       "id": 1438,
       "area": {
         "id": 28
@@ -513,11 +437,9 @@
     },
     {
       "name": "Forester's Gate",
-      "environment": -1,
       "exits": {
         "north": 1438
       },
-      "weight": 1,
       "id": 1439,
       "area": {
         "id": 28
@@ -525,12 +447,10 @@
     },
     {
       "name": "North Pier Street",
-      "environment": -1,
       "exits": {
         "south": 1418,
         "north": 1507
       },
-      "weight": 1,
       "id": 1448,
       "area": {
         "id": 28
@@ -538,11 +458,9 @@
     },
     {
       "name": "Cobblestone courtyard",
-      "environment": -1,
       "exits": {
         "south": 1448
       },
-      "weight": 1,
       "id": 1507,
       "area": {
         "id": 28
@@ -550,12 +468,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1509,
         "west": 1406
       },
-      "weight": 1,
       "id": 1508,
       "area": {
         "id": 28
@@ -563,13 +479,11 @@
     },
     {
       "name": "East Merchant's Row, south of Saul's Formal Wear",
-      "environment": -1,
       "exits": {
         "west": 1508,
         "east": 1510,
         "north": 1624
       },
-      "weight": 1,
       "id": 1509,
       "area": {
         "id": 28
@@ -577,13 +491,11 @@
     },
     {
       "name": "East Merchant's Row, south of a livestock lot",
-      "environment": -1,
       "exits": {
         "west": 1509,
         "east": 1511,
         "north": 1623
       },
-      "weight": 1,
       "id": 1510,
       "area": {
         "id": 28
@@ -591,13 +503,11 @@
     },
     {
       "name": "East Merchant's Row, south of Mother Whitman's",
-      "environment": -1,
       "exits": {
         "west": 1510,
         "east": 1512,
         "north": 1622
       },
-      "weight": 1,
       "id": 1511,
       "area": {
         "id": 28
@@ -605,12 +515,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1513,
         "west": 1511
       },
-      "weight": 1,
       "id": 1512,
       "area": {
         "id": 28
@@ -618,12 +526,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1514,
         "west": 1512
       },
-      "weight": 1,
       "id": 1513,
       "area": {
         "id": 28
@@ -631,13 +537,11 @@
     },
     {
       "name": "East Merchant's Row, south of Sithicus",
-      "environment": -1,
       "exits": {
         "west": 1513,
         "east": 1515,
         "north": 1621
       },
-      "weight": 1,
       "id": 1514,
       "area": {
         "id": 28
@@ -645,12 +549,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1516,
         "west": 1514
       },
-      "weight": 1,
       "id": 1515,
       "area": {
         "id": 28
@@ -658,13 +560,11 @@
     },
     {
       "name": "Merchant's Row and Pensji Lane",
-      "environment": -1,
       "exits": {
         "west": 1515,
         "east": 1517,
         "south": 1520
       },
-      "weight": 1,
       "id": 1516,
       "area": {
         "id": 28
@@ -672,12 +572,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1518,
         "west": 1516
       },
-      "weight": 1,
       "id": 1517,
       "area": {
         "id": 28
@@ -685,12 +583,10 @@
     },
     {
       "name": "East Merchant's Row",
-      "environment": -1,
       "exits": {
         "east": 1519,
         "west": 1517
       },
-      "weight": 1,
       "id": 1518,
       "area": {
         "id": 28
@@ -698,11 +594,9 @@
     },
     {
       "name": "End of Merchant's Row",
-      "environment": -1,
       "exits": {
         "west": 1518
       },
-      "weight": 1,
       "id": 1519,
       "area": {
         "id": 28
@@ -710,12 +604,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1521,
         "north": 1516
       },
-      "weight": 1,
       "id": 1520,
       "area": {
         "id": 28
@@ -723,12 +615,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1522,
         "north": 1520
       },
-      "weight": 1,
       "id": 1521,
       "area": {
         "id": 28
@@ -736,12 +626,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1523,
         "north": 1521
       },
-      "weight": 1,
       "id": 1522,
       "area": {
         "id": 28
@@ -749,12 +637,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1524,
         "north": 1522
       },
-      "weight": 1,
       "id": 1523,
       "area": {
         "id": 28
@@ -762,12 +648,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1525,
         "north": 1523
       },
-      "weight": 1,
       "id": 1524,
       "area": {
         "id": 28
@@ -775,13 +659,11 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1526,
         "east": 1606,
         "north": 1524
       },
-      "weight": 1,
       "id": 1525,
       "area": {
         "id": 28
@@ -789,12 +671,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1527,
         "north": 1525
       },
-      "weight": 1,
       "id": 1526,
       "area": {
         "id": 28
@@ -802,12 +682,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1528,
         "north": 1526
       },
-      "weight": 1,
       "id": 1527,
       "area": {
         "id": 28
@@ -815,12 +693,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1529,
         "north": 1527
       },
-      "weight": 1,
       "id": 1528,
       "area": {
         "id": 28
@@ -828,12 +704,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1530,
         "north": 1528
       },
-      "weight": 1,
       "id": 1529,
       "area": {
         "id": 28
@@ -841,12 +715,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1531,
         "north": 1529
       },
-      "weight": 1,
       "id": 1530,
       "area": {
         "id": 28
@@ -854,12 +726,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1532,
         "north": 1530
       },
-      "weight": 1,
       "id": 1531,
       "area": {
         "id": 28
@@ -867,12 +737,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1533,
         "north": 1531
       },
-      "weight": 1,
       "id": 1532,
       "area": {
         "id": 28
@@ -880,13 +748,11 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1534,
         "east": 1597,
         "north": 1532
       },
-      "weight": 1,
       "id": 1533,
       "area": {
         "id": 28
@@ -894,12 +760,10 @@
     },
     {
       "name": "Pensji Lane",
-      "environment": -1,
       "exits": {
         "south": 1542,
         "north": 1533
       },
-      "weight": 1,
       "id": 1534,
       "area": {
         "id": 28
@@ -907,12 +771,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1536,
         "west": 1557
       },
-      "weight": 1,
       "id": 1535,
       "area": {
         "id": 28
@@ -920,12 +782,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1537,
         "west": 1535
       },
-      "weight": 1,
       "id": 1536,
       "area": {
         "id": 28
@@ -933,12 +793,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1538,
         "west": 1536
       },
-      "weight": 1,
       "id": 1537,
       "area": {
         "id": 28
@@ -946,12 +804,10 @@
     },
     {
       "name": "City Barracks Gate",
-      "environment": -1,
       "exits": {
         "east": 1539,
         "west": 1537
       },
-      "weight": 1,
       "id": 1538,
       "area": {
         "id": 28
@@ -959,12 +815,10 @@
     },
     {
       "name": "West Martial Row",
-      "environment": -1,
       "exits": {
         "east": 1540,
         "west": 1538
       },
-      "weight": 1,
       "id": 1539,
       "area": {
         "id": 28
@@ -972,12 +826,10 @@
     },
     {
       "name": "West Martial Row",
-      "environment": -1,
       "exits": {
         "east": 1541,
         "west": 1539
       },
-      "weight": 1,
       "id": 1540,
       "area": {
         "id": 28
@@ -985,12 +837,10 @@
     },
     {
       "name": "West Martial Row",
-      "environment": -1,
       "exits": {
         "east": 1542,
         "west": 1540
       },
-      "weight": 1,
       "id": 1541,
       "area": {
         "id": 28
@@ -998,13 +848,11 @@
     },
     {
       "name": "Intersection of Martial Row and Pensji Lane",
-      "environment": -1,
       "exits": {
         "west": 1541,
         "east": 1591,
         "north": 1534
       },
-      "weight": 1,
       "id": 1542,
       "area": {
         "id": 28
@@ -1012,12 +860,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1546,
         "north": 1544
       },
-      "weight": 1,
       "id": 1543,
       "area": {
         "id": 28
@@ -1025,12 +871,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1543,
         "north": 1558
       },
-      "weight": 1,
       "id": 1544,
       "area": {
         "id": 28
@@ -1038,12 +882,10 @@
     },
     {
       "name": "Ambassador Gate",
-      "environment": -1,
       "exits": {
         "east": 1546,
         "west": 1434
       },
-      "weight": 1,
       "id": 1545,
       "area": {
         "id": 28
@@ -1051,13 +893,11 @@
     },
     {
       "name": "Intersection of Church Road and Embassy Row",
-      "environment": -1,
       "exits": {
         "west": 1545,
         "east": 1547,
         "north": 1543
       },
-      "weight": 1,
       "id": 1546,
       "area": {
         "id": 28
@@ -1065,12 +905,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1548,
         "west": 1546
       },
-      "weight": 1,
       "id": 1547,
       "area": {
         "id": 28
@@ -1078,12 +916,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1549,
         "west": 1547
       },
-      "weight": 1,
       "id": 1548,
       "area": {
         "id": 28
@@ -1091,12 +927,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1550,
         "west": 1548
       },
-      "weight": 1,
       "id": 1549,
       "area": {
         "id": 28
@@ -1104,12 +938,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1551,
         "west": 1549
       },
-      "weight": 1,
       "id": 1550,
       "area": {
         "id": 28
@@ -1117,12 +949,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1552,
         "west": 1550
       },
-      "weight": 1,
       "id": 1551,
       "area": {
         "id": 28
@@ -1130,12 +960,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1553,
         "west": 1551
       },
-      "weight": 1,
       "id": 1552,
       "area": {
         "id": 28
@@ -1143,12 +971,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1554,
         "west": 1552
       },
-      "weight": 1,
       "id": 1553,
       "area": {
         "id": 28
@@ -1156,12 +982,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1555,
         "west": 1553
       },
-      "weight": 1,
       "id": 1554,
       "area": {
         "id": 28
@@ -1169,12 +993,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1556,
         "west": 1554
       },
-      "weight": 1,
       "id": 1555,
       "area": {
         "id": 28
@@ -1182,12 +1004,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1557,
         "west": 1555
       },
-      "weight": 1,
       "id": 1556,
       "area": {
         "id": 28
@@ -1195,12 +1015,10 @@
     },
     {
       "name": "Embassy Row",
-      "environment": -1,
       "exits": {
         "east": 1535,
         "west": 1556
       },
-      "weight": 1,
       "id": 1557,
       "area": {
         "id": 28
@@ -1208,12 +1026,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1544,
         "north": 1559
       },
-      "weight": 1,
       "id": 1558,
       "area": {
         "id": 28
@@ -1221,12 +1037,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1558,
         "north": 1560
       },
-      "weight": 1,
       "id": 1559,
       "area": {
         "id": 28
@@ -1234,12 +1048,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1559,
         "north": 1561
       },
-      "weight": 1,
       "id": 1560,
       "area": {
         "id": 28
@@ -1247,12 +1059,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1560,
         "north": 1562
       },
-      "weight": 1,
       "id": 1561,
       "area": {
         "id": 28
@@ -1260,12 +1070,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1561,
         "north": 1563
       },
-      "weight": 1,
       "id": 1562,
       "area": {
         "id": 28
@@ -1273,12 +1081,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1562,
         "north": 1564
       },
-      "weight": 1,
       "id": 1563,
       "area": {
         "id": 28
@@ -1286,12 +1092,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1563,
         "north": 1565
       },
-      "weight": 1,
       "id": 1564,
       "area": {
         "id": 28
@@ -1299,12 +1103,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1564,
         "north": 1566
       },
-      "weight": 1,
       "id": 1565,
       "area": {
         "id": 28
@@ -1312,12 +1114,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1565,
         "north": 1567
       },
-      "weight": 1,
       "id": 1566,
       "area": {
         "id": 28
@@ -1325,12 +1125,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1566,
         "north": 1568
       },
-      "weight": 1,
       "id": 1567,
       "area": {
         "id": 28
@@ -1338,12 +1136,10 @@
     },
     {
       "name": "West Church Road",
-      "environment": -1,
       "exits": {
         "south": 1567,
         "north": 1569
       },
-      "weight": 1,
       "id": 1568,
       "area": {
         "id": 28
@@ -1351,12 +1147,10 @@
     },
     {
       "name": "Church Road Bend",
-      "environment": -1,
       "exits": {
         "east": 1570,
         "south": 1568
       },
-      "weight": 1,
       "id": 1569,
       "area": {
         "id": 28
@@ -1364,12 +1158,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1571,
         "west": 1569
       },
-      "weight": 1,
       "id": 1570,
       "area": {
         "id": 28
@@ -1377,12 +1169,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1572,
         "west": 1570
       },
-      "weight": 1,
       "id": 1571,
       "area": {
         "id": 28
@@ -1390,12 +1180,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1573,
         "west": 1571
       },
-      "weight": 1,
       "id": 1572,
       "area": {
         "id": 28
@@ -1403,12 +1191,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1574,
         "west": 1572
       },
-      "weight": 1,
       "id": 1573,
       "area": {
         "id": 28
@@ -1416,12 +1202,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1575,
         "west": 1573
       },
-      "weight": 1,
       "id": 1574,
       "area": {
         "id": 28
@@ -1429,12 +1213,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1576,
         "west": 1574
       },
-      "weight": 1,
       "id": 1575,
       "area": {
         "id": 28
@@ -1442,12 +1224,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1577,
         "west": 1575
       },
-      "weight": 1,
       "id": 1576,
       "area": {
         "id": 28
@@ -1455,12 +1235,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1578,
         "west": 1576
       },
-      "weight": 1,
       "id": 1577,
       "area": {
         "id": 28
@@ -1468,12 +1246,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1579,
         "west": 1577
       },
-      "weight": 1,
       "id": 1578,
       "area": {
         "id": 28
@@ -1481,14 +1257,12 @@
     },
     {
       "name": "Intersection of Castle Road and Church Road",
-      "environment": -1,
       "exits": {
         "south": 1585,
         "west": 1578,
         "east": 1580,
         "north": 1584
       },
-      "weight": 1,
       "id": 1579,
       "area": {
         "id": 28
@@ -1496,12 +1270,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1581,
         "west": 1579
       },
-      "weight": 1,
       "id": 1580,
       "area": {
         "id": 28
@@ -1509,12 +1281,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1582,
         "west": 1580
       },
-      "weight": 1,
       "id": 1581,
       "area": {
         "id": 28
@@ -1522,12 +1292,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "east": 1583,
         "west": 1581
       },
-      "weight": 1,
       "id": 1582,
       "area": {
         "id": 28
@@ -1535,12 +1303,10 @@
     },
     {
       "name": "North Church Road",
-      "environment": -1,
       "exits": {
         "down": 1653,
         "west": 1582
       },
-      "weight": 1,
       "id": 1583,
       "area": {
         "id": 28
@@ -1548,14 +1314,12 @@
     },
     {
       "name": "Olde City Gate",
-      "environment": -1,
       "exits": {
         "south": 1579,
         "west": 1588,
         "east": 1587,
         "north": 1406
       },
-      "weight": 1,
       "id": 1584,
       "area": {
         "id": 28
@@ -1563,12 +1327,10 @@
     },
     {
       "name": "Castle Drawbridge",
-      "environment": -1,
       "exits": {
         "south": 1586,
         "north": 1579
       },
-      "weight": 1,
       "id": 1585,
       "area": {
         "id": 28
@@ -1576,11 +1338,9 @@
     },
     {
       "name": "Castle Gatehouse",
-      "environment": -1,
       "exits": {
         "north": 1585
       },
-      "weight": 1,
       "id": 1586,
       "area": {
         "id": 28
@@ -1588,11 +1348,9 @@
     },
     {
       "name": "Krakenwater",
-      "environment": -1,
       "exits": {
         "west": 1584
       },
-      "weight": 1,
       "id": 1587,
       "area": {
         "id": 28
@@ -1600,12 +1358,10 @@
     },
     {
       "name": "Deep Sea Thunder",
-      "environment": -1,
       "exits": {
         "east": 1584,
         "west": 1589
       },
-      "weight": 1,
       "id": 1588,
       "area": {
         "id": 28
@@ -1613,13 +1369,11 @@
     },
     {
       "name": "The Silver Griffin",
-      "environment": -1,
       "exits": {
         "west": 1590,
         "east": 1588,
         "north": 1408
       },
-      "weight": 1,
       "id": 1589,
       "area": {
         "id": 28
@@ -1627,12 +1381,10 @@
     },
     {
       "name": "Horrors of the Deep",
-      "environment": -1,
       "exits": {
         "east": 1589,
         "north": 1409
       },
-      "weight": 1,
       "id": 1590,
       "area": {
         "id": 28
@@ -1640,12 +1392,10 @@
     },
     {
       "name": "East Martial Row",
-      "environment": -1,
       "exits": {
         "east": 1592,
         "west": 1542
       },
-      "weight": 1,
       "id": 1591,
       "area": {
         "id": 28
@@ -1653,12 +1403,10 @@
     },
     {
       "name": "East Martial Row",
-      "environment": -1,
       "exits": {
         "east": 1593,
         "west": 1591
       },
-      "weight": 1,
       "id": 1592,
       "area": {
         "id": 28
@@ -1666,12 +1414,10 @@
     },
     {
       "name": "East Martial Row",
-      "environment": -1,
       "exits": {
         "west": 1592,
         "north": 1594
       },
-      "weight": 1,
       "id": 1593,
       "area": {
         "id": 28
@@ -1679,12 +1425,10 @@
     },
     {
       "name": "Army Encampment Gate",
-      "environment": -1,
       "exits": {
         "west": 1595,
         "south": 1593
       },
-      "weight": 1,
       "id": 1594,
       "area": {
         "id": 28
@@ -1692,12 +1436,10 @@
     },
     {
       "name": "Punishment Grounds",
-      "environment": -1,
       "exits": {
         "east": 1594,
         "west": 1596
       },
-      "weight": 1,
       "id": 1595,
       "area": {
         "id": 28
@@ -1705,12 +1447,10 @@
     },
     {
       "name": "Parade Grounds",
-      "environment": -1,
       "exits": {
         "east": 1595,
         "north": 1597
       },
-      "weight": 1,
       "id": 1596,
       "area": {
         "id": 28
@@ -1718,13 +1458,11 @@
     },
     {
       "name": "Cavalry Gate",
-      "environment": -1,
       "exits": {
         "west": 1533,
         "south": 1596,
         "north": 1598
       },
-      "weight": 1,
       "id": 1597,
       "area": {
         "id": 28
@@ -1732,13 +1470,11 @@
     },
     {
       "name": "Training Grounds",
-      "environment": -1,
       "exits": {
         "south": 1597,
         "east": 1600,
         "north": 1599
       },
-      "weight": 1,
       "id": 1598,
       "area": {
         "id": 28
@@ -1746,11 +1482,9 @@
     },
     {
       "name": "Combat Training",
-      "environment": -1,
       "exits": {
         "south": 1598
       },
-      "weight": 1,
       "id": 1599,
       "area": {
         "id": 28
@@ -1758,14 +1492,12 @@
     },
     {
       "name": "Post Exchange",
-      "environment": -1,
       "exits": {
         "south": 1602,
         "west": 1598,
         "east": 1601,
         "north": 1603
       },
-      "weight": 1,
       "id": 1600,
       "area": {
         "id": 28
@@ -1773,11 +1505,9 @@
     },
     {
       "name": "Stockade",
-      "environment": -1,
       "exits": {
         "west": 1600
       },
-      "weight": 1,
       "id": 1601,
       "area": {
         "id": 28
@@ -1785,12 +1515,10 @@
     },
     {
       "name": "Infirmary",
-      "environment": -1,
       "exits": {
         "east": 1605,
         "north": 1600
       },
-      "weight": 1,
       "id": 1602,
       "area": {
         "id": 28
@@ -1798,12 +1526,10 @@
     },
     {
       "name": "Soldiers' Tent",
-      "environment": -1,
       "exits": {
         "east": 1604,
         "south": 1600
       },
-      "weight": 1,
       "id": 1603,
       "area": {
         "id": 28
@@ -1811,11 +1537,9 @@
     },
     {
       "name": "Soldiers' Tent",
-      "environment": -1,
       "exits": {
         "west": 1603
       },
-      "weight": 1,
       "id": 1604,
       "area": {
         "id": 28
@@ -1823,11 +1547,9 @@
     },
     {
       "name": "You move the partition to the side and walk into the back of the tent.",
-      "environment": -1,
       "exits": {
         "west": 1602
       },
-      "weight": 1,
       "id": 1605,
       "area": {
         "id": 28
@@ -1835,11 +1557,9 @@
     },
     {
       "name": "Sithicus",
-      "environment": -1,
       "exits": {
         "south": 1514
       },
-      "weight": 1,
       "id": 1621,
       "area": {
         "id": 28
@@ -1847,11 +1567,9 @@
     },
     {
       "name": "Mother Whitman's Confections Shop",
-      "environment": -1,
       "exits": {
         "south": 1511
       },
-      "weight": 1,
       "id": 1622,
       "area": {
         "id": 28
@@ -1859,12 +1577,10 @@
     },
     {
       "name": "Livestock Lot",
-      "environment": -1,
       "exits": {
         "south": 1510,
         "north": 1643
       },
-      "weight": 1,
       "id": 1623,
       "area": {
         "id": 28
@@ -1872,11 +1588,9 @@
     },
     {
       "name": "Saul's formal wear",
-      "environment": -1,
       "exits": {
         "south": 1509
       },
-      "weight": 1,
       "id": 1624,
       "area": {
         "id": 28
@@ -1884,11 +1598,9 @@
     },
     {
       "name": "Quicksilver Delivery Service",
-      "environment": -1,
       "exits": {
         "east": 1405
       },
-      "weight": 1,
       "id": 1625,
       "area": {
         "id": 28
@@ -1896,11 +1608,9 @@
     },
     {
       "name": "Jusonah's Pawn and Polearms",
-      "environment": -1,
       "exits": {
         "east": 1404
       },
-      "weight": 1,
       "id": 1626,
       "area": {
         "id": 28
@@ -1908,12 +1618,10 @@
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
-      "environment": -1,
       "exits": {
         "west": 1404,
         "south": 1637
       },
-      "weight": 1,
       "id": 1627,
       "area": {
         "id": 28
@@ -1921,12 +1629,10 @@
     },
     {
       "name": "Zomar's Dry Goods",
-      "environment": -1,
       "exits": {
         "east": 1403,
         "down": 1629
       },
-      "weight": 1,
       "id": 1628,
       "area": {
         "id": 28
@@ -1934,11 +1640,9 @@
     },
     {
       "name": "The Art of Darkness",
-      "environment": -1,
       "exits": {
         "up": 1628
       },
-      "weight": 1,
       "id": 1629,
       "area": {
         "id": 28
@@ -1946,11 +1650,9 @@
     },
     {
       "name": "Burrow's Map Shop",
-      "environment": -1,
       "exits": {
         "west": 1403
       },
-      "weight": 1,
       "id": 1630,
       "area": {
         "id": 28
@@ -1958,12 +1660,10 @@
     },
     {
       "name": "Muddy Lane",
-      "environment": -1,
       "exits": {
         "east": 1402,
         "west": 1632
       },
-      "weight": 1,
       "id": 1631,
       "area": {
         "id": 28
@@ -1971,11 +1671,9 @@
     },
     {
       "name": "Muddy Lane",
-      "environment": -1,
       "exits": {
         "east": 1631
       },
-      "weight": 1,
       "id": 1632,
       "area": {
         "id": 28
@@ -1983,12 +1681,10 @@
     },
     {
       "name": "Muddy Lane",
-      "environment": -1,
       "exits": {
         "east": 1634,
         "west": 1402
       },
-      "weight": 1,
       "id": 1633,
       "area": {
         "id": 28
@@ -1996,11 +1692,9 @@
     },
     {
       "name": "Farm Road",
-      "environment": -1,
       "exits": {
         "west": 1633
       },
-      "weight": 1,
       "id": 1634,
       "area": {
         "id": 28
@@ -2008,11 +1702,9 @@
     },
     {
       "name": "West Ready Room",
-      "environment": -1,
       "exits": {
         "east": 1401
       },
-      "weight": 1,
       "id": 1635,
       "area": {
         "id": 28
@@ -2020,11 +1712,9 @@
     },
     {
       "name": "East Ready Room",
-      "environment": -1,
       "exits": {
         "west": 1401
       },
-      "weight": 1,
       "id": 1636,
       "area": {
         "id": 28
@@ -2032,11 +1722,9 @@
     },
     {
       "name": "Player Appreciation Week Discussions",
-      "environment": -1,
       "exits": {
         "north": 1627
       },
-      "weight": 1,
       "id": 1637,
       "area": {
         "id": 28
@@ -2044,11 +1732,9 @@
     },
     {
       "name": "Mudball Arena Entrance",
-      "environment": -1,
       "exits": {
         "up": 1583
       },
-      "weight": 1,
       "id": 1653,
       "area": {
         "id": 28

--- a/maps/nature-preserve.json
+++ b/maps/nature-preserve.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "Bridge",
-      "environment": -1,
       "exits": {
         "west": 433
       },
-      "weight": 1,
       "id": 432,
       "area": {
         "id": 5
@@ -17,11 +15,9 @@
     },
     {
       "name": "Waterfall",
-      "environment": -1,
       "exits": {
         "east": 432
       },
-      "weight": 1,
       "id": 433,
       "area": {
         "id": 5
@@ -29,11 +25,9 @@
     },
     {
       "name": "",
-      "environment": -1,
       "exits": {
         "north": 435
       },
-      "weight": 1,
       "id": 434,
       "area": {
         "id": 5
@@ -41,12 +35,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "west": 436,
         "south": 434
       },
-      "weight": 1,
       "id": 435,
       "area": {
         "id": 5
@@ -54,12 +46,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "east": 435,
         "west": 437
       },
-      "weight": 1,
       "id": 436,
       "area": {
         "id": 5
@@ -67,12 +57,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "east": 436,
         "west": 438
       },
-      "weight": 1,
       "id": 437,
       "area": {
         "id": 5
@@ -80,13 +68,11 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "west": 439,
         "east": 437,
         "south": 440
       },
-      "weight": 1,
       "id": 438,
       "area": {
         "id": 5
@@ -94,12 +80,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "east": 438,
         "west": 445
       },
-      "weight": 1,
       "id": 439,
       "area": {
         "id": 5
@@ -107,12 +91,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 441,
         "north": 438
       },
-      "weight": 1,
       "id": 440,
       "area": {
         "id": 5
@@ -120,12 +102,10 @@
     },
     {
       "name": "Tropical Forest",
-      "environment": -1,
       "exits": {
         "south": 442,
         "north": 440
       },
-      "weight": 1,
       "id": 441,
       "area": {
         "id": 5
@@ -133,13 +113,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 443,
         "east": 444,
         "north": 441
       },
-      "weight": 1,
       "id": 442,
       "area": {
         "id": 5
@@ -147,11 +125,9 @@
     },
     {
       "name": "Bird Sanctuary",
-      "environment": -1,
       "exits": {
         "east": 442
       },
-      "weight": 1,
       "id": 443,
       "area": {
         "id": 5
@@ -159,11 +135,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 442
       },
-      "weight": 1,
       "id": 444,
       "area": {
         "id": 5
@@ -171,13 +145,11 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "west": 496,
         "east": 439,
         "north": 446
       },
-      "weight": 1,
       "id": 445,
       "area": {
         "id": 5
@@ -185,12 +157,10 @@
     },
     {
       "name": "Entrance to Queen's Meadow",
-      "environment": -1,
       "exits": {
         "south": 445,
         "north": 447
       },
-      "weight": 1,
       "id": 446,
       "area": {
         "id": 5
@@ -198,12 +168,10 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "south": 446,
         "north": 448
       },
-      "weight": 1,
       "id": 447,
       "area": {
         "id": 5
@@ -211,12 +179,10 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "south": 447,
         "north": 449
       },
-      "weight": 1,
       "id": 448,
       "area": {
         "id": 5
@@ -224,13 +190,11 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "west": 450,
         "south": 448,
         "north": 494
       },
-      "weight": 1,
       "id": 449,
       "area": {
         "id": 5
@@ -238,12 +202,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 449,
         "west": 451
       },
-      "weight": 1,
       "id": 450,
       "area": {
         "id": 5
@@ -251,12 +213,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 450,
         "west": 452
       },
-      "weight": 1,
       "id": 451,
       "area": {
         "id": 5
@@ -264,12 +224,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 451,
         "west": 453
       },
-      "weight": 1,
       "id": 452,
       "area": {
         "id": 5
@@ -277,13 +235,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 455,
         "east": 452,
         "north": 454
       },
-      "weight": 1,
       "id": 453,
       "area": {
         "id": 5
@@ -291,11 +247,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 453
       },
-      "weight": 1,
       "id": 454,
       "area": {
         "id": 5
@@ -303,12 +257,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 456,
         "north": 453
       },
-      "weight": 1,
       "id": 455,
       "area": {
         "id": 5
@@ -316,12 +268,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 457,
         "north": 455
       },
-      "weight": 1,
       "id": 456,
       "area": {
         "id": 5
@@ -329,12 +279,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 456,
         "west": 458
       },
-      "weight": 1,
       "id": 457,
       "area": {
         "id": 5
@@ -342,12 +290,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 457,
         "north": 459
       },
-      "weight": 1,
       "id": 458,
       "area": {
         "id": 5
@@ -355,12 +301,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 458,
         "north": 460
       },
-      "weight": 1,
       "id": 459,
       "area": {
         "id": 5
@@ -368,13 +312,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 495,
         "south": 459,
         "north": 461
       },
-      "weight": 1,
       "id": 460,
       "area": {
         "id": 5
@@ -382,13 +324,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 463,
         "east": 462,
         "south": 460
       },
-      "weight": 1,
       "id": 461,
       "area": {
         "id": 5
@@ -396,12 +336,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 461,
         "north": 464
       },
-      "weight": 1,
       "id": 462,
       "area": {
         "id": 5
@@ -409,11 +347,9 @@
     },
     {
       "name": "Sink Hole",
-      "environment": -1,
       "exits": {
         "east": 461
       },
-      "weight": 1,
       "id": 463,
       "area": {
         "id": 5
@@ -421,13 +357,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 486,
         "east": 465,
         "south": 462
       },
-      "weight": 1,
       "id": 464,
       "area": {
         "id": 5
@@ -435,12 +369,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 464,
         "north": 466
       },
-      "weight": 1,
       "id": 465,
       "area": {
         "id": 5
@@ -448,12 +380,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 467,
         "south": 465
       },
-      "weight": 1,
       "id": 466,
       "area": {
         "id": 5
@@ -461,12 +391,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 468,
         "west": 466
       },
-      "weight": 1,
       "id": 467,
       "area": {
         "id": 5
@@ -474,12 +402,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 469,
         "west": 467
       },
-      "weight": 1,
       "id": 468,
       "area": {
         "id": 5
@@ -487,12 +413,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 470,
         "west": 468
       },
-      "weight": 1,
       "id": 469,
       "area": {
         "id": 5
@@ -500,13 +424,11 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "west": 469,
         "south": 493,
         "north": 471
       },
-      "weight": 1,
       "id": 470,
       "area": {
         "id": 5
@@ -514,12 +436,10 @@
     },
     {
       "name": "Tropical Landscape",
-      "environment": -1,
       "exits": {
         "south": 470,
         "north": 472
       },
-      "weight": 1,
       "id": 471,
       "area": {
         "id": 5
@@ -527,12 +447,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 471,
         "north": 473
       },
-      "weight": 1,
       "id": 472,
       "area": {
         "id": 5
@@ -540,13 +458,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 476,
         "east": 474,
         "south": 472
       },
-      "weight": 1,
       "id": 473,
       "area": {
         "id": 5
@@ -554,12 +470,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 475,
         "west": 473
       },
-      "weight": 1,
       "id": 474,
       "area": {
         "id": 5
@@ -567,11 +481,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 474
       },
-      "weight": 1,
       "id": 475,
       "area": {
         "id": 5
@@ -579,12 +491,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "northwest": 477,
         "east": 473
       },
-      "weight": 1,
       "id": 476,
       "area": {
         "id": 5
@@ -592,13 +502,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "southwest": 478,
         "southeast": 476,
         "north": 490
       },
-      "weight": 1,
       "id": 477,
       "area": {
         "id": 5
@@ -606,12 +514,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 479,
         "northeast": 477
       },
-      "weight": 1,
       "id": 478,
       "area": {
         "id": 5
@@ -619,13 +525,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 480,
         "east": 478,
         "south": 487
       },
-      "weight": 1,
       "id": 479,
       "area": {
         "id": 5
@@ -633,12 +537,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 479,
         "west": 481
       },
-      "weight": 1,
       "id": 480,
       "area": {
         "id": 5
@@ -646,12 +548,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 480,
         "south": 482
       },
-      "weight": 1,
       "id": 481,
       "area": {
         "id": 5
@@ -659,13 +559,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 483,
         "south": 484,
         "north": 481
       },
-      "weight": 1,
       "id": 482,
       "area": {
         "id": 5
@@ -673,11 +571,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 482
       },
-      "weight": 1,
       "id": 483,
       "area": {
         "id": 5
@@ -685,12 +581,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 485,
         "north": 482
       },
-      "weight": 1,
       "id": 484,
       "area": {
         "id": 5
@@ -698,12 +592,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 486,
         "north": 484
       },
-      "weight": 1,
       "id": 485,
       "area": {
         "id": 5
@@ -711,12 +603,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 464,
         "north": 485
       },
-      "weight": 1,
       "id": 486,
       "area": {
         "id": 5
@@ -724,12 +614,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 488,
         "north": 479
       },
-      "weight": 1,
       "id": 487,
       "area": {
         "id": 5
@@ -737,12 +625,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 489,
         "north": 487
       },
-      "weight": 1,
       "id": 488,
       "area": {
         "id": 5
@@ -750,11 +636,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 488
       },
-      "weight": 1,
       "id": 489,
       "area": {
         "id": 5
@@ -762,12 +646,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 477,
         "north": 491
       },
-      "weight": 1,
       "id": 490,
       "area": {
         "id": 5
@@ -775,12 +657,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 492,
         "south": 490
       },
-      "weight": 1,
       "id": 491,
       "area": {
         "id": 5
@@ -788,11 +668,9 @@
     },
     {
       "name": "A Hollowed Tree",
-      "environment": -1,
       "exits": {
         "west": 491
       },
-      "weight": 1,
       "id": 492,
       "area": {
         "id": 5
@@ -800,12 +678,10 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "south": 494,
         "north": 470
       },
-      "weight": 1,
       "id": 493,
       "area": {
         "id": 5
@@ -813,12 +689,10 @@
     },
     {
       "name": "Queen's Meadow",
-      "environment": -1,
       "exits": {
         "south": 449,
         "north": 493
       },
-      "weight": 1,
       "id": 494,
       "area": {
         "id": 5
@@ -826,11 +700,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 460
       },
-      "weight": 1,
       "id": 495,
       "area": {
         "id": 5
@@ -838,12 +710,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "east": 445,
         "west": 497
       },
-      "weight": 1,
       "id": 496,
       "area": {
         "id": 5
@@ -851,13 +721,11 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "west": 498,
         "east": 496,
         "south": 501
       },
-      "weight": 1,
       "id": 497,
       "area": {
         "id": 5
@@ -865,12 +733,10 @@
     },
     {
       "name": "Canopy Trail",
-      "environment": -1,
       "exits": {
         "east": 497,
         "north": 499
       },
-      "weight": 1,
       "id": 498,
       "area": {
         "id": 5
@@ -878,12 +744,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 500,
         "south": 498
       },
-      "weight": 1,
       "id": 499,
       "area": {
         "id": 5
@@ -891,11 +755,9 @@
     },
     {
       "name": "Dragon's Den",
-      "environment": -1,
       "exits": {
         "west": 499
       },
-      "weight": 1,
       "id": 500,
       "area": {
         "id": 5
@@ -903,12 +765,10 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "south": 502,
         "north": 497
       },
-      "weight": 1,
       "id": 501,
       "area": {
         "id": 5
@@ -916,13 +776,11 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 504,
         "east": 503,
         "north": 501
       },
-      "weight": 1,
       "id": 502,
       "area": {
         "id": 5
@@ -930,11 +788,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "west": 502
       },
-      "weight": 1,
       "id": 503,
       "area": {
         "id": 5
@@ -942,11 +798,9 @@
     },
     {
       "name": "Nature Preserve",
-      "environment": -1,
       "exits": {
         "east": 502
       },
-      "weight": 1,
       "id": 504,
       "area": {
         "id": 5

--- a/maps/promenade-des-trafficants.json
+++ b/maps/promenade-des-trafficants.json
@@ -5,12 +5,10 @@
   "rooms": [
     {
       "name": "Promenade des Trafficants",
-      "environment": -1,
       "exits": {
         "south": 1147,
         "north": 1170
       },
-      "weight": 1,
       "id": 1169,
       "area": {
         "id": 22
@@ -18,12 +16,10 @@
     },
     {
       "name": "The Promenade's gate",
-      "environment": -1,
       "exits": {
         "south": 1169,
         "north": 1171
       },
-      "weight": 1,
       "id": 1170,
       "area": {
         "id": 22
@@ -31,13 +27,11 @@
     },
     {
       "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
-      "environment": -1,
       "exits": {
         "south": 1170,
         "east": 1184,
         "north": 1172
       },
-      "weight": 1,
       "id": 1171,
       "area": {
         "id": 22
@@ -45,13 +39,11 @@
     },
     {
       "name": "Moonlit Promenade",
-      "environment": -1,
       "exits": {
         "west": 1173,
         "south": 1171,
         "north": 1174
       },
-      "weight": 1,
       "id": 1172,
       "area": {
         "id": 22
@@ -59,11 +51,9 @@
     },
     {
       "name": "Mekalar's Outdoor Gear",
-      "environment": -1,
       "exits": {
         "east": 1172
       },
-      "weight": 1,
       "id": 1173,
       "area": {
         "id": 22
@@ -71,13 +61,11 @@
     },
     {
       "name": "Moonlit Promenade",
-      "environment": -1,
       "exits": {
         "south": 1172,
         "east": 1183,
         "north": 1175
       },
-      "weight": 1,
       "id": 1174,
       "area": {
         "id": 22
@@ -85,12 +73,10 @@
     },
     {
       "name": "Middle of the moonlit Promenade",
-      "environment": -1,
       "exits": {
         "south": 1174,
         "north": 1176
       },
-      "weight": 1,
       "id": 1175,
       "area": {
         "id": 22
@@ -98,12 +84,10 @@
     },
     {
       "name": "Moonlit Promenade",
-      "environment": -1,
       "exits": {
         "south": 1175,
         "north": 1177
       },
-      "weight": 1,
       "id": 1176,
       "area": {
         "id": 22
@@ -111,13 +95,11 @@
     },
     {
       "name": "Moonlit Promenade",
-      "environment": -1,
       "exits": {
         "west": 1182,
         "south": 1176,
         "north": 1178
       },
-      "weight": 1,
       "id": 1177,
       "area": {
         "id": 22
@@ -125,12 +107,10 @@
     },
     {
       "name": "Moonlit Promenade",
-      "environment": -1,
       "exits": {
         "south": 1177,
         "north": 1179
       },
-      "weight": 1,
       "id": 1178,
       "area": {
         "id": 22
@@ -138,13 +118,11 @@
     },
     {
       "name": "Northern end of the moonlit Promenade",
-      "environment": -1,
       "exits": {
         "west": 1181,
         "south": 1178,
         "north": 1180
       },
-      "weight": 1,
       "id": 1179,
       "area": {
         "id": 22
@@ -152,11 +130,9 @@
     },
     {
       "name": "Enchanter's Store",
-      "environment": -1,
       "exits": {
         "south": 1179
       },
-      "weight": 1,
       "id": 1180,
       "area": {
         "id": 22
@@ -164,11 +140,9 @@
     },
     {
       "name": "Gere's Petshop",
-      "environment": -1,
       "exits": {
         "east": 1179
       },
-      "weight": 1,
       "id": 1181,
       "area": {
         "id": 22
@@ -176,11 +150,9 @@
     },
     {
       "name": "Carpenter's shop",
-      "environment": -1,
       "exits": {
         "east": 1177
       },
-      "weight": 1,
       "id": 1182,
       "area": {
         "id": 22
@@ -188,11 +160,9 @@
     },
     {
       "name": "Roget's Furrier",
-      "environment": -1,
       "exits": {
         "west": 1174
       },
-      "weight": 1,
       "id": 1183,
       "area": {
         "id": 22
@@ -200,11 +170,9 @@
     },
     {
       "name": "Volshev's Advertising Agency",
-      "environment": -1,
       "exits": {
         "west": 1171
       },
-      "weight": 1,
       "id": 1184,
       "area": {
         "id": 22

--- a/maps/pylus.json
+++ b/maps/pylus.json
@@ -5,11 +5,9 @@
   "rooms": [
     {
       "name": "End of Pylus road",
-      "environment": -1,
       "exits": {
         "south": 1206
       },
-      "weight": 1,
       "id": 1205,
       "area": {
         "id": 24
@@ -17,12 +15,10 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "south": 1207,
         "north": 1205
       },
-      "weight": 1,
       "id": 1206,
       "area": {
         "id": 24
@@ -30,13 +26,11 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "south": 1208,
         "east": 1212,
         "north": 1206
       },
-      "weight": 1,
       "id": 1207,
       "area": {
         "id": 24
@@ -44,13 +38,11 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "west": 1209,
         "south": 1213,
         "north": 1207
       },
-      "weight": 1,
       "id": 1208,
       "area": {
         "id": 24
@@ -58,13 +50,11 @@
     },
     {
       "name": "Freemason's",
-      "environment": -1,
       "exits": {
         "south": 1210,
         "east": 1208,
         "north": 1211
       },
-      "weight": 1,
       "id": 1209,
       "area": {
         "id": 24
@@ -72,11 +62,9 @@
     },
     {
       "name": "Apprentice's",
-      "environment": -1,
       "exits": {
         "north": 1209
       },
-      "weight": 1,
       "id": 1210,
       "area": {
         "id": 24
@@ -84,11 +72,9 @@
     },
     {
       "name": "Master stonemason's",
-      "environment": -1,
       "exits": {
         "south": 1209
       },
-      "weight": 1,
       "id": 1211,
       "area": {
         "id": 24
@@ -96,11 +82,9 @@
     },
     {
       "name": "Mausoleum entrance",
-      "environment": -1,
       "exits": {
         "west": 1207
       },
-      "weight": 1,
       "id": 1212,
       "area": {
         "id": 24
@@ -108,12 +92,10 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "south": 1214,
         "north": 1208
       },
-      "weight": 1,
       "id": 1213,
       "area": {
         "id": 24
@@ -121,14 +103,12 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "south": 1215,
         "west": 1218,
         "east": 1219,
         "north": 1213
       },
-      "weight": 1,
       "id": 1214,
       "area": {
         "id": 24
@@ -136,14 +116,12 @@
     },
     {
       "name": "Pylus road",
-      "environment": -1,
       "exits": {
         "southwest": 1216,
         "east": 1222,
         "southeast": 1217,
         "north": 1214
       },
-      "weight": 1,
       "id": 1215,
       "area": {
         "id": 24
@@ -151,11 +129,9 @@
     },
     {
       "name": "Porch",
-      "environment": -1,
       "exits": {
         "northeast": 1215
       },
-      "weight": 1,
       "id": 1216,
       "area": {
         "id": 24
@@ -163,11 +139,9 @@
     },
     {
       "name": "Sanity's Requiem",
-      "environment": -1,
       "exits": {
         "northwest": 1215
       },
-      "weight": 1,
       "id": 1217,
       "area": {
         "id": 24
@@ -175,11 +149,9 @@
     },
     {
       "name": "Hall of Bacchus",
-      "environment": -1,
       "exits": {
         "east": 1214
       },
-      "weight": 1,
       "id": 1218,
       "area": {
         "id": 24
@@ -187,12 +159,10 @@
     },
     {
       "name": "Triage",
-      "environment": -1,
       "exits": {
         "west": 1214,
         "north": 1220
       },
-      "weight": 1,
       "id": 1219,
       "area": {
         "id": 24
@@ -200,12 +170,10 @@
     },
     {
       "name": "Waiting room",
-      "environment": -1,
       "exits": {
         "east": 1221,
         "south": 1219
       },
-      "weight": 1,
       "id": 1220,
       "area": {
         "id": 24
@@ -213,11 +181,9 @@
     },
     {
       "name": "Operating room",
-      "environment": -1,
       "exits": {
         "west": 1220
       },
-      "weight": 1,
       "id": 1221,
       "area": {
         "id": 24
@@ -225,12 +191,10 @@
     },
     {
       "name": "Pylus road checkpoint",
-      "environment": -1,
       "exits": {
         "east": 1289,
         "west": 1215
       },
-      "weight": 1,
       "id": 1222,
       "area": {
         "id": 24
@@ -238,13 +202,11 @@
     },
     {
       "name": "Iola square",
-      "environment": -1,
       "exits": {
         "west": 1289,
         "south": 1227,
         "north": 1225
       },
-      "weight": 1,
       "id": 1224,
       "area": {
         "id": 24
@@ -252,13 +214,11 @@
     },
     {
       "name": "Iola way",
-      "environment": -1,
       "exits": {
         "west": 1363,
         "south": 1224,
         "north": 1226
       },
-      "weight": 1,
       "id": 1225,
       "area": {
         "id": 24
@@ -266,12 +226,10 @@
     },
     {
       "name": "Iola way",
-      "environment": -1,
       "exits": {
         "south": 1225,
         "north": 1248
       },
-      "weight": 1,
       "id": 1226,
       "area": {
         "id": 24
@@ -279,14 +237,12 @@
     },
     {
       "name": "Iola way",
-      "environment": -1,
       "exits": {
         "south": 1228,
         "west": 1247,
         "east": 1246,
         "north": 1224
       },
-      "weight": 1,
       "id": 1227,
       "area": {
         "id": 24
@@ -294,14 +250,12 @@
     },
     {
       "name": "Iola way",
-      "environment": -1,
       "exits": {
         "south": 1229,
         "west": 1244,
         "east": 1243,
         "north": 1227
       },
-      "weight": 1,
       "id": 1228,
       "area": {
         "id": 24
@@ -309,13 +263,11 @@
     },
     {
       "name": "Iola bridge",
-      "environment": -1,
       "exits": {
         "southwest": 1230,
         "east": 1231,
         "north": 1228
       },
-      "weight": 1,
       "id": 1229,
       "area": {
         "id": 24
@@ -323,12 +275,10 @@
     },
     {
       "name": "Large field",
-      "environment": -1,
       "exits": {
         "west": 1239,
         "northeast": 1229
       },
-      "weight": 1,
       "id": 1230,
       "area": {
         "id": 24
@@ -336,13 +286,11 @@
     },
     {
       "name": "Polema street",
-      "environment": -1,
       "exits": {
         "west": 1229,
         "east": 1233,
         "south": 1232
       },
-      "weight": 1,
       "id": 1231,
       "area": {
         "id": 24
@@ -350,11 +298,9 @@
     },
     {
       "name": "Gay house",
-      "environment": -1,
       "exits": {
         "north": 1231
       },
-      "weight": 1,
       "id": 1232,
       "area": {
         "id": 24
@@ -362,14 +308,12 @@
     },
     {
       "name": "Polema street",
-      "environment": -1,
       "exits": {
         "south": 1234,
         "west": 1231,
         "east": 1235,
         "north": 1238
       },
-      "weight": 1,
       "id": 1233,
       "area": {
         "id": 24
@@ -377,11 +321,9 @@
     },
     {
       "name": "Short house",
-      "environment": -1,
       "exits": {
         "north": 1233
       },
-      "weight": 1,
       "id": 1234,
       "area": {
         "id": 24
@@ -389,13 +331,11 @@
     },
     {
       "name": "Polema street",
-      "environment": -1,
       "exits": {
         "west": 1233,
         "east": 1237,
         "north": 1236
       },
-      "weight": 1,
       "id": 1235,
       "area": {
         "id": 24
@@ -403,11 +343,9 @@
     },
     {
       "name": "Bright house",
-      "environment": -1,
       "exits": {
         "south": 1235
       },
-      "weight": 1,
       "id": 1236,
       "area": {
         "id": 24
@@ -415,11 +353,9 @@
     },
     {
       "name": "Foyer",
-      "environment": -1,
       "exits": {
         "west": 1235
       },
-      "weight": 1,
       "id": 1237,
       "area": {
         "id": 24
@@ -427,11 +363,9 @@
     },
     {
       "name": "Tall house",
-      "environment": -1,
       "exits": {
         "south": 1233
       },
-      "weight": 1,
       "id": 1238,
       "area": {
         "id": 24
@@ -439,13 +373,11 @@
     },
     {
       "name": "Gymnasium foyer",
-      "environment": -1,
       "exits": {
         "west": 1240,
         "east": 1230,
         "south": 1241
       },
-      "weight": 1,
       "id": 1239,
       "area": {
         "id": 24
@@ -453,11 +385,9 @@
     },
     {
       "name": "Changing room",
-      "environment": -1,
       "exits": {
         "east": 1239
       },
-      "weight": 1,
       "id": 1240,
       "area": {
         "id": 24
@@ -465,12 +395,10 @@
     },
     {
       "name": "Gymnasium hallway",
-      "environment": -1,
       "exits": {
         "south": 1242,
         "north": 1239
       },
-      "weight": 1,
       "id": 1241,
       "area": {
         "id": 24
@@ -478,11 +406,9 @@
     },
     {
       "name": "Natatorium",
-      "environment": -1,
       "exits": {
         "north": 1241
       },
-      "weight": 1,
       "id": 1242,
       "area": {
         "id": 24
@@ -490,11 +416,9 @@
     },
     {
       "name": "Vegetable seller's",
-      "environment": -1,
       "exits": {
         "west": 1228
       },
-      "weight": 1,
       "id": 1243,
       "area": {
         "id": 24
@@ -502,12 +426,10 @@
     },
     {
       "name": "Herbarium",
-      "environment": -1,
       "exits": {
         "east": 1228,
         "south": 1245
       },
-      "weight": 1,
       "id": 1244,
       "area": {
         "id": 24
@@ -515,11 +437,9 @@
     },
     {
       "name": "Herb garden",
-      "environment": -1,
       "exits": {
         "north": 1244
       },
-      "weight": 1,
       "id": 1245,
       "area": {
         "id": 24
@@ -527,11 +447,9 @@
     },
     {
       "name": "Butcher shop",
-      "environment": -1,
       "exits": {
         "west": 1227
       },
-      "weight": 1,
       "id": 1246,
       "area": {
         "id": 24
@@ -539,11 +457,9 @@
     },
     {
       "name": "Guild/Shop Space for rent",
-      "environment": -1,
       "exits": {
         "east": 1227
       },
-      "weight": 1,
       "id": 1247,
       "area": {
         "id": 24
@@ -551,13 +467,11 @@
     },
     {
       "name": "Iola way",
-      "environment": -1,
       "exits": {
         "west": 1249,
         "east": 1252,
         "south": 1226
       },
-      "weight": 1,
       "id": 1248,
       "area": {
         "id": 24
@@ -565,12 +479,10 @@
     },
     {
       "name": "Garden entry",
-      "environment": -1,
       "exits": {
         "east": 1248,
         "north": 1250
       },
-      "weight": 1,
       "id": 1249,
       "area": {
         "id": 24
@@ -578,12 +490,10 @@
     },
     {
       "name": "Garden clearing",
-      "environment": -1,
       "exits": {
         "west": 1251,
         "south": 1249
       },
-      "weight": 1,
       "id": 1250,
       "area": {
         "id": 24
@@ -591,12 +501,10 @@
     },
     {
       "name": "Entry to akademos",
-      "environment": -1,
       "exits": {
         "east": 1250,
         "west": 1374
       },
-      "weight": 1,
       "id": 1251,
       "area": {
         "id": 24
@@ -604,12 +512,10 @@
     },
     {
       "name": "Ithsma street",
-      "environment": -1,
       "exits": {
         "east": 1253,
         "west": 1248
       },
-      "weight": 1,
       "id": 1252,
       "area": {
         "id": 24
@@ -617,13 +523,11 @@
     },
     {
       "name": "Ithsma street",
-      "environment": -1,
       "exits": {
         "west": 1252,
         "east": 1255,
         "south": 1254
       },
-      "weight": 1,
       "id": 1253,
       "area": {
         "id": 24
@@ -631,12 +535,10 @@
     },
     {
       "name": "Short path",
-      "environment": -1,
       "exits": {
         "south": 1375,
         "north": 1253
       },
-      "weight": 1,
       "id": 1254,
       "area": {
         "id": 24
@@ -644,13 +546,11 @@
     },
     {
       "name": "Ithsma street",
-      "environment": -1,
       "exits": {
         "west": 1253,
         "east": 1389,
         "north": 1256
       },
-      "weight": 1,
       "id": 1255,
       "area": {
         "id": 24
@@ -658,12 +558,10 @@
     },
     {
       "name": "Before the Palace",
-      "environment": -1,
       "exits": {
         "south": 1255,
         "north": 1257
       },
-      "weight": 1,
       "id": 1256,
       "area": {
         "id": 24
@@ -671,12 +569,10 @@
     },
     {
       "name": "Threshold to the Grand Rotunda",
-      "environment": -1,
       "exits": {
         "south": 1256,
         "north": 1258
       },
-      "weight": 1,
       "id": 1257,
       "area": {
         "id": 24
@@ -684,13 +580,11 @@
     },
     {
       "name": "Grand Rotunda",
-      "environment": -1,
       "exits": {
         "west": 1259,
         "east": 1362,
         "south": 1257
       },
-      "weight": 1,
       "id": 1258,
       "area": {
         "id": 24
@@ -698,13 +592,11 @@
     },
     {
       "name": "Administrative hallway",
-      "environment": -1,
       "exits": {
         "west": 1261,
         "east": 1258,
         "north": 1260
       },
-      "weight": 1,
       "id": 1259,
       "area": {
         "id": 24
@@ -712,11 +604,9 @@
     },
     {
       "name": "Office of the Magistrate",
-      "environment": -1,
       "exits": {
         "south": 1259
       },
-      "weight": 1,
       "id": 1260,
       "area": {
         "id": 24
@@ -724,13 +614,11 @@
     },
     {
       "name": "Administrative hallway",
-      "environment": -1,
       "exits": {
         "west": 1262,
         "east": 1259,
         "south": 1391
       },
-      "weight": 1,
       "id": 1261,
       "area": {
         "id": 24
@@ -738,11 +626,9 @@
     },
     {
       "name": "Royal Throne Room",
-      "environment": -1,
       "exits": {
         "east": 1261
       },
-      "weight": 1,
       "id": 1262,
       "area": {
         "id": 24
@@ -750,14 +636,12 @@
     },
     {
       "name": "Gate of Triumph",
-      "environment": -1,
       "exits": {
         "south": 1290,
         "west": 1222,
         "east": 1224,
         "north": 1291
       },
-      "weight": 1,
       "id": 1289,
       "area": {
         "id": 24
@@ -765,11 +649,9 @@
     },
     {
       "name": "Southern niche",
-      "environment": -1,
       "exits": {
         "north": 1289
       },
-      "weight": 1,
       "id": 1290,
       "area": {
         "id": 24
@@ -777,11 +659,9 @@
     },
     {
       "name": "Northern niche",
-      "environment": -1,
       "exits": {
         "south": 1289
       },
-      "weight": 1,
       "id": 1291,
       "area": {
         "id": 24
@@ -789,13 +669,11 @@
     },
     {
       "name": "Guard Post",
-      "environment": -1,
       "exits": {
         "west": 1258,
         "east": 1392,
         "north": 1395
       },
-      "weight": 1,
       "id": 1362,
       "area": {
         "id": 24
@@ -803,12 +681,10 @@
     },
     {
       "name": "Doorway",
-      "environment": -1,
       "exits": {
         "east": 1225,
         "west": 1364
       },
-      "weight": 1,
       "id": 1363,
       "area": {
         "id": 24
@@ -816,12 +692,10 @@
     },
     {
       "name": "Statued hallway",
-      "environment": -1,
       "exits": {
         "east": 1363,
         "west": 1365
       },
-      "weight": 1,
       "id": 1364,
       "area": {
         "id": 24
@@ -829,13 +703,11 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "west": 1366,
         "east": 1364,
         "north": 1367
       },
-      "weight": 1,
       "id": 1365,
       "area": {
         "id": 24
@@ -843,11 +715,9 @@
     },
     {
       "name": "Captain's office",
-      "environment": -1,
       "exits": {
         "east": 1365
       },
-      "weight": 1,
       "id": 1366,
       "area": {
         "id": 24
@@ -855,12 +725,10 @@
     },
     {
       "name": "Courtyard",
-      "environment": -1,
       "exits": {
         "south": 1365,
         "north": 1368
       },
-      "weight": 1,
       "id": 1367,
       "area": {
         "id": 24
@@ -868,12 +736,10 @@
     },
     {
       "name": "Courtyard",
-      "environment": -1,
       "exits": {
         "south": 1367,
         "north": 1369
       },
-      "weight": 1,
       "id": 1368,
       "area": {
         "id": 24
@@ -881,14 +747,12 @@
     },
     {
       "name": "Hallway",
-      "environment": -1,
       "exits": {
         "up": 1373,
         "west": 1370,
         "east": 1371,
         "south": 1368
       },
-      "weight": 1,
       "id": 1369,
       "area": {
         "id": 24
@@ -896,11 +760,9 @@
     },
     {
       "name": "West wing",
-      "environment": -1,
       "exits": {
         "east": 1369
       },
-      "weight": 1,
       "id": 1370,
       "area": {
         "id": 24
@@ -908,12 +770,10 @@
     },
     {
       "name": "East wing",
-      "environment": -1,
       "exits": {
         "west": 1369,
         "south": 1372
       },
-      "weight": 1,
       "id": 1371,
       "area": {
         "id": 24
@@ -921,11 +781,9 @@
     },
     {
       "name": "East wing hallway",
-      "environment": -1,
       "exits": {
         "north": 1371
       },
-      "weight": 1,
       "id": 1372,
       "area": {
         "id": 24
@@ -933,11 +791,9 @@
     },
     {
       "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
-      "environment": -1,
       "exits": {
         "down": 1369
       },
-      "weight": 1,
       "id": 1373,
       "area": {
         "id": 24
@@ -945,11 +801,9 @@
     },
     {
       "name": "Akademos",
-      "environment": -1,
       "exits": {
         "east": 1251
       },
-      "weight": 1,
       "id": 1374,
       "area": {
         "id": 24
@@ -957,12 +811,10 @@
     },
     {
       "name": "Temple entry",
-      "environment": -1,
       "exits": {
         "south": 1376,
         "north": 1254
       },
-      "weight": 1,
       "id": 1375,
       "area": {
         "id": 24
@@ -970,14 +822,12 @@
     },
     {
       "name": "Temple rotunda",
-      "environment": -1,
       "exits": {
         "south": 1377,
         "west": 1381,
         "east": 1384,
         "north": 1375
       },
-      "weight": 1,
       "id": 1376,
       "area": {
         "id": 24
@@ -985,12 +835,10 @@
     },
     {
       "name": "Temple hallway",
-      "environment": -1,
       "exits": {
         "south": 1378,
         "north": 1376
       },
-      "weight": 1,
       "id": 1377,
       "area": {
         "id": 24
@@ -998,13 +846,11 @@
     },
     {
       "name": "End of temple hallway",
-      "environment": -1,
       "exits": {
         "west": 1380,
         "east": 1379,
         "north": 1377
       },
-      "weight": 1,
       "id": 1378,
       "area": {
         "id": 24
@@ -1012,11 +858,9 @@
     },
     {
       "name": "Folio depository",
-      "environment": -1,
       "exits": {
         "west": 1378
       },
-      "weight": 1,
       "id": 1379,
       "area": {
         "id": 24
@@ -1024,11 +868,9 @@
     },
     {
       "name": "Reliquary",
-      "environment": -1,
       "exits": {
         "east": 1378
       },
-      "weight": 1,
       "id": 1380,
       "area": {
         "id": 24
@@ -1036,12 +878,10 @@
     },
     {
       "name": "Hall of Peace",
-      "environment": -1,
       "exits": {
         "east": 1376,
         "west": 1382
       },
-      "weight": 1,
       "id": 1381,
       "area": {
         "id": 24
@@ -1049,13 +889,11 @@
     },
     {
       "name": "Hall of Peace",
-      "environment": -1,
       "exits": {
         "west": 1383,
         "east": 1381,
         "south": 1387
       },
-      "weight": 1,
       "id": 1382,
       "area": {
         "id": 24
@@ -1063,11 +901,9 @@
     },
     {
       "name": "Rotunda of Peace",
-      "environment": -1,
       "exits": {
         "east": 1382
       },
-      "weight": 1,
       "id": 1383,
       "area": {
         "id": 24
@@ -1075,13 +911,11 @@
     },
     {
       "name": "Hall of War",
-      "environment": -1,
       "exits": {
         "west": 1376,
         "east": 1385,
         "south": 1388
       },
-      "weight": 1,
       "id": 1384,
       "area": {
         "id": 24
@@ -1089,12 +923,10 @@
     },
     {
       "name": "Hall of War",
-      "environment": -1,
       "exits": {
         "east": 1386,
         "west": 1384
       },
-      "weight": 1,
       "id": 1385,
       "area": {
         "id": 24
@@ -1102,11 +934,9 @@
     },
     {
       "name": "Rotunda of War",
-      "environment": -1,
       "exits": {
         "west": 1385
       },
-      "weight": 1,
       "id": 1386,
       "area": {
         "id": 24
@@ -1114,11 +944,9 @@
     },
     {
       "name": "Chapel of Peace",
-      "environment": -1,
       "exits": {
         "north": 1382
       },
-      "weight": 1,
       "id": 1387,
       "area": {
         "id": 24
@@ -1126,11 +954,9 @@
     },
     {
       "name": "Chapel of War",
-      "environment": -1,
       "exits": {
         "north": 1384
       },
-      "weight": 1,
       "id": 1388,
       "area": {
         "id": 24
@@ -1138,12 +964,10 @@
     },
     {
       "name": "Ithsma street",
-      "environment": -1,
       "exits": {
         "east": 1390,
         "west": 1255
       },
-      "weight": 1,
       "id": 1389,
       "area": {
         "id": 24
@@ -1151,11 +975,9 @@
     },
     {
       "name": "End of Ithsma street",
-      "environment": -1,
       "exits": {
         "west": 1389
       },
-      "weight": 1,
       "id": 1390,
       "area": {
         "id": 24
@@ -1163,11 +985,9 @@
     },
     {
       "name": "Office of the Secretary",
-      "environment": -1,
       "exits": {
         "north": 1261
       },
-      "weight": 1,
       "id": 1391,
       "area": {
         "id": 24
@@ -1175,13 +995,11 @@
     },
     {
       "name": "Formal gardens",
-      "environment": -1,
       "exits": {
         "west": 1362,
         "east": 1393,
         "south": 1394
       },
-      "weight": 1,
       "id": 1392,
       "area": {
         "id": 24
@@ -1189,11 +1007,9 @@
     },
     {
       "name": "A private corner in the garden",
-      "environment": -1,
       "exits": {
         "west": 1392
       },
-      "weight": 1,
       "id": 1393,
       "area": {
         "id": 24
@@ -1201,11 +1017,9 @@
     },
     {
       "name": "A private corner in the garden",
-      "environment": -1,
       "exits": {
         "north": 1392
       },
-      "weight": 1,
       "id": 1394,
       "area": {
         "id": 24
@@ -1213,12 +1027,10 @@
     },
     {
       "name": "Residential hallway",
-      "environment": -1,
       "exits": {
         "east": 1396,
         "south": 1362
       },
-      "weight": 1,
       "id": 1395,
       "area": {
         "id": 24
@@ -1226,13 +1038,11 @@
     },
     {
       "name": "Residential hallway",
-      "environment": -1,
       "exits": {
         "west": 1395,
         "east": 1397,
         "north": 1398
       },
-      "weight": 1,
       "id": 1396,
       "area": {
         "id": 24
@@ -1240,12 +1050,10 @@
     },
     {
       "name": "The harem",
-      "environment": -1,
       "exits": {
         "west": 1396,
         "north": 1400
       },
-      "weight": 1,
       "id": 1397,
       "area": {
         "id": 24
@@ -1253,12 +1061,10 @@
     },
     {
       "name": "The Royal Chambers",
-      "environment": -1,
       "exits": {
         "west": 1399,
         "south": 1396
       },
-      "weight": 1,
       "id": 1398,
       "area": {
         "id": 24
@@ -1266,11 +1072,9 @@
     },
     {
       "name": "The royal dressing room",
-      "environment": -1,
       "exits": {
         "east": 1398
       },
-      "weight": 1,
       "id": 1399,
       "area": {
         "id": 24
@@ -1278,11 +1082,9 @@
     },
     {
       "name": "The Consort's chambers",
-      "environment": -1,
       "exits": {
         "south": 1397
       },
-      "weight": 1,
       "id": 1400,
       "area": {
         "id": 24

--- a/maps/wheatfield.json
+++ b/maps/wheatfield.json
@@ -5,13 +5,11 @@
   "rooms": [
     {
       "name": "Road Through a Wheatfield",
-      "environment": -1,
       "exits": {
         "east": 1639,
         "southeast": 1641,
         "south": 1640
       },
-      "weight": 1,
       "id": 1638,
       "area": {
         "id": 31
@@ -19,7 +17,6 @@
     },
     {
       "name": "Road Through a Wheatfield",
-      "environment": -1,
       "exits": {
         "southeast": 1648,
         "south": 1641,
@@ -27,7 +24,6 @@
         "east": 1649,
         "west": 1638
       },
-      "weight": 1,
       "id": 1639,
       "area": {
         "id": 31
@@ -35,7 +31,6 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "west": 1645,
         "southeast": 1642,
@@ -45,7 +40,6 @@
         "east": 1641,
         "north": 1638
       },
-      "weight": 1,
       "id": 1640,
       "area": {
         "id": 31
@@ -53,7 +47,6 @@
     },
     {
       "name": "Road Through A Wheatfield",
-      "environment": -1,
       "exits": {
         "west": 1640,
         "northwest": 1638,
@@ -63,7 +56,6 @@
         "east": 1648,
         "north": 1639
       },
-      "weight": 1,
       "id": 1641,
       "area": {
         "id": 31
@@ -71,7 +63,6 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "northwest": 1640,
         "west": 1643,
@@ -79,7 +70,6 @@
         "east": 1646,
         "north": 1641
       },
-      "weight": 1,
       "id": 1642,
       "area": {
         "id": 31
@@ -87,7 +77,6 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "northwest": 1645,
         "south": 1623,
@@ -96,7 +85,6 @@
         "east": 1642,
         "north": 1640
       },
-      "weight": 1,
       "id": 1643,
       "area": {
         "id": 31
@@ -104,13 +92,11 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "northeast": 1640,
         "east": 1643,
         "north": 1645
       },
-      "weight": 1,
       "id": 1644,
       "area": {
         "id": 31
@@ -118,13 +104,11 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "east": 1640,
         "southeast": 1643,
         "south": 1644
       },
-      "weight": 1,
       "id": 1645,
       "area": {
         "id": 31
@@ -132,13 +116,11 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "west": 1642,
         "east": 1647,
         "north": 1648
       },
-      "weight": 1,
       "id": 1646,
       "area": {
         "id": 31
@@ -146,11 +128,9 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "west": 1646
       },
-      "weight": 1,
       "id": 1647,
       "area": {
         "id": 31
@@ -158,7 +138,6 @@
     },
     {
       "name": "Road Through a Wheatfield",
-      "environment": -1,
       "exits": {
         "northwest": 1639,
         "south": 1646,
@@ -166,7 +145,6 @@
         "west": 1641,
         "north": 1649
       },
-      "weight": 1,
       "id": 1648,
       "area": {
         "id": 31
@@ -174,13 +152,11 @@
     },
     {
       "name": "Wheatfield",
-      "environment": -1,
       "exits": {
         "southwest": 1641,
         "west": 1639,
         "south": 1648
       },
-      "weight": 1,
       "id": 1649,
       "area": {
         "id": 31


### PR DESCRIPTION
### Motivation
- Exported map JSON files include explicit default fields `"environment": -1` and `"weight": 1` which are unnecessary and noisy in the exported room objects.
- The goal is to clean up the `maps/` exports by removing these redundant default properties to reduce file size and visual clutter.
- This change targets all files under `maps/` except `moraldecay.json` which should keep its existing entries.

### Description
- Removed every line matching `"environment": -1` and `"weight": 1` from `maps/*.json` while skipping `maps/moraldecay.json` using a small cleaning script.
- The change touches 37 map JSON files under `maps/` (bulk deletion of the default properties across room objects).
- Files remain valid JSON objects because only whole lines matching the exact default property patterns were stripped.

### Testing
- Ran the cleanup via a Python script that filters out lines matching `"environment": -1` and `"weight": 1` for all `maps/*.json` except `moraldecay.json` and wrote the updated files back to disk.
- Verified with `rg` (ripgrep) that the default patterns no longer appear in the modified map files and remain only in `moraldecay.json` as intended.
- Performed a quick review of the changed files to ensure JSON structure remained intact and no other keys were altered.
- No project automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d884586c083278cb9d148cbc163be)