### PR TITLE
Remove area id references from map JSON files

### DIFF
--- a/maps/anshelm.json
+++ b/maps/anshelm.json
@@ -8,10 +8,7 @@
       "exits": {
         "north": 236
       },
-      "id": 235,
-      "area": {
-        "id": 3
-      }
+      "id": 235
     },
     {
       "name": "Under the Anshelmish Gatehouse",
@@ -20,10 +17,7 @@
         "south": 235,
         "north": 237
       },
-      "id": 236,
-      "area": {
-        "id": 3
-      }
+      "id": 236
     },
     {
       "name": "Southern end of Rue du Nord",
@@ -33,10 +27,7 @@
         "southeast": 1154,
         "north": 238
       },
-      "id": 237,
-      "area": {
-        "id": 3
-      }
+      "id": 237
     },
     {
       "name": "Rue du Nord",
@@ -45,10 +36,7 @@
         "south": 237,
         "north": 239
       },
-      "id": 238,
-      "area": {
-        "id": 3
-      }
+      "id": 238
     },
     {
       "name": "Intersection of Rue du Nord and Beitel Straat",
@@ -58,10 +46,7 @@
         "east": 1185,
         "north": 240
       },
-      "id": 239,
-      "area": {
-        "id": 3
-      }
+      "id": 239
     },
     {
       "name": "Rue du Nord",
@@ -71,10 +56,7 @@
         "east": 1192,
         "north": 241
       },
-      "id": 240,
-      "area": {
-        "id": 3
-      }
+      "id": 240
     },
     {
       "name": "Rue du Nord",
@@ -83,10 +65,7 @@
         "south": 240,
         "north": 242
       },
-      "id": 241,
-      "area": {
-        "id": 3
-      }
+      "id": 241
     },
     {
       "name": "Gateway to Middle Bailey",
@@ -94,10 +73,7 @@
         "south": 241,
         "north": 243
       },
-      "id": 242,
-      "area": {
-        "id": 3
-      }
+      "id": 242
     },
     {
       "name": "Rue du Nord",
@@ -105,10 +81,7 @@
         "south": 242,
         "north": 244
       },
-      "id": 243,
-      "area": {
-        "id": 3
-      }
+      "id": 243
     },
     {
       "name": "Western intersection of Rue du Nord and Kirsch Lane",
@@ -117,10 +90,7 @@
         "east": 250,
         "south": 243
       },
-      "id": 244,
-      "area": {
-        "id": 3
-      }
+      "id": 244
     },
     {
       "name": "Kirsch Lane",
@@ -128,10 +98,7 @@
         "east": 244,
         "west": 246
       },
-      "id": 245,
-      "area": {
-        "id": 3
-      }
+      "id": 245
     },
     {
       "name": "Kirsch Lane",
@@ -140,10 +107,7 @@
         "east": 245,
         "south": 249
       },
-      "id": 246,
-      "area": {
-        "id": 3
-      }
+      "id": 246
     },
     {
       "name": "Western end of Kirsch Lane",
@@ -151,30 +115,21 @@
         "east": 246,
         "south": 248
       },
-      "id": 247,
-      "area": {
-        "id": 3
-      }
+      "id": 247
     },
     {
       "name": "Construction site",
       "exits": {
         "north": 247
       },
-      "id": 248,
-      "area": {
-        "id": 3
-      }
+      "id": 248
     },
     {
       "name": "Kaneohe Armory",
       "exits": {
         "north": 246
       },
-      "id": 249,
-      "area": {
-        "id": 3
-      }
+      "id": 249
     },
     {
       "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
@@ -183,10 +138,7 @@
         "east": 283,
         "north": 251
       },
-      "id": 250,
-      "area": {
-        "id": 3
-      }
+      "id": 250
     },
     {
       "name": "Rue du Nord",
@@ -195,10 +147,7 @@
         "east": 1193,
         "north": 252
       },
-      "id": 251,
-      "area": {
-        "id": 3
-      }
+      "id": 251
     },
     {
       "name": "Rue du Nord",
@@ -206,10 +155,7 @@
         "south": 251,
         "north": 253
       },
-      "id": 252,
-      "area": {
-        "id": 3
-      }
+      "id": 252
     },
     {
       "name": "Rue du Nord",
@@ -217,10 +163,7 @@
         "south": 252,
         "north": 254
       },
-      "id": 253,
-      "area": {
-        "id": 3
-      }
+      "id": 253
     },
     {
       "name": "Rue du Nord",
@@ -228,10 +171,7 @@
         "south": 253,
         "north": 255
       },
-      "id": 254,
-      "area": {
-        "id": 3
-      }
+      "id": 254
     },
     {
       "name": "Central Square on the Rue du Nord",
@@ -241,10 +181,7 @@
         "east": 1194,
         "north": 256
       },
-      "id": 255,
-      "area": {
-        "id": 3
-      }
+      "id": 255
     },
     {
       "name": "Rue du Nord",
@@ -252,10 +189,7 @@
         "south": 255,
         "north": 257
       },
-      "id": 256,
-      "area": {
-        "id": 3
-      }
+      "id": 256
     },
     {
       "name": "Rue du Nord",
@@ -263,10 +197,7 @@
         "south": 256,
         "north": 258
       },
-      "id": 257,
-      "area": {
-        "id": 3
-      }
+      "id": 257
     },
     {
       "name": "Intersection of Rue du Nord and East Geld Strasse",
@@ -275,10 +206,7 @@
         "east": 281,
         "south": 257
       },
-      "id": 258,
-      "area": {
-        "id": 3
-      }
+      "id": 258
     },
     {
       "name": "Rue du Nord",
@@ -286,10 +214,7 @@
         "east": 258,
         "west": 260
       },
-      "id": 259,
-      "area": {
-        "id": 3
-      }
+      "id": 259
     },
     {
       "name": "Intersection of Rue du Nord and West Geld Strasse",
@@ -298,10 +223,7 @@
         "east": 259,
         "north": 264
       },
-      "id": 260,
-      "area": {
-        "id": 3
-      }
+      "id": 260
     },
     {
       "name": "Geld Strasse",
@@ -309,10 +231,7 @@
         "east": 260,
         "west": 262
       },
-      "id": 261,
-      "area": {
-        "id": 3
-      }
+      "id": 261
     },
     {
       "name": "Geld Strasse",
@@ -320,20 +239,14 @@
         "east": 261,
         "west": 263
       },
-      "id": 262,
-      "area": {
-        "id": 3
-      }
+      "id": 262
     },
     {
       "name": "Western end of Geld Strasse",
       "exits": {
         "east": 262
       },
-      "id": 263,
-      "area": {
-        "id": 3
-      }
+      "id": 263
     },
     {
       "name": "Rue du Nord",
@@ -341,10 +254,7 @@
         "south": 260,
         "north": 265
       },
-      "id": 264,
-      "area": {
-        "id": 3
-      }
+      "id": 264
     },
     {
       "name": "Gateway to Upper Bailey",
@@ -354,10 +264,7 @@
         "east": 1198,
         "north": 266
       },
-      "id": 265,
-      "area": {
-        "id": 3
-      }
+      "id": 265
     },
     {
       "name": "Rue du Nord",
@@ -365,10 +272,7 @@
         "south": 265,
         "north": 267
       },
-      "id": 266,
-      "area": {
-        "id": 3
-      }
+      "id": 266
     },
     {
       "name": "Intersection of Rue du Nord and Kasernegade",
@@ -378,10 +282,7 @@
         "east": 276,
         "north": 273
       },
-      "id": 267,
-      "area": {
-        "id": 3
-      }
+      "id": 267
     },
     {
       "name": "Kasernegade",
@@ -389,10 +290,7 @@
         "east": 267,
         "west": 269
       },
-      "id": 268,
-      "area": {
-        "id": 3
-      }
+      "id": 268
     },
     {
       "name": "Kasernegade",
@@ -400,10 +298,7 @@
         "east": 268,
         "west": 270
       },
-      "id": 269,
-      "area": {
-        "id": 3
-      }
+      "id": 269
     },
     {
       "name": "Kasernegade",
@@ -412,10 +307,7 @@
         "east": 269,
         "south": 1199
       },
-      "id": 270,
-      "area": {
-        "id": 3
-      }
+      "id": 270
     },
     {
       "name": "Western end of Kasernegade",
@@ -423,20 +315,14 @@
         "east": 270,
         "north": 272
       },
-      "id": 271,
-      "area": {
-        "id": 3
-      }
+      "id": 271
     },
     {
       "name": "Construction site",
       "exits": {
         "south": 271
       },
-      "id": 272,
-      "area": {
-        "id": 3
-      }
+      "id": 272
     },
     {
       "name": "Rue du Nord",
@@ -445,10 +331,7 @@
         "northwest": 1202,
         "north": 274
       },
-      "id": 273,
-      "area": {
-        "id": 3
-      }
+      "id": 273
     },
     {
       "name": "Under the Town Gate",
@@ -456,20 +339,14 @@
         "south": 273,
         "north": 275
       },
-      "id": 274,
-      "area": {
-        "id": 3
-      }
+      "id": 274
     },
     {
       "name": "Before the Anshelm Town Gate",
       "exits": {
         "south": 274
       },
-      "id": 275,
-      "area": {
-        "id": 3
-      }
+      "id": 275
     },
     {
       "name": "Kasernegade",
@@ -478,10 +355,7 @@
         "east": 277,
         "north": 1200
       },
-      "id": 276,
-      "area": {
-        "id": 3
-      }
+      "id": 276
     },
     {
       "name": "Kasernegade",
@@ -489,10 +363,7 @@
         "east": 278,
         "west": 276
       },
-      "id": 277,
-      "area": {
-        "id": 3
-      }
+      "id": 277
     },
     {
       "name": "Kasernegade",
@@ -500,10 +371,7 @@
         "east": 279,
         "west": 277
       },
-      "id": 278,
-      "area": {
-        "id": 3
-      }
+      "id": 278
     },
     {
       "name": "Kasernegade",
@@ -511,10 +379,7 @@
         "east": 280,
         "west": 278
       },
-      "id": 279,
-      "area": {
-        "id": 3
-      }
+      "id": 279
     },
     {
       "name": "Eastern end of Kasernegade",
@@ -522,10 +387,7 @@
         "west": 279,
         "south": 1201
       },
-      "id": 280,
-      "area": {
-        "id": 3
-      }
+      "id": 280
     },
     {
       "name": "Geld Strasse",
@@ -534,20 +396,14 @@
         "east": 1328,
         "north": 1197
       },
-      "id": 281,
-      "area": {
-        "id": 3
-      }
+      "id": 281
     },
     {
       "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
       "exits": {
         "east": 265
       },
-      "id": 282,
-      "area": {
-        "id": 3
-      }
+      "id": 282
     },
     {
       "name": "Kirsch Lane",
@@ -556,10 +412,7 @@
         "east": 284,
         "north": 1326
       },
-      "id": 283,
-      "area": {
-        "id": 3
-      }
+      "id": 283
     },
     {
       "name": "Kirsch Lane",
@@ -568,20 +421,14 @@
         "east": 285,
         "north": 1327
       },
-      "id": 284,
-      "area": {
-        "id": 3
-      }
+      "id": 284
     },
     {
       "name": "Eastern end of Kirsch Lane",
       "exits": {
         "west": 284
       },
-      "id": 285,
-      "area": {
-        "id": 3
-      }
+      "id": 285
     },
     {
       "name": "Hawaiian Ryan's",
@@ -589,10 +436,7 @@
         "east": 238,
         "north": 414
       },
-      "id": 413,
-      "area": {
-        "id": 3
-      }
+      "id": 413
     },
     {
       "name": "Beitel Straad",
@@ -602,10 +446,7 @@
         "east": 239,
         "north": 415
       },
-      "id": 414,
-      "area": {
-        "id": 3
-      }
+      "id": 414
     },
     {
       "name": "Club Femme Nu",
@@ -613,10 +454,7 @@
         "east": 240,
         "south": 414
       },
-      "id": 415,
-      "area": {
-        "id": 3
-      }
+      "id": 415
     },
     {
       "name": "Western Guard Post",
@@ -624,10 +462,7 @@
         "up": 1136,
         "northeast": 237
       },
-      "id": 1135,
-      "area": {
-        "id": 3
-      }
+      "id": 1135
     },
     {
       "name": "Arleg bows to you.",
@@ -635,10 +470,7 @@
         "down": 1135,
         "up": 1137
       },
-      "id": 1136,
-      "area": {
-        "id": 3
-      }
+      "id": 1136
     },
     {
       "name": "Second Floor Landing",
@@ -647,10 +479,7 @@
         "east": 1142,
         "up": 1138
       },
-      "id": 1137,
-      "area": {
-        "id": 3
-      }
+      "id": 1137
     },
     {
       "name": "Third Floor Passage",
@@ -659,10 +488,7 @@
         "east": 1144,
         "up": 1139
       },
-      "id": 1138,
-      "area": {
-        "id": 3
-      }
+      "id": 1138
     },
     {
       "name": "Western Spire Stairwell",
@@ -670,30 +496,21 @@
         "down": 1138,
         "up": 1140
       },
-      "id": 1139,
-      "area": {
-        "id": 3
-      }
+      "id": 1139
     },
     {
       "name": "Roof of the Western Spire",
       "exits": {
         "down": 1139
       },
-      "id": 1140,
-      "area": {
-        "id": 3
-      }
+      "id": 1140
     },
     {
       "name": "Western Stairwell",
       "exits": {
         "up": 1137
       },
-      "id": 1141,
-      "area": {
-        "id": 3
-      }
+      "id": 1141
     },
     {
       "name": "Killing Room",
@@ -701,10 +518,7 @@
         "east": 1153,
         "west": 1137
       },
-      "id": 1142,
-      "area": {
-        "id": 3
-      }
+      "id": 1142
     },
     {
       "name": "Anshelm Lounge",
@@ -712,10 +526,7 @@
         "east": 236,
         "west": 1204
       },
-      "id": 1143,
-      "area": {
-        "id": 3
-      }
+      "id": 1143
     },
     {
       "name": "Gatehouse Mess Hall",
@@ -723,10 +534,7 @@
         "east": 1145,
         "west": 1138
       },
-      "id": 1144,
-      "area": {
-        "id": 3
-      }
+      "id": 1144
     },
     {
       "name": "Gatehouse Barracks",
@@ -734,10 +542,7 @@
         "east": 1146,
         "west": 1144
       },
-      "id": 1145,
-      "area": {
-        "id": 3
-      }
+      "id": 1145
     },
     {
       "name": "Third Floor Passage",
@@ -745,10 +550,7 @@
         "up": 1151,
         "west": 1145
       },
-      "id": 1146,
-      "area": {
-        "id": 3
-      }
+      "id": 1146
     },
     {
       "name": "Beitel Straad at the Promenade",
@@ -757,30 +559,21 @@
         "east": 414,
         "north": 1169
       },
-      "id": 1147,
-      "area": {
-        "id": 3
-      }
+      "id": 1147
     },
     {
       "name": "Eastern Stairwell",
       "exits": {
         "down": 1149
       },
-      "id": 1148,
-      "area": {
-        "id": 3
-      }
+      "id": 1148
     },
     {
       "name": "Base of the Eastern Stairwell",
       "exits": {
         "up": 1148
       },
-      "id": 1149,
-      "area": {
-        "id": 3
-      }
+      "id": 1149
     },
     {
       "name": "Beitel Straad",
@@ -789,10 +582,7 @@
         "east": 1147,
         "south": 1168
       },
-      "id": 1150,
-      "area": {
-        "id": 3
-      }
+      "id": 1150
     },
     {
       "name": "Eastern Spire Stairwell",
@@ -800,30 +590,21 @@
         "down": 1149,
         "up": 1152
       },
-      "id": 1151,
-      "area": {
-        "id": 3
-      }
+      "id": 1151
     },
     {
       "name": "Roof of the Eastern Spire",
       "exits": {
         "down": 1151
       },
-      "id": 1152,
-      "area": {
-        "id": 3
-      }
+      "id": 1152
     },
     {
       "name": "Tider bows to you.",
       "exits": {
         "west": 1142
       },
-      "id": 1153,
-      "area": {
-        "id": 3
-      }
+      "id": 1153
     },
     {
       "name": "Eastern Guard Post",
@@ -831,10 +612,7 @@
         "northwest": 237,
         "east": 1155
       },
-      "id": 1154,
-      "area": {
-        "id": 3
-      }
+      "id": 1154
     },
     {
       "name": "Ganran bows to you.",
@@ -843,20 +621,14 @@
         "down": 1156,
         "west": 1154
       },
-      "id": 1155,
-      "area": {
-        "id": 3
-      }
+      "id": 1155
     },
     {
       "name": "Gatehouse Armoury",
       "exits": {
         "up": 1155
       },
-      "id": 1156,
-      "area": {
-        "id": 3
-      }
+      "id": 1156
     },
     {
       "name": "Western end of Beitel Straad",
@@ -864,10 +636,7 @@
         "east": 1150,
         "north": 1164
       },
-      "id": 1157,
-      "area": {
-        "id": 3
-      }
+      "id": 1157
     },
     {
       "name": "Eastern Stairwell",
@@ -875,10 +644,7 @@
         "down": 1155,
         "up": 1159
       },
-      "id": 1158,
-      "area": {
-        "id": 3
-      }
+      "id": 1158
     },
     {
       "name": "Olotia bows to you.",
@@ -886,10 +652,7 @@
         "down": 1158,
         "west": 1160
       },
-      "id": 1159,
-      "area": {
-        "id": 3
-      }
+      "id": 1159
     },
     {
       "name": "Tiran bows to you.",
@@ -897,10 +660,7 @@
         "east": 1159,
         "west": 1161
       },
-      "id": 1160,
-      "area": {
-        "id": 3
-      }
+      "id": 1160
     },
     {
       "name": "Killing Room",
@@ -908,10 +668,7 @@
         "east": 1160,
         "west": 1162
       },
-      "id": 1161,
-      "area": {
-        "id": 3
-      }
+      "id": 1161
     },
     {
       "name": "Second Floor Landing",
@@ -919,10 +676,7 @@
         "east": 1161,
         "down": 1163
       },
-      "id": 1162,
-      "area": {
-        "id": 3
-      }
+      "id": 1162
     },
     {
       "name": "Western Stairwell",
@@ -930,20 +684,14 @@
         "down": 1135,
         "up": 1162
       },
-      "id": 1163,
-      "area": {
-        "id": 3
-      }
+      "id": 1163
     },
     {
       "name": "The Inner Bailey",
       "exits": {
         "north": 1150
       },
-      "id": 1168,
-      "area": {
-        "id": 3
-      }
+      "id": 1168
     },
     {
       "name": "Beitel Straad",
@@ -952,10 +700,7 @@
         "east": 1186,
         "north": 1191
       },
-      "id": 1185,
-      "area": {
-        "id": 3
-      }
+      "id": 1185
     },
     {
       "name": "Beitel Straad",
@@ -964,10 +709,7 @@
         "east": 1187,
         "north": 1190
       },
-      "id": 1186,
-      "area": {
-        "id": 3
-      }
+      "id": 1186
     },
     {
       "name": "Beitel Straad",
@@ -975,10 +717,7 @@
         "east": 1188,
         "west": 1186
       },
-      "id": 1187,
-      "area": {
-        "id": 3
-      }
+      "id": 1187
     },
     {
       "name": "Beitel Straad",
@@ -986,20 +725,14 @@
         "east": 1189,
         "west": 1187
       },
-      "id": 1188,
-      "area": {
-        "id": 3
-      }
+      "id": 1188
     },
     {
       "name": "Eastern end of Beitel Straad",
       "exits": {
         "west": 1188
       },
-      "id": 1189,
-      "area": {
-        "id": 3
-      }
+      "id": 1189
     },
     {
       "name": "The Banana Hammock",
@@ -1007,10 +740,7 @@
         "west": 1191,
         "south": 1186
       },
-      "id": 1190,
-      "area": {
-        "id": 3
-      }
+      "id": 1190
     },
     {
       "name": "Jack's Bistro",
@@ -1018,40 +748,28 @@
         "east": 1190,
         "south": 1185
       },
-      "id": 1191,
-      "area": {
-        "id": 3
-      }
+      "id": 1191
     },
     {
       "name": "Second Bank of Anshelm",
       "exits": {
         "west": 240
       },
-      "id": 1192,
-      "area": {
-        "id": 3
-      }
+      "id": 1192
     },
     {
       "name": "The Anshelmish General Store",
       "exits": {
         "west": 251
       },
-      "id": 1193,
-      "area": {
-        "id": 3
-      }
+      "id": 1193
     },
     {
       "name": "Construction site",
       "exits": {
         "west": 255
       },
-      "id": 1194,
-      "area": {
-        "id": 3
-      }
+      "id": 1194
     },
     {
       "name": "Anshelmish Keep's drawbridge",
@@ -1059,110 +777,77 @@
         "east": 255,
         "west": 1196
       },
-      "id": 1195,
-      "area": {
-        "id": 3
-      }
+      "id": 1195
     },
     {
       "name": "Construction site",
       "exits": {
         "east": 1195
       },
-      "id": 1196,
-      "area": {
-        "id": 3
-      }
+      "id": 1196
     },
     {
       "name": "Private Entry",
       "exits": {
         "south": 281
       },
-      "id": 1197,
-      "area": {
-        "id": 3
-      }
+      "id": 1197
     },
     {
       "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
       "exits": {
         "west": 265
       },
-      "id": 1198,
-      "area": {
-        "id": 3
-      }
+      "id": 1198
     },
     {
       "name": "Armourer's Shack",
       "exits": {
         "north": 270
       },
-      "id": 1199,
-      "area": {
-        "id": 3
-      }
+      "id": 1199
     },
     {
       "name": "Construction site",
       "exits": {
         "south": 276
       },
-      "id": 1200,
-      "area": {
-        "id": 3
-      }
+      "id": 1200
     },
     {
       "name": "Construction site",
       "exits": {
         "north": 280
       },
-      "id": 1201,
-      "area": {
-        "id": 3
-      }
+      "id": 1201
     },
     {
       "name": "Construction site",
       "exits": {
         "southeast": 273
       },
-      "id": 1202,
-      "area": {
-        "id": 3
-      }
+      "id": 1202
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": {
         "east": 1143
       },
-      "id": 1204,
-      "area": {
-        "id": 3
-      }
+      "id": 1204
     },
     {
       "name": "La Cosa Nostra",
       "exits": {
         "south": 283
       },
-      "id": 1326,
-      "area": {
-        "id": 3
-      }
+      "id": 1326
     },
     {
       "name": "Anshelm Stables",
       "exits": {
         "south": 284
       },
-      "id": 1327,
-      "area": {
-        "id": 3
-      }
+      "id": 1327
     },
     {
       "name": "Eastern end of Geld Strasse",
@@ -1170,10 +855,7 @@
         "east": 1329,
         "west": 281
       },
-      "id": 1328,
-      "area": {
-        "id": 3
-      }
+      "id": 1328
     },
     {
       "name": "With a little strain, you are able to pull open the heavy doors and enter",
@@ -1181,10 +863,7 @@
         "east": 1330,
         "west": 1328
       },
-      "id": 1329,
-      "area": {
-        "id": 3
-      }
+      "id": 1329
     },
     {
       "name": "Naive",
@@ -1194,40 +873,28 @@
         "east": 1331,
         "north": 1333
       },
-      "id": 1330,
-      "area": {
-        "id": 3
-      }
+      "id": 1330
     },
     {
       "name": "Altar of the Rose",
       "exits": {
         "west": 1330
       },
-      "id": 1331,
-      "area": {
-        "id": 3
-      }
+      "id": 1331
     },
     {
       "name": "Southern statuary",
       "exits": {
         "north": 1330
       },
-      "id": 1332,
-      "area": {
-        "id": 3
-      }
+      "id": 1332
     },
     {
       "name": "Northern statuary",
       "exits": {
         "south": 1330
       },
-      "id": 1333,
-      "area": {
-        "id": 3
-      }
+      "id": 1333
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/anthill.json
+++ b/maps/anthill.json
@@ -10,10 +10,7 @@
         "down": 1744,
         "north": 1740
       },
-      "id": 1723,
-      "area": {
-        "id": 34
-      }
+      "id": 1723
     },
     {
       "name": "Inside the Anthill",
@@ -22,10 +19,7 @@
         "southeast": 1743,
         "south": 1723
       },
-      "id": 1740,
-      "area": {
-        "id": 34
-      }
+      "id": 1740
     },
     {
       "name": "Inside the Anthill",
@@ -33,10 +27,7 @@
         "southeast": 1742,
         "northeast": 1740
       },
-      "id": 1741,
-      "area": {
-        "id": 34
-      }
+      "id": 1741
     },
     {
       "name": "Inside the Anthill",
@@ -44,10 +35,7 @@
         "northwest": 1741,
         "northeast": 1743
       },
-      "id": 1742,
-      "area": {
-        "id": 34
-      }
+      "id": 1742
     },
     {
       "name": "Inside the Anthill",
@@ -55,10 +43,7 @@
         "northwest": 1740,
         "southwest": 1742
       },
-      "id": 1743,
-      "area": {
-        "id": 34
-      }
+      "id": 1743
     },
     {
       "name": "In the Heart of the Anthill",
@@ -70,10 +55,7 @@
         "down": 1754,
         "northwest": 1747
       },
-      "id": 1744,
-      "area": {
-        "id": 34
-      }
+      "id": 1744
     },
     {
       "name": "In the Heart of the Anthill",
@@ -81,20 +63,14 @@
         "southwest": 1744,
         "south": 1746
       },
-      "id": 1745,
-      "area": {
-        "id": 34
-      }
+      "id": 1745
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "north": 1745
       },
-      "id": 1746,
-      "area": {
-        "id": 34
-      }
+      "id": 1746
     },
     {
       "name": "In the Heart of the Anthill",
@@ -103,40 +79,28 @@
         "northeast": 1748,
         "southeast": 1744
       },
-      "id": 1747,
-      "area": {
-        "id": 34
-      }
+      "id": 1747
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "southwest": 1747
       },
-      "id": 1748,
-      "area": {
-        "id": 34
-      }
+      "id": 1748
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "northeast": 1747
       },
-      "id": 1749,
-      "area": {
-        "id": 34
-      }
+      "id": 1749
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "northeast": 1744
       },
-      "id": 1750,
-      "area": {
-        "id": 34
-      }
+      "id": 1750
     },
     {
       "name": "In the Heart of the Anthill",
@@ -145,30 +109,21 @@
         "northeast": 1752,
         "northwest": 1744
       },
-      "id": 1751,
-      "area": {
-        "id": 34
-      }
+      "id": 1751
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "southwest": 1751
       },
-      "id": 1752,
-      "area": {
-        "id": 34
-      }
+      "id": 1752
     },
     {
       "name": "In the Heart of the Anthill",
       "exits": {
         "northeast": 1751
       },
-      "id": 1753,
-      "area": {
-        "id": 34
-      }
+      "id": 1753
     },
     {
       "name": "At the Base of the Anthill",
@@ -177,10 +132,7 @@
         "east": 1758,
         "south": 1755
       },
-      "id": 1754,
-      "area": {
-        "id": 34
-      }
+      "id": 1754
     },
     {
       "name": "At the Base of the Anthill",
@@ -188,10 +140,7 @@
         "southeast": 1756,
         "north": 1754
       },
-      "id": 1755,
-      "area": {
-        "id": 34
-      }
+      "id": 1755
     },
     {
       "name": "At the Base of the Anthill",
@@ -199,20 +148,14 @@
         "northwest": 1755,
         "southwest": 1757
       },
-      "id": 1756,
-      "area": {
-        "id": 34
-      }
+      "id": 1756
     },
     {
       "name": "At the Base of the Anthill",
       "exits": {
         "northeast": 1756
       },
-      "id": 1757,
-      "area": {
-        "id": 34
-      }
+      "id": 1757
     },
     {
       "name": "At the Base of the Anthill",
@@ -222,10 +165,7 @@
         "northwest": 1762,
         "west": 1754
       },
-      "id": 1758,
-      "area": {
-        "id": 34
-      }
+      "id": 1758
     },
     {
       "name": "At the Base of the Anthill",
@@ -233,10 +173,7 @@
         "northwest": 1760,
         "southwest": 1758
       },
-      "id": 1759,
-      "area": {
-        "id": 34
-      }
+      "id": 1759
     },
     {
       "name": "At the Base of the Anthill",
@@ -245,20 +182,14 @@
         "northwest": 1761,
         "southeast": 1759
       },
-      "id": 1760,
-      "area": {
-        "id": 34
-      }
+      "id": 1760
     },
     {
       "name": "At the Base of the Anthill",
       "exits": {
         "southeast": 1760
       },
-      "id": 1761,
-      "area": {
-        "id": 34
-      }
+      "id": 1761
     },
     {
       "name": "At the Base of the Anthill",
@@ -267,10 +198,7 @@
         "northeast": 1760,
         "southeast": 1758
       },
-      "id": 1762,
-      "area": {
-        "id": 34
-      }
+      "id": 1762
     },
     {
       "name": "At the Base of the Anthill",
@@ -278,20 +206,14 @@
         "northwest": 1758,
         "northeast": 1764
       },
-      "id": 1763,
-      "area": {
-        "id": 34
-      }
+      "id": 1763
     },
     {
       "name": "At the Base of the Anthill",
       "exits": {
         "southwest": 1763
       },
-      "id": 1764,
-      "area": {
-        "id": 34
-      }
+      "id": 1764
     },
     {
       "name": "At the Base of the Anthill",
@@ -299,10 +221,7 @@
         "northwest": 1766,
         "northeast": 1762
       },
-      "id": 1765,
-      "area": {
-        "id": 34
-      }
+      "id": 1765
     },
     {
       "name": "At the Base of the Anthill",
@@ -311,10 +230,7 @@
         "northeast": 1770,
         "southeast": 1765
       },
-      "id": 1766,
-      "area": {
-        "id": 34
-      }
+      "id": 1766
     },
     {
       "name": "At the Base of the Anthill",
@@ -322,10 +238,7 @@
         "southeast": 1768,
         "northeast": 1766
       },
-      "id": 1767,
-      "area": {
-        "id": 34
-      }
+      "id": 1767
     },
     {
       "name": "At the Base of the Anthill",
@@ -333,30 +246,21 @@
         "northwest": 1767,
         "southeast": 1769
       },
-      "id": 1768,
-      "area": {
-        "id": 34
-      }
+      "id": 1768
     },
     {
       "name": "At the Base of the Anthill",
       "exits": {
         "northwest": 1768
       },
-      "id": 1769,
-      "area": {
-        "id": 34
-      }
+      "id": 1769
     },
     {
       "name": "At the Base of the Anthill",
       "exits": {
         "southwest": 1766
       },
-      "id": 1770,
-      "area": {
-        "id": 34
-      }
+      "id": 1770
     },
     {
       "name": "Beneath the Anthill",
@@ -366,10 +270,7 @@
         "east": 1782,
         "north": 1797
       },
-      "id": 1771,
-      "area": {
-        "id": 34
-      }
+      "id": 1771
     },
     {
       "name": "Beneath the Anthill",
@@ -377,10 +278,7 @@
         "northwest": 1773,
         "east": 1771
       },
-      "id": 1772,
-      "area": {
-        "id": 34
-      }
+      "id": 1772
     },
     {
       "name": "Beneath the Anthill",
@@ -389,10 +287,7 @@
         "southeast": 1772,
         "south": 1791
       },
-      "id": 1773,
-      "area": {
-        "id": 34
-      }
+      "id": 1773
     },
     {
       "name": "Beneath the Anthill",
@@ -401,10 +296,7 @@
         "west": 1773,
         "north": 1783
       },
-      "id": 1774,
-      "area": {
-        "id": 34
-      }
+      "id": 1774
     },
     {
       "name": "Beneath the Anthill",
@@ -412,10 +304,7 @@
         "southwest": 1774,
         "east": 1776
       },
-      "id": 1775,
-      "area": {
-        "id": 34
-      }
+      "id": 1775
     },
     {
       "name": "Beneath the Anthill",
@@ -423,10 +312,7 @@
         "west": 1775,
         "south": 1777
       },
-      "id": 1776,
-      "area": {
-        "id": 34
-      }
+      "id": 1776
     },
     {
       "name": "Beneath the Anthill",
@@ -437,10 +323,7 @@
         "east": 1799,
         "north": 1776
       },
-      "id": 1777,
-      "area": {
-        "id": 34
-      }
+      "id": 1777
     },
     {
       "name": "Beneath the Anthill",
@@ -448,10 +331,7 @@
         "southwest": 1777,
         "east": 1779
       },
-      "id": 1778,
-      "area": {
-        "id": 34
-      }
+      "id": 1778
     },
     {
       "name": "Beneath the Anthill",
@@ -459,10 +339,7 @@
         "west": 1778,
         "south": 1780
       },
-      "id": 1779,
-      "area": {
-        "id": 34
-      }
+      "id": 1779
     },
     {
       "name": "Beneath the Anthill",
@@ -471,10 +348,7 @@
         "south": 1803,
         "north": 1779
       },
-      "id": 1780,
-      "area": {
-        "id": 34
-      }
+      "id": 1780
     },
     {
       "name": "Beneath the Anthill",
@@ -483,10 +357,7 @@
         "west": 1782,
         "south": 1800
       },
-      "id": 1781,
-      "area": {
-        "id": 34
-      }
+      "id": 1781
     },
     {
       "name": "Beneath the Anthill",
@@ -495,10 +366,7 @@
         "east": 1781,
         "north": 1777
       },
-      "id": 1782,
-      "area": {
-        "id": 34
-      }
+      "id": 1782
     },
     {
       "name": "Beneath the Anthill",
@@ -506,10 +374,7 @@
         "west": 1784,
         "south": 1774
       },
-      "id": 1783,
-      "area": {
-        "id": 34
-      }
+      "id": 1783
     },
     {
       "name": "Beneath the Anthill",
@@ -517,10 +382,7 @@
         "southwest": 1785,
         "east": 1783
       },
-      "id": 1784,
-      "area": {
-        "id": 34
-      }
+      "id": 1784
     },
     {
       "name": "Beneath the Anthill",
@@ -528,10 +390,7 @@
         "west": 1786,
         "northeast": 1784
       },
-      "id": 1785,
-      "area": {
-        "id": 34
-      }
+      "id": 1785
     },
     {
       "name": "Beneath the Anthill",
@@ -539,10 +398,7 @@
         "east": 1785,
         "south": 1787
       },
-      "id": 1786,
-      "area": {
-        "id": 34
-      }
+      "id": 1786
     },
     {
       "name": "Beneath the Anthill",
@@ -550,10 +406,7 @@
         "southwest": 1788,
         "north": 1786
       },
-      "id": 1787,
-      "area": {
-        "id": 34
-      }
+      "id": 1787
     },
     {
       "name": "Near the Queen's Lair",
@@ -561,10 +414,7 @@
         "northeast": 1787,
         "north": 1789
       },
-      "id": 1788,
-      "area": {
-        "id": 34
-      }
+      "id": 1788
     },
     {
       "name": "Near the Queen's Lair",
@@ -572,20 +422,14 @@
         "south": 1788,
         "north": 1790
       },
-      "id": 1789,
-      "area": {
-        "id": 34
-      }
+      "id": 1789
     },
     {
       "name": "The Ant Lair",
       "exits": {
         "south": 1789
       },
-      "id": 1790,
-      "area": {
-        "id": 34
-      }
+      "id": 1790
     },
     {
       "name": "Beneath the Anthill",
@@ -594,10 +438,7 @@
         "southeast": 1796,
         "north": 1773
       },
-      "id": 1791,
-      "area": {
-        "id": 34
-      }
+      "id": 1791
     },
     {
       "name": "Beneath the Anthill",
@@ -606,10 +447,7 @@
         "east": 1796,
         "north": 1791
       },
-      "id": 1792,
-      "area": {
-        "id": 34
-      }
+      "id": 1792
     },
     {
       "name": "Beneath the Anthill",
@@ -617,10 +455,7 @@
         "east": 1792,
         "north": 1794
       },
-      "id": 1793,
-      "area": {
-        "id": 34
-      }
+      "id": 1793
     },
     {
       "name": "Beneath the Anthill",
@@ -628,20 +463,14 @@
         "southwest": 1795,
         "south": 1793
       },
-      "id": 1794,
-      "area": {
-        "id": 34
-      }
+      "id": 1794
     },
     {
       "name": "Beneath the Anthill",
       "exits": {
         "northeast": 1794
       },
-      "id": 1795,
-      "area": {
-        "id": 34
-      }
+      "id": 1795
     },
     {
       "name": "Beneath the Anthill",
@@ -649,10 +478,7 @@
         "northwest": 1791,
         "west": 1792
       },
-      "id": 1796,
-      "area": {
-        "id": 34
-      }
+      "id": 1796
     },
     {
       "name": "Beneath the Anthill",
@@ -660,30 +486,21 @@
         "east": 1777,
         "south": 1771
       },
-      "id": 1797,
-      "area": {
-        "id": 34
-      }
+      "id": 1797
     },
     {
       "name": "Beneath the Anthill",
       "exits": {
         "north": 1771
       },
-      "id": 1798,
-      "area": {
-        "id": 34
-      }
+      "id": 1798
     },
     {
       "name": "Beneath the Anthill",
       "exits": {
         "west": 1777
       },
-      "id": 1799,
-      "area": {
-        "id": 34
-      }
+      "id": 1799
     },
     {
       "name": "Beneath the Anthill",
@@ -692,20 +509,14 @@
         "east": 1802,
         "north": 1781
       },
-      "id": 1800,
-      "area": {
-        "id": 34
-      }
+      "id": 1800
     },
     {
       "name": "Beneath the Anthill",
       "exits": {
         "east": 1800
       },
-      "id": 1801,
-      "area": {
-        "id": 34
-      }
+      "id": 1801
     },
     {
       "name": "Beneath the Anthill",
@@ -713,10 +524,7 @@
         "west": 1800,
         "north": 1803
       },
-      "id": 1802,
-      "area": {
-        "id": 34
-      }
+      "id": 1802
     },
     {
       "name": "Beneath the Anthill",
@@ -725,10 +533,7 @@
         "east": 1804,
         "north": 1780
       },
-      "id": 1803,
-      "area": {
-        "id": 34
-      }
+      "id": 1803
     },
     {
       "name": "Beneath the Anthill",
@@ -736,27 +541,18 @@
         "west": 1803,
         "north": 1805
       },
-      "id": 1804,
-      "area": {
-        "id": 34
-      }
+      "id": 1804
     },
     {
       "name": "Beneath the Anthill",
       "exits": {
         "south": 1804
       },
-      "id": 1805,
-      "area": {
-        "id": 34
-      }
+      "id": 1805
     },
     {
       "name": "At the top of the anthill.",
-      "id": 1806,
-      "area": {
-        "id": 34
-      }
+      "id": 1806
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area10.json
+++ b/maps/area10.json
@@ -9,10 +9,7 @@
         "south": 201,
         "north": 932
       },
-      "id": 931,
-      "area": {
-        "id": 10
-      }
+      "id": 931
     },
     {
       "name": "Hallway",
@@ -22,10 +19,7 @@
         "east": 934,
         "north": 937
       },
-      "id": 932,
-      "area": {
-        "id": 10
-      }
+      "id": 932
     },
     {
       "name": "Corner",
@@ -33,10 +27,7 @@
         "east": 932,
         "north": 939
       },
-      "id": 933,
-      "area": {
-        "id": 10
-      }
+      "id": 933
     },
     {
       "name": "Corner",
@@ -44,10 +35,7 @@
         "west": 932,
         "north": 935
       },
-      "id": 934,
-      "area": {
-        "id": 10
-      }
+      "id": 934
     },
     {
       "name": "Hallway",
@@ -56,10 +44,7 @@
         "east": 945,
         "north": 936
       },
-      "id": 935,
-      "area": {
-        "id": 10
-      }
+      "id": 935
     },
     {
       "name": "Hallway",
@@ -68,10 +53,7 @@
         "east": 946,
         "north": 947
       },
-      "id": 936,
-      "area": {
-        "id": 10
-      }
+      "id": 936
     },
     {
       "name": "Courtyard",
@@ -79,10 +61,7 @@
         "south": 932,
         "north": 938
       },
-      "id": 937,
-      "area": {
-        "id": 10
-      }
+      "id": 937
     },
     {
       "name": "Courtyard",
@@ -90,10 +69,7 @@
         "south": 937,
         "north": 941
       },
-      "id": 938,
-      "area": {
-        "id": 10
-      }
+      "id": 938
     },
     {
       "name": "Hallway",
@@ -102,10 +78,7 @@
         "south": 933,
         "north": 940
       },
-      "id": 939,
-      "area": {
-        "id": 10
-      }
+      "id": 939
     },
     {
       "name": "Hallway",
@@ -114,10 +87,7 @@
         "south": 939,
         "north": 944
       },
-      "id": 940,
-      "area": {
-        "id": 10
-      }
+      "id": 940
     },
     {
       "name": "Archway",
@@ -127,30 +97,21 @@
         "east": 947,
         "north": 948
       },
-      "id": 941,
-      "area": {
-        "id": 10
-      }
+      "id": 941
     },
     {
       "name": "Quarters",
       "exits": {
         "east": 939
       },
-      "id": 942,
-      "area": {
-        "id": 10
-      }
+      "id": 942
     },
     {
       "name": "Quarters",
       "exits": {
         "east": 940
       },
-      "id": 943,
-      "area": {
-        "id": 10
-      }
+      "id": 943
     },
     {
       "name": "Corner",
@@ -158,30 +119,21 @@
         "east": 941,
         "south": 940
       },
-      "id": 944,
-      "area": {
-        "id": 10
-      }
+      "id": 944
     },
     {
       "name": "Quarters",
       "exits": {
         "west": 935
       },
-      "id": 945,
-      "area": {
-        "id": 10
-      }
+      "id": 945
     },
     {
       "name": "Quarters",
       "exits": {
         "west": 936
       },
-      "id": 946,
-      "area": {
-        "id": 10
-      }
+      "id": 946
     },
     {
       "name": "Corner",
@@ -189,10 +141,7 @@
         "west": 941,
         "south": 936
       },
-      "id": 947,
-      "area": {
-        "id": 10
-      }
+      "id": 947
     },
     {
       "name": "Temple Chamber",
@@ -202,10 +151,7 @@
         "east": 952,
         "north": 949
       },
-      "id": 948,
-      "area": {
-        "id": 10
-      }
+      "id": 948
     },
     {
       "name": "Hallway",
@@ -213,40 +159,28 @@
         "south": 948,
         "north": 950
       },
-      "id": 949,
-      "area": {
-        "id": 10
-      }
+      "id": 949
     },
     {
       "name": "Library",
       "exits": {
         "south": 949
       },
-      "id": 950,
-      "area": {
-        "id": 10
-      }
+      "id": 950
     },
     {
       "name": "Kitchen",
       "exits": {
         "east": 948
       },
-      "id": 951,
-      "area": {
-        "id": 10
-      }
+      "id": 951
     },
     {
       "name": "Storage",
       "exits": {
         "west": 948
       },
-      "id": 952,
-      "area": {
-        "id": 10
-      }
+      "id": 952
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area11.json
+++ b/maps/area11.json
@@ -10,10 +10,7 @@
         "east": 877,
         "south": 131
       },
-      "id": 858,
-      "area": {
-        "id": 11
-      }
+      "id": 858
     },
     {
       "name": "On a dusty path",
@@ -22,10 +19,7 @@
         "northwest": 860,
         "north": 864
       },
-      "id": 859,
-      "area": {
-        "id": 11
-      }
+      "id": 859
     },
     {
       "name": "A living room made of glass",
@@ -34,10 +28,7 @@
         "northwest": 861,
         "southeast": 859
       },
-      "id": 860,
-      "area": {
-        "id": 11
-      }
+      "id": 860
     },
     {
       "name": "A kitchen made of glass",
@@ -45,10 +36,7 @@
         "southwest": 862,
         "southeast": 860
       },
-      "id": 861,
-      "area": {
-        "id": 11
-      }
+      "id": 861
     },
     {
       "name": "Sylvia's workroom",
@@ -56,10 +44,7 @@
         "southeast": 863,
         "northeast": 861
       },
-      "id": 862,
-      "area": {
-        "id": 11
-      }
+      "id": 862
     },
     {
       "name": "A bedroom made of glass",
@@ -67,10 +52,7 @@
         "northwest": 862,
         "northeast": 860
       },
-      "id": 863,
-      "area": {
-        "id": 11
-      }
+      "id": 863
     },
     {
       "name": "On a dusty path",
@@ -78,10 +60,7 @@
         "south": 859,
         "north": 865
       },
-      "id": 864,
-      "area": {
-        "id": 11
-      }
+      "id": 864
     },
     {
       "name": "On a dusty path",
@@ -90,10 +69,7 @@
         "northwest": 866,
         "south": 864
       },
-      "id": 865,
-      "area": {
-        "id": 11
-      }
+      "id": 865
     },
     {
       "name": "Inside a small home",
@@ -101,20 +77,14 @@
         "southeast": 865,
         "west": 867
       },
-      "id": 866,
-      "area": {
-        "id": 11
-      }
+      "id": 866
     },
     {
       "name": "A large kitchen",
       "exits": {
         "east": 866
       },
-      "id": 867,
-      "area": {
-        "id": 11
-      }
+      "id": 867
     },
     {
       "name": "On a dusty path",
@@ -123,10 +93,7 @@
         "east": 875,
         "north": 869
       },
-      "id": 868,
-      "area": {
-        "id": 11
-      }
+      "id": 868
     },
     {
       "name": "Bottom floor of the silo",
@@ -134,10 +101,7 @@
         "up": 870,
         "south": 868
       },
-      "id": 869,
-      "area": {
-        "id": 11
-      }
+      "id": 869
     },
     {
       "name": "On a dusty path",
@@ -145,10 +109,7 @@
         "west": 868,
         "south": 876
       },
-      "id": 875,
-      "area": {
-        "id": 11
-      }
+      "id": 875
     },
     {
       "name": "On a dusty path",
@@ -157,10 +118,7 @@
         "east": 953,
         "north": 875
       },
-      "id": 876,
-      "area": {
-        "id": 11
-      }
+      "id": 876
     },
     {
       "name": "On a dusty path",
@@ -168,10 +126,7 @@
         "west": 858,
         "north": 876
       },
-      "id": 877,
-      "area": {
-        "id": 11
-      }
+      "id": 877
     },
     {
       "name": "On the porch",
@@ -179,10 +134,7 @@
         "east": 954,
         "west": 876
       },
-      "id": 953,
-      "area": {
-        "id": 11
-      }
+      "id": 953
     },
     {
       "name": "In the sitting room",
@@ -191,10 +143,7 @@
         "east": 955,
         "south": 958
       },
-      "id": 954,
-      "area": {
-        "id": 11
-      }
+      "id": 954
     },
     {
       "name": "In the kitchen",
@@ -202,10 +151,7 @@
         "west": 954,
         "south": 956
       },
-      "id": 955,
-      "area": {
-        "id": 11
-      }
+      "id": 955
     },
     {
       "name": "In the dining room",
@@ -214,10 +160,7 @@
         "east": 957,
         "north": 955
       },
-      "id": 956,
-      "area": {
-        "id": 11
-      }
+      "id": 956
     },
     {
       "name": "You leave the farmhouse and enter the backyard.",
@@ -225,10 +168,7 @@
         "east": 959,
         "west": 956
       },
-      "id": 957,
-      "area": {
-        "id": 11
-      }
+      "id": 957
     },
     {
       "name": "In the study",
@@ -236,10 +176,7 @@
         "east": 956,
         "north": 954
       },
-      "id": 958,
-      "area": {
-        "id": 11
-      }
+      "id": 958
     },
     {
       "name": "In a shed",
@@ -247,20 +184,14 @@
         "up": 960,
         "west": 957
       },
-      "id": 959,
-      "area": {
-        "id": 11
-      }
+      "id": 959
     },
     {
       "name": "Above the shed",
       "exits": {
         "down": 959
       },
-      "id": 960,
-      "area": {
-        "id": 11
-      }
+      "id": 960
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area12.json
+++ b/maps/area12.json
@@ -9,10 +9,7 @@
         "south": 128,
         "north": 882
       },
-      "id": 881,
-      "area": {
-        "id": 12
-      }
+      "id": 881
     },
     {
       "name": "Cemetery Lane.",
@@ -20,10 +17,7 @@
         "south": 881,
         "north": 883
       },
-      "id": 882,
-      "area": {
-        "id": 12
-      }
+      "id": 882
     },
     {
       "name": "A cemetery.",
@@ -31,10 +25,7 @@
         "east": 884,
         "south": 882
       },
-      "id": 883,
-      "area": {
-        "id": 12
-      }
+      "id": 883
     },
     {
       "name": "A cemetery.",
@@ -42,10 +33,7 @@
         "west": 883,
         "north": 885
       },
-      "id": 884,
-      "area": {
-        "id": 12
-      }
+      "id": 884
     },
     {
       "name": "A cemetery.",
@@ -53,10 +41,7 @@
         "west": 886,
         "south": 884
       },
-      "id": 885,
-      "area": {
-        "id": 12
-      }
+      "id": 885
     },
     {
       "name": "A cemetery.",
@@ -64,10 +49,7 @@
         "east": 885,
         "north": 887
       },
-      "id": 886,
-      "area": {
-        "id": 12
-      }
+      "id": 886
     },
     {
       "name": "A cemetery.",
@@ -77,20 +59,14 @@
         "east": 892,
         "north": 888
       },
-      "id": 887,
-      "area": {
-        "id": 12
-      }
+      "id": 887
     },
     {
       "name": "A cemetery.",
       "exits": {
         "south": 887
       },
-      "id": 888,
-      "area": {
-        "id": 12
-      }
+      "id": 888
     },
     {
       "name": "A cemetery.",
@@ -98,10 +74,7 @@
         "east": 887,
         "south": 890
       },
-      "id": 889,
-      "area": {
-        "id": 12
-      }
+      "id": 889
     },
     {
       "name": "A cemetery.",
@@ -109,30 +82,21 @@
         "south": 891,
         "north": 889
       },
-      "id": 890,
-      "area": {
-        "id": 12
-      }
+      "id": 890
     },
     {
       "name": "Thieves Guild",
       "exits": {
         "north": 890
       },
-      "id": 891,
-      "area": {
-        "id": 12
-      }
+      "id": 891
     },
     {
       "name": "A cemetery.",
       "exits": {
         "west": 887
       },
-      "id": 892,
-      "area": {
-        "id": 12
-      }
+      "id": 892
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area13.json
+++ b/maps/area13.json
@@ -12,10 +12,7 @@
         "east": 1001,
         "north": 1009
       },
-      "id": 1000,
-      "area": {
-        "id": 13
-      }
+      "id": 1000
     },
     {
       "name": "Hallway",
@@ -24,10 +21,7 @@
         "east": 1002,
         "west": 1000
       },
-      "id": 1001,
-      "area": {
-        "id": 13
-      }
+      "id": 1001
     },
     {
       "name": "Ballroom",
@@ -37,10 +31,7 @@
         "east": 1003,
         "north": 1014
       },
-      "id": 1002,
-      "area": {
-        "id": 13
-      }
+      "id": 1002
     },
     {
       "name": "Dance Floor",
@@ -49,10 +40,7 @@
         "east": 1004,
         "south": 1006
       },
-      "id": 1003,
-      "area": {
-        "id": 13
-      }
+      "id": 1003
     },
     {
       "name": "Gaston's table",
@@ -61,10 +49,7 @@
         "south": 1005,
         "north": 1013
       },
-      "id": 1004,
-      "area": {
-        "id": 13
-      }
+      "id": 1004
     },
     {
       "name": "Dance Floor",
@@ -73,10 +58,7 @@
         "south": 1012,
         "north": 1004
       },
-      "id": 1005,
-      "area": {
-        "id": 13
-      }
+      "id": 1005
     },
     {
       "name": "Dance Floor",
@@ -85,10 +67,7 @@
         "east": 1005,
         "north": 1003
       },
-      "id": 1006,
-      "area": {
-        "id": 13
-      }
+      "id": 1006
     },
     {
       "name": "Buffet table",
@@ -96,60 +75,42 @@
         "east": 1006,
         "north": 1002
       },
-      "id": 1007,
-      "area": {
-        "id": 13
-      }
+      "id": 1007
     },
     {
       "name": "Kitchen",
       "exits": {
         "southwest": 1001
       },
-      "id": 1008,
-      "area": {
-        "id": 13
-      }
+      "id": 1008
     },
     {
       "name": "Library",
       "exits": {
         "south": 1000
       },
-      "id": 1009,
-      "area": {
-        "id": 13
-      }
+      "id": 1009
     },
     {
       "name": "Map Room",
       "exits": {
         "north": 1000
       },
-      "id": 1010,
-      "area": {
-        "id": 13
-      }
+      "id": 1010
     },
     {
       "name": "House of Clan Lord Gaston",
       "exits": {
         "down": 1000
       },
-      "id": 1011,
-      "area": {
-        "id": 13
-      }
+      "id": 1011
     },
     {
       "name": "Deck",
       "exits": {
         "north": 1005
       },
-      "id": 1012,
-      "area": {
-        "id": 13
-      }
+      "id": 1012
     },
     {
       "name": "Bandstand",
@@ -157,10 +118,7 @@
         "west": 1014,
         "south": 1004
       },
-      "id": 1013,
-      "area": {
-        "id": 13
-      }
+      "id": 1013
     },
     {
       "name": "Dark corner",
@@ -168,10 +126,7 @@
         "east": 1013,
         "south": 1002
       },
-      "id": 1014,
-      "area": {
-        "id": 13
-      }
+      "id": 1014
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area14.json
+++ b/maps/area14.json
@@ -10,10 +10,7 @@
         "east": 1017,
         "north": 1020
       },
-      "id": 1018,
-      "area": {
-        "id": 14
-      }
+      "id": 1018
     },
     {
       "name": "Hallway",
@@ -21,10 +18,7 @@
         "south": 1018,
         "north": 1021
       },
-      "id": 1020,
-      "area": {
-        "id": 14
-      }
+      "id": 1020
     },
     {
       "name": "Hallway",
@@ -33,10 +27,7 @@
         "east": 1022,
         "north": 1024
       },
-      "id": 1021,
-      "area": {
-        "id": 14
-      }
+      "id": 1021
     },
     {
       "name": "Bunk Area",
@@ -44,20 +35,14 @@
         "west": 1021,
         "south": 1023
       },
-      "id": 1022,
-      "area": {
-        "id": 14
-      }
+      "id": 1022
     },
     {
       "name": "Banquet Hall",
       "exits": {
         "north": 1022
       },
-      "id": 1023,
-      "area": {
-        "id": 14
-      }
+      "id": 1023
     },
     {
       "name": "Hallway",
@@ -66,10 +51,7 @@
         "east": 1029,
         "north": 1025
       },
-      "id": 1024,
-      "area": {
-        "id": 14
-      }
+      "id": 1024
     },
     {
       "name": "Ready Room",
@@ -78,10 +60,7 @@
         "east": 1028,
         "north": 1026
       },
-      "id": 1025,
-      "area": {
-        "id": 14
-      }
+      "id": 1025
     },
     {
       "name": "Outer Wall",
@@ -89,10 +68,7 @@
         "east": 1027,
         "south": 1025
       },
-      "id": 1026,
-      "area": {
-        "id": 14
-      }
+      "id": 1026
     },
     {
       "name": "Outer Wall",
@@ -100,30 +76,21 @@
         "east": 963,
         "west": 1026
       },
-      "id": 1027,
-      "area": {
-        "id": 14
-      }
+      "id": 1027
     },
     {
       "name": "Armoury",
       "exits": {
         "west": 1025
       },
-      "id": 1028,
-      "area": {
-        "id": 14
-      }
+      "id": 1028
     },
     {
       "name": "Strategist's Room",
       "exits": {
         "west": 1024
       },
-      "id": 1029,
-      "area": {
-        "id": 14
-      }
+      "id": 1029
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area16.json
+++ b/maps/area16.json
@@ -5,27 +5,18 @@
   "rooms": [
     {
       "name": "Southwest Tower",
-      "id": 1036,
-      "area": {
-        "id": 16
-      }
+      "id": 1036
     },
     {
       "name": "Empty Closet",
-      "id": 1037,
-      "area": {
-        "id": 16
-      }
+      "id": 1037
     },
     {
       "name": "Thief Hideout Entrance",
       "exits": {
         "up": 1037
       },
-      "id": 1038,
-      "area": {
-        "id": 16
-      }
+      "id": 1038
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area17.json
+++ b/maps/area17.json
@@ -9,10 +9,7 @@
         "east": 1049,
         "north": 1040
       },
-      "id": 1039,
-      "area": {
-        "id": 17
-      }
+      "id": 1039
     },
     {
       "name": "A bend in the hallway",
@@ -20,10 +17,7 @@
         "east": 1041,
         "south": 1039
       },
-      "id": 1040,
-      "area": {
-        "id": 17
-      }
+      "id": 1040
     },
     {
       "name": "Cobwebs brush against the left side of your face as you walk through them.",
@@ -31,10 +25,7 @@
         "east": 1042,
         "west": 1040
       },
-      "id": 1041,
-      "area": {
-        "id": 17
-      }
+      "id": 1041
     },
     {
       "name": "The Great Hall",
@@ -42,10 +33,7 @@
         "east": 1043,
         "west": 1041
       },
-      "id": 1042,
-      "area": {
-        "id": 17
-      }
+      "id": 1042
     },
     {
       "name": "A bend in the hallway",
@@ -53,10 +41,7 @@
         "west": 1042,
         "south": 1044
       },
-      "id": 1043,
-      "area": {
-        "id": 17
-      }
+      "id": 1043
     },
     {
       "name": "Barrack",
@@ -65,10 +50,7 @@
         "south": 1046,
         "north": 1043
       },
-      "id": 1044,
-      "area": {
-        "id": 17
-      }
+      "id": 1044
     },
     {
       "name": "First floor landing",
@@ -76,10 +58,7 @@
         "east": 1044,
         "up": 1050
       },
-      "id": 1045,
-      "area": {
-        "id": 17
-      }
+      "id": 1045
     },
     {
       "name": "Barrack",
@@ -87,10 +66,7 @@
         "south": 1047,
         "north": 1044
       },
-      "id": 1046,
-      "area": {
-        "id": 17
-      }
+      "id": 1046
     },
     {
       "name": "Staging Room",
@@ -98,30 +74,21 @@
         "west": 1048,
         "north": 1046
       },
-      "id": 1047,
-      "area": {
-        "id": 17
-      }
+      "id": 1047
     },
     {
       "name": "Sally Port",
       "exits": {
         "east": 1047
       },
-      "id": 1048,
-      "area": {
-        "id": 17
-      }
+      "id": 1048
     },
     {
       "name": "An office",
       "exits": {
         "west": 1039
       },
-      "id": 1049,
-      "area": {
-        "id": 17
-      }
+      "id": 1049
     },
     {
       "name": "Second floor landing",
@@ -130,10 +97,7 @@
         "down": 1045,
         "north": 1069
       },
-      "id": 1050,
-      "area": {
-        "id": 17
-      }
+      "id": 1050
     },
     {
       "name": "Third floor landing",
@@ -143,10 +107,7 @@
         "east": 1065,
         "north": 1064
       },
-      "id": 1051,
-      "area": {
-        "id": 17
-      }
+      "id": 1051
     },
     {
       "name": "Stairwell",
@@ -157,10 +118,7 @@
         "east": 1059,
         "north": 1057
       },
-      "id": 1052,
-      "area": {
-        "id": 17
-      }
+      "id": 1052
     },
     {
       "name": "Northeast Tower Roof",
@@ -169,10 +127,7 @@
         "east": 1056,
         "north": 1052
       },
-      "id": 1053,
-      "area": {
-        "id": 17
-      }
+      "id": 1053
     },
     {
       "name": "Northeast Tower Roof",
@@ -180,10 +135,7 @@
         "east": 1055,
         "north": 1053
       },
-      "id": 1054,
-      "area": {
-        "id": 17
-      }
+      "id": 1054
     },
     {
       "name": "Southeast corner of roof",
@@ -191,10 +143,7 @@
         "west": 1054,
         "north": 1056
       },
-      "id": 1055,
-      "area": {
-        "id": 17
-      }
+      "id": 1055
     },
     {
       "name": "Northeast Tower Roof",
@@ -203,10 +152,7 @@
         "south": 1055,
         "north": 1059
       },
-      "id": 1056,
-      "area": {
-        "id": 17
-      }
+      "id": 1056
     },
     {
       "name": "Northeast Tower Roof",
@@ -214,10 +160,7 @@
         "east": 1058,
         "south": 1052
       },
-      "id": 1057,
-      "area": {
-        "id": 17
-      }
+      "id": 1057
     },
     {
       "name": "Northeast corner of roof",
@@ -225,10 +168,7 @@
         "west": 1057,
         "south": 1059
       },
-      "id": 1058,
-      "area": {
-        "id": 17
-      }
+      "id": 1058
     },
     {
       "name": "Northeast Tower Roof",
@@ -237,10 +177,7 @@
         "south": 1056,
         "north": 1058
       },
-      "id": 1059,
-      "area": {
-        "id": 17
-      }
+      "id": 1059
     },
     {
       "name": "Northeast Tower Roof",
@@ -249,10 +186,7 @@
         "east": 1052,
         "north": 1061
       },
-      "id": 1060,
-      "area": {
-        "id": 17
-      }
+      "id": 1060
     },
     {
       "name": "Northeast Tower Roof",
@@ -260,10 +194,7 @@
         "west": 1062,
         "south": 1060
       },
-      "id": 1061,
-      "area": {
-        "id": 17
-      }
+      "id": 1061
     },
     {
       "name": "Northwest corner of roof",
@@ -271,10 +202,7 @@
         "east": 1061,
         "south": 1063
       },
-      "id": 1062,
-      "area": {
-        "id": 17
-      }
+      "id": 1062
     },
     {
       "name": "Northeast Tower Roof",
@@ -282,20 +210,14 @@
         "east": 1060,
         "north": 1062
       },
-      "id": 1063,
-      "area": {
-        "id": 17
-      }
+      "id": 1063
     },
     {
       "name": "Guard Post",
       "exits": {
         "south": 1051
       },
-      "id": 1064,
-      "area": {
-        "id": 17
-      }
+      "id": 1064
     },
     {
       "name": "Hallway",
@@ -303,10 +225,7 @@
         "west": 1051,
         "south": 1066
       },
-      "id": 1065,
-      "area": {
-        "id": 17
-      }
+      "id": 1065
     },
     {
       "name": "Hall",
@@ -314,10 +233,7 @@
         "south": 1067,
         "north": 1065
       },
-      "id": 1066,
-      "area": {
-        "id": 17
-      }
+      "id": 1066
     },
     {
       "name": "War Room",
@@ -325,20 +241,14 @@
         "west": 1068,
         "north": 1066
       },
-      "id": 1067,
-      "area": {
-        "id": 17
-      }
+      "id": 1067
     },
     {
       "name": "Portal Chamber",
       "exits": {
         "east": 1067
       },
-      "id": 1068,
-      "area": {
-        "id": 17
-      }
+      "id": 1068
     },
     {
       "name": "Guard Post",
@@ -347,10 +257,7 @@
         "east": 1072,
         "south": 1050
       },
-      "id": 1069,
-      "area": {
-        "id": 17
-      }
+      "id": 1069
     },
     {
       "name": "Prison Wing",
@@ -359,20 +266,14 @@
         "east": 1069,
         "south": 1077
       },
-      "id": 1070,
-      "area": {
-        "id": 17
-      }
+      "id": 1070
     },
     {
       "name": "Prison cell",
       "exits": {
         "east": 1070
       },
-      "id": 1071,
-      "area": {
-        "id": 17
-      }
+      "id": 1071
     },
     {
       "name": "Hallway",
@@ -380,10 +281,7 @@
         "west": 1069,
         "south": 1073
       },
-      "id": 1072,
-      "area": {
-        "id": 17
-      }
+      "id": 1072
     },
     {
       "name": "An alarm sounds as you pass the threshold of the magic barrier.",
@@ -391,10 +289,7 @@
         "south": 1074,
         "north": 1072
       },
-      "id": 1073,
-      "area": {
-        "id": 17
-      }
+      "id": 1073
     },
     {
       "name": "Witch's Workroom",
@@ -403,40 +298,28 @@
         "south": 1076,
         "north": 1073
       },
-      "id": 1074,
-      "area": {
-        "id": 17
-      }
+      "id": 1074
     },
     {
       "name": "Library",
       "exits": {
         "east": 1074
       },
-      "id": 1075,
-      "area": {
-        "id": 17
-      }
+      "id": 1075
     },
     {
       "name": "Morgue",
       "exits": {
         "north": 1074
       },
-      "id": 1076,
-      "area": {
-        "id": 17
-      }
+      "id": 1076
     },
     {
       "name": "Prison cell",
       "exits": {
         "north": 1070
       },
-      "id": 1077,
-      "area": {
-        "id": 17
-      }
+      "id": 1077
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area18.json
+++ b/maps/area18.json
@@ -12,50 +12,35 @@
         "east": 76,
         "north": 1078
       },
-      "id": 77,
-      "area": {
-        "id": 18
-      }
+      "id": 77
     },
     {
       "name": "Lord's Stable",
       "exits": {
         "south": 77
       },
-      "id": 1078,
-      "area": {
-        "id": 18
-      }
+      "id": 1078
     },
     {
       "name": "Kitchen",
       "exits": {
         "north": 77
       },
-      "id": 1079,
-      "area": {
-        "id": 18
-      }
+      "id": 1079
     },
     {
       "name": "Bracknar's Garden",
       "exits": {
         "east": 77
       },
-      "id": 1080,
-      "area": {
-        "id": 18
-      }
+      "id": 1080
     },
     {
       "name": "House of Clan Lord Bracknar",
       "exits": {
         "down": 77
       },
-      "id": 1081,
-      "area": {
-        "id": 18
-      }
+      "id": 1081
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area19.json
+++ b/maps/area19.json
@@ -10,20 +10,14 @@
         "east": 87,
         "west": 1084
       },
-      "id": 1082,
-      "area": {
-        "id": 19
-      }
+      "id": 1082
     },
     {
       "name": "Blockhouse",
       "exits": {
         "down": 1082
       },
-      "id": 1083,
-      "area": {
-        "id": 19
-      }
+      "id": 1083
     },
     {
       "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
@@ -33,10 +27,7 @@
         "east": 1082,
         "north": 1092
       },
-      "id": 1084,
-      "area": {
-        "id": 19
-      }
+      "id": 1084
     },
     {
       "name": "Eastern bailey",
@@ -44,10 +35,7 @@
         "east": 1084,
         "west": 1086
       },
-      "id": 1085,
-      "area": {
-        "id": 19
-      }
+      "id": 1085
     },
     {
       "name": "Western bailey",
@@ -56,10 +44,7 @@
         "east": 1085,
         "north": 1870
       },
-      "id": 1086,
-      "area": {
-        "id": 19
-      }
+      "id": 1086
     },
     {
       "name": "Long hallway",
@@ -68,10 +53,7 @@
         "south": 1088,
         "north": 1084
       },
-      "id": 1087,
-      "area": {
-        "id": 19
-      }
+      "id": 1087
     },
     {
       "name": "Passage",
@@ -79,20 +61,14 @@
         "up": 1090,
         "north": 1087
       },
-      "id": 1088,
-      "area": {
-        "id": 19
-      }
+      "id": 1088
     },
     {
       "name": "Sun Court",
       "exits": {
         "east": 1087
       },
-      "id": 1089,
-      "area": {
-        "id": 19
-      }
+      "id": 1089
     },
     {
       "name": "Stairwell",
@@ -100,50 +76,35 @@
         "down": 1088,
         "up": 1091
       },
-      "id": 1090,
-      "area": {
-        "id": 19
-      }
+      "id": 1090
     },
     {
       "name": "Southeast Watchtower",
       "exits": {
         "down": 1090
       },
-      "id": 1091,
-      "area": {
-        "id": 19
-      }
+      "id": 1091
     },
     {
       "name": "Long hallway",
       "exits": {
         "south": 1084
       },
-      "id": 1092,
-      "area": {
-        "id": 19
-      }
+      "id": 1092
     },
     {
       "name": "Armoury",
       "exits": {
         "south": 1086
       },
-      "id": 1870,
-      "area": {
-        "id": 19
-      }
+      "id": 1870
     },
     {
       "name": "Stables",
       "exits": {
         "north": 1086
       },
-      "id": 1871,
-      "area": {
-        "id": 19
-      }
+      "id": 1871
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area20.json
+++ b/maps/area20.json
@@ -10,10 +10,7 @@
         "east": 1100,
         "south": 1101
       },
-      "id": 1099,
-      "area": {
-        "id": 20
-      }
+      "id": 1099
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -22,20 +19,14 @@
         "southeast": 1102,
         "west": 1099
       },
-      "id": 1100,
-      "area": {
-        "id": 20
-      }
+      "id": 1100
     },
     {
       "name": "Crypt of the Honored Dead.",
       "exits": {
         "north": 1099
       },
-      "id": 1101,
-      "area": {
-        "id": 20
-      }
+      "id": 1101
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -43,10 +34,7 @@
         "northwest": 1100,
         "southeast": 1115
       },
-      "id": 1102,
-      "area": {
-        "id": 20
-      }
+      "id": 1102
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -54,10 +42,7 @@
         "southwest": 1100,
         "northeast": 1104
       },
-      "id": 1103,
-      "area": {
-        "id": 20
-      }
+      "id": 1103
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -65,10 +50,7 @@
         "southwest": 1103,
         "east": 1105
       },
-      "id": 1104,
-      "area": {
-        "id": 20
-      }
+      "id": 1104
     },
     {
       "name": "Battle of the Sand Gargoyles",
@@ -78,10 +60,7 @@
         "east": 1106,
         "north": 1107
       },
-      "id": 1105,
-      "area": {
-        "id": 20
-      }
+      "id": 1105
     },
     {
       "name": "Battle of the Sand Gargoyles",
@@ -91,40 +70,28 @@
         "east": 1110,
         "north": 1109
       },
-      "id": 1106,
-      "area": {
-        "id": 20
-      }
+      "id": 1106
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "south": 1105
       },
-      "id": 1107,
-      "area": {
-        "id": 20
-      }
+      "id": 1107
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "north": 1105
       },
-      "id": 1108,
-      "area": {
-        "id": 20
-      }
+      "id": 1108
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "south": 1106
       },
-      "id": 1109,
-      "area": {
-        "id": 20
-      }
+      "id": 1109
     },
     {
       "name": "Battle of the Sand Gargoyles",
@@ -134,50 +101,35 @@
         "east": 1114,
         "north": 1112
       },
-      "id": 1110,
-      "area": {
-        "id": 20
-      }
+      "id": 1110
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "north": 1106
       },
-      "id": 1111,
-      "area": {
-        "id": 20
-      }
+      "id": 1111
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "south": 1110
       },
-      "id": 1112,
-      "area": {
-        "id": 20
-      }
+      "id": 1112
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "north": 1110
       },
-      "id": 1113,
-      "area": {
-        "id": 20
-      }
+      "id": 1113
     },
     {
       "name": "Battle of the Sand Gargoyles",
       "exits": {
         "west": 1110
       },
-      "id": 1114,
-      "area": {
-        "id": 20
-      }
+      "id": 1114
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -185,10 +137,7 @@
         "northwest": 1102,
         "east": 1116
       },
-      "id": 1115,
-      "area": {
-        "id": 20
-      }
+      "id": 1115
     },
     {
       "name": "Battle of Maiden's Kiss",
@@ -198,10 +147,7 @@
         "east": 1117,
         "north": 1124
       },
-      "id": 1116,
-      "area": {
-        "id": 20
-      }
+      "id": 1116
     },
     {
       "name": "Battle of Maiden's Kiss",
@@ -211,10 +157,7 @@
         "east": 1118,
         "north": 1122
       },
-      "id": 1117,
-      "area": {
-        "id": 20
-      }
+      "id": 1117
     },
     {
       "name": "Battle of Maiden's Kiss",
@@ -223,70 +166,49 @@
         "south": 1119,
         "north": 1120
       },
-      "id": 1118,
-      "area": {
-        "id": 20
-      }
+      "id": 1118
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "north": 1118
       },
-      "id": 1119,
-      "area": {
-        "id": 20
-      }
+      "id": 1119
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "south": 1118
       },
-      "id": 1120,
-      "area": {
-        "id": 20
-      }
+      "id": 1120
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "north": 1117
       },
-      "id": 1121,
-      "area": {
-        "id": 20
-      }
+      "id": 1121
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "south": 1117
       },
-      "id": 1122,
-      "area": {
-        "id": 20
-      }
+      "id": 1122
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "north": 1116
       },
-      "id": 1123,
-      "area": {
-        "id": 20
-      }
+      "id": 1123
     },
     {
       "name": "Battle of Maiden's Kiss",
       "exits": {
         "south": 1116
       },
-      "id": 1124,
-      "area": {
-        "id": 20
-      }
+      "id": 1124
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area21.json
+++ b/maps/area21.json
@@ -11,40 +11,28 @@
         "northwest": 1165,
         "north": 1166
       },
-      "id": 1164,
-      "area": {
-        "id": 21
-      }
+      "id": 1164
     },
     {
       "name": "You brush aside the blanket and duck to pass through the small door.",
       "exits": {
         "southeast": 1164
       },
-      "id": 1165,
-      "area": {
-        "id": 21
-      }
+      "id": 1165
     },
     {
       "name": "You feel strange walking into the kitchen - that's where women belong.",
       "exits": {
         "south": 1164
       },
-      "id": 1166,
-      "area": {
-        "id": 21
-      }
+      "id": 1166
     },
     {
       "name": "You brush aside the blanket and duck to pass through the small door.",
       "exits": {
         "southwest": 1164
       },
-      "id": 1167,
-      "area": {
-        "id": 21
-      }
+      "id": 1167
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area23.json
+++ b/maps/area23.json
@@ -11,40 +11,28 @@
         "east": 241,
         "north": 418
       },
-      "id": 416,
-      "area": {
-        "id": 23
-      }
+      "id": 416
     },
     {
       "name": "City Unemployment Office",
       "exits": {
         "east": 416
       },
-      "id": 417,
-      "area": {
-        "id": 23
-      }
+      "id": 417
     },
     {
       "name": "City Unemployment Office",
       "exits": {
         "south": 416
       },
-      "id": 418,
-      "area": {
-        "id": 23
-      }
+      "id": 418
     },
     {
       "name": "City Unemployment Office",
       "exits": {
         "north": 416
       },
-      "id": 1203,
-      "area": {
-        "id": 23
-      }
+      "id": 1203
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area25.json
+++ b/maps/area25.json
@@ -8,10 +8,7 @@
       "exits": {
         "north": 1263
       },
-      "id": 1223,
-      "area": {
-        "id": 25
-      }
+      "id": 1223
     },
     {
       "name": "Hallway",
@@ -21,10 +18,7 @@
         "east": 1278,
         "north": 1264
       },
-      "id": 1263,
-      "area": {
-        "id": 25
-      }
+      "id": 1263
     },
     {
       "name": "Hallway",
@@ -32,10 +26,7 @@
         "south": 1263,
         "north": 1265
       },
-      "id": 1264,
-      "area": {
-        "id": 25
-      }
+      "id": 1264
     },
     {
       "name": "Hallway",
@@ -44,10 +35,7 @@
         "east": 1275,
         "north": 1266
       },
-      "id": 1265,
-      "area": {
-        "id": 25
-      }
+      "id": 1265
     },
     {
       "name": "Hallway",
@@ -57,10 +45,7 @@
         "east": 1273,
         "north": 1267
       },
-      "id": 1266,
-      "area": {
-        "id": 25
-      }
+      "id": 1266
     },
     {
       "name": "End of Hallway",
@@ -69,20 +54,14 @@
         "east": 1269,
         "south": 1266
       },
-      "id": 1267,
-      "area": {
-        "id": 25
-      }
+      "id": 1267
     },
     {
       "name": "Munchkin Romper Room",
       "exits": {
         "east": 1267
       },
-      "id": 1268,
-      "area": {
-        "id": 25
-      }
+      "id": 1268
     },
     {
       "name": "Mages' Barracks",
@@ -90,20 +69,14 @@
         "east": 1270,
         "west": 1267
       },
-      "id": 1269,
-      "area": {
-        "id": 25
-      }
+      "id": 1269
     },
     {
       "name": "Munchkin Library",
       "exits": {
         "west": 1269
       },
-      "id": 1270,
-      "area": {
-        "id": 25
-      }
+      "id": 1270
     },
     {
       "name": "Munchkin Mess Hall",
@@ -111,20 +84,14 @@
         "east": 1266,
         "west": 1272
       },
-      "id": 1271,
-      "area": {
-        "id": 25
-      }
+      "id": 1271
     },
     {
       "name": "Kitchen",
       "exits": {
         "east": 1271
       },
-      "id": 1272,
-      "area": {
-        "id": 25
-      }
+      "id": 1272
     },
     {
       "name": "Fighters' Barracks",
@@ -132,10 +99,7 @@
         "east": 1274,
         "west": 1266
       },
-      "id": 1273,
-      "area": {
-        "id": 25
-      }
+      "id": 1273
     },
     {
       "name": "Fighters' Barracks",
@@ -143,20 +107,14 @@
         "west": 1273,
         "south": 1288
       },
-      "id": 1274,
-      "area": {
-        "id": 25
-      }
+      "id": 1274
     },
     {
       "name": "Munchkin Smithy",
       "exits": {
         "west": 1265
       },
-      "id": 1275,
-      "area": {
-        "id": 25
-      }
+      "id": 1275
     },
     {
       "name": "Hallway",
@@ -164,10 +122,7 @@
         "east": 1263,
         "west": 1277
       },
-      "id": 1276,
-      "area": {
-        "id": 25
-      }
+      "id": 1276
     },
     {
       "name": "Hallway",
@@ -176,10 +131,7 @@
         "east": 1276,
         "south": 1280
       },
-      "id": 1277,
-      "area": {
-        "id": 25
-      }
+      "id": 1277
     },
     {
       "name": "Narrow Hallway",
@@ -188,10 +140,7 @@
         "east": 1279,
         "north": 1286
       },
-      "id": 1278,
-      "area": {
-        "id": 25
-      }
+      "id": 1278
     },
     {
       "name": "End of Narrow Hallway",
@@ -199,10 +148,7 @@
         "west": 1278,
         "north": 1287
       },
-      "id": 1279,
-      "area": {
-        "id": 25
-      }
+      "id": 1279
     },
     {
       "name": "A Dark Tunnel",
@@ -210,10 +156,7 @@
         "south": 1284,
         "north": 1277
       },
-      "id": 1280,
-      "area": {
-        "id": 25
-      }
+      "id": 1280
     },
     {
       "name": "End of Hallway",
@@ -222,30 +165,21 @@
         "east": 1277,
         "north": 1283
       },
-      "id": 1281,
-      "area": {
-        "id": 25
-      }
+      "id": 1281
     },
     {
       "name": "Munchkin Leader's Quarters",
       "exits": {
         "north": 1281
       },
-      "id": 1282,
-      "area": {
-        "id": 25
-      }
+      "id": 1282
     },
     {
       "name": "Munchkin Leader's Harem",
       "exits": {
         "south": 1281
       },
-      "id": 1283,
-      "area": {
-        "id": 25
-      }
+      "id": 1283
     },
     {
       "name": "A Dark Tunnel",
@@ -253,50 +187,35 @@
         "northeast": 1285,
         "north": 1280
       },
-      "id": 1284,
-      "area": {
-        "id": 25
-      }
+      "id": 1284
     },
     {
       "name": "A Dark Tunnel",
       "exits": {
         "southwest": 1284
       },
-      "id": 1285,
-      "area": {
-        "id": 25
-      }
+      "id": 1285
     },
     {
       "name": "Dank Cell",
       "exits": {
         "south": 1278
       },
-      "id": 1286,
-      "area": {
-        "id": 25
-      }
+      "id": 1286
     },
     {
       "name": "Dank Cell",
       "exits": {
         "south": 1279
       },
-      "id": 1287,
-      "area": {
-        "id": 25
-      }
+      "id": 1287
     },
     {
       "name": "The Lollipop Guild",
       "exits": {
         "north": 1274
       },
-      "id": 1288,
-      "area": {
-        "id": 25
-      }
+      "id": 1288
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area27.json
+++ b/maps/area27.json
@@ -9,10 +9,7 @@
         "west": 1336,
         "south": 1335
       },
-      "id": 1334,
-      "area": {
-        "id": 27
-      }
+      "id": 1334
     },
     {
       "name": "Inside of Bracknar Gate",
@@ -20,10 +17,7 @@
         "south": 261,
         "north": 1334
       },
-      "id": 1335,
-      "area": {
-        "id": 27
-      }
+      "id": 1335
     },
     {
       "name": "Sitting Room",
@@ -31,10 +25,7 @@
         "east": 1334,
         "north": 1337
       },
-      "id": 1336,
-      "area": {
-        "id": 27
-      }
+      "id": 1336
     },
     {
       "name": "Guarded hallway",
@@ -42,20 +33,14 @@
         "south": 1336,
         "north": 1361
       },
-      "id": 1337,
-      "area": {
-        "id": 27
-      }
+      "id": 1337
     },
     {
       "name": "Clan Lord's Private Chambers",
       "exits": {
         "south": 1337
       },
-      "id": 1361,
-      "area": {
-        "id": 27
-      }
+      "id": 1361
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area29.json
+++ b/maps/area29.json
@@ -10,10 +10,7 @@
         "east": 1496,
         "south": 1441
       },
-      "id": 1440,
-      "area": {
-        "id": 29
-      }
+      "id": 1440
     },
     {
       "name": "Light forest",
@@ -23,10 +20,7 @@
         "east": 1495,
         "north": 1440
       },
-      "id": 1441,
-      "area": {
-        "id": 29
-      }
+      "id": 1441
     },
     {
       "name": "The Valley",
@@ -36,10 +30,7 @@
         "east": 1443,
         "north": 1441
       },
-      "id": 1442,
-      "area": {
-        "id": 29
-      }
+      "id": 1442
     },
     {
       "name": "The Valley",
@@ -49,10 +40,7 @@
         "east": 1444,
         "north": 1495
       },
-      "id": 1443,
-      "area": {
-        "id": 29
-      }
+      "id": 1443
     },
     {
       "name": "The Valley",
@@ -62,10 +50,7 @@
         "east": 1445,
         "north": 1498
       },
-      "id": 1444,
-      "area": {
-        "id": 29
-      }
+      "id": 1444
     },
     {
       "name": "Light forest",
@@ -74,10 +59,7 @@
         "east": 1446,
         "south": 1460
       },
-      "id": 1445,
-      "area": {
-        "id": 29
-      }
+      "id": 1445
     },
     {
       "name": "Meadow",
@@ -86,10 +68,7 @@
         "east": 1447,
         "south": 1459
       },
-      "id": 1446,
-      "area": {
-        "id": 29
-      }
+      "id": 1446
     },
     {
       "name": "Meadow",
@@ -98,10 +77,7 @@
         "east": 1449,
         "south": 1452
       },
-      "id": 1447,
-      "area": {
-        "id": 29
-      }
+      "id": 1447
     },
     {
       "name": "Light forest",
@@ -109,10 +85,7 @@
         "east": 1450,
         "west": 1447
       },
-      "id": 1449,
-      "area": {
-        "id": 29
-      }
+      "id": 1449
     },
     {
       "name": "Light forest",
@@ -120,20 +93,14 @@
         "east": 1451,
         "west": 1449
       },
-      "id": 1450,
-      "area": {
-        "id": 29
-      }
+      "id": 1450
     },
     {
       "name": "Light forest",
       "exits": {
         "west": 1450
       },
-      "id": 1451,
-      "area": {
-        "id": 29
-      }
+      "id": 1451
     },
     {
       "name": "Light forest",
@@ -142,10 +109,7 @@
         "south": 1453,
         "north": 1447
       },
-      "id": 1452,
-      "area": {
-        "id": 29
-      }
+      "id": 1452
     },
     {
       "name": "Light forest",
@@ -154,10 +118,7 @@
         "south": 1454,
         "north": 1452
       },
-      "id": 1453,
-      "area": {
-        "id": 29
-      }
+      "id": 1453
     },
     {
       "name": "Dense forest",
@@ -166,10 +127,7 @@
         "south": 1455,
         "north": 1453
       },
-      "id": 1454,
-      "area": {
-        "id": 29
-      }
+      "id": 1454
     },
     {
       "name": "Light forest",
@@ -177,10 +135,7 @@
         "west": 1456,
         "north": 1454
       },
-      "id": 1455,
-      "area": {
-        "id": 29
-      }
+      "id": 1455
     },
     {
       "name": "Dense forest",
@@ -190,10 +145,7 @@
         "east": 1455,
         "north": 1457
       },
-      "id": 1456,
-      "area": {
-        "id": 29
-      }
+      "id": 1456
     },
     {
       "name": "Dense forest",
@@ -203,10 +155,7 @@
         "east": 1454,
         "north": 1458
       },
-      "id": 1457,
-      "area": {
-        "id": 29
-      }
+      "id": 1457
     },
     {
       "name": "Light forest",
@@ -216,10 +165,7 @@
         "east": 1453,
         "north": 1459
       },
-      "id": 1458,
-      "area": {
-        "id": 29
-      }
+      "id": 1458
     },
     {
       "name": "Meadow",
@@ -229,10 +175,7 @@
         "east": 1452,
         "north": 1446
       },
-      "id": 1459,
-      "area": {
-        "id": 29
-      }
+      "id": 1459
     },
     {
       "name": "Meadow",
@@ -242,10 +185,7 @@
         "east": 1459,
         "north": 1445
       },
-      "id": 1460,
-      "area": {
-        "id": 29
-      }
+      "id": 1460
     },
     {
       "name": "Meadow",
@@ -255,10 +195,7 @@
         "east": 1458,
         "north": 1460
       },
-      "id": 1461,
-      "area": {
-        "id": 29
-      }
+      "id": 1461
     },
     {
       "name": "Dense forest",
@@ -268,10 +205,7 @@
         "east": 1457,
         "north": 1461
       },
-      "id": 1462,
-      "area": {
-        "id": 29
-      }
+      "id": 1462
     },
     {
       "name": "Dense forest",
@@ -281,10 +215,7 @@
         "east": 1456,
         "north": 1462
       },
-      "id": 1463,
-      "area": {
-        "id": 29
-      }
+      "id": 1463
     },
     {
       "name": "Mountain Range",
@@ -293,10 +224,7 @@
         "east": 1499,
         "north": 1463
       },
-      "id": 1464,
-      "area": {
-        "id": 29
-      }
+      "id": 1464
     },
     {
       "name": "Mountain Range",
@@ -305,10 +233,7 @@
         "east": 1464,
         "north": 1480
       },
-      "id": 1465,
-      "area": {
-        "id": 29
-      }
+      "id": 1465
     },
     {
       "name": "Mountain Range",
@@ -317,10 +242,7 @@
         "east": 1465,
         "north": 1481
       },
-      "id": 1466,
-      "area": {
-        "id": 29
-      }
+      "id": 1466
     },
     {
       "name": "Mountain Range",
@@ -329,10 +251,7 @@
         "east": 1466,
         "north": 1482
       },
-      "id": 1467,
-      "area": {
-        "id": 29
-      }
+      "id": 1467
     },
     {
       "name": "Mountain Range",
@@ -340,10 +259,7 @@
         "east": 1467,
         "west": 1469
       },
-      "id": 1468,
-      "area": {
-        "id": 29
-      }
+      "id": 1468
     },
     {
       "name": "Mountain Range",
@@ -351,10 +267,7 @@
         "east": 1468,
         "north": 1470
       },
-      "id": 1469,
-      "area": {
-        "id": 29
-      }
+      "id": 1469
     },
     {
       "name": "Mountain Range",
@@ -362,10 +275,7 @@
         "south": 1469,
         "north": 1471
       },
-      "id": 1470,
-      "area": {
-        "id": 29
-      }
+      "id": 1470
     },
     {
       "name": "Mountain Range",
@@ -374,10 +284,7 @@
         "east": 1484,
         "north": 1472
       },
-      "id": 1471,
-      "area": {
-        "id": 29
-      }
+      "id": 1471
     },
     {
       "name": "Mountain Range",
@@ -386,10 +293,7 @@
         "east": 1485,
         "north": 1473
       },
-      "id": 1472,
-      "area": {
-        "id": 29
-      }
+      "id": 1472
     },
     {
       "name": "Mountain Range",
@@ -398,10 +302,7 @@
         "east": 1474,
         "north": 1489
       },
-      "id": 1473,
-      "area": {
-        "id": 29
-      }
+      "id": 1473
     },
     {
       "name": "Light forest",
@@ -411,10 +312,7 @@
         "east": 1475,
         "north": 1494
       },
-      "id": 1474,
-      "area": {
-        "id": 29
-      }
+      "id": 1474
     },
     {
       "name": "Light forest",
@@ -424,10 +322,7 @@
         "east": 1476,
         "north": 1442
       },
-      "id": 1475,
-      "area": {
-        "id": 29
-      }
+      "id": 1475
     },
     {
       "name": "Light forest",
@@ -437,10 +332,7 @@
         "east": 1477,
         "north": 1443
       },
-      "id": 1476,
-      "area": {
-        "id": 29
-      }
+      "id": 1476
     },
     {
       "name": "The Valley",
@@ -450,10 +342,7 @@
         "east": 1460,
         "north": 1444
       },
-      "id": 1477,
-      "area": {
-        "id": 29
-      }
+      "id": 1477
     },
     {
       "name": "The Valley",
@@ -463,10 +352,7 @@
         "east": 1461,
         "north": 1477
       },
-      "id": 1478,
-      "area": {
-        "id": 29
-      }
+      "id": 1478
     },
     {
       "name": "The Valley",
@@ -476,10 +362,7 @@
         "east": 1462,
         "north": 1478
       },
-      "id": 1479,
-      "area": {
-        "id": 29
-      }
+      "id": 1479
     },
     {
       "name": "The Valley",
@@ -489,10 +372,7 @@
         "east": 1463,
         "north": 1479
       },
-      "id": 1480,
-      "area": {
-        "id": 29
-      }
+      "id": 1480
     },
     {
       "name": "Dense forest",
@@ -502,10 +382,7 @@
         "east": 1480,
         "north": 1488
       },
-      "id": 1481,
-      "area": {
-        "id": 29
-      }
+      "id": 1481
     },
     {
       "name": "Dense forest",
@@ -514,10 +391,7 @@
         "east": 1481,
         "north": 1483
       },
-      "id": 1482,
-      "area": {
-        "id": 29
-      }
+      "id": 1482
     },
     {
       "name": "Dense forest",
@@ -527,10 +401,7 @@
         "east": 1488,
         "north": 1486
       },
-      "id": 1483,
-      "area": {
-        "id": 29
-      }
+      "id": 1483
     },
     {
       "name": "Dense forest",
@@ -539,10 +410,7 @@
         "east": 1483,
         "north": 1485
       },
-      "id": 1484,
-      "area": {
-        "id": 29
-      }
+      "id": 1484
     },
     {
       "name": "Light forest",
@@ -552,10 +420,7 @@
         "east": 1486,
         "north": 1474
       },
-      "id": 1485,
-      "area": {
-        "id": 29
-      }
+      "id": 1485
     },
     {
       "name": "Light forest",
@@ -565,10 +430,7 @@
         "east": 1487,
         "north": 1475
       },
-      "id": 1486,
-      "area": {
-        "id": 29
-      }
+      "id": 1486
     },
     {
       "name": "Light forest",
@@ -578,10 +440,7 @@
         "east": 1478,
         "north": 1476
       },
-      "id": 1487,
-      "area": {
-        "id": 29
-      }
+      "id": 1487
     },
     {
       "name": "Dense forest",
@@ -591,10 +450,7 @@
         "east": 1479,
         "north": 1487
       },
-      "id": 1488,
-      "area": {
-        "id": 29
-      }
+      "id": 1488
     },
     {
       "name": "Mountain Range",
@@ -603,10 +459,7 @@
         "east": 1494,
         "north": 1490
       },
-      "id": 1489,
-      "area": {
-        "id": 29
-      }
+      "id": 1489
     },
     {
       "name": "Mountain Range",
@@ -615,10 +468,7 @@
         "east": 1493,
         "north": 1491
       },
-      "id": 1490,
-      "area": {
-        "id": 29
-      }
+      "id": 1490
     },
     {
       "name": "Mountain Range",
@@ -627,10 +477,7 @@
         "east": 1492,
         "south": 1490
       },
-      "id": 1491,
-      "area": {
-        "id": 29
-      }
+      "id": 1491
     },
     {
       "name": "The Valley",
@@ -639,10 +486,7 @@
         "east": 1440,
         "south": 1493
       },
-      "id": 1492,
-      "area": {
-        "id": 29
-      }
+      "id": 1492
     },
     {
       "name": "The Valley",
@@ -652,10 +496,7 @@
         "east": 1441,
         "north": 1492
       },
-      "id": 1493,
-      "area": {
-        "id": 29
-      }
+      "id": 1493
     },
     {
       "name": "The Valley",
@@ -665,10 +506,7 @@
         "east": 1442,
         "north": 1493
       },
-      "id": 1494,
-      "area": {
-        "id": 29
-      }
+      "id": 1494
     },
     {
       "name": "Light forest",
@@ -678,10 +516,7 @@
         "east": 1498,
         "north": 1496
       },
-      "id": 1495,
-      "area": {
-        "id": 29
-      }
+      "id": 1495
     },
     {
       "name": "Light forest",
@@ -690,10 +525,7 @@
         "east": 1497,
         "south": 1495
       },
-      "id": 1496,
-      "area": {
-        "id": 29
-      }
+      "id": 1496
     },
     {
       "name": "Light forest",
@@ -701,10 +533,7 @@
         "west": 1496,
         "south": 1498
       },
-      "id": 1497,
-      "area": {
-        "id": 29
-      }
+      "id": 1497
     },
     {
       "name": "Light forest",
@@ -713,10 +542,7 @@
         "south": 1444,
         "north": 1497
       },
-      "id": 1498,
-      "area": {
-        "id": 29
-      }
+      "id": 1498
     },
     {
       "name": "Meadow",
@@ -725,10 +551,7 @@
         "south": 1505,
         "north": 1456
       },
-      "id": 1499,
-      "area": {
-        "id": 29
-      }
+      "id": 1499
     },
     {
       "name": "Path",
@@ -738,10 +561,7 @@
         "east": 1473,
         "north": 1504
       },
-      "id": 1500,
-      "area": {
-        "id": 29
-      }
+      "id": 1500
     },
     {
       "name": "Forest",
@@ -749,10 +569,7 @@
         "west": 1502,
         "north": 1500
       },
-      "id": 1501,
-      "area": {
-        "id": 29
-      }
+      "id": 1501
     },
     {
       "name": "Beach",
@@ -760,10 +577,7 @@
         "east": 1501,
         "north": 1503
       },
-      "id": 1502,
-      "area": {
-        "id": 29
-      }
+      "id": 1502
     },
     {
       "name": "Beach",
@@ -771,40 +585,28 @@
         "east": 1500,
         "south": 1502
       },
-      "id": 1503,
-      "area": {
-        "id": 29
-      }
+      "id": 1503
     },
     {
       "name": "Lighthouse Base",
       "exits": {
         "south": 1500
       },
-      "id": 1504,
-      "area": {
-        "id": 29
-      }
+      "id": 1504
     },
     {
       "name": "Mountain Range",
       "exits": {
         "north": 1499
       },
-      "id": 1505,
-      "area": {
-        "id": 29
-      }
+      "id": 1505
     },
     {
       "name": "Mine Entrance",
       "exits": {
         "up": 1491
       },
-      "id": 1506,
-      "area": {
-        "id": 29
-      }
+      "id": 1506
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area32.json
+++ b/maps/area32.json
@@ -9,10 +9,7 @@
         "east": 1651,
         "west": 1673
       },
-      "id": 1650,
-      "area": {
-        "id": 32
-      }
+      "id": 1650
     },
     {
       "name": "North Moat",
@@ -20,10 +17,7 @@
         "east": 1652,
         "west": 1650
       },
-      "id": 1651,
-      "area": {
-        "id": 32
-      }
+      "id": 1651
     },
     {
       "name": "North Moat",
@@ -31,10 +25,7 @@
         "east": 1654,
         "west": 1651
       },
-      "id": 1652,
-      "area": {
-        "id": 32
-      }
+      "id": 1652
     },
     {
       "name": "North Moat",
@@ -42,10 +33,7 @@
         "west": 1652,
         "south": 1655
       },
-      "id": 1654,
-      "area": {
-        "id": 32
-      }
+      "id": 1654
     },
     {
       "name": "East Moat",
@@ -53,10 +41,7 @@
         "south": 1656,
         "north": 1654
       },
-      "id": 1655,
-      "area": {
-        "id": 32
-      }
+      "id": 1655
     },
     {
       "name": "East Moat",
@@ -64,10 +49,7 @@
         "south": 1657,
         "north": 1655
       },
-      "id": 1656,
-      "area": {
-        "id": 32
-      }
+      "id": 1656
     },
     {
       "name": "East Moat",
@@ -75,10 +57,7 @@
         "south": 1658,
         "north": 1656
       },
-      "id": 1657,
-      "area": {
-        "id": 32
-      }
+      "id": 1657
     },
     {
       "name": "East Moat",
@@ -86,10 +65,7 @@
         "south": 1659,
         "north": 1657
       },
-      "id": 1658,
-      "area": {
-        "id": 32
-      }
+      "id": 1658
     },
     {
       "name": "East Moat",
@@ -97,10 +73,7 @@
         "south": 1660,
         "north": 1658
       },
-      "id": 1659,
-      "area": {
-        "id": 32
-      }
+      "id": 1659
     },
     {
       "name": "East Moat",
@@ -108,10 +81,7 @@
         "south": 1661,
         "north": 1659
       },
-      "id": 1660,
-      "area": {
-        "id": 32
-      }
+      "id": 1660
     },
     {
       "name": "East Moat",
@@ -119,10 +89,7 @@
         "south": 1662,
         "north": 1660
       },
-      "id": 1661,
-      "area": {
-        "id": 32
-      }
+      "id": 1661
     },
     {
       "name": "East Moat",
@@ -130,10 +97,7 @@
         "south": 1663,
         "north": 1661
       },
-      "id": 1662,
-      "area": {
-        "id": 32
-      }
+      "id": 1662
     },
     {
       "name": "East Moat",
@@ -141,10 +105,7 @@
         "south": 1664,
         "north": 1662
       },
-      "id": 1663,
-      "area": {
-        "id": 32
-      }
+      "id": 1663
     },
     {
       "name": "South Moat",
@@ -152,10 +113,7 @@
         "west": 1665,
         "north": 1663
       },
-      "id": 1664,
-      "area": {
-        "id": 32
-      }
+      "id": 1664
     },
     {
       "name": "South Moat",
@@ -163,10 +121,7 @@
         "east": 1664,
         "west": 1666
       },
-      "id": 1665,
-      "area": {
-        "id": 32
-      }
+      "id": 1665
     },
     {
       "name": "South Moat",
@@ -174,10 +129,7 @@
         "east": 1665,
         "west": 1667
       },
-      "id": 1666,
-      "area": {
-        "id": 32
-      }
+      "id": 1666
     },
     {
       "name": "South Moat",
@@ -185,10 +137,7 @@
         "east": 1666,
         "west": 1668
       },
-      "id": 1667,
-      "area": {
-        "id": 32
-      }
+      "id": 1667
     },
     {
       "name": "South Moat",
@@ -196,10 +145,7 @@
         "east": 1667,
         "west": 1669
       },
-      "id": 1668,
-      "area": {
-        "id": 32
-      }
+      "id": 1668
     },
     {
       "name": "South Moat",
@@ -207,10 +153,7 @@
         "east": 1668,
         "west": 1670
       },
-      "id": 1669,
-      "area": {
-        "id": 32
-      }
+      "id": 1669
     },
     {
       "name": "South Moat",
@@ -218,10 +161,7 @@
         "east": 1669,
         "west": 1671
       },
-      "id": 1670,
-      "area": {
-        "id": 32
-      }
+      "id": 1670
     },
     {
       "name": "South Moat",
@@ -229,10 +169,7 @@
         "east": 1670,
         "west": 1672
       },
-      "id": 1671,
-      "area": {
-        "id": 32
-      }
+      "id": 1671
     },
     {
       "name": "South Moat",
@@ -240,10 +177,7 @@
         "east": 1671,
         "north": 1686
       },
-      "id": 1672,
-      "area": {
-        "id": 32
-      }
+      "id": 1672
     },
     {
       "name": "North Moat - Under Draw Bridge",
@@ -251,10 +185,7 @@
         "east": 1650,
         "west": 1674
       },
-      "id": 1673,
-      "area": {
-        "id": 32
-      }
+      "id": 1673
     },
     {
       "name": "North Moat",
@@ -262,10 +193,7 @@
         "east": 1673,
         "west": 1675
       },
-      "id": 1674,
-      "area": {
-        "id": 32
-      }
+      "id": 1674
     },
     {
       "name": "North Moat",
@@ -273,10 +201,7 @@
         "east": 1674,
         "west": 1676
       },
-      "id": 1675,
-      "area": {
-        "id": 32
-      }
+      "id": 1675
     },
     {
       "name": "North Moat",
@@ -284,10 +209,7 @@
         "east": 1675,
         "west": 1677
       },
-      "id": 1676,
-      "area": {
-        "id": 32
-      }
+      "id": 1676
     },
     {
       "name": "North Moat",
@@ -295,10 +217,7 @@
         "east": 1676,
         "south": 1678
       },
-      "id": 1677,
-      "area": {
-        "id": 32
-      }
+      "id": 1677
     },
     {
       "name": "West Moat",
@@ -306,10 +225,7 @@
         "south": 1679,
         "north": 1677
       },
-      "id": 1678,
-      "area": {
-        "id": 32
-      }
+      "id": 1678
     },
     {
       "name": "West Moat",
@@ -317,10 +233,7 @@
         "south": 1680,
         "north": 1678
       },
-      "id": 1679,
-      "area": {
-        "id": 32
-      }
+      "id": 1679
     },
     {
       "name": "West Moat",
@@ -328,10 +241,7 @@
         "south": 1681,
         "north": 1679
       },
-      "id": 1680,
-      "area": {
-        "id": 32
-      }
+      "id": 1680
     },
     {
       "name": "West Moat",
@@ -339,10 +249,7 @@
         "south": 1682,
         "north": 1680
       },
-      "id": 1681,
-      "area": {
-        "id": 32
-      }
+      "id": 1681
     },
     {
       "name": "West Moat",
@@ -350,10 +257,7 @@
         "south": 1683,
         "north": 1681
       },
-      "id": 1682,
-      "area": {
-        "id": 32
-      }
+      "id": 1682
     },
     {
       "name": "West Moat",
@@ -361,10 +265,7 @@
         "south": 1684,
         "north": 1682
       },
-      "id": 1683,
-      "area": {
-        "id": 32
-      }
+      "id": 1683
     },
     {
       "name": "West Moat",
@@ -372,10 +273,7 @@
         "south": 1685,
         "north": 1683
       },
-      "id": 1684,
-      "area": {
-        "id": 32
-      }
+      "id": 1684
     },
     {
       "name": "West Moat",
@@ -383,10 +281,7 @@
         "south": 1686,
         "north": 1684
       },
-      "id": 1685,
-      "area": {
-        "id": 32
-      }
+      "id": 1685
     },
     {
       "name": "West Moat",
@@ -394,10 +289,7 @@
         "south": 1672,
         "north": 1685
       },
-      "id": 1686,
-      "area": {
-        "id": 32
-      }
+      "id": 1686
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area33.json
+++ b/maps/area33.json
@@ -10,10 +10,7 @@
         "northeast": 1726,
         "southeast": 1724
       },
-      "id": 990,
-      "area": {
-        "id": 33
-      }
+      "id": 990
     },
     {
       "name": "Gate to the Village Green",
@@ -21,10 +18,7 @@
         "east": 1693,
         "south": 1688
       },
-      "id": 1687,
-      "area": {
-        "id": 33
-      }
+      "id": 1687
     },
     {
       "name": "Northwest Green",
@@ -33,10 +27,7 @@
         "east": 1694,
         "north": 1687
       },
-      "id": 1688,
-      "area": {
-        "id": 33
-      }
+      "id": 1688
     },
     {
       "name": "Northwest Green",
@@ -45,10 +36,7 @@
         "east": 1690,
         "north": 1688
       },
-      "id": 1689,
-      "area": {
-        "id": 33
-      }
+      "id": 1689
     },
     {
       "name": "Northwest Green",
@@ -58,10 +46,7 @@
         "east": 1691,
         "north": 1694
       },
-      "id": 1690,
-      "area": {
-        "id": 33
-      }
+      "id": 1690
     },
     {
       "name": "Northwest Green",
@@ -71,10 +56,7 @@
         "east": 1692,
         "north": 1704
       },
-      "id": 1691,
-      "area": {
-        "id": 33
-      }
+      "id": 1691
     },
     {
       "name": "Northeast Green",
@@ -84,10 +66,7 @@
         "east": 1706,
         "north": 1703
       },
-      "id": 1692,
-      "area": {
-        "id": 33
-      }
+      "id": 1692
     },
     {
       "name": "Northwestern Green",
@@ -96,10 +75,7 @@
         "east": 1695,
         "south": 1694
       },
-      "id": 1693,
-      "area": {
-        "id": 33
-      }
+      "id": 1693
     },
     {
       "name": "Northwest Green",
@@ -109,10 +85,7 @@
         "east": 1704,
         "north": 1693
       },
-      "id": 1694,
-      "area": {
-        "id": 33
-      }
+      "id": 1694
     },
     {
       "name": "Northwestern Green",
@@ -121,10 +94,7 @@
         "east": 1696,
         "south": 1704
       },
-      "id": 1695,
-      "area": {
-        "id": 33
-      }
+      "id": 1695
     },
     {
       "name": "Northeastern Green",
@@ -133,10 +103,7 @@
         "east": 1697,
         "south": 1703
       },
-      "id": 1696,
-      "area": {
-        "id": 33
-      }
+      "id": 1696
     },
     {
       "name": "Northeast Green",
@@ -145,10 +112,7 @@
         "east": 1698,
         "south": 1705
       },
-      "id": 1697,
-      "area": {
-        "id": 33
-      }
+      "id": 1697
     },
     {
       "name": "Northeast Green",
@@ -156,10 +120,7 @@
         "west": 1697,
         "south": 1710
       },
-      "id": 1698,
-      "area": {
-        "id": 33
-      }
+      "id": 1698
     },
     {
       "name": "Southwest Green",
@@ -168,10 +129,7 @@
         "east": 1700,
         "north": 1689
       },
-      "id": 1699,
-      "area": {
-        "id": 33
-      }
+      "id": 1699
     },
     {
       "name": "Southwest Green",
@@ -181,10 +139,7 @@
         "east": 1701,
         "north": 1690
       },
-      "id": 1700,
-      "area": {
-        "id": 33
-      }
+      "id": 1700
     },
     {
       "name": "Southwest Green",
@@ -194,10 +149,7 @@
         "east": 1702,
         "north": 1691
       },
-      "id": 1701,
-      "area": {
-        "id": 33
-      }
+      "id": 1701
     },
     {
       "name": "Southeast Green",
@@ -207,10 +159,7 @@
         "east": 1707,
         "north": 1692
       },
-      "id": 1702,
-      "area": {
-        "id": 33
-      }
+      "id": 1702
     },
     {
       "name": "Northeast Green",
@@ -220,10 +169,7 @@
         "east": 1705,
         "north": 1696
       },
-      "id": 1703,
-      "area": {
-        "id": 33
-      }
+      "id": 1703
     },
     {
       "name": "Northwest Green",
@@ -233,10 +179,7 @@
         "east": 1703,
         "north": 1695
       },
-      "id": 1704,
-      "area": {
-        "id": 33
-      }
+      "id": 1704
     },
     {
       "name": "Northeast Green",
@@ -246,10 +189,7 @@
         "east": 1710,
         "north": 1697
       },
-      "id": 1705,
-      "area": {
-        "id": 33
-      }
+      "id": 1705
     },
     {
       "name": "Northeast Green",
@@ -259,10 +199,7 @@
         "east": 1709,
         "north": 1705
       },
-      "id": 1706,
-      "area": {
-        "id": 33
-      }
+      "id": 1706
     },
     {
       "name": "Ruins in the Southeast Green",
@@ -272,10 +209,7 @@
         "east": 1708,
         "north": 1706
       },
-      "id": 1707,
-      "area": {
-        "id": 33
-      }
+      "id": 1707
     },
     {
       "name": "Ruins in the Southeast Green",
@@ -284,10 +218,7 @@
         "south": 1716,
         "north": 1709
       },
-      "id": 1708,
-      "area": {
-        "id": 33
-      }
+      "id": 1708
     },
     {
       "name": "Northeastern Green",
@@ -296,10 +227,7 @@
         "south": 1708,
         "north": 1710
       },
-      "id": 1709,
-      "area": {
-        "id": 33
-      }
+      "id": 1709
     },
     {
       "name": "Northeast Green",
@@ -309,10 +237,7 @@
         "east": 1722,
         "north": 1698
       },
-      "id": 1710,
-      "area": {
-        "id": 33
-      }
+      "id": 1710
     },
     {
       "name": "Southwest Green",
@@ -322,10 +247,7 @@
         "east": 1714,
         "north": 1701
       },
-      "id": 1711,
-      "area": {
-        "id": 33
-      }
+      "id": 1711
     },
     {
       "name": "Southwest Green",
@@ -335,10 +257,7 @@
         "east": 1711,
         "north": 1700
       },
-      "id": 1712,
-      "area": {
-        "id": 33
-      }
+      "id": 1712
     },
     {
       "name": "Southwest Green",
@@ -347,10 +266,7 @@
         "east": 1712,
         "north": 1699
       },
-      "id": 1713,
-      "area": {
-        "id": 33
-      }
+      "id": 1713
     },
     {
       "name": "Southeast Green",
@@ -359,10 +275,7 @@
         "east": 1715,
         "north": 1702
       },
-      "id": 1714,
-      "area": {
-        "id": 33
-      }
+      "id": 1714
     },
     {
       "name": "Southeast Green",
@@ -371,10 +284,7 @@
         "east": 1716,
         "north": 1707
       },
-      "id": 1715,
-      "area": {
-        "id": 33
-      }
+      "id": 1715
     },
     {
       "name": "Southeast Green",
@@ -382,10 +292,7 @@
         "west": 1715,
         "north": 1708
       },
-      "id": 1716,
-      "area": {
-        "id": 33
-      }
+      "id": 1716
     },
     {
       "name": "Southwest Green",
@@ -393,10 +300,7 @@
         "west": 1718,
         "north": 1711
       },
-      "id": 1717,
-      "area": {
-        "id": 33
-      }
+      "id": 1717
     },
     {
       "name": "Dark Southwest Green",
@@ -406,10 +310,7 @@
         "east": 1717,
         "north": 1712
       },
-      "id": 1718,
-      "area": {
-        "id": 33
-      }
+      "id": 1718
     },
     {
       "name": "Dark Southwest Green",
@@ -418,10 +319,7 @@
         "east": 1718,
         "north": 1713
       },
-      "id": 1719,
-      "area": {
-        "id": 33
-      }
+      "id": 1719
     },
     {
       "name": "Dark Southwest Green",
@@ -429,10 +327,7 @@
         "east": 1721,
         "north": 1719
       },
-      "id": 1720,
-      "area": {
-        "id": 33
-      }
+      "id": 1720
     },
     {
       "name": "Dark Southwest Green",
@@ -440,20 +335,14 @@
         "west": 1720,
         "north": 1718
       },
-      "id": 1721,
-      "area": {
-        "id": 33
-      }
+      "id": 1721
     },
     {
       "name": "The Herb Exchange",
       "exits": {
         "west": 1710
       },
-      "id": 1722,
-      "area": {
-        "id": 33
-      }
+      "id": 1722
     },
     {
       "name": "Oak Treehouse Rope Bridge",
@@ -461,10 +350,7 @@
         "northwest": 990,
         "southeast": 1729
       },
-      "id": 1724,
-      "area": {
-        "id": 33
-      }
+      "id": 1724
     },
     {
       "name": "Oak Treehouse Rope Bridge",
@@ -472,10 +358,7 @@
         "southwest": 1728,
         "northeast": 990
       },
-      "id": 1725,
-      "area": {
-        "id": 33
-      }
+      "id": 1725
     },
     {
       "name": "Oak Treehouse Rope Bridge",
@@ -483,30 +366,21 @@
         "southwest": 990,
         "northeast": 1727
       },
-      "id": 1726,
-      "area": {
-        "id": 33
-      }
+      "id": 1726
     },
     {
       "name": "Living Quarters in the Oak",
       "exits": {
         "southwest": 1726
       },
-      "id": 1727,
-      "area": {
-        "id": 33
-      }
+      "id": 1727
     },
     {
       "name": "Living Quarters in the Oak",
       "exits": {
         "northeast": 1725
       },
-      "id": 1728,
-      "area": {
-        "id": 33
-      }
+      "id": 1728
     },
     {
       "name": "Oak Treehouse Gazebo",
@@ -514,10 +388,7 @@
         "northwest": 1724,
         "east": 1730
       },
-      "id": 1729,
-      "area": {
-        "id": 33
-      }
+      "id": 1729
     },
     {
       "name": "Long Rope Bridge",
@@ -525,10 +396,7 @@
         "east": 1731,
         "west": 1729
       },
-      "id": 1730,
-      "area": {
-        "id": 33
-      }
+      "id": 1730
     },
     {
       "name": "The rope bridge sways underfoot, but you maintain your balance.",
@@ -538,30 +406,21 @@
         "east": 1733,
         "south": 1734
       },
-      "id": 1731,
-      "area": {
-        "id": 33
-      }
+      "id": 1731
     },
     {
       "name": "You push open the door and proceed northeast into the large room.",
       "exits": {
         "southwest": 1731
       },
-      "id": 1732,
-      "area": {
-        "id": 33
-      }
+      "id": 1732
     },
     {
       "name": "You push open the door to the private quarters.",
       "exits": {
         "west": 1731
       },
-      "id": 1733,
-      "area": {
-        "id": 33
-      }
+      "id": 1733
     },
     {
       "name": "Gingerly, you step out onto the taunt rope bridge.",
@@ -569,10 +428,7 @@
         "south": 1735,
         "north": 1731
       },
-      "id": 1734,
-      "area": {
-        "id": 33
-      }
+      "id": 1734
     },
     {
       "name": "You scurry across the swinging rope bridge.",
@@ -580,10 +436,7 @@
         "southeast": 1736,
         "north": 1734
       },
-      "id": 1735,
-      "area": {
-        "id": 33
-      }
+      "id": 1735
     },
     {
       "name": "Tel'Quesir Throne Room",
@@ -592,10 +445,7 @@
         "northwest": 1735,
         "southeast": 1737
       },
-      "id": 1736,
-      "area": {
-        "id": 33
-      }
+      "id": 1736
     },
     {
       "name": "White Chapel",
@@ -603,10 +453,7 @@
         "northwest": 1736,
         "north": 1738
       },
-      "id": 1737,
-      "area": {
-        "id": 33
-      }
+      "id": 1737
     },
     {
       "name": "Hall of Ministers",
@@ -614,10 +461,7 @@
         "southwest": 1736,
         "south": 1737
       },
-      "id": 1738,
-      "area": {
-        "id": 33
-      }
+      "id": 1738
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area36.json
+++ b/maps/area36.json
@@ -8,10 +8,7 @@
       "exits": {
         "east": 1825
       },
-      "id": 1824,
-      "area": {
-        "id": 36
-      }
+      "id": 1824
     },
     {
       "name": "A wide tunnel",
@@ -20,20 +17,14 @@
         "south": 1826,
         "north": 1827
       },
-      "id": 1825,
-      "area": {
-        "id": 36
-      }
+      "id": 1825
     },
     {
       "name": "A den",
       "exits": {
         "north": 1825
       },
-      "id": 1826,
-      "area": {
-        "id": 36
-      }
+      "id": 1826
     },
     {
       "name": "A tunnel",
@@ -41,10 +32,7 @@
         "south": 1825,
         "north": 1828
       },
-      "id": 1827,
-      "area": {
-        "id": 36
-      }
+      "id": 1827
     },
     {
       "name": "A bend in the tunnel",
@@ -52,10 +40,7 @@
         "east": 1829,
         "south": 1827
       },
-      "id": 1828,
-      "area": {
-        "id": 36
-      }
+      "id": 1828
     },
     {
       "name": "A tunnel",
@@ -63,10 +48,7 @@
         "east": 1830,
         "west": 1828
       },
-      "id": 1829,
-      "area": {
-        "id": 36
-      }
+      "id": 1829
     },
     {
       "name": "T-intersection",
@@ -75,10 +57,7 @@
         "south": 1831,
         "north": 1833
       },
-      "id": 1830,
-      "area": {
-        "id": 36
-      }
+      "id": 1830
     },
     {
       "name": "The widening tunnel",
@@ -86,30 +65,21 @@
         "east": 1832,
         "north": 1830
       },
-      "id": 1831,
-      "area": {
-        "id": 36
-      }
+      "id": 1831
     },
     {
       "name": "A large chamber",
       "exits": {
         "west": 1831
       },
-      "id": 1832,
-      "area": {
-        "id": 36
-      }
+      "id": 1832
     },
     {
       "name": "A small chamber",
       "exits": {
         "south": 1830
       },
-      "id": 1833,
-      "area": {
-        "id": 36
-      }
+      "id": 1833
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area38.json
+++ b/maps/area38.json
@@ -9,10 +9,7 @@
         "south": 1861,
         "north": 1864
       },
-      "id": 1863,
-      "area": {
-        "id": 38
-      }
+      "id": 1863
     },
     {
       "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
@@ -20,10 +17,7 @@
         "south": 1863,
         "north": 1865
       },
-      "id": 1864,
-      "area": {
-        "id": 38
-      }
+      "id": 1864
     },
     {
       "name": "You step down into the sandy courtyard.",
@@ -31,10 +25,7 @@
         "south": 1864,
         "north": 1866
       },
-      "id": 1865,
-      "area": {
-        "id": 38
-      }
+      "id": 1865
     },
     {
       "name": "Northwest Training Yard",
@@ -42,10 +33,7 @@
         "south": 1865,
         "north": 1867
       },
-      "id": 1866,
-      "area": {
-        "id": 38
-      }
+      "id": 1866
     },
     {
       "name": "You step up onto the boardwalk that rings the practice yard.",
@@ -53,20 +41,14 @@
         "south": 1866,
         "north": 1868
       },
-      "id": 1867,
-      "area": {
-        "id": 38
-      }
+      "id": 1867
     },
     {
       "name": "You slide back the fusumi with a flick of your hand.",
       "exits": {
         "south": 1867
       },
-      "id": 1868,
-      "area": {
-        "id": 38
-      }
+      "id": 1868
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area6.json
+++ b/maps/area6.json
@@ -8,10 +8,7 @@
       "exits": {
         "north": 507
       },
-      "id": 506,
-      "area": {
-        "id": 6
-      }
+      "id": 506
     },
     {
       "name": "Narrow Gorge",
@@ -19,20 +16,14 @@
         "west": 508,
         "south": 506
       },
-      "id": 507,
-      "area": {
-        "id": 6
-      }
+      "id": 507
     },
     {
       "name": "Old Guard Room",
       "exits": {
         "east": 507
       },
-      "id": 508,
-      "area": {
-        "id": 6
-      }
+      "id": 508
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area7.json
+++ b/maps/area7.json
@@ -5,20 +5,14 @@
   "rooms": [
     {
       "name": "",
-      "id": 509,
-      "area": {
-        "id": 7
-      }
+      "id": 509
     },
     {
       "name": "Barbarian Clearing",
       "exits": {
         "north": 511
       },
-      "id": 510,
-      "area": {
-        "id": 7
-      }
+      "id": 510
     },
     {
       "name": "Underground Pond",
@@ -27,10 +21,7 @@
         "west": 518,
         "south": 510
       },
-      "id": 511,
-      "area": {
-        "id": 7
-      }
+      "id": 511
     },
     {
       "name": "Cave Passage",
@@ -38,10 +29,7 @@
         "south": 513,
         "northeast": 511
       },
-      "id": 512,
-      "area": {
-        "id": 7
-      }
+      "id": 512
     },
     {
       "name": "Cave Passage",
@@ -49,17 +37,11 @@
         "south": 515,
         "north": 512
       },
-      "id": 513,
-      "area": {
-        "id": 7
-      }
+      "id": 513
     },
     {
       "name": "You begin to climb into the pit, and the descent seems simple enough.",
-      "id": 514,
-      "area": {
-        "id": 7
-      }
+      "id": 514
     },
     {
       "name": "Bottom of a Deep Dark Pit",
@@ -67,10 +49,7 @@
         "east": 516,
         "north": 513
       },
-      "id": 515,
-      "area": {
-        "id": 7
-      }
+      "id": 515
     },
     {
       "name": "Dark Barricade",
@@ -78,10 +57,7 @@
         "east": 517,
         "west": 515
       },
-      "id": 516,
-      "area": {
-        "id": 7
-      }
+      "id": 516
     },
     {
       "name": "Corridor",
@@ -89,10 +65,7 @@
         "east": 519,
         "west": 516
       },
-      "id": 517,
-      "area": {
-        "id": 7
-      }
+      "id": 517
     },
     {
       "name": "Cave Passage",
@@ -100,10 +73,7 @@
         "southwest": 1292,
         "east": 511
       },
-      "id": 518,
-      "area": {
-        "id": 7
-      }
+      "id": 518
     },
     {
       "name": "Passage Way",
@@ -113,20 +83,14 @@
         "east": 523,
         "north": 521
       },
-      "id": 519,
-      "area": {
-        "id": 7
-      }
+      "id": 519
     },
     {
       "name": "Barracks",
       "exits": {
         "north": 519
       },
-      "id": 520,
-      "area": {
-        "id": 7
-      }
+      "id": 520
     },
     {
       "name": "Mess Hall",
@@ -134,20 +98,14 @@
         "south": 519,
         "north": 522
       },
-      "id": 521,
-      "area": {
-        "id": 7
-      }
+      "id": 521
     },
     {
       "name": "Kitchen",
       "exits": {
         "south": 521
       },
-      "id": 522,
-      "area": {
-        "id": 7
-      }
+      "id": 522
     },
     {
       "name": "Passage Way",
@@ -157,10 +115,7 @@
         "east": 1295,
         "north": 1294
       },
-      "id": 523,
-      "area": {
-        "id": 7
-      }
+      "id": 523
     },
     {
       "name": "Passage Way",
@@ -168,10 +123,7 @@
         "south": 525,
         "north": 523
       },
-      "id": 524,
-      "area": {
-        "id": 7
-      }
+      "id": 524
     },
     {
       "name": "Passage Way",
@@ -180,50 +132,35 @@
         "south": 526,
         "north": 524
       },
-      "id": 525,
-      "area": {
-        "id": 7
-      }
+      "id": 525
     },
     {
       "name": "Circular room",
       "exits": {
         "north": 525
       },
-      "id": 526,
-      "area": {
-        "id": 7
-      }
+      "id": 526
     },
     {
       "name": "Cave Waterfall",
       "exits": {
         "northeast": 518
       },
-      "id": 1292,
-      "area": {
-        "id": 7
-      }
+      "id": 1292
     },
     {
       "name": "Throne Room",
       "exits": {
         "east": 525
       },
-      "id": 1293,
-      "area": {
-        "id": 7
-      }
+      "id": 1293
     },
     {
       "name": "Mess Hall",
       "exits": {
         "south": 523
       },
-      "id": 1294,
-      "area": {
-        "id": 7
-      }
+      "id": 1294
     },
     {
       "name": "New Tunnel",
@@ -231,20 +168,14 @@
         "east": 1296,
         "west": 523
       },
-      "id": 1295,
-      "area": {
-        "id": 7
-      }
+      "id": 1295
     },
     {
       "name": "New Tunnel",
       "exits": {
         "west": 1295
       },
-      "id": 1296,
-      "area": {
-        "id": 7
-      }
+      "id": 1296
     },
     {
       "name": "New Tunnel",
@@ -254,40 +185,28 @@
         "east": 1301,
         "north": 1300
       },
-      "id": 1297,
-      "area": {
-        "id": 7
-      }
+      "id": 1297
     },
     {
       "name": "You pass through the door and it closes and locks behind you.",
       "exits": {
         "east": 1297
       },
-      "id": 1298,
-      "area": {
-        "id": 7
-      }
+      "id": 1298
     },
     {
       "name": "Nursery",
       "exits": {
         "north": 1297
       },
-      "id": 1299,
-      "area": {
-        "id": 7
-      }
+      "id": 1299
     },
     {
       "name": "Barracks",
       "exits": {
         "south": 1297
       },
-      "id": 1300,
-      "area": {
-        "id": 7
-      }
+      "id": 1300
     },
     {
       "name": "New Tunnel: Checkpoint",
@@ -295,10 +214,7 @@
         "east": 1302,
         "west": 1297
       },
-      "id": 1301,
-      "area": {
-        "id": 7
-      }
+      "id": 1301
     },
     {
       "name": "Top of the mine shaft",
@@ -306,10 +222,7 @@
         "down": 1303,
         "west": 1301
       },
-      "id": 1302,
-      "area": {
-        "id": 7
-      }
+      "id": 1302
     },
     {
       "name": "You let up on the ropes, and the counterweight slowly glides you down the",
@@ -317,10 +230,7 @@
         "down": 1304,
         "up": 1302
       },
-      "id": 1303,
-      "area": {
-        "id": 7
-      }
+      "id": 1303
     },
     {
       "name": "You let up on the ropes, and the counterweight slowly glides you down the",
@@ -330,10 +240,7 @@
         "east": 1320,
         "north": 1311
       },
-      "id": 1304,
-      "area": {
-        "id": 7
-      }
+      "id": 1304
     },
     {
       "name": "Twisting Tunnel",
@@ -342,10 +249,7 @@
         "northeast": 1304,
         "southeast": 1309
       },
-      "id": 1305,
-      "area": {
-        "id": 7
-      }
+      "id": 1305
     },
     {
       "name": "Twisting Tunnel",
@@ -354,30 +258,21 @@
         "northwest": 1308,
         "southeast": 1307
       },
-      "id": 1306,
-      "area": {
-        "id": 7
-      }
+      "id": 1306
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "northwest": 1306
       },
-      "id": 1307,
-      "area": {
-        "id": 7
-      }
+      "id": 1307
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "southeast": 1306
       },
-      "id": 1308,
-      "area": {
-        "id": 7
-      }
+      "id": 1308
     },
     {
       "name": "Twisting Tunnel",
@@ -385,20 +280,14 @@
         "northwest": 1305,
         "northeast": 1310
       },
-      "id": 1309,
-      "area": {
-        "id": 7
-      }
+      "id": 1309
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "southwest": 1309
       },
-      "id": 1310,
-      "area": {
-        "id": 7
-      }
+      "id": 1310
     },
     {
       "name": "Twisting Tunnel",
@@ -406,10 +295,7 @@
         "south": 1304,
         "northeast": 1312
       },
-      "id": 1311,
-      "area": {
-        "id": 7
-      }
+      "id": 1311
     },
     {
       "name": "Twisting Tunnel",
@@ -417,10 +303,7 @@
         "southwest": 1311,
         "north": 1313
       },
-      "id": 1312,
-      "area": {
-        "id": 7
-      }
+      "id": 1312
     },
     {
       "name": "Twisting Tunnel",
@@ -429,10 +312,7 @@
         "northwest": 1316,
         "south": 1312
       },
-      "id": 1313,
-      "area": {
-        "id": 7
-      }
+      "id": 1313
     },
     {
       "name": "Twisting Tunnel",
@@ -440,20 +320,14 @@
         "southeast": 1315,
         "west": 1313
       },
-      "id": 1314,
-      "area": {
-        "id": 7
-      }
+      "id": 1314
     },
     {
       "name": "Your left arm is now in full health.",
       "exits": {
         "northwest": 1314
       },
-      "id": 1315,
-      "area": {
-        "id": 7
-      }
+      "id": 1315
     },
     {
       "name": "Twisting Tunnel",
@@ -462,10 +336,7 @@
         "southeast": 1313,
         "north": 1317
       },
-      "id": 1316,
-      "area": {
-        "id": 7
-      }
+      "id": 1316
     },
     {
       "name": "Twisting Tunnel",
@@ -473,30 +344,21 @@
         "northwest": 1318,
         "south": 1316
       },
-      "id": 1317,
-      "area": {
-        "id": 7
-      }
+      "id": 1317
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "southeast": 1317
       },
-      "id": 1318,
-      "area": {
-        "id": 7
-      }
+      "id": 1318
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "southwest": 1316
       },
-      "id": 1319,
-      "area": {
-        "id": 7
-      }
+      "id": 1319
     },
     {
       "name": "Twisting Tunnel",
@@ -504,10 +366,7 @@
         "west": 1304,
         "northeast": 1321
       },
-      "id": 1320,
-      "area": {
-        "id": 7
-      }
+      "id": 1320
     },
     {
       "name": "Twisting Tunnel",
@@ -517,10 +376,7 @@
         "southeast": 1322,
         "north": 1324
       },
-      "id": 1321,
-      "area": {
-        "id": 7
-      }
+      "id": 1321
     },
     {
       "name": "Twisting Tunnel",
@@ -528,40 +384,28 @@
         "northwest": 1321,
         "east": 1323
       },
-      "id": 1322,
-      "area": {
-        "id": 7
-      }
+      "id": 1322
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "west": 1322
       },
-      "id": 1323,
-      "area": {
-        "id": 7
-      }
+      "id": 1323
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "south": 1321
       },
-      "id": 1324,
-      "area": {
-        "id": 7
-      }
+      "id": 1324
     },
     {
       "name": "Twisting Tunnel",
       "exits": {
         "east": 1321
       },
-      "id": 1325,
-      "area": {
-        "id": 7
-      }
+      "id": 1325
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area8.json
+++ b/maps/area8.json
@@ -8,10 +8,7 @@
       "exits": {
         "northeast": 530
       },
-      "id": 529,
-      "area": {
-        "id": 8
-      }
+      "id": 529
     },
     {
       "name": "The start of a forest path",
@@ -20,10 +17,7 @@
         "northeast": 531,
         "northwest": 532
       },
-      "id": 530,
-      "area": {
-        "id": 8
-      }
+      "id": 530
     },
     {
       "name": "A forest path",
@@ -32,10 +26,7 @@
         "northeast": 539,
         "east": 551
       },
-      "id": 531,
-      "area": {
-        "id": 8
-      }
+      "id": 531
     },
     {
       "name": "A forest path",
@@ -45,10 +36,7 @@
         "southeast": 530,
         "north": 533
       },
-      "id": 532,
-      "area": {
-        "id": 8
-      }
+      "id": 532
     },
     {
       "name": "A forest path",
@@ -60,10 +48,7 @@
         "east": 578,
         "north": 591
       },
-      "id": 533,
-      "area": {
-        "id": 8
-      }
+      "id": 533
     },
     {
       "name": "A forest path",
@@ -74,10 +59,7 @@
         "east": 533,
         "north": 592
       },
-      "id": 534,
-      "area": {
-        "id": 8
-      }
+      "id": 534
     },
     {
       "name": "A forest path",
@@ -86,10 +68,7 @@
         "east": 532,
         "north": 534
       },
-      "id": 535,
-      "area": {
-        "id": 8
-      }
+      "id": 535
     },
     {
       "name": "River Bank",
@@ -98,10 +77,7 @@
         "northeast": 592,
         "east": 534
       },
-      "id": 536,
-      "area": {
-        "id": 8
-      }
+      "id": 536
     },
     {
       "name": "River Bank",
@@ -109,20 +85,14 @@
         "southwest": 538,
         "northeast": 536
       },
-      "id": 537,
-      "area": {
-        "id": 8
-      }
+      "id": 537
     },
     {
       "name": "Gryphon Nest",
       "exits": {
         "northeast": 537
       },
-      "id": 538,
-      "area": {
-        "id": 8
-      }
+      "id": 538
     },
     {
       "name": "A clearing in the forest",
@@ -132,10 +102,7 @@
         "east": 550,
         "south": 551
       },
-      "id": 539,
-      "area": {
-        "id": 8
-      }
+      "id": 539
     },
     {
       "name": "A forest path",
@@ -145,10 +112,7 @@
         "east": 549,
         "south": 550
       },
-      "id": 540,
-      "area": {
-        "id": 8
-      }
+      "id": 540
     },
     {
       "name": "A forest path",
@@ -159,10 +123,7 @@
         "east": 548,
         "west": 575
       },
-      "id": 541,
-      "area": {
-        "id": 8
-      }
+      "id": 541
     },
     {
       "name": "A forest",
@@ -172,10 +133,7 @@
         "east": 547,
         "south": 548
       },
-      "id": 542,
-      "area": {
-        "id": 8
-      }
+      "id": 542
     },
     {
       "name": "A dark forest",
@@ -185,10 +143,7 @@
         "east": 546,
         "south": 547
       },
-      "id": 543,
-      "area": {
-        "id": 8
-      }
+      "id": 543
     },
     {
       "name": "A forest",
@@ -197,10 +152,7 @@
         "east": 545,
         "south": 546
       },
-      "id": 544,
-      "area": {
-        "id": 8
-      }
+      "id": 544
     },
     {
       "name": "A forest glade",
@@ -210,10 +162,7 @@
         "east": 558,
         "south": 557
       },
-      "id": 545,
-      "area": {
-        "id": 8
-      }
+      "id": 545
     },
     {
       "name": "A forest glade",
@@ -225,10 +174,7 @@
         "east": 557,
         "north": 544
       },
-      "id": 546,
-      "area": {
-        "id": 8
-      }
+      "id": 546
     },
     {
       "name": "A forest path",
@@ -240,10 +186,7 @@
         "east": 556,
         "north": 543
       },
-      "id": 547,
-      "area": {
-        "id": 8
-      }
+      "id": 547
     },
     {
       "name": "A path in the forest",
@@ -255,10 +198,7 @@
         "east": 555,
         "north": 542
       },
-      "id": 548,
-      "area": {
-        "id": 8
-      }
+      "id": 548
     },
     {
       "name": "A clearing in the forest",
@@ -270,10 +210,7 @@
         "east": 554,
         "north": 541
       },
-      "id": 549,
-      "area": {
-        "id": 8
-      }
+      "id": 549
     },
     {
       "name": "A forest",
@@ -285,10 +222,7 @@
         "east": 553,
         "north": 540
       },
-      "id": 550,
-      "area": {
-        "id": 8
-      }
+      "id": 550
     },
     {
       "name": "A forest path",
@@ -299,10 +233,7 @@
         "east": 552,
         "north": 539
       },
-      "id": 551,
-      "area": {
-        "id": 8
-      }
+      "id": 551
     },
     {
       "name": "A forest path",
@@ -312,10 +243,7 @@
         "east": 565,
         "north": 550
       },
-      "id": 552,
-      "area": {
-        "id": 8
-      }
+      "id": 552
     },
     {
       "name": "A forest path",
@@ -327,10 +255,7 @@
         "east": 564,
         "north": 549
       },
-      "id": 553,
-      "area": {
-        "id": 8
-      }
+      "id": 553
     },
     {
       "name": "A forest path",
@@ -342,10 +267,7 @@
         "east": 563,
         "north": 548
       },
-      "id": 554,
-      "area": {
-        "id": 8
-      }
+      "id": 554
     },
     {
       "name": "A path through the forest",
@@ -357,10 +279,7 @@
         "east": 562,
         "north": 547
       },
-      "id": 555,
-      "area": {
-        "id": 8
-      }
+      "id": 555
     },
     {
       "name": "A forest path",
@@ -372,10 +291,7 @@
         "east": 561,
         "north": 546
       },
-      "id": 556,
-      "area": {
-        "id": 8
-      }
+      "id": 556
     },
     {
       "name": "A forest",
@@ -387,10 +303,7 @@
         "east": 560,
         "north": 545
       },
-      "id": 557,
-      "area": {
-        "id": 8
-      }
+      "id": 557
     },
     {
       "name": "A forest path",
@@ -400,10 +313,7 @@
         "east": 559,
         "south": 560
       },
-      "id": 558,
-      "area": {
-        "id": 8
-      }
+      "id": 558
     },
     {
       "name": "A forest path",
@@ -412,10 +322,7 @@
         "west": 558,
         "south": 573
       },
-      "id": 559,
-      "area": {
-        "id": 8
-      }
+      "id": 559
     },
     {
       "name": "A path in the forest",
@@ -427,10 +334,7 @@
         "east": 573,
         "north": 558
       },
-      "id": 560,
-      "area": {
-        "id": 8
-      }
+      "id": 560
     },
     {
       "name": "A forest path",
@@ -442,10 +346,7 @@
         "east": 572,
         "north": 557
       },
-      "id": 561,
-      "area": {
-        "id": 8
-      }
+      "id": 561
     },
     {
       "name": "A forest path",
@@ -457,10 +358,7 @@
         "east": 571,
         "north": 556
       },
-      "id": 562,
-      "area": {
-        "id": 8
-      }
+      "id": 562
     },
     {
       "name": "A forest",
@@ -472,10 +370,7 @@
         "east": 570,
         "north": 555
       },
-      "id": 563,
-      "area": {
-        "id": 8
-      }
+      "id": 563
     },
     {
       "name": "A forest path",
@@ -487,10 +382,7 @@
         "east": 569,
         "north": 554
       },
-      "id": 564,
-      "area": {
-        "id": 8
-      }
+      "id": 564
     },
     {
       "name": "A forest path",
@@ -502,10 +394,7 @@
         "east": 568,
         "north": 553
       },
-      "id": 565,
-      "area": {
-        "id": 8
-      }
+      "id": 565
     },
     {
       "name": "A dark forest glade",
@@ -513,10 +402,7 @@
         "southwest": 567,
         "northeast": 565
       },
-      "id": 566,
-      "area": {
-        "id": 8
-      }
+      "id": 566
     },
     {
       "name": "A forest path",
@@ -524,10 +410,7 @@
         "west": 601,
         "northeast": 566
       },
-      "id": 567,
-      "area": {
-        "id": 8
-      }
+      "id": 567
     },
     {
       "name": "A forest path",
@@ -537,10 +420,7 @@
         "west": 565,
         "north": 564
       },
-      "id": 568,
-      "area": {
-        "id": 8
-      }
+      "id": 568
     },
     {
       "name": "A path through the forest",
@@ -550,10 +430,7 @@
         "west": 564,
         "north": 563
       },
-      "id": 569,
-      "area": {
-        "id": 8
-      }
+      "id": 569
     },
     {
       "name": "A forest glade",
@@ -563,10 +440,7 @@
         "west": 563,
         "north": 562
       },
-      "id": 570,
-      "area": {
-        "id": 8
-      }
+      "id": 570
     },
     {
       "name": "A forest path",
@@ -576,10 +450,7 @@
         "west": 562,
         "north": 561
       },
-      "id": 571,
-      "area": {
-        "id": 8
-      }
+      "id": 571
     },
     {
       "name": "A forest path",
@@ -589,10 +460,7 @@
         "west": 561,
         "north": 560
       },
-      "id": 572,
-      "area": {
-        "id": 8
-      }
+      "id": 572
     },
     {
       "name": "A forest path",
@@ -601,10 +469,7 @@
         "west": 560,
         "north": 559
       },
-      "id": 573,
-      "area": {
-        "id": 8
-      }
+      "id": 573
     },
     {
       "name": "Forest Glade",
@@ -612,20 +477,14 @@
         "northeast": 568,
         "north": 565
       },
-      "id": 574,
-      "area": {
-        "id": 8
-      }
+      "id": 574
     },
     {
       "name": "A forest",
       "exits": {
         "east": 541
       },
-      "id": 575,
-      "area": {
-        "id": 8
-      }
+      "id": 575
     },
     {
       "name": "The start of a forest path",
@@ -633,20 +492,14 @@
         "southwest": 577,
         "north": 551
       },
-      "id": 576,
-      "area": {
-        "id": 8
-      }
+      "id": 576
     },
     {
       "name": "The start of a forest path",
       "exits": {
         "northeast": 576
       },
-      "id": 577,
-      "area": {
-        "id": 8
-      }
+      "id": 577
     },
     {
       "name": "A forest path",
@@ -657,10 +510,7 @@
         "east": 600,
         "north": 596
       },
-      "id": 578,
-      "area": {
-        "id": 8
-      }
+      "id": 578
     },
     {
       "name": "A forest path",
@@ -670,10 +520,7 @@
         "west": 596,
         "north": 597
       },
-      "id": 579,
-      "area": {
-        "id": 8
-      }
+      "id": 579
     },
     {
       "name": "A clearing in the forest",
@@ -683,10 +530,7 @@
         "west": 597,
         "north": 598
       },
-      "id": 580,
-      "area": {
-        "id": 8
-      }
+      "id": 580
     },
     {
       "name": "A forest path",
@@ -696,10 +540,7 @@
         "west": 598,
         "north": 585
       },
-      "id": 581,
-      "area": {
-        "id": 8
-      }
+      "id": 581
     },
     {
       "name": "Forest Mound",
@@ -710,10 +551,7 @@
         "east": 599,
         "north": 584
       },
-      "id": 582,
-      "area": {
-        "id": 8
-      }
+      "id": 582
     },
     {
       "name": "A forest path",
@@ -721,10 +559,7 @@
         "southwest": 582,
         "west": 584
       },
-      "id": 583,
-      "area": {
-        "id": 8
-      }
+      "id": 583
     },
     {
       "name": "A forest glade",
@@ -734,10 +569,7 @@
         "east": 583,
         "south": 582
       },
-      "id": 584,
-      "area": {
-        "id": 8
-      }
+      "id": 584
     },
     {
       "name": "A forest path",
@@ -748,10 +580,7 @@
         "east": 582,
         "north": 586
       },
-      "id": 585,
-      "area": {
-        "id": 8
-      }
+      "id": 585
     },
     {
       "name": "A forest glade",
@@ -761,10 +590,7 @@
         "east": 584,
         "south": 585
       },
-      "id": 586,
-      "area": {
-        "id": 8
-      }
+      "id": 586
     },
     {
       "name": "A river bank",
@@ -773,10 +599,7 @@
         "east": 586,
         "south": 588
       },
-      "id": 587,
-      "area": {
-        "id": 8
-      }
+      "id": 587
     },
     {
       "name": "A dark forest glade",
@@ -788,10 +611,7 @@
         "east": 589,
         "north": 587
       },
-      "id": 588,
-      "area": {
-        "id": 8
-      }
+      "id": 588
     },
     {
       "name": "A forest glade",
@@ -803,10 +623,7 @@
         "east": 598,
         "north": 595
       },
-      "id": 589,
-      "area": {
-        "id": 8
-      }
+      "id": 589
     },
     {
       "name": "A forest",
@@ -818,10 +635,7 @@
         "east": 597,
         "north": 594
       },
-      "id": 590,
-      "area": {
-        "id": 8
-      }
+      "id": 590
     },
     {
       "name": "A forest",
@@ -833,10 +647,7 @@
         "east": 596,
         "north": 593
       },
-      "id": 591,
-      "area": {
-        "id": 8
-      }
+      "id": 591
     },
     {
       "name": "A river bank",
@@ -846,10 +657,7 @@
         "east": 591,
         "south": 534
       },
-      "id": 592,
-      "area": {
-        "id": 8
-      }
+      "id": 592
     },
     {
       "name": "A river bank",
@@ -859,10 +667,7 @@
         "east": 590,
         "south": 591
       },
-      "id": 593,
-      "area": {
-        "id": 8
-      }
+      "id": 593
     },
     {
       "name": "A riverbank",
@@ -872,10 +677,7 @@
         "east": 589,
         "south": 590
       },
-      "id": 594,
-      "area": {
-        "id": 8
-      }
+      "id": 594
     },
     {
       "name": "A river bank",
@@ -885,10 +687,7 @@
         "east": 585,
         "south": 589
       },
-      "id": 595,
-      "area": {
-        "id": 8
-      }
+      "id": 595
     },
     {
       "name": "A path through the forest",
@@ -900,10 +699,7 @@
         "east": 579,
         "north": 590
       },
-      "id": 596,
-      "area": {
-        "id": 8
-      }
+      "id": 596
     },
     {
       "name": "A forest path",
@@ -915,10 +711,7 @@
         "east": 580,
         "north": 589
       },
-      "id": 597,
-      "area": {
-        "id": 8
-      }
+      "id": 597
     },
     {
       "name": "A forest path",
@@ -930,40 +723,28 @@
         "east": 581,
         "north": 588
       },
-      "id": 598,
-      "area": {
-        "id": 8
-      }
+      "id": 598
     },
     {
       "name": "A small clearing",
       "exits": {
         "west": 582
       },
-      "id": 599,
-      "area": {
-        "id": 8
-      }
+      "id": 599
     },
     {
       "name": "Druids Guild",
       "exits": {
         "west": 578
       },
-      "id": 600,
-      "area": {
-        "id": 8
-      }
+      "id": 600
     },
     {
       "name": "Large home",
       "exits": {
         "east": 567
       },
-      "id": 601,
-      "area": {
-        "id": 8
-      }
+      "id": 601
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/balin.json
+++ b/maps/balin.json
@@ -8,10 +8,7 @@
       "exits": {
         "north": 606
       },
-      "id": 605,
-      "area": {
-        "id": 9
-      }
+      "id": 605
     },
     {
       "name": "A sandy beachhead",
@@ -21,10 +18,7 @@
         "east": 626,
         "north": 607
       },
-      "id": 606,
-      "area": {
-        "id": 9
-      }
+      "id": 606
     },
     {
       "name": "A narrow path between the dunes",
@@ -33,10 +27,7 @@
         "east": 628,
         "north": 608
       },
-      "id": 607,
-      "area": {
-        "id": 9
-      }
+      "id": 607
     },
     {
       "name": "A Dune Path",
@@ -44,10 +35,7 @@
         "south": 607,
         "north": 609
       },
-      "id": 608,
-      "area": {
-        "id": 9
-      }
+      "id": 608
     },
     {
       "name": "The City Gate",
@@ -57,10 +45,7 @@
         "east": 634,
         "north": 610
       },
-      "id": 609,
-      "area": {
-        "id": 9
-      }
+      "id": 609
     },
     {
       "name": "Intersection of Silver Street and Balin Road",
@@ -70,10 +55,7 @@
         "east": 660,
         "north": 611
       },
-      "id": 610,
-      "area": {
-        "id": 9
-      }
+      "id": 610
     },
     {
       "name": "Silver Street",
@@ -82,10 +64,7 @@
         "east": 713,
         "north": 612
       },
-      "id": 611,
-      "area": {
-        "id": 9
-      }
+      "id": 611
     },
     {
       "name": "Silver Street",
@@ -94,10 +73,7 @@
         "east": 674,
         "north": 613
       },
-      "id": 612,
-      "area": {
-        "id": 9
-      }
+      "id": 612
     },
     {
       "name": "Silver Street",
@@ -107,10 +83,7 @@
         "east": 676,
         "north": 614
       },
-      "id": 613,
-      "area": {
-        "id": 9
-      }
+      "id": 613
     },
     {
       "name": "A Grand Plaza",
@@ -120,10 +93,7 @@
         "east": 677,
         "north": 615
       },
-      "id": 614,
-      "area": {
-        "id": 9
-      }
+      "id": 614
     },
     {
       "name": "Silver Street",
@@ -132,10 +102,7 @@
         "south": 614,
         "north": 616
       },
-      "id": 615,
-      "area": {
-        "id": 9
-      }
+      "id": 615
     },
     {
       "name": "Silver Street",
@@ -144,10 +111,7 @@
         "east": 689,
         "north": 617
       },
-      "id": 616,
-      "area": {
-        "id": 9
-      }
+      "id": 616
     },
     {
       "name": "Silver Street",
@@ -156,10 +120,7 @@
         "south": 616,
         "north": 618
       },
-      "id": 617,
-      "area": {
-        "id": 9
-      }
+      "id": 617
     },
     {
       "name": "Silver Street",
@@ -169,10 +130,7 @@
         "east": 691,
         "north": 619
       },
-      "id": 618,
-      "area": {
-        "id": 9
-      }
+      "id": 618
     },
     {
       "name": "End of Silver Street",
@@ -180,10 +138,7 @@
         "east": 620,
         "south": 618
       },
-      "id": 619,
-      "area": {
-        "id": 9
-      }
+      "id": 619
     },
     {
       "name": "Island smeltery",
@@ -191,27 +146,18 @@
         "east": 621,
         "west": 619
       },
-      "id": 620,
-      "area": {
-        "id": 9
-      }
+      "id": 620
     },
     {
       "name": "Repair Shop",
       "exits": {
         "west": 620
       },
-      "id": 621,
-      "area": {
-        "id": 9
-      }
+      "id": 621
     },
     {
       "name": "A Bloody Arena.",
-      "id": 622,
-      "area": {
-        "id": 9
-      }
+      "id": 622
     },
     {
       "name": "Western Part of Beach",
@@ -219,10 +165,7 @@
         "east": 606,
         "west": 624
       },
-      "id": 623,
-      "area": {
-        "id": 9
-      }
+      "id": 623
     },
     {
       "name": "East of the waterfall",
@@ -230,20 +173,14 @@
         "east": 623,
         "west": 625
       },
-      "id": 624,
-      "area": {
-        "id": 9
-      }
+      "id": 624
     },
     {
       "name": "The base of a waterfall",
       "exits": {
         "east": 624
       },
-      "id": 625,
-      "area": {
-        "id": 9
-      }
+      "id": 625
     },
     {
       "name": "Ruins",
@@ -251,20 +188,14 @@
         "east": 627,
         "west": 606
       },
-      "id": 626,
-      "area": {
-        "id": 9
-      }
+      "id": 626
     },
     {
       "name": "Eastern Beach",
       "exits": {
         "west": 626
       },
-      "id": 627,
-      "area": {
-        "id": 9
-      }
+      "id": 627
     },
     {
       "name": "A valley between two large dunes",
@@ -272,10 +203,7 @@
         "east": 629,
         "west": 607
       },
-      "id": 628,
-      "area": {
-        "id": 9
-      }
+      "id": 628
     },
     {
       "name": "A desert plain",
@@ -283,20 +211,14 @@
         "west": 628,
         "north": 630
       },
-      "id": 629,
-      "area": {
-        "id": 9
-      }
+      "id": 629
     },
     {
       "name": "A dead end",
       "exits": {
         "south": 629
       },
-      "id": 630,
-      "area": {
-        "id": 9
-      }
+      "id": 630
     },
     {
       "name": "Guard Room",
@@ -304,10 +226,7 @@
         "east": 609,
         "west": 632
       },
-      "id": 631,
-      "area": {
-        "id": 9
-      }
+      "id": 631
     },
     {
       "name": "Armoury",
@@ -315,30 +234,21 @@
         "east": 631,
         "west": 633
       },
-      "id": 632,
-      "area": {
-        "id": 9
-      }
+      "id": 632
     },
     {
       "name": "Elderoak's Quarters",
       "exits": {
         "east": 632
       },
-      "id": 633,
-      "area": {
-        "id": 9
-      }
+      "id": 633
     },
     {
       "name": "A guard house",
       "exits": {
         "west": 609
       },
-      "id": 634,
-      "area": {
-        "id": 9
-      }
+      "id": 634
     },
     {
       "name": "Balin Road",
@@ -349,10 +259,7 @@
         "east": 610,
         "west": 636
       },
-      "id": 635,
-      "area": {
-        "id": 9
-      }
+      "id": 635
     },
     {
       "name": "Balin Road",
@@ -362,10 +269,7 @@
         "southeast": 721,
         "west": 637
       },
-      "id": 636,
-      "area": {
-        "id": 9
-      }
+      "id": 636
     },
     {
       "name": "West End of Balin Road",
@@ -375,10 +279,7 @@
         "east": 636,
         "south": 723
       },
-      "id": 637,
-      "area": {
-        "id": 9
-      }
+      "id": 637
     },
     {
       "name": "Tunnel Under Canal",
@@ -386,10 +287,7 @@
         "east": 637,
         "west": 639
       },
-      "id": 638,
-      "area": {
-        "id": 9
-      }
+      "id": 638
     },
     {
       "name": "South End of Highland Avenue",
@@ -397,10 +295,7 @@
         "east": 638,
         "west": 640
       },
-      "id": 639,
-      "area": {
-        "id": 9
-      }
+      "id": 639
     },
     {
       "name": "Highland Avenue",
@@ -409,10 +304,7 @@
         "east": 639,
         "north": 641
       },
-      "id": 640,
-      "area": {
-        "id": 9
-      }
+      "id": 640
     },
     {
       "name": "Highland Avenue",
@@ -420,10 +312,7 @@
         "south": 640,
         "north": 642
       },
-      "id": 641,
-      "area": {
-        "id": 9
-      }
+      "id": 641
     },
     {
       "name": "Highland Avenue",
@@ -431,10 +320,7 @@
         "west": 643,
         "south": 641
       },
-      "id": 642,
-      "area": {
-        "id": 9
-      }
+      "id": 642
     },
     {
       "name": "Highland Avenue",
@@ -443,10 +329,7 @@
         "east": 642,
         "north": 644
       },
-      "id": 643,
-      "area": {
-        "id": 9
-      }
+      "id": 643
     },
     {
       "name": "Highland Avenue",
@@ -456,40 +339,28 @@
         "east": 648,
         "north": 645
       },
-      "id": 644,
-      "area": {
-        "id": 9
-      }
+      "id": 644
     },
     {
       "name": "Dwarven Hut",
       "exits": {
         "south": 644
       },
-      "id": 645,
-      "area": {
-        "id": 9
-      }
+      "id": 645
     },
     {
       "name": "You trundle past the facade and arrive on a beautiful street.",
       "exits": {
         "east": 644
       },
-      "id": 646,
-      "area": {
-        "id": 9
-      }
+      "id": 646
     },
     {
       "name": "Gnome Hut",
       "exits": {
         "north": 643
       },
-      "id": 647,
-      "area": {
-        "id": 9
-      }
+      "id": 647
     },
     {
       "name": "Highland Avenue",
@@ -499,20 +370,14 @@
         "east": 649,
         "north": 650
       },
-      "id": 648,
-      "area": {
-        "id": 9
-      }
+      "id": 648
     },
     {
       "name": "Dwarven Home",
       "exits": {
         "west": 648
       },
-      "id": 649,
-      "area": {
-        "id": 9
-      }
+      "id": 649
     },
     {
       "name": "Highland Avenue",
@@ -520,20 +385,14 @@
         "west": 652,
         "south": 648
       },
-      "id": 650,
-      "area": {
-        "id": 9
-      }
+      "id": 650
     },
     {
       "name": "Dwarven Shack",
       "exits": {
         "north": 648
       },
-      "id": 651,
-      "area": {
-        "id": 9
-      }
+      "id": 651
     },
     {
       "name": "Highland Avenue",
@@ -542,10 +401,7 @@
         "east": 650,
         "north": 654
       },
-      "id": 652,
-      "area": {
-        "id": 9
-      }
+      "id": 652
     },
     {
       "name": "Dwarven Home",
@@ -553,10 +409,7 @@
         "east": 652,
         "south": 656
       },
-      "id": 653,
-      "area": {
-        "id": 9
-      }
+      "id": 653
     },
     {
       "name": "Highland Avenue",
@@ -564,10 +417,7 @@
         "south": 652,
         "north": 655
       },
-      "id": 654,
-      "area": {
-        "id": 9
-      }
+      "id": 654
     },
     {
       "name": "House of Balin",
@@ -575,20 +425,14 @@
         "west": 712,
         "south": 654
       },
-      "id": 655,
-      "area": {
-        "id": 9
-      }
+      "id": 655
     },
     {
       "name": "Dwarven Home",
       "exits": {
         "north": 653
       },
-      "id": 656,
-      "area": {
-        "id": 9
-      }
+      "id": 656
     },
     {
       "name": "Keep Of Alcibiades",
@@ -597,30 +441,21 @@
         "east": 658,
         "north": 640
       },
-      "id": 657,
-      "area": {
-        "id": 9
-      }
+      "id": 657
     },
     {
       "name": "Study",
       "exits": {
         "west": 657
       },
-      "id": 658,
-      "area": {
-        "id": 9
-      }
+      "id": 658
     },
     {
       "name": "Bedroom:",
       "exits": {
         "east": 657
       },
-      "id": 659,
-      "area": {
-        "id": 9
-      }
+      "id": 659
     },
     {
       "name": "Balin Road",
@@ -628,10 +463,7 @@
         "east": 661,
         "west": 610
       },
-      "id": 660,
-      "area": {
-        "id": 9
-      }
+      "id": 660
     },
     {
       "name": "Balin Road",
@@ -640,10 +472,7 @@
         "east": 662,
         "south": 673
       },
-      "id": 661,
-      "area": {
-        "id": 9
-      }
+      "id": 661
     },
     {
       "name": "Balin Road",
@@ -652,10 +481,7 @@
         "east": 663,
         "north": 672
       },
-      "id": 662,
-      "area": {
-        "id": 9
-      }
+      "id": 662
     },
     {
       "name": "Balin Road",
@@ -665,10 +491,7 @@
         "east": 664,
         "north": 671
       },
-      "id": 663,
-      "area": {
-        "id": 9
-      }
+      "id": 663
     },
     {
       "name": "Balin Road",
@@ -678,10 +501,7 @@
         "east": 665,
         "north": 668
       },
-      "id": 664,
-      "area": {
-        "id": 9
-      }
+      "id": 664
     },
     {
       "name": "East End of Balin Road",
@@ -689,30 +509,21 @@
         "west": 664,
         "south": 666
       },
-      "id": 665,
-      "area": {
-        "id": 9
-      }
+      "id": 665
     },
     {
       "name": "Arched Gates",
       "exits": {
         "north": 665
       },
-      "id": 666,
-      "area": {
-        "id": 9
-      }
+      "id": 666
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "north": 664
       },
-      "id": 667,
-      "area": {
-        "id": 9
-      }
+      "id": 667
     },
     {
       "name": "Island Historical Society",
@@ -720,30 +531,21 @@
         "south": 664,
         "north": 669
       },
-      "id": 668,
-      "area": {
-        "id": 9
-      }
+      "id": 668
     },
     {
       "name": "Office",
       "exits": {
         "south": 668
       },
-      "id": 669,
-      "area": {
-        "id": 9
-      }
+      "id": 669
     },
     {
       "name": "Elven Mercantile",
       "exits": {
         "north": 663
       },
-      "id": 670,
-      "area": {
-        "id": 9
-      }
+      "id": 670
     },
     {
       "name": "Temple Shop",
@@ -751,10 +553,7 @@
         "west": 672,
         "south": 663
       },
-      "id": 671,
-      "area": {
-        "id": 9
-      }
+      "id": 671
     },
     {
       "name": "Temple Plaza",
@@ -763,40 +562,28 @@
         "east": 671,
         "south": 662
       },
-      "id": 672,
-      "area": {
-        "id": 9
-      }
+      "id": 672
     },
     {
       "name": "Seed Shop",
       "exits": {
         "north": 661
       },
-      "id": 673,
-      "area": {
-        "id": 9
-      }
+      "id": 673
     },
     {
       "name": "City Pastry Shop",
       "exits": {
         "west": 612
       },
-      "id": 674,
-      "area": {
-        "id": 9
-      }
+      "id": 674
     },
     {
       "name": "Soylent Green",
       "exits": {
         "east": 613
       },
-      "id": 675,
-      "area": {
-        "id": 9
-      }
+      "id": 675
     },
     {
       "name": "Mariner's Revenge",
@@ -804,10 +591,7 @@
         "west": 613,
         "north": 677
       },
-      "id": 676,
-      "area": {
-        "id": 9
-      }
+      "id": 676
     },
     {
       "name": "Gate House",
@@ -817,10 +601,7 @@
         "east": 693,
         "north": 686
       },
-      "id": 677,
-      "area": {
-        "id": 9
-      }
+      "id": 677
     },
     {
       "name": "Gate House",
@@ -828,10 +609,7 @@
         "east": 614,
         "west": 679
       },
-      "id": 678,
-      "area": {
-        "id": 9
-      }
+      "id": 678
     },
     {
       "name": "Foyer",
@@ -840,10 +618,7 @@
         "east": 678,
         "north": 680
       },
-      "id": 679,
-      "area": {
-        "id": 9
-      }
+      "id": 679
     },
     {
       "name": "Hallway",
@@ -851,10 +626,7 @@
         "south": 679,
         "north": 681
       },
-      "id": 680,
-      "area": {
-        "id": 9
-      }
+      "id": 680
     },
     {
       "name": "Audience Hall",
@@ -862,10 +634,7 @@
         "west": 682,
         "south": 680
       },
-      "id": 681,
-      "area": {
-        "id": 9
-      }
+      "id": 681
     },
     {
       "name": "Council Chamber",
@@ -873,20 +642,14 @@
         "east": 681,
         "west": 683
       },
-      "id": 682,
-      "area": {
-        "id": 9
-      }
+      "id": 682
     },
     {
       "name": "Trophy Room",
       "exits": {
         "east": 682
       },
-      "id": 683,
-      "area": {
-        "id": 9
-      }
+      "id": 683
     },
     {
       "name": "Hallway",
@@ -894,20 +657,14 @@
         "south": 685,
         "north": 679
       },
-      "id": 684,
-      "area": {
-        "id": 9
-      }
+      "id": 684
     },
     {
       "name": "Lady Roland's Bedroom",
       "exits": {
         "north": 684
       },
-      "id": 685,
-      "area": {
-        "id": 9
-      }
+      "id": 685
     },
     {
       "name": "RIIS",
@@ -915,50 +672,35 @@
         "down": 687,
         "south": 677
       },
-      "id": 686,
-      "area": {
-        "id": 9
-      }
+      "id": 686
     },
     {
       "name": "Crack of Doom",
       "exits": {
         "up": 686
       },
-      "id": 687,
-      "area": {
-        "id": 9
-      }
+      "id": 687
     },
     {
       "name": "Rhian's Potion Shop",
       "exits": {
         "east": 615
       },
-      "id": 688,
-      "area": {
-        "id": 9
-      }
+      "id": 688
     },
     {
       "name": "Alchemist Shop",
       "exits": {
         "west": 616
       },
-      "id": 689,
-      "area": {
-        "id": 9
-      }
+      "id": 689
     },
     {
       "name": "Entrance to the Hall of Records",
       "exits": {
         "east": 617
       },
-      "id": 690,
-      "area": {
-        "id": 9
-      }
+      "id": 690
     },
     {
       "name": "Power System Generator",
@@ -966,20 +708,14 @@
         "east": 692,
         "west": 618
       },
-      "id": 691,
-      "area": {
-        "id": 9
-      }
+      "id": 691
     },
     {
       "name": "Power System Internals",
       "exits": {
         "west": 691
       },
-      "id": 692,
-      "area": {
-        "id": 9
-      }
+      "id": 692
     },
     {
       "name": "Entryway",
@@ -988,10 +724,7 @@
         "south": 694,
         "north": 696
       },
-      "id": 693,
-      "area": {
-        "id": 9
-      }
+      "id": 693
     },
     {
       "name": "South Corridor",
@@ -999,20 +732,14 @@
         "south": 695,
         "north": 693
       },
-      "id": 694,
-      "area": {
-        "id": 9
-      }
+      "id": 694
     },
     {
       "name": "Guard Post",
       "exits": {
         "north": 694
       },
-      "id": 695,
-      "area": {
-        "id": 9
-      }
+      "id": 695
     },
     {
       "name": "North Corridor",
@@ -1020,10 +747,7 @@
         "south": 693,
         "north": 697
       },
-      "id": 696,
-      "area": {
-        "id": 9
-      }
+      "id": 696
     },
     {
       "name": "Guard Room",
@@ -1031,10 +755,7 @@
         "east": 698,
         "south": 696
       },
-      "id": 697,
-      "area": {
-        "id": 9
-      }
+      "id": 697
     },
     {
       "name": "West Harem",
@@ -1042,10 +763,7 @@
         "east": 699,
         "west": 697
       },
-      "id": 698,
-      "area": {
-        "id": 9
-      }
+      "id": 698
     },
     {
       "name": "East Harem",
@@ -1053,10 +771,7 @@
         "east": 700,
         "west": 698
       },
-      "id": 699,
-      "area": {
-        "id": 9
-      }
+      "id": 699
     },
     {
       "name": "Bedchamber",
@@ -1064,10 +779,7 @@
         "east": 701,
         "west": 699
       },
-      "id": 700,
-      "area": {
-        "id": 9
-      }
+      "id": 700
     },
     {
       "name": "Entryway",
@@ -1075,10 +787,7 @@
         "west": 700,
         "south": 702
       },
-      "id": 701,
-      "area": {
-        "id": 9
-      }
+      "id": 701
     },
     {
       "name": "Turkish Bath",
@@ -1087,10 +796,7 @@
         "east": 708,
         "north": 701
       },
-      "id": 702,
-      "area": {
-        "id": 9
-      }
+      "id": 702
     },
     {
       "name": "Turkish Bath",
@@ -1099,10 +805,7 @@
         "east": 707,
         "north": 702
       },
-      "id": 703,
-      "area": {
-        "id": 9
-      }
+      "id": 703
     },
     {
       "name": "Turkish Bath",
@@ -1111,20 +814,14 @@
         "east": 706,
         "north": 703
       },
-      "id": 704,
-      "area": {
-        "id": 9
-      }
+      "id": 704
     },
     {
       "name": "South Entryway",
       "exits": {
         "north": 704
       },
-      "id": 705,
-      "area": {
-        "id": 9
-      }
+      "id": 705
     },
     {
       "name": "Turkish Bath",
@@ -1133,10 +830,7 @@
         "south": 710,
         "north": 707
       },
-      "id": 706,
-      "area": {
-        "id": 9
-      }
+      "id": 706
     },
     {
       "name": "Turkish Bath",
@@ -1145,10 +839,7 @@
         "south": 706,
         "north": 708
       },
-      "id": 707,
-      "area": {
-        "id": 9
-      }
+      "id": 707
     },
     {
       "name": "Turkish Bath",
@@ -1157,47 +848,32 @@
         "south": 707,
         "north": 709
       },
-      "id": 708,
-      "area": {
-        "id": 9
-      }
+      "id": 708
     },
     {
       "name": "Turkish Bath",
       "exits": {
         "south": 708
       },
-      "id": 709,
-      "area": {
-        "id": 9
-      }
+      "id": 709
     },
     {
       "name": "Turkish Bath",
       "exits": {
         "north": 706
       },
-      "id": 710,
-      "area": {
-        "id": 9
-      }
+      "id": 710
     },
     {
       "name": "The hermit says: Is there anything you would like to talk about?",
-      "id": 711,
-      "area": {
-        "id": 9
-      }
+      "id": 711
     },
     {
       "name": "Hermit's Chamber",
       "exits": {
         "east": 655
       },
-      "id": 712,
-      "area": {
-        "id": 9
-      }
+      "id": 712
     },
     {
       "name": "Temple",
@@ -1206,10 +882,7 @@
         "east": 714,
         "north": 716
       },
-      "id": 713,
-      "area": {
-        "id": 9
-      }
+      "id": 713
     },
     {
       "name": "Central Chamber",
@@ -1217,10 +890,7 @@
         "east": 715,
         "west": 713
       },
-      "id": 714,
-      "area": {
-        "id": 9
-      }
+      "id": 714
     },
     {
       "name": "Eastern Chamber",
@@ -1228,80 +898,56 @@
         "east": 672,
         "west": 714
       },
-      "id": 715,
-      "area": {
-        "id": 9
-      }
+      "id": 715
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": {
         "south": 713
       },
-      "id": 716,
-      "area": {
-        "id": 9
-      }
+      "id": 716
     },
     {
       "name": "Poison Shop",
       "exits": {
         "north": 635
       },
-      "id": 717,
-      "area": {
-        "id": 9
-      }
+      "id": 717
     },
     {
       "name": "Taxidermist",
       "exits": {
         "southwest": 635
       },
-      "id": 718,
-      "area": {
-        "id": 9
-      }
+      "id": 718
     },
     {
       "name": "Weaver's",
       "exits": {
         "southeast": 635
       },
-      "id": 719,
-      "area": {
-        "id": 9
-      }
+      "id": 719
     },
     {
       "name": "Foyer of House of Ill Repute",
       "exits": {
         "southwest": 637
       },
-      "id": 720,
-      "area": {
-        "id": 9
-      }
+      "id": 720
     },
     {
       "name": "Balin Road Pub",
       "exits": {
         "northwest": 636
       },
-      "id": 721,
-      "area": {
-        "id": 9
-      }
+      "id": 721
     },
     {
       "name": "Wheelwright",
       "exits": {
         "northeast": 636
       },
-      "id": 722,
-      "area": {
-        "id": 9
-      }
+      "id": 722
     },
     {
       "name": "Crowded Thoroughfare",
@@ -1309,10 +955,7 @@
         "south": 724,
         "north": 637
       },
-      "id": 723,
-      "area": {
-        "id": 9
-      }
+      "id": 723
     },
     {
       "name": "Archway of Servitude",
@@ -1320,10 +963,7 @@
         "south": 725,
         "north": 723
       },
-      "id": 724,
-      "area": {
-        "id": 9
-      }
+      "id": 724
     },
     {
       "name": "Bazaar Crossroad",
@@ -1332,10 +972,7 @@
         "east": 729,
         "north": 724
       },
-      "id": 725,
-      "area": {
-        "id": 9
-      }
+      "id": 725
     },
     {
       "name": "Western District",
@@ -1343,10 +980,7 @@
         "east": 725,
         "south": 727
       },
-      "id": 726,
-      "area": {
-        "id": 9
-      }
+      "id": 726
     },
     {
       "name": "Western District",
@@ -1354,10 +988,7 @@
         "south": 728,
         "north": 726
       },
-      "id": 727,
-      "area": {
-        "id": 9
-      }
+      "id": 727
     },
     {
       "name": "Western slave bazaar",
@@ -1365,10 +996,7 @@
         "east": 732,
         "north": 727
       },
-      "id": 728,
-      "area": {
-        "id": 9
-      }
+      "id": 728
     },
     {
       "name": "Eastern District",
@@ -1376,10 +1004,7 @@
         "west": 725,
         "south": 730
       },
-      "id": 729,
-      "area": {
-        "id": 9
-      }
+      "id": 729
     },
     {
       "name": "Eastern District",
@@ -1387,10 +1012,7 @@
         "south": 731,
         "north": 729
       },
-      "id": 730,
-      "area": {
-        "id": 9
-      }
+      "id": 730
     },
     {
       "name": "Eastern slave bazaar",
@@ -1398,10 +1020,7 @@
         "west": 732,
         "north": 730
       },
-      "id": 731,
-      "area": {
-        "id": 9
-      }
+      "id": 731
     },
     {
       "name": "Central slave bazaar",
@@ -1410,20 +1029,14 @@
         "east": 731,
         "south": 733
       },
-      "id": 732,
-      "area": {
-        "id": 9
-      }
+      "id": 732
     },
     {
       "name": "Administrative hallway",
       "exits": {
         "north": 732
       },
-      "id": 733,
-      "area": {
-        "id": 9
-      }
+      "id": 733
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/candera.json
+++ b/maps/candera.json
@@ -10,10 +10,7 @@
         "east": 2,
         "south": 57
       },
-      "id": 1,
-      "area": {
-        "id": 1
-      }
+      "id": 1
     },
     {
       "name": "New Outer Wall",
@@ -21,10 +18,7 @@
         "east": 3,
         "west": 1
       },
-      "id": 2,
-      "area": {
-        "id": 1
-      }
+      "id": 2
     },
     {
       "name": "New Outer Wall",
@@ -32,10 +26,7 @@
         "east": 4,
         "west": 2
       },
-      "id": 3,
-      "area": {
-        "id": 1
-      }
+      "id": 3
     },
     {
       "name": "New Outer Wall",
@@ -43,10 +34,7 @@
         "east": 5,
         "west": 3
       },
-      "id": 4,
-      "area": {
-        "id": 1
-      }
+      "id": 4
     },
     {
       "name": "New Outer Wall",
@@ -54,10 +42,7 @@
         "east": 6,
         "west": 4
       },
-      "id": 5,
-      "area": {
-        "id": 1
-      }
+      "id": 5
     },
     {
       "name": "New Outer Wall",
@@ -65,10 +50,7 @@
         "east": 7,
         "west": 5
       },
-      "id": 6,
-      "area": {
-        "id": 1
-      }
+      "id": 6
     },
     {
       "name": "Entrance to the Northeast Tower",
@@ -76,10 +58,7 @@
         "east": 8,
         "west": 6
       },
-      "id": 7,
-      "area": {
-        "id": 1
-      }
+      "id": 7
     },
     {
       "name": "Northeast Corner",
@@ -87,10 +66,7 @@
         "west": 7,
         "south": 9
       },
-      "id": 8,
-      "area": {
-        "id": 1
-      }
+      "id": 8
     },
     {
       "name": "Entrance to the Northeast Tower",
@@ -98,10 +74,7 @@
         "south": 10,
         "north": 8
       },
-      "id": 9,
-      "area": {
-        "id": 1
-      }
+      "id": 9
     },
     {
       "name": "New Outer Wall",
@@ -109,10 +82,7 @@
         "south": 11,
         "north": 9
       },
-      "id": 10,
-      "area": {
-        "id": 1
-      }
+      "id": 10
     },
     {
       "name": "New Outer Wall",
@@ -120,10 +90,7 @@
         "south": 12,
         "north": 10
       },
-      "id": 11,
-      "area": {
-        "id": 1
-      }
+      "id": 11
     },
     {
       "name": "New Outer Wall",
@@ -131,10 +98,7 @@
         "south": 13,
         "north": 11
       },
-      "id": 12,
-      "area": {
-        "id": 1
-      }
+      "id": 12
     },
     {
       "name": "New Outer Wall",
@@ -142,10 +106,7 @@
         "south": 14,
         "north": 12
       },
-      "id": 13,
-      "area": {
-        "id": 1
-      }
+      "id": 13
     },
     {
       "name": "New Outer Wall",
@@ -153,10 +114,7 @@
         "south": 15,
         "north": 13
       },
-      "id": 14,
-      "area": {
-        "id": 1
-      }
+      "id": 14
     },
     {
       "name": "East Wall Guard Station",
@@ -165,10 +123,7 @@
         "east": 973,
         "north": 14
       },
-      "id": 15,
-      "area": {
-        "id": 1
-      }
+      "id": 15
     },
     {
       "name": "New Outer Wall",
@@ -176,10 +131,7 @@
         "south": 17,
         "north": 15
       },
-      "id": 16,
-      "area": {
-        "id": 1
-      }
+      "id": 16
     },
     {
       "name": "New Outer Wall",
@@ -187,10 +139,7 @@
         "south": 18,
         "north": 16
       },
-      "id": 17,
-      "area": {
-        "id": 1
-      }
+      "id": 17
     },
     {
       "name": "New Outer Wall",
@@ -198,10 +147,7 @@
         "south": 19,
         "north": 17
       },
-      "id": 18,
-      "area": {
-        "id": 1
-      }
+      "id": 18
     },
     {
       "name": "New Outer Wall",
@@ -209,10 +155,7 @@
         "south": 20,
         "north": 18
       },
-      "id": 19,
-      "area": {
-        "id": 1
-      }
+      "id": 19
     },
     {
       "name": "New Outer Wall",
@@ -220,10 +163,7 @@
         "south": 21,
         "north": 19
       },
-      "id": 20,
-      "area": {
-        "id": 1
-      }
+      "id": 20
     },
     {
       "name": "New Outer Wall",
@@ -231,10 +171,7 @@
         "south": 22,
         "north": 20
       },
-      "id": 21,
-      "area": {
-        "id": 1
-      }
+      "id": 21
     },
     {
       "name": "New Outer Wall",
@@ -242,10 +179,7 @@
         "west": 23,
         "north": 21
       },
-      "id": 22,
-      "area": {
-        "id": 1
-      }
+      "id": 22
     },
     {
       "name": "New Outer Wall",
@@ -253,10 +187,7 @@
         "east": 22,
         "west": 24
       },
-      "id": 23,
-      "area": {
-        "id": 1
-      }
+      "id": 23
     },
     {
       "name": "New Outer Wall",
@@ -264,10 +195,7 @@
         "east": 23,
         "west": 25
       },
-      "id": 24,
-      "area": {
-        "id": 1
-      }
+      "id": 24
     },
     {
       "name": "New Outer Wall",
@@ -275,10 +203,7 @@
         "east": 24,
         "west": 26
       },
-      "id": 25,
-      "area": {
-        "id": 1
-      }
+      "id": 25
     },
     {
       "name": "New Outer Wall",
@@ -286,10 +211,7 @@
         "east": 25,
         "west": 27
       },
-      "id": 26,
-      "area": {
-        "id": 1
-      }
+      "id": 26
     },
     {
       "name": "New Outer Wall",
@@ -297,10 +219,7 @@
         "east": 26,
         "west": 28
       },
-      "id": 27,
-      "area": {
-        "id": 1
-      }
+      "id": 27
     },
     {
       "name": "New Outer Wall",
@@ -308,10 +227,7 @@
         "east": 27,
         "west": 29
       },
-      "id": 28,
-      "area": {
-        "id": 1
-      }
+      "id": 28
     },
     {
       "name": "South Wall Guard Station",
@@ -320,10 +236,7 @@
         "east": 28,
         "south": 1030
       },
-      "id": 29,
-      "area": {
-        "id": 1
-      }
+      "id": 29
     },
     {
       "name": "New Outer Wall",
@@ -331,10 +244,7 @@
         "east": 29,
         "west": 31
       },
-      "id": 30,
-      "area": {
-        "id": 1
-      }
+      "id": 30
     },
     {
       "name": "New Outer Wall",
@@ -342,10 +252,7 @@
         "east": 30,
         "west": 32
       },
-      "id": 31,
-      "area": {
-        "id": 1
-      }
+      "id": 31
     },
     {
       "name": "New Outer Wall",
@@ -353,10 +260,7 @@
         "east": 31,
         "west": 33
       },
-      "id": 32,
-      "area": {
-        "id": 1
-      }
+      "id": 32
     },
     {
       "name": "New Outer Wall",
@@ -364,10 +268,7 @@
         "east": 32,
         "west": 34
       },
-      "id": 33,
-      "area": {
-        "id": 1
-      }
+      "id": 33
     },
     {
       "name": "New Outer Wall",
@@ -375,10 +276,7 @@
         "east": 33,
         "west": 35
       },
-      "id": 34,
-      "area": {
-        "id": 1
-      }
+      "id": 34
     },
     {
       "name": "New Outer Wall",
@@ -386,10 +284,7 @@
         "east": 34,
         "west": 36
       },
-      "id": 35,
-      "area": {
-        "id": 1
-      }
+      "id": 35
     },
     {
       "name": "Southwest Corner",
@@ -397,10 +292,7 @@
         "east": 35,
         "north": 37
       },
-      "id": 36,
-      "area": {
-        "id": 1
-      }
+      "id": 36
     },
     {
       "name": "New Outer Wall",
@@ -408,10 +300,7 @@
         "south": 36,
         "north": 38
       },
-      "id": 37,
-      "area": {
-        "id": 1
-      }
+      "id": 37
     },
     {
       "name": "New Outer Wall",
@@ -419,10 +308,7 @@
         "south": 37,
         "north": 39
       },
-      "id": 38,
-      "area": {
-        "id": 1
-      }
+      "id": 38
     },
     {
       "name": "New Outer Wall",
@@ -430,10 +316,7 @@
         "south": 38,
         "north": 40
       },
-      "id": 39,
-      "area": {
-        "id": 1
-      }
+      "id": 39
     },
     {
       "name": "New Outer Wall",
@@ -441,10 +324,7 @@
         "south": 39,
         "north": 41
       },
-      "id": 40,
-      "area": {
-        "id": 1
-      }
+      "id": 40
     },
     {
       "name": "New Outer Wall",
@@ -452,10 +332,7 @@
         "south": 40,
         "north": 42
       },
-      "id": 41,
-      "area": {
-        "id": 1
-      }
+      "id": 41
     },
     {
       "name": "New Outer Wall",
@@ -463,10 +340,7 @@
         "south": 41,
         "north": 43
       },
-      "id": 42,
-      "area": {
-        "id": 1
-      }
+      "id": 42
     },
     {
       "name": "West Wall Guard Station",
@@ -475,10 +349,7 @@
         "south": 42,
         "north": 44
       },
-      "id": 43,
-      "area": {
-        "id": 1
-      }
+      "id": 43
     },
     {
       "name": "New Outer Wall",
@@ -486,10 +357,7 @@
         "south": 43,
         "north": 45
       },
-      "id": 44,
-      "area": {
-        "id": 1
-      }
+      "id": 44
     },
     {
       "name": "New Outer Wall",
@@ -497,10 +365,7 @@
         "south": 44,
         "north": 46
       },
-      "id": 45,
-      "area": {
-        "id": 1
-      }
+      "id": 45
     },
     {
       "name": "New Outer Wall",
@@ -508,10 +373,7 @@
         "south": 45,
         "north": 47
       },
-      "id": 46,
-      "area": {
-        "id": 1
-      }
+      "id": 46
     },
     {
       "name": "New Outer Wall",
@@ -519,10 +381,7 @@
         "south": 46,
         "north": 48
       },
-      "id": 47,
-      "area": {
-        "id": 1
-      }
+      "id": 47
     },
     {
       "name": "New Outer Wall",
@@ -530,10 +389,7 @@
         "south": 47,
         "north": 49
       },
-      "id": 48,
-      "area": {
-        "id": 1
-      }
+      "id": 48
     },
     {
       "name": "Entrance to the Northwest Tower",
@@ -541,10 +397,7 @@
         "south": 48,
         "north": 50
       },
-      "id": 49,
-      "area": {
-        "id": 1
-      }
+      "id": 49
     },
     {
       "name": "Northwest Corner",
@@ -552,10 +405,7 @@
         "east": 51,
         "south": 49
       },
-      "id": 50,
-      "area": {
-        "id": 1
-      }
+      "id": 50
     },
     {
       "name": "Entrance to the Northwest Tower",
@@ -563,10 +413,7 @@
         "east": 52,
         "west": 50
       },
-      "id": 51,
-      "area": {
-        "id": 1
-      }
+      "id": 51
     },
     {
       "name": "New Outer Wall",
@@ -574,10 +421,7 @@
         "east": 53,
         "west": 51
       },
-      "id": 52,
-      "area": {
-        "id": 1
-      }
+      "id": 52
     },
     {
       "name": "New Outer Wall",
@@ -585,10 +429,7 @@
         "east": 54,
         "west": 52
       },
-      "id": 53,
-      "area": {
-        "id": 1
-      }
+      "id": 53
     },
     {
       "name": "New Outer Wall",
@@ -596,10 +437,7 @@
         "east": 55,
         "west": 53
       },
-      "id": 54,
-      "area": {
-        "id": 1
-      }
+      "id": 54
     },
     {
       "name": "New Outer Wall",
@@ -607,10 +445,7 @@
         "east": 56,
         "west": 54
       },
-      "id": 55,
-      "area": {
-        "id": 1
-      }
+      "id": 55
     },
     {
       "name": "New Outer Wall",
@@ -618,10 +453,7 @@
         "east": 1,
         "west": 55
       },
-      "id": 56,
-      "area": {
-        "id": 1
-      }
+      "id": 56
     },
     {
       "name": "Warrior's Walk",
@@ -631,10 +463,7 @@
         "east": 964,
         "north": 1
       },
-      "id": 57,
-      "area": {
-        "id": 1
-      }
+      "id": 57
     },
     {
       "name": "Warrior's Walk",
@@ -644,10 +473,7 @@
         "east": 966,
         "north": 57
       },
-      "id": 58,
-      "area": {
-        "id": 1
-      }
+      "id": 58
     },
     {
       "name": "Warrior's Walk",
@@ -656,10 +482,7 @@
         "south": 60,
         "north": 58
       },
-      "id": 59,
-      "area": {
-        "id": 1
-      }
+      "id": 59
     },
     {
       "name": "Warrior's Walk",
@@ -669,10 +492,7 @@
         "east": 969,
         "north": 59
       },
-      "id": 60,
-      "area": {
-        "id": 1
-      }
+      "id": 60
     },
     {
       "name": "Warrior's Walk",
@@ -681,10 +501,7 @@
         "south": 62,
         "north": 60
       },
-      "id": 61,
-      "area": {
-        "id": 1
-      }
+      "id": 61
     },
     {
       "name": "Warrior's Walk",
@@ -694,10 +511,7 @@
         "east": 972,
         "north": 61
       },
-      "id": 62,
-      "area": {
-        "id": 1
-      }
+      "id": 62
     },
     {
       "name": "Canderan Well",
@@ -707,10 +521,7 @@
         "east": 94,
         "north": 62
       },
-      "id": 63,
-      "area": {
-        "id": 1
-      }
+      "id": 63
     },
     {
       "name": "Warrior's Walk",
@@ -720,10 +531,7 @@
         "east": 427,
         "north": 63
       },
-      "id": 64,
-      "area": {
-        "id": 1
-      }
+      "id": 64
     },
     {
       "name": "Warrior's Walk",
@@ -733,10 +541,7 @@
         "east": 1015,
         "north": 64
       },
-      "id": 65,
-      "area": {
-        "id": 1
-      }
+      "id": 65
     },
     {
       "name": "Warrior's Walk",
@@ -744,10 +549,7 @@
         "south": 67,
         "north": 65
       },
-      "id": 66,
-      "area": {
-        "id": 1
-      }
+      "id": 66
     },
     {
       "name": "Warrior's Walk",
@@ -755,10 +557,7 @@
         "south": 68,
         "north": 66
       },
-      "id": 67,
-      "area": {
-        "id": 1
-      }
+      "id": 67
     },
     {
       "name": "Warrior's Walk",
@@ -767,10 +566,7 @@
         "east": 431,
         "north": 67
       },
-      "id": 68,
-      "area": {
-        "id": 1
-      }
+      "id": 68
     },
     {
       "name": "House of Lord Candera",
@@ -780,30 +576,21 @@
         "east": 71,
         "north": 68
       },
-      "id": 69,
-      "area": {
-        "id": 1
-      }
+      "id": 69
     },
     {
       "name": "House of Lord Candera",
       "exits": {
         "east": 69
       },
-      "id": 70,
-      "area": {
-        "id": 1
-      }
+      "id": 70
     },
     {
       "name": "House of Lord Candera",
       "exits": {
         "west": 69
       },
-      "id": 71,
-      "area": {
-        "id": 1
-      }
+      "id": 71
     },
     {
       "name": "Clansmen Way",
@@ -812,10 +599,7 @@
         "east": 63,
         "south": 429
       },
-      "id": 72,
-      "area": {
-        "id": 1
-      }
+      "id": 72
     },
     {
       "name": "Clansmen Way",
@@ -825,10 +609,7 @@
         "east": 72,
         "north": 1017
       },
-      "id": 73,
-      "area": {
-        "id": 1
-      }
+      "id": 73
     },
     {
       "name": "Clansmen Way",
@@ -838,10 +619,7 @@
         "east": 73,
         "north": 1018
       },
-      "id": 74,
-      "area": {
-        "id": 1
-      }
+      "id": 74
     },
     {
       "name": "Clansmen Way",
@@ -850,10 +628,7 @@
         "east": 74,
         "south": 1095
       },
-      "id": 75,
-      "area": {
-        "id": 1
-      }
+      "id": 75
     },
     {
       "name": "Clansmen Way",
@@ -863,10 +638,7 @@
         "east": 75,
         "north": 86
       },
-      "id": 76,
-      "area": {
-        "id": 1
-      }
+      "id": 76
     },
     {
       "name": "Zoman's Flat",
@@ -874,10 +646,7 @@
         "south": 79,
         "north": 76
       },
-      "id": 78,
-      "area": {
-        "id": 1
-      }
+      "id": 78
     },
     {
       "name": "Zoman's Flat",
@@ -886,10 +655,7 @@
         "east": 1096,
         "north": 78
       },
-      "id": 79,
-      "area": {
-        "id": 1
-      }
+      "id": 79
     },
     {
       "name": "Zoman's Flat",
@@ -897,10 +663,7 @@
         "south": 81,
         "north": 79
       },
-      "id": 80,
-      "area": {
-        "id": 1
-      }
+      "id": 80
     },
     {
       "name": "Zoman's Flat",
@@ -908,10 +671,7 @@
         "south": 82,
         "north": 80
       },
-      "id": 81,
-      "area": {
-        "id": 1
-      }
+      "id": 81
     },
     {
       "name": "Zoman's Flat",
@@ -921,10 +681,7 @@
         "east": 1098,
         "north": 81
       },
-      "id": 82,
-      "area": {
-        "id": 1
-      }
+      "id": 82
     },
     {
       "name": "Temple of Air",
@@ -933,10 +690,7 @@
         "east": 85,
         "north": 82
       },
-      "id": 83,
-      "area": {
-        "id": 1
-      }
+      "id": 83
     },
     {
       "name": "Temple of Air",
@@ -944,10 +698,7 @@
         "east": 83,
         "up": 1130
       },
-      "id": 84,
-      "area": {
-        "id": 1
-      }
+      "id": 84
     },
     {
       "name": "Temple of Air",
@@ -955,10 +706,7 @@
         "up": 1131,
         "west": 83
       },
-      "id": 85,
-      "area": {
-        "id": 1
-      }
+      "id": 85
     },
     {
       "name": "Suran's Flat",
@@ -966,10 +714,7 @@
         "south": 76,
         "north": 87
       },
-      "id": 86,
-      "area": {
-        "id": 1
-      }
+      "id": 86
     },
     {
       "name": "Suran's Flat",
@@ -978,10 +723,7 @@
         "south": 86,
         "north": 88
       },
-      "id": 87,
-      "area": {
-        "id": 1
-      }
+      "id": 87
     },
     {
       "name": "Suran's Flat",
@@ -989,10 +731,7 @@
         "south": 87,
         "north": 89
       },
-      "id": 88,
-      "area": {
-        "id": 1
-      }
+      "id": 88
     },
     {
       "name": "Suran's Flat",
@@ -1000,10 +739,7 @@
         "south": 88,
         "north": 90
       },
-      "id": 89,
-      "area": {
-        "id": 1
-      }
+      "id": 89
     },
     {
       "name": "Suran's Flat",
@@ -1013,10 +749,7 @@
         "east": 1094,
         "north": 91
       },
-      "id": 90,
-      "area": {
-        "id": 1
-      }
+      "id": 90
     },
     {
       "name": "Temple of Water",
@@ -1025,10 +758,7 @@
         "east": 93,
         "south": 90
       },
-      "id": 91,
-      "area": {
-        "id": 1
-      }
+      "id": 91
     },
     {
       "name": "Temple of Water",
@@ -1036,10 +766,7 @@
         "east": 91,
         "up": 1132
       },
-      "id": 92,
-      "area": {
-        "id": 1
-      }
+      "id": 92
     },
     {
       "name": "Temple of Water",
@@ -1047,10 +774,7 @@
         "up": 1133,
         "west": 91
       },
-      "id": 93,
-      "area": {
-        "id": 1
-      }
+      "id": 93
     },
     {
       "name": "Clansmen Way",
@@ -1060,10 +784,7 @@
         "east": 95,
         "north": 972
       },
-      "id": 94,
-      "area": {
-        "id": 1
-      }
+      "id": 94
     },
     {
       "name": "Clansmen Way",
@@ -1072,10 +793,7 @@
         "east": 96,
         "south": 975
       },
-      "id": 95,
-      "area": {
-        "id": 1
-      }
+      "id": 95
     },
     {
       "name": "Clansmen Way",
@@ -1085,10 +803,7 @@
         "east": 97,
         "north": 977
       },
-      "id": 96,
-      "area": {
-        "id": 1
-      }
+      "id": 96
     },
     {
       "name": "Clansmen Way",
@@ -1097,10 +812,7 @@
         "east": 98,
         "north": 428
       },
-      "id": 97,
-      "area": {
-        "id": 1
-      }
+      "id": 97
     },
     {
       "name": "Clansmen Way",
@@ -1110,10 +822,7 @@
         "east": 1000,
         "north": 107
       },
-      "id": 98,
-      "area": {
-        "id": 1
-      }
+      "id": 98
     },
     {
       "name": "Fallah's Flat:",
@@ -1121,10 +830,7 @@
         "south": 100,
         "north": 98
       },
-      "id": 99,
-      "area": {
-        "id": 1
-      }
+      "id": 99
     },
     {
       "name": "Fallah's Flat:",
@@ -1134,10 +840,7 @@
         "east": 997,
         "north": 99
       },
-      "id": 100,
-      "area": {
-        "id": 1
-      }
+      "id": 100
     },
     {
       "name": "Fallah's Flat",
@@ -1145,10 +848,7 @@
         "south": 102,
         "north": 100
       },
-      "id": 101,
-      "area": {
-        "id": 1
-      }
+      "id": 101
     },
     {
       "name": "Fallah's Flat",
@@ -1156,10 +856,7 @@
         "south": 103,
         "north": 101
       },
-      "id": 102,
-      "area": {
-        "id": 1
-      }
+      "id": 102
     },
     {
       "name": "Fallah's Flat:",
@@ -1169,10 +866,7 @@
         "east": 999,
         "north": 102
       },
-      "id": 103,
-      "area": {
-        "id": 1
-      }
+      "id": 103
     },
     {
       "name": "Temple of Earth",
@@ -1181,10 +875,7 @@
         "east": 106,
         "north": 103
       },
-      "id": 104,
-      "area": {
-        "id": 1
-      }
+      "id": 104
     },
     {
       "name": "Temple of Earth",
@@ -1192,10 +883,7 @@
         "east": 104,
         "up": 1127
       },
-      "id": 105,
-      "area": {
-        "id": 1
-      }
+      "id": 105
     },
     {
       "name": "Temple of Earth",
@@ -1203,10 +891,7 @@
         "up": 1126,
         "west": 104
       },
-      "id": 106,
-      "area": {
-        "id": 1
-      }
+      "id": 106
     },
     {
       "name": "Phaekads Flat:",
@@ -1214,10 +899,7 @@
         "south": 98,
         "north": 108
       },
-      "id": 107,
-      "area": {
-        "id": 1
-      }
+      "id": 107
     },
     {
       "name": "Phaekads Flat:",
@@ -1225,10 +907,7 @@
         "south": 107,
         "north": 109
       },
-      "id": 108,
-      "area": {
-        "id": 1
-      }
+      "id": 108
     },
     {
       "name": "Phaekads Flat",
@@ -1236,10 +915,7 @@
         "south": 108,
         "north": 110
       },
-      "id": 109,
-      "area": {
-        "id": 1
-      }
+      "id": 109
     },
     {
       "name": "Phaekads Flat",
@@ -1247,10 +923,7 @@
         "south": 109,
         "north": 111
       },
-      "id": 110,
-      "area": {
-        "id": 1
-      }
+      "id": 110
     },
     {
       "name": "Phaekads Flat:",
@@ -1259,10 +932,7 @@
         "east": 996,
         "north": 112
       },
-      "id": 111,
-      "area": {
-        "id": 1
-      }
+      "id": 111
     },
     {
       "name": "Temple of Fire",
@@ -1271,10 +941,7 @@
         "east": 114,
         "south": 111
       },
-      "id": 112,
-      "area": {
-        "id": 1
-      }
+      "id": 112
     },
     {
       "name": "Temple of Fire",
@@ -1282,10 +949,7 @@
         "east": 112,
         "up": 1129
       },
-      "id": 113,
-      "area": {
-        "id": 1
-      }
+      "id": 113
     },
     {
       "name": "Temple of Fire",
@@ -1293,10 +957,7 @@
         "up": 1128,
         "west": 112
       },
-      "id": 114,
-      "area": {
-        "id": 1
-      }
+      "id": 114
     },
     {
       "name": "The Rabbit's Hole",
@@ -1304,10 +965,7 @@
         "west": 64,
         "north": 94
       },
-      "id": 427,
-      "area": {
-        "id": 1
-      }
+      "id": 427
     },
     {
       "name": "6 Feet Under",
@@ -1315,10 +973,7 @@
         "west": 977,
         "south": 97
       },
-      "id": 428,
-      "area": {
-        "id": 1
-      }
+      "id": 428
     },
     {
       "name": "Morbid Curiosity",
@@ -1326,40 +981,28 @@
         "east": 64,
         "north": 72
       },
-      "id": 429,
-      "area": {
-        "id": 1
-      }
+      "id": 429
     },
     {
       "name": "Scribe",
       "exits": {
         "east": 65
       },
-      "id": 430,
-      "area": {
-        "id": 1
-      }
+      "id": 430
     },
     {
       "name": "Servants Quarters",
       "exits": {
         "west": 68
       },
-      "id": 431,
-      "area": {
-        "id": 1
-      }
+      "id": 431
     },
     {
       "name": "Slave Auction:",
       "exits": {
         "east": 100
       },
-      "id": 505,
-      "area": {
-        "id": 1
-      }
+      "id": 505
     },
     {
       "name": "Eastern Entrance",
@@ -1367,30 +1010,21 @@
         "east": 57,
         "west": 1027
       },
-      "id": 963,
-      "area": {
-        "id": 1
-      }
+      "id": 963
     },
     {
       "name": "Widow's House",
       "exits": {
         "west": 57
       },
-      "id": 964,
-      "area": {
-        "id": 1
-      }
+      "id": 964
     },
     {
       "name": "A Jeweler's Shop",
       "exits": {
         "east": 58
       },
-      "id": 965,
-      "area": {
-        "id": 1
-      }
+      "id": 965
     },
     {
       "name": "Farmer's Smith",
@@ -1398,10 +1032,7 @@
         "east": 989,
         "west": 58
       },
-      "id": 966,
-      "area": {
-        "id": 1
-      }
+      "id": 966
     },
     {
       "name": "Candera Information Bureau",
@@ -1409,50 +1040,35 @@
         "east": 59,
         "north": 1125
       },
-      "id": 967,
-      "area": {
-        "id": 1
-      }
+      "id": 967
     },
     {
       "name": "Lizard Skin Trader",
       "exits": {
         "east": 60
       },
-      "id": 968,
-      "area": {
-        "id": 1
-      }
+      "id": 968
     },
     {
       "name": "Shaman's Shack",
       "exits": {
         "west": 60
       },
-      "id": 969,
-      "area": {
-        "id": 1
-      }
+      "id": 969
     },
     {
       "name": "Silk Shop",
       "exits": {
         "east": 61
       },
-      "id": 970,
-      "area": {
-        "id": 1
-      }
+      "id": 970
     },
     {
       "name": "Barbarian's Guild",
       "exits": {
         "east": 62
       },
-      "id": 971,
-      "area": {
-        "id": 1
-      }
+      "id": 971
     },
     {
       "name": "Trader's Shack",
@@ -1460,10 +1076,7 @@
         "west": 62,
         "south": 94
       },
-      "id": 972,
-      "area": {
-        "id": 1
-      }
+      "id": 972
     },
     {
       "name": "East Wall Guard Station",
@@ -1472,110 +1085,77 @@
         "south": 974,
         "north": 986
       },
-      "id": 973,
-      "area": {
-        "id": 1
-      }
+      "id": 973
     },
     {
       "name": "Living Quarters",
       "exits": {
         "north": 973
       },
-      "id": 974,
-      "area": {
-        "id": 1
-      }
+      "id": 974
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "north": 95
       },
-      "id": 975,
-      "area": {
-        "id": 1
-      }
+      "id": 975
     },
     {
       "name": "Back Alley",
       "exits": {
         "north": 96
       },
-      "id": 976,
-      "area": {
-        "id": 1
-      }
+      "id": 976
     },
     {
       "name": "Sleeping Quarters",
       "exits": {
         "south": 973
       },
-      "id": 986,
-      "area": {
-        "id": 1
-      }
+      "id": 986
     },
     {
       "name": "Candera Priest's Hut",
       "exits": {
         "west": 111
       },
-      "id": 996,
-      "area": {
-        "id": 1
-      }
+      "id": 996
     },
     {
       "name": "Pillow Shop:",
       "exits": {
         "west": 100
       },
-      "id": 997,
-      "area": {
-        "id": 1
-      }
+      "id": 997
     },
     {
       "name": "Relic Shop:",
       "exits": {
         "east": 103
       },
-      "id": 998,
-      "area": {
-        "id": 1
-      }
+      "id": 998
     },
     {
       "name": "Butcher Shop:",
       "exits": {
         "west": 103
       },
-      "id": 999,
-      "area": {
-        "id": 1
-      }
+      "id": 999
     },
     {
       "name": "Snake Charmer",
       "exits": {
         "west": 65
       },
-      "id": 1015,
-      "area": {
-        "id": 1
-      }
+      "id": 1015
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "north": 73
       },
-      "id": 1016,
-      "area": {
-        "id": 1
-      }
+      "id": 1016
     },
     {
       "name": "Kaimuki Q's",
@@ -1583,20 +1163,14 @@
         "west": 1018,
         "south": 73
       },
-      "id": 1017,
-      "area": {
-        "id": 1
-      }
+      "id": 1017
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "north": 74
       },
-      "id": 1019,
-      "area": {
-        "id": 1
-      }
+      "id": 1019
     },
     {
       "name": "South Wall Guard Station",
@@ -1605,30 +1179,21 @@
         "east": 1032,
         "north": 29
       },
-      "id": 1030,
-      "area": {
-        "id": 1
-      }
+      "id": 1030
     },
     {
       "name": "Living Quarters",
       "exits": {
         "east": 1030
       },
-      "id": 1031,
-      "area": {
-        "id": 1
-      }
+      "id": 1031
     },
     {
       "name": "Sleeping Quarters",
       "exits": {
         "west": 1030
       },
-      "id": 1032,
-      "area": {
-        "id": 1
-      }
+      "id": 1032
     },
     {
       "name": "West Wall Guard Station",
@@ -1637,80 +1202,56 @@
         "east": 43,
         "north": 1035
       },
-      "id": 1033,
-      "area": {
-        "id": 1
-      }
+      "id": 1033
     },
     {
       "name": "Living Quarters",
       "exits": {
         "north": 1033
       },
-      "id": 1034,
-      "area": {
-        "id": 1
-      }
+      "id": 1034
     },
     {
       "name": "Sleeping Quarters",
       "exits": {
         "south": 1033
       },
-      "id": 1035,
-      "area": {
-        "id": 1
-      }
+      "id": 1035
     },
     {
       "name": "Goondala's Flowers",
       "exits": {
         "east": 90
       },
-      "id": 1093,
-      "area": {
-        "id": 1
-      }
+      "id": 1093
     },
     {
       "name": "Weapon Master's Shop",
       "exits": {
         "west": 90
       },
-      "id": 1094,
-      "area": {
-        "id": 1
-      }
+      "id": 1094
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "north": 75
       },
-      "id": 1095,
-      "area": {
-        "id": 1
-      }
+      "id": 1095
     },
     {
       "name": "Alchemist's Shop",
       "exits": {
         "west": 79
       },
-      "id": 1096,
-      "area": {
-        "id": 1
-      }
+      "id": 1096
     },
     {
       "name": "Canderan Guard House",
       "exits": {
         "east": 82
       },
-      "id": 1097,
-      "area": {
-        "id": 1
-      }
+      "id": 1097
     },
     {
       "name": "Crypt of the Honored Dead",
@@ -1718,110 +1259,77 @@
         "down": 1099,
         "west": 82
       },
-      "id": 1098,
-      "area": {
-        "id": 1
-      }
+      "id": 1098
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": {
         "south": 967
       },
-      "id": 1125,
-      "area": {
-        "id": 1
-      }
+      "id": 1125
     },
     {
       "name": "Temple of Earth",
       "exits": {
         "down": 106
       },
-      "id": 1126,
-      "area": {
-        "id": 1
-      }
+      "id": 1126
     },
     {
       "name": "Temple of Earth",
       "exits": {
         "down": 105
       },
-      "id": 1127,
-      "area": {
-        "id": 1
-      }
+      "id": 1127
     },
     {
       "name": "Temple of Fire",
       "exits": {
         "down": 114
       },
-      "id": 1128,
-      "area": {
-        "id": 1
-      }
+      "id": 1128
     },
     {
       "name": "Temple of Fire",
       "exits": {
         "down": 113
       },
-      "id": 1129,
-      "area": {
-        "id": 1
-      }
+      "id": 1129
     },
     {
       "name": "Temple of Air",
       "exits": {
         "down": 84
       },
-      "id": 1130,
-      "area": {
-        "id": 1
-      }
+      "id": 1130
     },
     {
       "name": "Temple of Air",
       "exits": {
         "down": 85
       },
-      "id": 1131,
-      "area": {
-        "id": 1
-      }
+      "id": 1131
     },
     {
       "name": "Temple of Water",
       "exits": {
         "down": 92
       },
-      "id": 1132,
-      "area": {
-        "id": 1
-      }
+      "id": 1132
     },
     {
       "name": "Temple of Water",
       "exits": {
         "down": 93
       },
-      "id": 1133,
-      "area": {
-        "id": 1
-      }
+      "id": 1133
     },
     {
       "name": "House of Lord Candera",
       "exits": {
         "down": 69
       },
-      "id": 1134,
-      "area": {
-        "id": 1
-      }
+      "id": 1134
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/chikurin-forest.json
+++ b/maps/chikurin-forest.json
@@ -10,10 +10,7 @@
         "northwest": 1835,
         "north": 1856
       },
-      "id": 1834,
-      "area": {
-        "id": 37
-      }
+      "id": 1834
     },
     {
       "name": "Bamboo Forest",
@@ -23,10 +20,7 @@
         "southeast": 1834,
         "north": 1836
       },
-      "id": 1835,
-      "area": {
-        "id": 37
-      }
+      "id": 1835
     },
     {
       "name": "Bamboo Forest",
@@ -37,10 +31,7 @@
         "east": 1857,
         "north": 1855
       },
-      "id": 1836,
-      "area": {
-        "id": 37
-      }
+      "id": 1836
     },
     {
       "name": "Bamboo Forest",
@@ -50,10 +41,7 @@
         "southeast": 1836,
         "north": 1838
       },
-      "id": 1837,
-      "area": {
-        "id": 37
-      }
+      "id": 1837
     },
     {
       "name": "Calm Clearing in the Bamboo Forest",
@@ -64,10 +52,7 @@
         "east": 1851,
         "north": 1839
       },
-      "id": 1838,
-      "area": {
-        "id": 37
-      }
+      "id": 1838
     },
     {
       "name": "Bamboo Forest",
@@ -77,10 +62,7 @@
         "southeast": 1851,
         "south": 1838
       },
-      "id": 1839,
-      "area": {
-        "id": 37
-      }
+      "id": 1839
     },
     {
       "name": "Bamboo Forest, Near a Pond",
@@ -92,10 +74,7 @@
         "east": 1846,
         "north": 1841
       },
-      "id": 1840,
-      "area": {
-        "id": 37
-      }
+      "id": 1840
     },
     {
       "name": "Bamboo Forest",
@@ -104,10 +83,7 @@
         "southeast": 1846,
         "south": 1840
       },
-      "id": 1841,
-      "area": {
-        "id": 37
-      }
+      "id": 1841
     },
     {
       "name": "Chikurin Forest Path",
@@ -117,10 +93,7 @@
         "east": 1845,
         "north": 1843
       },
-      "id": 1842,
-      "area": {
-        "id": 37
-      }
+      "id": 1842
     },
     {
       "name": "Chikurin Path, south of Semai Pass",
@@ -128,20 +101,14 @@
         "south": 1842,
         "north": 1844
       },
-      "id": 1843,
-      "area": {
-        "id": 37
-      }
+      "id": 1843
     },
     {
       "name": "Heading north, you enter the narrow Semai Pass.",
       "exits": {
         "south": 1843
       },
-      "id": 1844,
-      "area": {
-        "id": 37
-      }
+      "id": 1844
     },
     {
       "name": "Bamboo Forest",
@@ -150,10 +117,7 @@
         "west": 1842,
         "south": 1848
       },
-      "id": 1845,
-      "area": {
-        "id": 37
-      }
+      "id": 1845
     },
     {
       "name": "Chikurin Forest Path",
@@ -167,10 +131,7 @@
         "east": 1848,
         "north": 1842
       },
-      "id": 1846,
-      "area": {
-        "id": 37
-      }
+      "id": 1846
     },
     {
       "name": "Bamboo Forest",
@@ -181,10 +142,7 @@
         "east": 1852,
         "north": 1848
       },
-      "id": 1847,
-      "area": {
-        "id": 37
-      }
+      "id": 1847
     },
     {
       "name": "Bamboo Forest",
@@ -196,10 +154,7 @@
         "southeast": 1852,
         "north": 1845
       },
-      "id": 1848,
-      "area": {
-        "id": 37
-      }
+      "id": 1848
     },
     {
       "name": "Chikurin Forest Path",
@@ -210,10 +165,7 @@
         "west": 1850,
         "north": 1846
       },
-      "id": 1849,
-      "area": {
-        "id": 37
-      }
+      "id": 1849
     },
     {
       "name": "Bamboo Forest",
@@ -225,10 +177,7 @@
         "east": 1849,
         "north": 1840
       },
-      "id": 1850,
-      "area": {
-        "id": 37
-      }
+      "id": 1850
     },
     {
       "name": "Bamboo Forest",
@@ -242,10 +191,7 @@
         "east": 1854,
         "north": 1850
       },
-      "id": 1851,
-      "area": {
-        "id": 37
-      }
+      "id": 1851
     },
     {
       "name": "Bamboo Forest, North of a Monastery",
@@ -253,10 +199,7 @@
         "northwest": 1848,
         "west": 1847
       },
-      "id": 1852,
-      "area": {
-        "id": 37
-      }
+      "id": 1852
     },
     {
       "name": "Bamboo Forest, West of a Monastery",
@@ -267,10 +210,7 @@
         "west": 1854,
         "north": 1847
       },
-      "id": 1853,
-      "area": {
-        "id": 37
-      }
+      "id": 1853
     },
     {
       "name": "Chikurin Forest Path",
@@ -281,10 +221,7 @@
         "east": 1853,
         "north": 1849
       },
-      "id": 1854,
-      "area": {
-        "id": 37
-      }
+      "id": 1854
     },
     {
       "name": "Bamboo Forest",
@@ -297,10 +234,7 @@
         "east": 1862,
         "north": 1851
       },
-      "id": 1855,
-      "area": {
-        "id": 37
-      }
+      "id": 1855
     },
     {
       "name": "Chikurin Forest Path",
@@ -310,20 +244,14 @@
         "east": 1858,
         "north": 1857
       },
-      "id": 1856,
-      "area": {
-        "id": 37
-      }
+      "id": 1856
     },
     {
       "name": "Chikurin Forest Path",
       "exits": {
         "north": 1862
       },
-      "id": 1857,
-      "area": {
-        "id": 37
-      }
+      "id": 1857
     },
     {
       "name": "Bamboo Forest",
@@ -333,10 +261,7 @@
         "northwest": 1857,
         "north": 1859
       },
-      "id": 1858,
-      "area": {
-        "id": 37
-      }
+      "id": 1858
     },
     {
       "name": "Bamboo Forest",
@@ -346,10 +271,7 @@
         "northwest": 1862,
         "north": 1860
       },
-      "id": 1859,
-      "area": {
-        "id": 37
-      }
+      "id": 1859
     },
     {
       "name": "Bamboo Forest",
@@ -360,10 +282,7 @@
         "east": 1861,
         "north": 1853
       },
-      "id": 1860,
-      "area": {
-        "id": 37
-      }
+      "id": 1860
     },
     {
       "name": "Bamboo Forest, South of a Monastery",
@@ -372,20 +291,14 @@
         "west": 1860,
         "north": 1863
       },
-      "id": 1861,
-      "area": {
-        "id": 37
-      }
+      "id": 1861
     },
     {
       "name": "Chikurin Forest Path",
       "exits": {
         "south": 1857
       },
-      "id": 1862,
-      "area": {
-        "id": 37
-      }
+      "id": 1862
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/crimsonaxe-mine.json
+++ b/maps/crimsonaxe-mine.json
@@ -9,20 +9,14 @@
         "down": 1809,
         "up": 1808
       },
-      "id": 1807,
-      "area": {
-        "id": 35
-      }
+      "id": 1807
     },
     {
       "name": "Crack in the mountainside",
       "exits": {
         "down": 1807
       },
-      "id": 1808,
-      "area": {
-        "id": 35
-      }
+      "id": 1808
     },
     {
       "name": "Giant cavern",
@@ -30,30 +24,21 @@
         "up": 1807,
         "west": 1810
       },
-      "id": 1809,
-      "area": {
-        "id": 35
-      }
+      "id": 1809
     },
     {
       "name": "Bright niche",
       "exits": {
         "east": 1809
       },
-      "id": 1810,
-      "area": {
-        "id": 35
-      }
+      "id": 1810
     },
     {
       "name": "The ore lift",
       "exits": {
         "south": 1812
       },
-      "id": 1811,
-      "area": {
-        "id": 35
-      }
+      "id": 1811
     },
     {
       "name": "The Crimsonaxe mine",
@@ -62,10 +47,7 @@
         "south": 1815,
         "north": 1811
       },
-      "id": 1812,
-      "area": {
-        "id": 35
-      }
+      "id": 1812
     },
     {
       "name": "A guard point",
@@ -74,20 +56,14 @@
         "east": 1812,
         "north": 1823
       },
-      "id": 1813,
-      "area": {
-        "id": 35
-      }
+      "id": 1813
     },
     {
       "name": "The immense stone slab moves suprisingly easily.",
       "exits": {
         "north": 1813
       },
-      "id": 1814,
-      "area": {
-        "id": 35
-      }
+      "id": 1814
     },
     {
       "name": "The Crimsonaxe mine",
@@ -96,10 +72,7 @@
         "east": 1821,
         "north": 1812
       },
-      "id": 1815,
-      "area": {
-        "id": 35
-      }
+      "id": 1815
     },
     {
       "name": "A bend in the tunnel.",
@@ -107,10 +80,7 @@
         "southeast": 1817,
         "north": 1815
       },
-      "id": 1816,
-      "area": {
-        "id": 35
-      }
+      "id": 1816
     },
     {
       "name": "A mine shaft.",
@@ -119,10 +89,7 @@
         "east": 1818,
         "up": 1820
       },
-      "id": 1817,
-      "area": {
-        "id": 35
-      }
+      "id": 1817
     },
     {
       "name": "A guard house.",
@@ -130,30 +97,21 @@
         "up": 1819,
         "west": 1817
       },
-      "id": 1818,
-      "area": {
-        "id": 35
-      }
+      "id": 1818
     },
     {
       "name": "A sentry room",
       "exits": {
         "down": 1818
       },
-      "id": 1819,
-      "area": {
-        "id": 35
-      }
+      "id": 1819
     },
     {
       "name": "A darkened entrance.",
       "exits": {
         "down": 1817
       },
-      "id": 1820,
-      "area": {
-        "id": 35
-      }
+      "id": 1820
     },
     {
       "name": "Mine catering",
@@ -161,30 +119,21 @@
         "west": 1815,
         "north": 1822
       },
-      "id": 1821,
-      "area": {
-        "id": 35
-      }
+      "id": 1821
     },
     {
       "name": "A smelly crevice.",
       "exits": {
         "south": 1821
       },
-      "id": 1822,
-      "area": {
-        "id": 35
-      }
+      "id": 1822
     },
     {
       "name": "The immense stone slab moves suprisingly easily.",
       "exits": {
         "south": 1813
       },
-      "id": 1823,
-      "area": {
-        "id": 35
-      }
+      "id": 1823
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/exedoria.json
+++ b/maps/exedoria.json
@@ -8,10 +8,7 @@
       "exits": {
         "east": 287
       },
-      "id": 286,
-      "area": {
-        "id": 4
-      }
+      "id": 286
     },
     {
       "name": "Main Street",
@@ -20,10 +17,7 @@
         "east": 288,
         "south": 330
       },
-      "id": 287,
-      "area": {
-        "id": 4
-      }
+      "id": 287
     },
     {
       "name": "Main Street",
@@ -33,10 +27,7 @@
         "east": 289,
         "north": 367
       },
-      "id": 288,
-      "area": {
-        "id": 4
-      }
+      "id": 288
     },
     {
       "name": "Main Street",
@@ -45,10 +36,7 @@
         "east": 290,
         "south": 366
       },
-      "id": 289,
-      "area": {
-        "id": 4
-      }
+      "id": 289
     },
     {
       "name": "Monument Circle, Main Street",
@@ -58,10 +46,7 @@
         "east": 291,
         "north": 369
       },
-      "id": 290,
-      "area": {
-        "id": 4
-      }
+      "id": 290
     },
     {
       "name": "Main Street",
@@ -71,10 +56,7 @@
         "east": 292,
         "north": 370
       },
-      "id": 291,
-      "area": {
-        "id": 4
-      }
+      "id": 291
     },
     {
       "name": "Main Street",
@@ -83,10 +65,7 @@
         "east": 293,
         "south": 383
       },
-      "id": 292,
-      "area": {
-        "id": 4
-      }
+      "id": 292
     },
     {
       "name": "Main Street",
@@ -94,10 +73,7 @@
         "east": 294,
         "west": 292
       },
-      "id": 293,
-      "area": {
-        "id": 4
-      }
+      "id": 293
     },
     {
       "name": "Main Street",
@@ -105,10 +81,7 @@
         "east": 295,
         "west": 293
       },
-      "id": 294,
-      "area": {
-        "id": 4
-      }
+      "id": 294
     },
     {
       "name": "Main Street",
@@ -116,10 +89,7 @@
         "east": 296,
         "west": 294
       },
-      "id": 295,
-      "area": {
-        "id": 4
-      }
+      "id": 295
     },
     {
       "name": "Main Street",
@@ -127,30 +97,21 @@
         "east": 297,
         "west": 295
       },
-      "id": 296,
-      "area": {
-        "id": 4
-      }
+      "id": 296
     },
     {
       "name": "Corigan Court Intersection",
       "exits": {
         "west": 296
       },
-      "id": 297,
-      "area": {
-        "id": 4
-      }
+      "id": 297
     },
     {
       "name": "City Hall",
       "exits": {
         "north": 291
       },
-      "id": 298,
-      "area": {
-        "id": 4
-      }
+      "id": 298
     },
     {
       "name": "Eithel Sirion",
@@ -158,10 +119,7 @@
         "south": 300,
         "north": 290
       },
-      "id": 299,
-      "area": {
-        "id": 4
-      }
+      "id": 299
     },
     {
       "name": "Brapnor Road",
@@ -171,20 +129,14 @@
         "east": 385,
         "north": 299
       },
-      "id": 300,
-      "area": {
-        "id": 4
-      }
+      "id": 300
     },
     {
       "name": "Frenchie's II",
       "exits": {
         "north": 300
       },
-      "id": 301,
-      "area": {
-        "id": 4
-      }
+      "id": 301
     },
     {
       "name": "Brapnor Road",
@@ -193,10 +145,7 @@
         "east": 300,
         "south": 392
       },
-      "id": 302,
-      "area": {
-        "id": 4
-      }
+      "id": 302
     },
     {
       "name": "Middle of Brapnor Road",
@@ -205,10 +154,7 @@
         "east": 302,
         "south": 329
       },
-      "id": 303,
-      "area": {
-        "id": 4
-      }
+      "id": 303
     },
     {
       "name": "Brapnor Road",
@@ -217,10 +163,7 @@
         "east": 303,
         "north": 330
       },
-      "id": 304,
-      "area": {
-        "id": 4
-      }
+      "id": 304
     },
     {
       "name": "Brapnor Road",
@@ -229,10 +172,7 @@
         "east": 304,
         "north": 393
       },
-      "id": 305,
-      "area": {
-        "id": 4
-      }
+      "id": 305
     },
     {
       "name": "Brapnor Road",
@@ -240,10 +180,7 @@
         "east": 305,
         "west": 307
       },
-      "id": 306,
-      "area": {
-        "id": 4
-      }
+      "id": 306
     },
     {
       "name": "End of Brapnor Road",
@@ -252,10 +189,7 @@
         "northwest": 331,
         "south": 308
       },
-      "id": 307,
-      "area": {
-        "id": 4
-      }
+      "id": 307
     },
     {
       "name": "Beginning of Lilu Lane",
@@ -263,10 +197,7 @@
         "south": 309,
         "north": 307
       },
-      "id": 308,
-      "area": {
-        "id": 4
-      }
+      "id": 308
     },
     {
       "name": "Lilu Lane",
@@ -274,10 +205,7 @@
         "south": 310,
         "north": 308
       },
-      "id": 309,
-      "area": {
-        "id": 4
-      }
+      "id": 309
     },
     {
       "name": "Middle of Lilu Lane",
@@ -286,10 +214,7 @@
         "south": 311,
         "north": 309
       },
-      "id": 310,
-      "area": {
-        "id": 4
-      }
+      "id": 310
     },
     {
       "name": "Lilu Lane",
@@ -297,10 +222,7 @@
         "south": 312,
         "north": 310
       },
-      "id": 311,
-      "area": {
-        "id": 4
-      }
+      "id": 311
     },
     {
       "name": "End of Lilu Lane",
@@ -309,10 +231,7 @@
         "south": 313,
         "north": 311
       },
-      "id": 312,
-      "area": {
-        "id": 4
-      }
+      "id": 312
     },
     {
       "name": "Beginning of Embassy Row",
@@ -320,10 +239,7 @@
         "east": 314,
         "north": 312
       },
-      "id": 313,
-      "area": {
-        "id": 4
-      }
+      "id": 313
     },
     {
       "name": "Embassy Row",
@@ -332,10 +248,7 @@
         "east": 315,
         "south": 322
       },
-      "id": 314,
-      "area": {
-        "id": 4
-      }
+      "id": 314
     },
     {
       "name": "Embassy Row",
@@ -345,10 +258,7 @@
         "east": 316,
         "north": 321
       },
-      "id": 315,
-      "area": {
-        "id": 4
-      }
+      "id": 315
     },
     {
       "name": "Embassy Row",
@@ -358,10 +268,7 @@
         "east": 317,
         "north": 319
       },
-      "id": 316,
-      "area": {
-        "id": 4
-      }
+      "id": 316
     },
     {
       "name": "Embassy Row",
@@ -370,20 +277,14 @@
         "east": 323,
         "north": 333
       },
-      "id": 317,
-      "area": {
-        "id": 4
-      }
+      "id": 317
     },
     {
       "name": "A Dark Hole in the Ground",
       "exits": {
         "north": 316
       },
-      "id": 318,
-      "area": {
-        "id": 4
-      }
+      "id": 318
     },
     {
       "name": "Guard Post for Gnome Embassy",
@@ -391,40 +292,28 @@
         "south": 316,
         "north": 926
       },
-      "id": 319,
-      "area": {
-        "id": 4
-      }
+      "id": 319
     },
     {
       "name": "Before a round door",
       "exits": {
         "north": 315
       },
-      "id": 320,
-      "area": {
-        "id": 4
-      }
+      "id": 320
     },
     {
       "name": "Junk yard",
       "exits": {
         "south": 315
       },
-      "id": 321,
-      "area": {
-        "id": 4
-      }
+      "id": 321
     },
     {
       "name": "Elven Embassy checkpoint",
       "exits": {
         "north": 314
       },
-      "id": 322,
-      "area": {
-        "id": 4
-      }
+      "id": 322
     },
     {
       "name": "End of Embassy Row",
@@ -432,10 +321,7 @@
         "west": 317,
         "north": 324
       },
-      "id": 323,
-      "area": {
-        "id": 4
-      }
+      "id": 323
     },
     {
       "name": "Southern end of alley",
@@ -443,10 +329,7 @@
         "south": 323,
         "north": 325
       },
-      "id": 324,
-      "area": {
-        "id": 4
-      }
+      "id": 324
     },
     {
       "name": "Bend in an alley",
@@ -454,10 +337,7 @@
         "west": 326,
         "south": 324
       },
-      "id": 325,
-      "area": {
-        "id": 4
-      }
+      "id": 325
     },
     {
       "name": "A bend in the alley",
@@ -465,10 +345,7 @@
         "east": 325,
         "north": 327
       },
-      "id": 326,
-      "area": {
-        "id": 4
-      }
+      "id": 326
     },
     {
       "name": "Dark and narrow alley",
@@ -476,10 +353,7 @@
         "south": 326,
         "north": 328
       },
-      "id": 327,
-      "area": {
-        "id": 4
-      }
+      "id": 327
     },
     {
       "name": "Dark alley",
@@ -487,10 +361,7 @@
         "south": 327,
         "north": 329
       },
-      "id": 328,
-      "area": {
-        "id": 4
-      }
+      "id": 328
     },
     {
       "name": "Alley entrance",
@@ -498,10 +369,7 @@
         "south": 328,
         "north": 303
       },
-      "id": 329,
-      "area": {
-        "id": 4
-      }
+      "id": 329
     },
     {
       "name": "The Excalibur, a closed guild",
@@ -509,10 +377,7 @@
         "south": 304,
         "north": 287
       },
-      "id": 330,
-      "area": {
-        "id": 4
-      }
+      "id": 330
     },
     {
       "name": "Foyer of the Exedorian Inn",
@@ -520,20 +385,14 @@
         "southeast": 307,
         "west": 332
       },
-      "id": 331,
-      "area": {
-        "id": 4
-      }
+      "id": 331
     },
     {
       "name": "Exedorian saloon",
       "exits": {
         "east": 331
       },
-      "id": 332,
-      "area": {
-        "id": 4
-      }
+      "id": 332
     },
     {
       "name": "Before the Dwarven Embassy",
@@ -541,20 +400,14 @@
         "south": 317,
         "north": 920
       },
-      "id": 333,
-      "area": {
-        "id": 4
-      }
+      "id": 333
     },
     {
       "name": "Keen Street West",
       "exits": {
         "east": 335
       },
-      "id": 334,
-      "area": {
-        "id": 4
-      }
+      "id": 334
     },
     {
       "name": "Keen Street",
@@ -562,10 +415,7 @@
         "east": 336,
         "west": 334
       },
-      "id": 335,
-      "area": {
-        "id": 4
-      }
+      "id": 335
     },
     {
       "name": "Keen Street",
@@ -574,10 +424,7 @@
         "east": 337,
         "north": 602
       },
-      "id": 336,
-      "area": {
-        "id": 4
-      }
+      "id": 336
     },
     {
       "name": "Keen Street",
@@ -586,10 +433,7 @@
         "east": 338,
         "south": 603
       },
-      "id": 337,
-      "area": {
-        "id": 4
-      }
+      "id": 337
     },
     {
       "name": "East Keen Street Bridge",
@@ -598,10 +442,7 @@
         "east": 339,
         "north": 604
       },
-      "id": 338,
-      "area": {
-        "id": 4
-      }
+      "id": 338
     },
     {
       "name": "Keen Street Bridge",
@@ -609,10 +450,7 @@
         "east": 340,
         "west": 338
       },
-      "id": 339,
-      "area": {
-        "id": 4
-      }
+      "id": 339
     },
     {
       "name": "Keen Street",
@@ -621,10 +459,7 @@
         "east": 341,
         "south": 343
       },
-      "id": 340,
-      "area": {
-        "id": 4
-      }
+      "id": 340
     },
     {
       "name": "Keen Street East",
@@ -632,10 +467,7 @@
         "west": 340,
         "north": 342
       },
-      "id": 341,
-      "area": {
-        "id": 4
-      }
+      "id": 341
     },
     {
       "name": "Guard Post",
@@ -643,10 +475,7 @@
         "south": 341,
         "north": 350
       },
-      "id": 342,
-      "area": {
-        "id": 4
-      }
+      "id": 342
     },
     {
       "name": "Statued lawn",
@@ -654,10 +483,7 @@
         "south": 344,
         "north": 340
       },
-      "id": 343,
-      "area": {
-        "id": 4
-      }
+      "id": 343
     },
     {
       "name": "Statued lawn",
@@ -665,10 +491,7 @@
         "south": 345,
         "north": 343
       },
-      "id": 344,
-      "area": {
-        "id": 4
-      }
+      "id": 344
     },
     {
       "name": "Manicured lawn",
@@ -676,10 +499,7 @@
         "south": 346,
         "north": 344
       },
-      "id": 345,
-      "area": {
-        "id": 4
-      }
+      "id": 345
     },
     {
       "name": "Cavernous foyer",
@@ -688,20 +508,14 @@
         "east": 347,
         "north": 345
       },
-      "id": 346,
-      "area": {
-        "id": 4
-      }
+      "id": 346
     },
     {
       "name": "Icy room",
       "exits": {
         "west": 346
       },
-      "id": 347,
-      "area": {
-        "id": 4
-      }
+      "id": 347
     },
     {
       "name": "Cold hallway",
@@ -709,20 +523,14 @@
         "east": 346,
         "south": 349
       },
-      "id": 348,
-      "area": {
-        "id": 4
-      }
+      "id": 348
     },
     {
       "name": "Snowy cave",
       "exits": {
         "north": 348
       },
-      "id": 349,
-      "area": {
-        "id": 4
-      }
+      "id": 349
     },
     {
       "name": "With no gate guard present, you are able to enter the walled estate",
@@ -730,10 +538,7 @@
         "south": 342,
         "north": 351
       },
-      "id": 350,
-      "area": {
-        "id": 4
-      }
+      "id": 350
     },
     {
       "name": "Foyer",
@@ -741,10 +546,7 @@
         "east": 352,
         "south": 350
       },
-      "id": 351,
-      "area": {
-        "id": 4
-      }
+      "id": 351
     },
     {
       "name": "Wood-paneled Hallway",
@@ -752,30 +554,21 @@
         "west": 351,
         "north": 353
       },
-      "id": 352,
-      "area": {
-        "id": 4
-      }
+      "id": 352
     },
     {
       "name": "Busy Kitchen",
       "exits": {
         "south": 352
       },
-      "id": 353,
-      "area": {
-        "id": 4
-      }
+      "id": 353
     },
     {
       "name": "Mom's General Store",
       "exits": {
         "east": 312
       },
-      "id": 354,
-      "area": {
-        "id": 4
-      }
+      "id": 354
     },
     {
       "name": "Drawbridge",
@@ -783,10 +576,7 @@
         "east": 310,
         "west": 356
       },
-      "id": 355,
-      "area": {
-        "id": 4
-      }
+      "id": 355
     },
     {
       "name": "Library's entrance",
@@ -796,10 +586,7 @@
         "east": 355,
         "north": 362
       },
-      "id": 356,
-      "area": {
-        "id": 4
-      }
+      "id": 356
     },
     {
       "name": "Cobblestoned hallway",
@@ -808,10 +595,7 @@
         "east": 360,
         "north": 356
       },
-      "id": 357,
-      "area": {
-        "id": 4
-      }
+      "id": 357
     },
     {
       "name": "A bend in the hallway",
@@ -819,40 +603,28 @@
         "west": 359,
         "north": 357
       },
-      "id": 358,
-      "area": {
-        "id": 4
-      }
+      "id": 358
     },
     {
       "name": "A monk's cell",
       "exits": {
         "east": 358
       },
-      "id": 359,
-      "area": {
-        "id": 4
-      }
+      "id": 359
     },
     {
       "name": "A monk's cell",
       "exits": {
         "west": 357
       },
-      "id": 360,
-      "area": {
-        "id": 4
-      }
+      "id": 360
     },
     {
       "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
       "exits": {
         "east": 356
       },
-      "id": 361,
-      "area": {
-        "id": 4
-      }
+      "id": 361
     },
     {
       "name": "Cobblestoned hallway",
@@ -861,20 +633,14 @@
         "east": 363,
         "north": 364
       },
-      "id": 362,
-      "area": {
-        "id": 4
-      }
+      "id": 362
     },
     {
       "name": "A monk's cell",
       "exits": {
         "west": 362
       },
-      "id": 363,
-      "area": {
-        "id": 4
-      }
+      "id": 363
     },
     {
       "name": "A bend in the hallway",
@@ -882,60 +648,42 @@
         "west": 365,
         "south": 362
       },
-      "id": 364,
-      "area": {
-        "id": 4
-      }
+      "id": 364
     },
     {
       "name": "A monk's cell",
       "exits": {
         "east": 364
       },
-      "id": 365,
-      "area": {
-        "id": 4
-      }
+      "id": 365
     },
     {
       "name": "The Cadaver Emporium",
       "exits": {
         "north": 289
       },
-      "id": 366,
-      "area": {
-        "id": 4
-      }
+      "id": 366
     },
     {
       "name": "Velvet Unicorn",
       "exits": {
         "south": 288
       },
-      "id": 367,
-      "area": {
-        "id": 4
-      }
+      "id": 367
     },
     {
       "name": "Eidolon Warlords",
       "exits": {
         "north": 288
       },
-      "id": 368,
-      "area": {
-        "id": 4
-      }
+      "id": 368
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": {
         "south": 290
       },
-      "id": 369,
-      "area": {
-        "id": 4
-      }
+      "id": 369
     },
     {
       "name": "Beginning of park path",
@@ -943,10 +691,7 @@
         "south": 291,
         "north": 371
       },
-      "id": 370,
-      "area": {
-        "id": 4
-      }
+      "id": 370
     },
     {
       "name": "Park path intersection",
@@ -956,20 +701,14 @@
         "east": 378,
         "north": 373
       },
-      "id": 371,
-      "area": {
-        "id": 4
-      }
+      "id": 371
     },
     {
       "name": "Exedoria Pet Cemetary",
       "exits": {
         "east": 371
       },
-      "id": 372,
-      "area": {
-        "id": 4
-      }
+      "id": 372
     },
     {
       "name": "Park path on the hill",
@@ -977,10 +716,7 @@
         "south": 371,
         "north": 374
       },
-      "id": 373,
-      "area": {
-        "id": 4
-      }
+      "id": 373
     },
     {
       "name": "Elevated park path",
@@ -988,10 +724,7 @@
         "south": 373,
         "north": 375
       },
-      "id": 374,
-      "area": {
-        "id": 4
-      }
+      "id": 374
     },
     {
       "name": "End of park path",
@@ -999,10 +732,7 @@
         "east": 376,
         "south": 374
       },
-      "id": 375,
-      "area": {
-        "id": 4
-      }
+      "id": 375
     },
     {
       "name": "Temple ruins",
@@ -1010,20 +740,14 @@
         "east": 377,
         "west": 375
       },
-      "id": 376,
-      "area": {
-        "id": 4
-      }
+      "id": 376
     },
     {
       "name": "Temple rotunda",
       "exits": {
         "west": 376
       },
-      "id": 377,
-      "area": {
-        "id": 4
-      }
+      "id": 377
     },
     {
       "name": "Gravel path to the mansion",
@@ -1031,10 +755,7 @@
         "east": 379,
         "west": 371
       },
-      "id": 378,
-      "area": {
-        "id": 4
-      }
+      "id": 378
     },
     {
       "name": "Gravel path on the hill",
@@ -1042,10 +763,7 @@
         "east": 380,
         "west": 378
       },
-      "id": 379,
-      "area": {
-        "id": 4
-      }
+      "id": 379
     },
     {
       "name": "Intersection in the gravel path",
@@ -1054,30 +772,21 @@
         "southeast": 382,
         "north": 381
       },
-      "id": 380,
-      "area": {
-        "id": 4
-      }
+      "id": 380
     },
     {
       "name": "Before a white mansion",
       "exits": {
         "south": 380
       },
-      "id": 381,
-      "area": {
-        "id": 4
-      }
+      "id": 381
     },
     {
       "name": "Outside the cemetery gate",
       "exits": {
         "northwest": 380
       },
-      "id": 382,
-      "area": {
-        "id": 4
-      }
+      "id": 382
     },
     {
       "name": "Guard Post",
@@ -1085,10 +794,7 @@
         "south": 384,
         "north": 292
       },
-      "id": 383,
-      "area": {
-        "id": 4
-      }
+      "id": 383
     },
     {
       "name": "Beginning of Brapnor Road",
@@ -1097,10 +803,7 @@
         "southeast": 386,
         "north": 383
       },
-      "id": 384,
-      "area": {
-        "id": 4
-      }
+      "id": 384
     },
     {
       "name": "Brapnor Road",
@@ -1108,10 +811,7 @@
         "east": 384,
         "west": 300
       },
-      "id": 385,
-      "area": {
-        "id": 4
-      }
+      "id": 385
     },
     {
       "name": "Necrom's Gate",
@@ -1119,10 +819,7 @@
         "northwest": 384,
         "southeast": 387
       },
-      "id": 386,
-      "area": {
-        "id": 4
-      }
+      "id": 386
     },
     {
       "name": "Paved intersection",
@@ -1131,10 +828,7 @@
         "northwest": 386,
         "south": 527
       },
-      "id": 387,
-      "area": {
-        "id": 4
-      }
+      "id": 387
     },
     {
       "name": "Eastern path through the University",
@@ -1142,10 +836,7 @@
         "east": 389,
         "west": 387
       },
-      "id": 388,
-      "area": {
-        "id": 4
-      }
+      "id": 388
     },
     {
       "name": "Eastern path through the University",
@@ -1153,10 +844,7 @@
         "east": 390,
         "west": 388
       },
-      "id": 389,
-      "area": {
-        "id": 4
-      }
+      "id": 389
     },
     {
       "name": "In front of a temporary building",
@@ -1165,40 +853,28 @@
         "east": 391,
         "south": 904
       },
-      "id": 390,
-      "area": {
-        "id": 4
-      }
+      "id": 390
     },
     {
       "name": "Construction site",
       "exits": {
         "west": 390
       },
-      "id": 391,
-      "area": {
-        "id": 4
-      }
+      "id": 391
     },
     {
       "name": "Delilah's Deli",
       "exits": {
         "north": 302
       },
-      "id": 392,
-      "area": {
-        "id": 4
-      }
+      "id": 392
     },
     {
       "name": "Guard Tower Entrance",
       "exits": {
         "south": 305
       },
-      "id": 393,
-      "area": {
-        "id": 4
-      }
+      "id": 393
     },
     {
       "name": "Southern path through the University",
@@ -1206,10 +882,7 @@
         "south": 528,
         "north": 387
       },
-      "id": 527,
-      "area": {
-        "id": 4
-      }
+      "id": 527
     },
     {
       "name": "Southern path through the University",
@@ -1218,20 +891,14 @@
         "east": 894,
         "north": 527
       },
-      "id": 528,
-      "area": {
-        "id": 4
-      }
+      "id": 528
     },
     {
       "name": "Railed entrance",
       "exits": {
         "south": 336
       },
-      "id": 602,
-      "area": {
-        "id": 4
-      }
+      "id": 602
     },
     {
       "name": "Flagstoned entry",
@@ -1239,10 +906,7 @@
         "south": 915,
         "north": 337
       },
-      "id": 603,
-      "area": {
-        "id": 4
-      }
+      "id": 603
     },
     {
       "name": "You rudely trespass on the private property.",
@@ -1251,10 +915,7 @@
         "northwest": 910,
         "south": 338
       },
-      "id": 604,
-      "area": {
-        "id": 4
-      }
+      "id": 604
     },
     {
       "name": "Dormitory foyer",
@@ -1263,20 +924,14 @@
         "south": 895,
         "north": 903
       },
-      "id": 894,
-      "area": {
-        "id": 4
-      }
+      "id": 894
     },
     {
       "name": "Dining commons",
       "exits": {
         "north": 894
       },
-      "id": 895,
-      "area": {
-        "id": 4
-      }
+      "id": 895
     },
     {
       "name": "Southern path through the University",
@@ -1284,10 +939,7 @@
         "south": 897,
         "north": 528
       },
-      "id": 896,
-      "area": {
-        "id": 4
-      }
+      "id": 896
     },
     {
       "name": "Southern path through the University",
@@ -1295,10 +947,7 @@
         "south": 898,
         "north": 896
       },
-      "id": 897,
-      "area": {
-        "id": 4
-      }
+      "id": 897
     },
     {
       "name": "Southern path through the University",
@@ -1306,10 +955,7 @@
         "south": 899,
         "north": 897
       },
-      "id": 898,
-      "area": {
-        "id": 4
-      }
+      "id": 898
     },
     {
       "name": "Southern path through the University",
@@ -1318,10 +964,7 @@
         "east": 900,
         "north": 898
       },
-      "id": 899,
-      "area": {
-        "id": 4
-      }
+      "id": 899
     },
     {
       "name": "School of Business",
@@ -1329,40 +972,28 @@
         "west": 899,
         "north": 901
       },
-      "id": 900,
-      "area": {
-        "id": 4
-      }
+      "id": 900
     },
     {
       "name": "Dean's office",
       "exits": {
         "south": 900
       },
-      "id": 901,
-      "area": {
-        "id": 4
-      }
+      "id": 901
     },
     {
       "name": "Construction site",
       "exits": {
         "north": 899
       },
-      "id": 902,
-      "area": {
-        "id": 4
-      }
+      "id": 902
     },
     {
       "name": "Resident Advisor's office",
       "exits": {
         "south": 894
       },
-      "id": 903,
-      "area": {
-        "id": 4
-      }
+      "id": 903
     },
     {
       "name": "Science building's entry",
@@ -1371,30 +1002,21 @@
         "east": 906,
         "north": 390
       },
-      "id": 904,
-      "area": {
-        "id": 4
-      }
+      "id": 904
     },
     {
       "name": "Science laboratory",
       "exits": {
         "east": 904
       },
-      "id": 905,
-      "area": {
-        "id": 4
-      }
+      "id": 905
     },
     {
       "name": "Science lecture hall",
       "exits": {
         "west": 904
       },
-      "id": 906,
-      "area": {
-        "id": 4
-      }
+      "id": 906
     },
     {
       "name": "Gravel Path",
@@ -1402,10 +1024,7 @@
         "northwest": 908,
         "southwest": 604
       },
-      "id": 907,
-      "area": {
-        "id": 4
-      }
+      "id": 907
     },
     {
       "name": "Vine-covered Entry",
@@ -1414,10 +1033,7 @@
         "southeast": 907,
         "north": 909
       },
-      "id": 908,
-      "area": {
-        "id": 4
-      }
+      "id": 908
     },
     {
       "name": "Grand Foyer",
@@ -1427,10 +1043,7 @@
         "east": 912,
         "south": 908
       },
-      "id": 909,
-      "area": {
-        "id": 4
-      }
+      "id": 909
     },
     {
       "name": "Gravel Path",
@@ -1438,20 +1051,14 @@
         "southeast": 604,
         "northeast": 908
       },
-      "id": 910,
-      "area": {
-        "id": 4
-      }
+      "id": 910
     },
     {
       "name": "Child's Den",
       "exits": {
         "east": 909
       },
-      "id": 911,
-      "area": {
-        "id": 4
-      }
+      "id": 911
     },
     {
       "name": "Wooded Hallway",
@@ -1459,30 +1066,21 @@
         "east": 913,
         "west": 909
       },
-      "id": 912,
-      "area": {
-        "id": 4
-      }
+      "id": 912
     },
     {
       "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
       "exits": {
         "west": 912
       },
-      "id": 913,
-      "area": {
-        "id": 4
-      }
+      "id": 913
     },
     {
       "name": "Treetop Bedroom",
       "exits": {
         "down": 909
       },
-      "id": 914,
-      "area": {
-        "id": 4
-      }
+      "id": 914
     },
     {
       "name": "Flagstoned path",
@@ -1492,10 +1090,7 @@
         "east": 918,
         "north": 603
       },
-      "id": 915,
-      "area": {
-        "id": 4
-      }
+      "id": 915
     },
     {
       "name": "Gray foyer",
@@ -1503,40 +1098,28 @@
         "south": 917,
         "north": 915
       },
-      "id": 916,
-      "area": {
-        "id": 4
-      }
+      "id": 916
     },
     {
       "name": "Trinian merchant's office",
       "exits": {
         "north": 916
       },
-      "id": 917,
-      "area": {
-        "id": 4
-      }
+      "id": 917
     },
     {
       "name": "Carriage house",
       "exits": {
         "west": 915
       },
-      "id": 918,
-      "area": {
-        "id": 4
-      }
+      "id": 918
     },
     {
       "name": "Slave quarters",
       "exits": {
         "east": 915
       },
-      "id": 919,
-      "area": {
-        "id": 4
-      }
+      "id": 919
     },
     {
       "name": "Dwarven Embassy foyer",
@@ -1547,10 +1130,7 @@
         "east": 925,
         "north": 924
       },
-      "id": 920,
-      "area": {
-        "id": 4
-      }
+      "id": 920
     },
     {
       "name": "Dwarven watchtower",
@@ -1558,50 +1138,35 @@
         "down": 920,
         "north": 922
       },
-      "id": 921,
-      "area": {
-        "id": 4
-      }
+      "id": 921
     },
     {
       "name": "Ambassadors Suite",
       "exits": {
         "south": 921
       },
-      "id": 922,
-      "area": {
-        "id": 4
-      }
+      "id": 922
     },
     {
       "name": "Dwarven brewery",
       "exits": {
         "east": 920
       },
-      "id": 923,
-      "area": {
-        "id": 4
-      }
+      "id": 923
     },
     {
       "name": "Dwarven Ambassador's office",
       "exits": {
         "south": 920
       },
-      "id": 924,
-      "area": {
-        "id": 4
-      }
+      "id": 924
     },
     {
       "name": "Dwarven armoury",
       "exits": {
         "west": 920
       },
-      "id": 925,
-      "area": {
-        "id": 4
-      }
+      "id": 925
     },
     {
       "name": "Ground Floor of the Windmill",
@@ -1611,30 +1176,21 @@
         "east": 928,
         "south": 319
       },
-      "id": 926,
-      "area": {
-        "id": 4
-      }
+      "id": 926
     },
     {
       "name": "Garden of Machines",
       "exits": {
         "east": 926
       },
-      "id": 927,
-      "area": {
-        "id": 4
-      }
+      "id": 927
     },
     {
       "name": "Cemetery",
       "exits": {
         "west": 926
       },
-      "id": 928,
-      "area": {
-        "id": 4
-      }
+      "id": 928
     },
     {
       "name": "Gnome Laboratory",
@@ -1642,20 +1198,14 @@
         "down": 926,
         "up": 930
       },
-      "id": 929,
-      "area": {
-        "id": 4
-      }
+      "id": 929
     },
     {
       "name": "Machinery Room",
       "exits": {
         "down": 929
       },
-      "id": 930,
-      "area": {
-        "id": 4
-      }
+      "id": 930
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/great-bazaar-of-candera.json
+++ b/maps/great-bazaar-of-candera.json
@@ -10,20 +10,14 @@
         "east": 428,
         "north": 995
       },
-      "id": 977,
-      "area": {
-        "id": 15
-      }
+      "id": 977
     },
     {
       "name": "Nut Shop",
       "exits": {
         "south": 989
       },
-      "id": 978,
-      "area": {
-        "id": 15
-      }
+      "id": 978
     },
     {
       "name": "Great Bazaar of Candera",
@@ -33,10 +27,7 @@
         "east": 991,
         "north": 989
       },
-      "id": 979,
-      "area": {
-        "id": 15
-      }
+      "id": 979
     },
     {
       "name": "Great Bazaar of Candera",
@@ -46,10 +37,7 @@
         "east": 993,
         "north": 979
       },
-      "id": 980,
-      "area": {
-        "id": 15
-      }
+      "id": 980
     },
     {
       "name": "Great Bazaar of Candera",
@@ -58,40 +46,28 @@
         "east": 995,
         "north": 980
       },
-      "id": 981,
-      "area": {
-        "id": 15
-      }
+      "id": 981
     },
     {
       "name": "Shader's Scales",
       "exits": {
         "east": 981
       },
-      "id": 982,
-      "area": {
-        "id": 15
-      }
+      "id": 982
     },
     {
       "name": "Omars' Oil:",
       "exits": {
         "east": 980
       },
-      "id": 983,
-      "area": {
-        "id": 15
-      }
+      "id": 983
     },
     {
       "name": "Smithy",
       "exits": {
         "east": 979
       },
-      "id": 984,
-      "area": {
-        "id": 15
-      }
+      "id": 984
     },
     {
       "name": "Great Bazaar of Candera",
@@ -101,30 +77,21 @@
         "east": 987,
         "north": 988
       },
-      "id": 985,
-      "area": {
-        "id": 15
-      }
+      "id": 985
     },
     {
       "name": "Lord Candera's Lottery",
       "exits": {
         "west": 985
       },
-      "id": 987,
-      "area": {
-        "id": 15
-      }
+      "id": 987
     },
     {
       "name": "Empty Tent",
       "exits": {
         "south": 985
       },
-      "id": 988,
-      "area": {
-        "id": 15
-      }
+      "id": 988
     },
     {
       "name": "Great Bazaar of Candera",
@@ -134,10 +101,7 @@
         "east": 985,
         "north": 978
       },
-      "id": 989,
-      "area": {
-        "id": 15
-      }
+      "id": 989
     },
     {
       "name": "Great Bazaar of Candera",
@@ -147,20 +111,14 @@
         "east": 992,
         "north": 985
       },
-      "id": 991,
-      "area": {
-        "id": 15
-      }
+      "id": 991
     },
     {
       "name": "Kamal's Camel Lot:",
       "exits": {
         "west": 991
       },
-      "id": 992,
-      "area": {
-        "id": 15
-      }
+      "id": 992
     },
     {
       "name": "Great Bazaar of Candera",
@@ -170,20 +128,14 @@
         "east": 994,
         "north": 991
       },
-      "id": 993,
-      "area": {
-        "id": 15
-      }
+      "id": 993
     },
     {
       "name": "Perfume Tent:",
       "exits": {
         "west": 993
       },
-      "id": 994,
-      "area": {
-        "id": 15
-      }
+      "id": 994
     },
     {
       "name": "Great Bazaar of Candera",
@@ -193,20 +145,14 @@
         "east": 1739,
         "north": 993
       },
-      "id": 995,
-      "area": {
-        "id": 15
-      }
+      "id": 995
     },
     {
       "name": "Landak's Hut:",
       "exits": {
         "west": 995
       },
-      "id": 1739,
-      "area": {
-        "id": 15
-      }
+      "id": 1739
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/ice-dragons-den.json
+++ b/maps/ice-dragons-den.json
@@ -8,10 +8,7 @@
       "exits": {
         "down": 1339
       },
-      "id": 1338,
-      "area": {
-        "id": 26
-      }
+      "id": 1338
     },
     {
       "name": "Near a Frozen Waterfall",
@@ -19,10 +16,7 @@
         "northwest": 1340,
         "east": 1342
       },
-      "id": 1339,
-      "area": {
-        "id": 26
-      }
+      "id": 1339
     },
     {
       "name": "By an Icy Gate",
@@ -30,20 +24,14 @@
         "southeast": 1339,
         "east": 1341
       },
-      "id": 1340,
-      "area": {
-        "id": 26
-      }
+      "id": 1340
     },
     {
       "name": "Edge of an Icy Cliff",
       "exits": {
         "west": 1340
       },
-      "id": 1341,
-      "area": {
-        "id": 26
-      }
+      "id": 1341
     },
     {
       "name": "On Top of a Frozen River",
@@ -51,10 +39,7 @@
         "west": 1339,
         "north": 1343
       },
-      "id": 1342,
-      "area": {
-        "id": 26
-      }
+      "id": 1342
     },
     {
       "name": "On Top of a Frozen River",
@@ -62,10 +47,7 @@
         "south": 1342,
         "north": 1344
       },
-      "id": 1343,
-      "area": {
-        "id": 26
-      }
+      "id": 1343
     },
     {
       "name": "Under a Snowy Overhang",
@@ -73,10 +55,7 @@
         "northwest": 1345,
         "south": 1343
       },
-      "id": 1344,
-      "area": {
-        "id": 26
-      }
+      "id": 1344
     },
     {
       "name": "On Top of an Icy Stream",
@@ -84,10 +63,7 @@
         "southeast": 1344,
         "west": 1346
       },
-      "id": 1345,
-      "area": {
-        "id": 26
-      }
+      "id": 1345
     },
     {
       "name": "On Top of an Icy Lake",
@@ -97,10 +73,7 @@
         "southeast": 1360,
         "west": 1358
       },
-      "id": 1346,
-      "area": {
-        "id": 26
-      }
+      "id": 1346
     },
     {
       "name": "On Top of an Icy Lake",
@@ -110,10 +83,7 @@
         "southeast": 1346,
         "south": 1358
       },
-      "id": 1347,
-      "area": {
-        "id": 26
-      }
+      "id": 1347
     },
     {
       "name": "Entrance to a Frozen Cavern",
@@ -121,10 +91,7 @@
         "southwest": 1347,
         "southeast": 1349
       },
-      "id": 1348,
-      "area": {
-        "id": 26
-      }
+      "id": 1348
     },
     {
       "name": "Frozen Cavern",
@@ -132,20 +99,14 @@
         "northwest": 1348,
         "east": 1350
       },
-      "id": 1349,
-      "area": {
-        "id": 26
-      }
+      "id": 1349
     },
     {
       "name": "End of a Frozen Cavern",
       "exits": {
         "west": 1349
       },
-      "id": 1350,
-      "area": {
-        "id": 26
-      }
+      "id": 1350
     },
     {
       "name": "On Top of an Icy Lake",
@@ -154,10 +115,7 @@
         "east": 1347,
         "south": 1356
       },
-      "id": 1351,
-      "area": {
-        "id": 26
-      }
+      "id": 1351
     },
     {
       "name": "On Top of an Icy Lake",
@@ -166,10 +124,7 @@
         "northwest": 1359,
         "south": 1353
       },
-      "id": 1352,
-      "area": {
-        "id": 26
-      }
+      "id": 1352
     },
     {
       "name": "On Top of an Icy Lake",
@@ -178,10 +133,7 @@
         "east": 1356,
         "north": 1352
       },
-      "id": 1353,
-      "area": {
-        "id": 26
-      }
+      "id": 1353
     },
     {
       "name": "Ice Cave Entrance",
@@ -189,20 +141,14 @@
         "east": 1355,
         "northeast": 1353
       },
-      "id": 1354,
-      "area": {
-        "id": 26
-      }
+      "id": 1354
     },
     {
       "name": "Inside an Ice Cave",
       "exits": {
         "west": 1354
       },
-      "id": 1355,
-      "area": {
-        "id": 26
-      }
+      "id": 1355
     },
     {
       "name": "On Top of an Icy Lake",
@@ -212,20 +158,14 @@
         "east": 1358,
         "north": 1351
       },
-      "id": 1356,
-      "area": {
-        "id": 26
-      }
+      "id": 1356
     },
     {
       "name": "Isolated Icy Area",
       "exits": {
         "north": 1356
       },
-      "id": 1357,
-      "area": {
-        "id": 26
-      }
+      "id": 1357
     },
     {
       "name": "On Top of an Icy Lake",
@@ -234,40 +174,28 @@
         "east": 1346,
         "north": 1347
       },
-      "id": 1358,
-      "area": {
-        "id": 26
-      }
+      "id": 1358
     },
     {
       "name": "Northern Shore of an Icy Lake",
       "exits": {
         "southeast": 1352
       },
-      "id": 1359,
-      "area": {
-        "id": 26
-      }
+      "id": 1359
     },
     {
       "name": "Snowy Overhang",
       "exits": {
         "northwest": 1346
       },
-      "id": 1360,
-      "area": {
-        "id": 26
-      }
+      "id": 1360
     },
     {
       "name": "down the waterfall.",
       "exits": {
         "down": 1339
       },
-      "id": 1869,
-      "area": {
-        "id": 26
-      }
+      "id": 1869
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/indel-city-park.json
+++ b/maps/indel-city-park.json
@@ -10,10 +10,7 @@
         "east": 1607,
         "north": 1608
       },
-      "id": 1606,
-      "area": {
-        "id": 30
-      }
+      "id": 1606
     },
     {
       "name": "Indel City Park",
@@ -22,10 +19,7 @@
         "east": 1613,
         "north": 1609
       },
-      "id": 1607,
-      "area": {
-        "id": 30
-      }
+      "id": 1607
     },
     {
       "name": "Indel City Park",
@@ -34,10 +28,7 @@
         "east": 1609,
         "north": 1611
       },
-      "id": 1608,
-      "area": {
-        "id": 30
-      }
+      "id": 1608
     },
     {
       "name": "Indel City Park",
@@ -47,10 +38,7 @@
         "east": 1610,
         "north": 1612
       },
-      "id": 1609,
-      "area": {
-        "id": 30
-      }
+      "id": 1609
     },
     {
       "name": "Indel City Park",
@@ -59,10 +47,7 @@
         "south": 1613,
         "north": 1614
       },
-      "id": 1610,
-      "area": {
-        "id": 30
-      }
+      "id": 1610
     },
     {
       "name": "Indel City Park",
@@ -71,10 +56,7 @@
         "east": 1612,
         "north": 1615
       },
-      "id": 1611,
-      "area": {
-        "id": 30
-      }
+      "id": 1611
     },
     {
       "name": "Indel City Park",
@@ -84,10 +66,7 @@
         "east": 1614,
         "north": 1616
       },
-      "id": 1612,
-      "area": {
-        "id": 30
-      }
+      "id": 1612
     },
     {
       "name": "Gazebo in the Park",
@@ -95,10 +74,7 @@
         "west": 1607,
         "north": 1610
       },
-      "id": 1613,
-      "area": {
-        "id": 30
-      }
+      "id": 1613
     },
     {
       "name": "Indel City Park",
@@ -107,10 +83,7 @@
         "south": 1610,
         "north": 1617
       },
-      "id": 1614,
-      "area": {
-        "id": 30
-      }
+      "id": 1614
     },
     {
       "name": "Indel City Park",
@@ -119,10 +92,7 @@
         "east": 1616,
         "north": 1619
       },
-      "id": 1615,
-      "area": {
-        "id": 30
-      }
+      "id": 1615
     },
     {
       "name": "Indel City Park",
@@ -132,10 +102,7 @@
         "east": 1617,
         "north": 1618
       },
-      "id": 1616,
-      "area": {
-        "id": 30
-      }
+      "id": 1616
     },
     {
       "name": "Indel City Park",
@@ -144,10 +111,7 @@
         "south": 1614,
         "north": 1620
       },
-      "id": 1617,
-      "area": {
-        "id": 30
-      }
+      "id": 1617
     },
     {
       "name": "Indel City Park",
@@ -156,10 +120,7 @@
         "east": 1620,
         "south": 1616
       },
-      "id": 1618,
-      "area": {
-        "id": 30
-      }
+      "id": 1618
     },
     {
       "name": "Indel City Park",
@@ -167,10 +128,7 @@
         "east": 1618,
         "south": 1615
       },
-      "id": 1619,
-      "area": {
-        "id": 30
-      }
+      "id": 1619
     },
     {
       "name": "Indel City Park",
@@ -178,10 +136,7 @@
         "west": 1618,
         "south": 1617
       },
-      "id": 1620,
-      "area": {
-        "id": 30
-      }
+      "id": 1620
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/indel.json
+++ b/maps/indel.json
@@ -10,10 +10,7 @@
         "east": 1636,
         "south": 1402
       },
-      "id": 1401,
-      "area": {
-        "id": 28
-      }
+      "id": 1401
     },
     {
       "name": "Castle Road",
@@ -23,10 +20,7 @@
         "east": 1633,
         "north": 1401
       },
-      "id": 1402,
-      "area": {
-        "id": 28
-      }
+      "id": 1402
     },
     {
       "name": "Castle Road",
@@ -36,10 +30,7 @@
         "east": 1630,
         "north": 1402
       },
-      "id": 1403,
-      "area": {
-        "id": 28
-      }
+      "id": 1403
     },
     {
       "name": "Castle Road Courtyard",
@@ -49,10 +40,7 @@
         "east": 1627,
         "north": 1403
       },
-      "id": 1404,
-      "area": {
-        "id": 28
-      }
+      "id": 1404
     },
     {
       "name": "Castle Road",
@@ -61,10 +49,7 @@
         "south": 1406,
         "north": 1404
       },
-      "id": 1405,
-      "area": {
-        "id": 28
-      }
+      "id": 1405
     },
     {
       "name": "Intersection of Castle Road and Merchant's Row",
@@ -74,10 +59,7 @@
         "east": 1508,
         "north": 1405
       },
-      "id": 1406,
-      "area": {
-        "id": 28
-      }
+      "id": 1406
     },
     {
       "name": "West Merchant's Row",
@@ -85,10 +67,7 @@
         "east": 1406,
         "west": 1408
       },
-      "id": 1407,
-      "area": {
-        "id": 28
-      }
+      "id": 1407
     },
     {
       "name": "West Merchant's Row, north of the Silver Griffin",
@@ -97,10 +76,7 @@
         "east": 1407,
         "south": 1589
       },
-      "id": 1408,
-      "area": {
-        "id": 28
-      }
+      "id": 1408
     },
     {
       "name": "West Merchant's Row, south of Big Bob's Sign Shop",
@@ -109,10 +85,7 @@
         "east": 1408,
         "south": 1590
       },
-      "id": 1409,
-      "area": {
-        "id": 28
-      }
+      "id": 1409
     },
     {
       "name": "West Merchant's Row",
@@ -120,10 +93,7 @@
         "east": 1409,
         "west": 1411
       },
-      "id": 1410,
-      "area": {
-        "id": 28
-      }
+      "id": 1410
     },
     {
       "name": "West Merchant's Row",
@@ -131,10 +101,7 @@
         "east": 1410,
         "west": 1412
       },
-      "id": 1411,
-      "area": {
-        "id": 28
-      }
+      "id": 1411
     },
     {
       "name": "West Merchant's Row",
@@ -142,10 +109,7 @@
         "east": 1411,
         "west": 1413
       },
-      "id": 1412,
-      "area": {
-        "id": 28
-      }
+      "id": 1412
     },
     {
       "name": "West Merchant's Row, south of Knights of Solamnia",
@@ -153,10 +117,7 @@
         "east": 1412,
         "west": 1414
       },
-      "id": 1413,
-      "area": {
-        "id": 28
-      }
+      "id": 1413
     },
     {
       "name": "West Merchant's Row",
@@ -164,10 +125,7 @@
         "east": 1413,
         "west": 1415
       },
-      "id": 1414,
-      "area": {
-        "id": 28
-      }
+      "id": 1414
     },
     {
       "name": "West Merchant's Row, south of the Cobbler's Shop",
@@ -175,10 +133,7 @@
         "east": 1414,
         "west": 1416
       },
-      "id": 1415,
-      "area": {
-        "id": 28
-      }
+      "id": 1415
     },
     {
       "name": "West Merchant's Row, south of Laird's Forge",
@@ -186,10 +141,7 @@
         "east": 1415,
         "west": 1417
       },
-      "id": 1416,
-      "area": {
-        "id": 28
-      }
+      "id": 1416
     },
     {
       "name": "West Merchant's Row",
@@ -197,10 +149,7 @@
         "east": 1416,
         "west": 1418
       },
-      "id": 1417,
-      "area": {
-        "id": 28
-      }
+      "id": 1417
     },
     {
       "name": "Pier Street and Merchant's Row",
@@ -209,10 +158,7 @@
         "east": 1417,
         "north": 1448
       },
-      "id": 1418,
-      "area": {
-        "id": 28
-      }
+      "id": 1418
     },
     {
       "name": "Pier Street",
@@ -220,10 +166,7 @@
         "south": 1420,
         "north": 1418
       },
-      "id": 1419,
-      "area": {
-        "id": 28
-      }
+      "id": 1419
     },
     {
       "name": "Pier Street",
@@ -231,10 +174,7 @@
         "south": 1421,
         "north": 1419
       },
-      "id": 1420,
-      "area": {
-        "id": 28
-      }
+      "id": 1420
     },
     {
       "name": "Pier Street",
@@ -242,10 +182,7 @@
         "south": 1422,
         "north": 1420
       },
-      "id": 1421,
-      "area": {
-        "id": 28
-      }
+      "id": 1421
     },
     {
       "name": "Pier Street west of the Waterfront Gate",
@@ -253,10 +190,7 @@
         "south": 1423,
         "north": 1421
       },
-      "id": 1422,
-      "area": {
-        "id": 28
-      }
+      "id": 1422
     },
     {
       "name": "Pier Street",
@@ -264,10 +198,7 @@
         "south": 1424,
         "north": 1422
       },
-      "id": 1423,
-      "area": {
-        "id": 28
-      }
+      "id": 1423
     },
     {
       "name": "Pier Street",
@@ -275,10 +206,7 @@
         "south": 1425,
         "north": 1423
       },
-      "id": 1424,
-      "area": {
-        "id": 28
-      }
+      "id": 1424
     },
     {
       "name": "Pier Street",
@@ -286,10 +214,7 @@
         "south": 1426,
         "north": 1424
       },
-      "id": 1425,
-      "area": {
-        "id": 28
-      }
+      "id": 1425
     },
     {
       "name": "Pier Street",
@@ -297,10 +222,7 @@
         "south": 1427,
         "north": 1425
       },
-      "id": 1426,
-      "area": {
-        "id": 28
-      }
+      "id": 1426
     },
     {
       "name": "Pier Street",
@@ -308,10 +230,7 @@
         "south": 1428,
         "north": 1426
       },
-      "id": 1427,
-      "area": {
-        "id": 28
-      }
+      "id": 1427
     },
     {
       "name": "Pier Street",
@@ -319,10 +238,7 @@
         "south": 1429,
         "north": 1427
       },
-      "id": 1428,
-      "area": {
-        "id": 28
-      }
+      "id": 1428
     },
     {
       "name": "South Pier Street",
@@ -330,10 +246,7 @@
         "south": 1430,
         "north": 1428
       },
-      "id": 1429,
-      "area": {
-        "id": 28
-      }
+      "id": 1429
     },
     {
       "name": "South Pier Street",
@@ -341,10 +254,7 @@
         "south": 1431,
         "north": 1429
       },
-      "id": 1430,
-      "area": {
-        "id": 28
-      }
+      "id": 1430
     },
     {
       "name": "South Pier Street",
@@ -352,10 +262,7 @@
         "south": 1432,
         "north": 1430
       },
-      "id": 1431,
-      "area": {
-        "id": 28
-      }
+      "id": 1431
     },
     {
       "name": "South Pier Street",
@@ -363,10 +270,7 @@
         "south": 1433,
         "north": 1431
       },
-      "id": 1432,
-      "area": {
-        "id": 28
-      }
+      "id": 1432
     },
     {
       "name": "South Pier Street",
@@ -374,10 +278,7 @@
         "south": 1434,
         "north": 1432
       },
-      "id": 1433,
-      "area": {
-        "id": 28
-      }
+      "id": 1433
     },
     {
       "name": "South Pier Street",
@@ -386,10 +287,7 @@
         "east": 1545,
         "north": 1433
       },
-      "id": 1434,
-      "area": {
-        "id": 28
-      }
+      "id": 1434
     },
     {
       "name": "South Pier Street",
@@ -397,10 +295,7 @@
         "south": 1436,
         "north": 1434
       },
-      "id": 1435,
-      "area": {
-        "id": 28
-      }
+      "id": 1435
     },
     {
       "name": "South Pier Street",
@@ -408,10 +303,7 @@
         "south": 1437,
         "north": 1435
       },
-      "id": 1436,
-      "area": {
-        "id": 28
-      }
+      "id": 1436
     },
     {
       "name": "South Pier Street",
@@ -419,10 +311,7 @@
         "south": 1438,
         "north": 1436
       },
-      "id": 1437,
-      "area": {
-        "id": 28
-      }
+      "id": 1437
     },
     {
       "name": "South Pier Street",
@@ -430,20 +319,14 @@
         "south": 1439,
         "north": 1437
       },
-      "id": 1438,
-      "area": {
-        "id": 28
-      }
+      "id": 1438
     },
     {
       "name": "Forester's Gate",
       "exits": {
         "north": 1438
       },
-      "id": 1439,
-      "area": {
-        "id": 28
-      }
+      "id": 1439
     },
     {
       "name": "North Pier Street",
@@ -451,20 +334,14 @@
         "south": 1418,
         "north": 1507
       },
-      "id": 1448,
-      "area": {
-        "id": 28
-      }
+      "id": 1448
     },
     {
       "name": "Cobblestone courtyard",
       "exits": {
         "south": 1448
       },
-      "id": 1507,
-      "area": {
-        "id": 28
-      }
+      "id": 1507
     },
     {
       "name": "East Merchant's Row",
@@ -472,10 +349,7 @@
         "east": 1509,
         "west": 1406
       },
-      "id": 1508,
-      "area": {
-        "id": 28
-      }
+      "id": 1508
     },
     {
       "name": "East Merchant's Row, south of Saul's Formal Wear",
@@ -484,10 +358,7 @@
         "east": 1510,
         "north": 1624
       },
-      "id": 1509,
-      "area": {
-        "id": 28
-      }
+      "id": 1509
     },
     {
       "name": "East Merchant's Row, south of a livestock lot",
@@ -496,10 +367,7 @@
         "east": 1511,
         "north": 1623
       },
-      "id": 1510,
-      "area": {
-        "id": 28
-      }
+      "id": 1510
     },
     {
       "name": "East Merchant's Row, south of Mother Whitman's",
@@ -508,10 +376,7 @@
         "east": 1512,
         "north": 1622
       },
-      "id": 1511,
-      "area": {
-        "id": 28
-      }
+      "id": 1511
     },
     {
       "name": "East Merchant's Row",
@@ -519,10 +384,7 @@
         "east": 1513,
         "west": 1511
       },
-      "id": 1512,
-      "area": {
-        "id": 28
-      }
+      "id": 1512
     },
     {
       "name": "East Merchant's Row",
@@ -530,10 +392,7 @@
         "east": 1514,
         "west": 1512
       },
-      "id": 1513,
-      "area": {
-        "id": 28
-      }
+      "id": 1513
     },
     {
       "name": "East Merchant's Row, south of Sithicus",
@@ -542,10 +401,7 @@
         "east": 1515,
         "north": 1621
       },
-      "id": 1514,
-      "area": {
-        "id": 28
-      }
+      "id": 1514
     },
     {
       "name": "East Merchant's Row",
@@ -553,10 +409,7 @@
         "east": 1516,
         "west": 1514
       },
-      "id": 1515,
-      "area": {
-        "id": 28
-      }
+      "id": 1515
     },
     {
       "name": "Merchant's Row and Pensji Lane",
@@ -565,10 +418,7 @@
         "east": 1517,
         "south": 1520
       },
-      "id": 1516,
-      "area": {
-        "id": 28
-      }
+      "id": 1516
     },
     {
       "name": "East Merchant's Row",
@@ -576,10 +426,7 @@
         "east": 1518,
         "west": 1516
       },
-      "id": 1517,
-      "area": {
-        "id": 28
-      }
+      "id": 1517
     },
     {
       "name": "East Merchant's Row",
@@ -587,20 +434,14 @@
         "east": 1519,
         "west": 1517
       },
-      "id": 1518,
-      "area": {
-        "id": 28
-      }
+      "id": 1518
     },
     {
       "name": "End of Merchant's Row",
       "exits": {
         "west": 1518
       },
-      "id": 1519,
-      "area": {
-        "id": 28
-      }
+      "id": 1519
     },
     {
       "name": "Pensji Lane",
@@ -608,10 +449,7 @@
         "south": 1521,
         "north": 1516
       },
-      "id": 1520,
-      "area": {
-        "id": 28
-      }
+      "id": 1520
     },
     {
       "name": "Pensji Lane",
@@ -619,10 +457,7 @@
         "south": 1522,
         "north": 1520
       },
-      "id": 1521,
-      "area": {
-        "id": 28
-      }
+      "id": 1521
     },
     {
       "name": "Pensji Lane",
@@ -630,10 +465,7 @@
         "south": 1523,
         "north": 1521
       },
-      "id": 1522,
-      "area": {
-        "id": 28
-      }
+      "id": 1522
     },
     {
       "name": "Pensji Lane",
@@ -641,10 +473,7 @@
         "south": 1524,
         "north": 1522
       },
-      "id": 1523,
-      "area": {
-        "id": 28
-      }
+      "id": 1523
     },
     {
       "name": "Pensji Lane",
@@ -652,10 +481,7 @@
         "south": 1525,
         "north": 1523
       },
-      "id": 1524,
-      "area": {
-        "id": 28
-      }
+      "id": 1524
     },
     {
       "name": "Pensji Lane",
@@ -664,10 +490,7 @@
         "east": 1606,
         "north": 1524
       },
-      "id": 1525,
-      "area": {
-        "id": 28
-      }
+      "id": 1525
     },
     {
       "name": "Pensji Lane",
@@ -675,10 +498,7 @@
         "south": 1527,
         "north": 1525
       },
-      "id": 1526,
-      "area": {
-        "id": 28
-      }
+      "id": 1526
     },
     {
       "name": "Pensji Lane",
@@ -686,10 +506,7 @@
         "south": 1528,
         "north": 1526
       },
-      "id": 1527,
-      "area": {
-        "id": 28
-      }
+      "id": 1527
     },
     {
       "name": "Pensji Lane",
@@ -697,10 +514,7 @@
         "south": 1529,
         "north": 1527
       },
-      "id": 1528,
-      "area": {
-        "id": 28
-      }
+      "id": 1528
     },
     {
       "name": "Pensji Lane",
@@ -708,10 +522,7 @@
         "south": 1530,
         "north": 1528
       },
-      "id": 1529,
-      "area": {
-        "id": 28
-      }
+      "id": 1529
     },
     {
       "name": "Pensji Lane",
@@ -719,10 +530,7 @@
         "south": 1531,
         "north": 1529
       },
-      "id": 1530,
-      "area": {
-        "id": 28
-      }
+      "id": 1530
     },
     {
       "name": "Pensji Lane",
@@ -730,10 +538,7 @@
         "south": 1532,
         "north": 1530
       },
-      "id": 1531,
-      "area": {
-        "id": 28
-      }
+      "id": 1531
     },
     {
       "name": "Pensji Lane",
@@ -741,10 +546,7 @@
         "south": 1533,
         "north": 1531
       },
-      "id": 1532,
-      "area": {
-        "id": 28
-      }
+      "id": 1532
     },
     {
       "name": "Pensji Lane",
@@ -753,10 +555,7 @@
         "east": 1597,
         "north": 1532
       },
-      "id": 1533,
-      "area": {
-        "id": 28
-      }
+      "id": 1533
     },
     {
       "name": "Pensji Lane",
@@ -764,10 +563,7 @@
         "south": 1542,
         "north": 1533
       },
-      "id": 1534,
-      "area": {
-        "id": 28
-      }
+      "id": 1534
     },
     {
       "name": "Embassy Row",
@@ -775,10 +571,7 @@
         "east": 1536,
         "west": 1557
       },
-      "id": 1535,
-      "area": {
-        "id": 28
-      }
+      "id": 1535
     },
     {
       "name": "Embassy Row",
@@ -786,10 +579,7 @@
         "east": 1537,
         "west": 1535
       },
-      "id": 1536,
-      "area": {
-        "id": 28
-      }
+      "id": 1536
     },
     {
       "name": "Embassy Row",
@@ -797,10 +587,7 @@
         "east": 1538,
         "west": 1536
       },
-      "id": 1537,
-      "area": {
-        "id": 28
-      }
+      "id": 1537
     },
     {
       "name": "City Barracks Gate",
@@ -808,10 +595,7 @@
         "east": 1539,
         "west": 1537
       },
-      "id": 1538,
-      "area": {
-        "id": 28
-      }
+      "id": 1538
     },
     {
       "name": "West Martial Row",
@@ -819,10 +603,7 @@
         "east": 1540,
         "west": 1538
       },
-      "id": 1539,
-      "area": {
-        "id": 28
-      }
+      "id": 1539
     },
     {
       "name": "West Martial Row",
@@ -830,10 +611,7 @@
         "east": 1541,
         "west": 1539
       },
-      "id": 1540,
-      "area": {
-        "id": 28
-      }
+      "id": 1540
     },
     {
       "name": "West Martial Row",
@@ -841,10 +619,7 @@
         "east": 1542,
         "west": 1540
       },
-      "id": 1541,
-      "area": {
-        "id": 28
-      }
+      "id": 1541
     },
     {
       "name": "Intersection of Martial Row and Pensji Lane",
@@ -853,10 +628,7 @@
         "east": 1591,
         "north": 1534
       },
-      "id": 1542,
-      "area": {
-        "id": 28
-      }
+      "id": 1542
     },
     {
       "name": "West Church Road",
@@ -864,10 +636,7 @@
         "south": 1546,
         "north": 1544
       },
-      "id": 1543,
-      "area": {
-        "id": 28
-      }
+      "id": 1543
     },
     {
       "name": "West Church Road",
@@ -875,10 +644,7 @@
         "south": 1543,
         "north": 1558
       },
-      "id": 1544,
-      "area": {
-        "id": 28
-      }
+      "id": 1544
     },
     {
       "name": "Ambassador Gate",
@@ -886,10 +652,7 @@
         "east": 1546,
         "west": 1434
       },
-      "id": 1545,
-      "area": {
-        "id": 28
-      }
+      "id": 1545
     },
     {
       "name": "Intersection of Church Road and Embassy Row",
@@ -898,10 +661,7 @@
         "east": 1547,
         "north": 1543
       },
-      "id": 1546,
-      "area": {
-        "id": 28
-      }
+      "id": 1546
     },
     {
       "name": "Embassy Row",
@@ -909,10 +669,7 @@
         "east": 1548,
         "west": 1546
       },
-      "id": 1547,
-      "area": {
-        "id": 28
-      }
+      "id": 1547
     },
     {
       "name": "Embassy Row",
@@ -920,10 +677,7 @@
         "east": 1549,
         "west": 1547
       },
-      "id": 1548,
-      "area": {
-        "id": 28
-      }
+      "id": 1548
     },
     {
       "name": "Embassy Row",
@@ -931,10 +685,7 @@
         "east": 1550,
         "west": 1548
       },
-      "id": 1549,
-      "area": {
-        "id": 28
-      }
+      "id": 1549
     },
     {
       "name": "Embassy Row",
@@ -942,10 +693,7 @@
         "east": 1551,
         "west": 1549
       },
-      "id": 1550,
-      "area": {
-        "id": 28
-      }
+      "id": 1550
     },
     {
       "name": "Embassy Row",
@@ -953,10 +701,7 @@
         "east": 1552,
         "west": 1550
       },
-      "id": 1551,
-      "area": {
-        "id": 28
-      }
+      "id": 1551
     },
     {
       "name": "Embassy Row",
@@ -964,10 +709,7 @@
         "east": 1553,
         "west": 1551
       },
-      "id": 1552,
-      "area": {
-        "id": 28
-      }
+      "id": 1552
     },
     {
       "name": "Embassy Row",
@@ -975,10 +717,7 @@
         "east": 1554,
         "west": 1552
       },
-      "id": 1553,
-      "area": {
-        "id": 28
-      }
+      "id": 1553
     },
     {
       "name": "Embassy Row",
@@ -986,10 +725,7 @@
         "east": 1555,
         "west": 1553
       },
-      "id": 1554,
-      "area": {
-        "id": 28
-      }
+      "id": 1554
     },
     {
       "name": "Embassy Row",
@@ -997,10 +733,7 @@
         "east": 1556,
         "west": 1554
       },
-      "id": 1555,
-      "area": {
-        "id": 28
-      }
+      "id": 1555
     },
     {
       "name": "Embassy Row",
@@ -1008,10 +741,7 @@
         "east": 1557,
         "west": 1555
       },
-      "id": 1556,
-      "area": {
-        "id": 28
-      }
+      "id": 1556
     },
     {
       "name": "Embassy Row",
@@ -1019,10 +749,7 @@
         "east": 1535,
         "west": 1556
       },
-      "id": 1557,
-      "area": {
-        "id": 28
-      }
+      "id": 1557
     },
     {
       "name": "West Church Road",
@@ -1030,10 +757,7 @@
         "south": 1544,
         "north": 1559
       },
-      "id": 1558,
-      "area": {
-        "id": 28
-      }
+      "id": 1558
     },
     {
       "name": "West Church Road",
@@ -1041,10 +765,7 @@
         "south": 1558,
         "north": 1560
       },
-      "id": 1559,
-      "area": {
-        "id": 28
-      }
+      "id": 1559
     },
     {
       "name": "West Church Road",
@@ -1052,10 +773,7 @@
         "south": 1559,
         "north": 1561
       },
-      "id": 1560,
-      "area": {
-        "id": 28
-      }
+      "id": 1560
     },
     {
       "name": "West Church Road",
@@ -1063,10 +781,7 @@
         "south": 1560,
         "north": 1562
       },
-      "id": 1561,
-      "area": {
-        "id": 28
-      }
+      "id": 1561
     },
     {
       "name": "West Church Road",
@@ -1074,10 +789,7 @@
         "south": 1561,
         "north": 1563
       },
-      "id": 1562,
-      "area": {
-        "id": 28
-      }
+      "id": 1562
     },
     {
       "name": "West Church Road",
@@ -1085,10 +797,7 @@
         "south": 1562,
         "north": 1564
       },
-      "id": 1563,
-      "area": {
-        "id": 28
-      }
+      "id": 1563
     },
     {
       "name": "West Church Road",
@@ -1096,10 +805,7 @@
         "south": 1563,
         "north": 1565
       },
-      "id": 1564,
-      "area": {
-        "id": 28
-      }
+      "id": 1564
     },
     {
       "name": "West Church Road",
@@ -1107,10 +813,7 @@
         "south": 1564,
         "north": 1566
       },
-      "id": 1565,
-      "area": {
-        "id": 28
-      }
+      "id": 1565
     },
     {
       "name": "West Church Road",
@@ -1118,10 +821,7 @@
         "south": 1565,
         "north": 1567
       },
-      "id": 1566,
-      "area": {
-        "id": 28
-      }
+      "id": 1566
     },
     {
       "name": "West Church Road",
@@ -1129,10 +829,7 @@
         "south": 1566,
         "north": 1568
       },
-      "id": 1567,
-      "area": {
-        "id": 28
-      }
+      "id": 1567
     },
     {
       "name": "West Church Road",
@@ -1140,10 +837,7 @@
         "south": 1567,
         "north": 1569
       },
-      "id": 1568,
-      "area": {
-        "id": 28
-      }
+      "id": 1568
     },
     {
       "name": "Church Road Bend",
@@ -1151,10 +845,7 @@
         "east": 1570,
         "south": 1568
       },
-      "id": 1569,
-      "area": {
-        "id": 28
-      }
+      "id": 1569
     },
     {
       "name": "North Church Road",
@@ -1162,10 +853,7 @@
         "east": 1571,
         "west": 1569
       },
-      "id": 1570,
-      "area": {
-        "id": 28
-      }
+      "id": 1570
     },
     {
       "name": "North Church Road",
@@ -1173,10 +861,7 @@
         "east": 1572,
         "west": 1570
       },
-      "id": 1571,
-      "area": {
-        "id": 28
-      }
+      "id": 1571
     },
     {
       "name": "North Church Road",
@@ -1184,10 +869,7 @@
         "east": 1573,
         "west": 1571
       },
-      "id": 1572,
-      "area": {
-        "id": 28
-      }
+      "id": 1572
     },
     {
       "name": "North Church Road",
@@ -1195,10 +877,7 @@
         "east": 1574,
         "west": 1572
       },
-      "id": 1573,
-      "area": {
-        "id": 28
-      }
+      "id": 1573
     },
     {
       "name": "North Church Road",
@@ -1206,10 +885,7 @@
         "east": 1575,
         "west": 1573
       },
-      "id": 1574,
-      "area": {
-        "id": 28
-      }
+      "id": 1574
     },
     {
       "name": "North Church Road",
@@ -1217,10 +893,7 @@
         "east": 1576,
         "west": 1574
       },
-      "id": 1575,
-      "area": {
-        "id": 28
-      }
+      "id": 1575
     },
     {
       "name": "North Church Road",
@@ -1228,10 +901,7 @@
         "east": 1577,
         "west": 1575
       },
-      "id": 1576,
-      "area": {
-        "id": 28
-      }
+      "id": 1576
     },
     {
       "name": "North Church Road",
@@ -1239,10 +909,7 @@
         "east": 1578,
         "west": 1576
       },
-      "id": 1577,
-      "area": {
-        "id": 28
-      }
+      "id": 1577
     },
     {
       "name": "North Church Road",
@@ -1250,10 +917,7 @@
         "east": 1579,
         "west": 1577
       },
-      "id": 1578,
-      "area": {
-        "id": 28
-      }
+      "id": 1578
     },
     {
       "name": "Intersection of Castle Road and Church Road",
@@ -1263,10 +927,7 @@
         "east": 1580,
         "north": 1584
       },
-      "id": 1579,
-      "area": {
-        "id": 28
-      }
+      "id": 1579
     },
     {
       "name": "North Church Road",
@@ -1274,10 +935,7 @@
         "east": 1581,
         "west": 1579
       },
-      "id": 1580,
-      "area": {
-        "id": 28
-      }
+      "id": 1580
     },
     {
       "name": "North Church Road",
@@ -1285,10 +943,7 @@
         "east": 1582,
         "west": 1580
       },
-      "id": 1581,
-      "area": {
-        "id": 28
-      }
+      "id": 1581
     },
     {
       "name": "North Church Road",
@@ -1296,10 +951,7 @@
         "east": 1583,
         "west": 1581
       },
-      "id": 1582,
-      "area": {
-        "id": 28
-      }
+      "id": 1582
     },
     {
       "name": "North Church Road",
@@ -1307,10 +959,7 @@
         "down": 1653,
         "west": 1582
       },
-      "id": 1583,
-      "area": {
-        "id": 28
-      }
+      "id": 1583
     },
     {
       "name": "Olde City Gate",
@@ -1320,10 +969,7 @@
         "east": 1587,
         "north": 1406
       },
-      "id": 1584,
-      "area": {
-        "id": 28
-      }
+      "id": 1584
     },
     {
       "name": "Castle Drawbridge",
@@ -1331,30 +977,21 @@
         "south": 1586,
         "north": 1579
       },
-      "id": 1585,
-      "area": {
-        "id": 28
-      }
+      "id": 1585
     },
     {
       "name": "Castle Gatehouse",
       "exits": {
         "north": 1585
       },
-      "id": 1586,
-      "area": {
-        "id": 28
-      }
+      "id": 1586
     },
     {
       "name": "Krakenwater",
       "exits": {
         "west": 1584
       },
-      "id": 1587,
-      "area": {
-        "id": 28
-      }
+      "id": 1587
     },
     {
       "name": "Deep Sea Thunder",
@@ -1362,10 +999,7 @@
         "east": 1584,
         "west": 1589
       },
-      "id": 1588,
-      "area": {
-        "id": 28
-      }
+      "id": 1588
     },
     {
       "name": "The Silver Griffin",
@@ -1374,10 +1008,7 @@
         "east": 1588,
         "north": 1408
       },
-      "id": 1589,
-      "area": {
-        "id": 28
-      }
+      "id": 1589
     },
     {
       "name": "Horrors of the Deep",
@@ -1385,10 +1016,7 @@
         "east": 1589,
         "north": 1409
       },
-      "id": 1590,
-      "area": {
-        "id": 28
-      }
+      "id": 1590
     },
     {
       "name": "East Martial Row",
@@ -1396,10 +1024,7 @@
         "east": 1592,
         "west": 1542
       },
-      "id": 1591,
-      "area": {
-        "id": 28
-      }
+      "id": 1591
     },
     {
       "name": "East Martial Row",
@@ -1407,10 +1032,7 @@
         "east": 1593,
         "west": 1591
       },
-      "id": 1592,
-      "area": {
-        "id": 28
-      }
+      "id": 1592
     },
     {
       "name": "East Martial Row",
@@ -1418,10 +1040,7 @@
         "west": 1592,
         "north": 1594
       },
-      "id": 1593,
-      "area": {
-        "id": 28
-      }
+      "id": 1593
     },
     {
       "name": "Army Encampment Gate",
@@ -1429,10 +1048,7 @@
         "west": 1595,
         "south": 1593
       },
-      "id": 1594,
-      "area": {
-        "id": 28
-      }
+      "id": 1594
     },
     {
       "name": "Punishment Grounds",
@@ -1440,10 +1056,7 @@
         "east": 1594,
         "west": 1596
       },
-      "id": 1595,
-      "area": {
-        "id": 28
-      }
+      "id": 1595
     },
     {
       "name": "Parade Grounds",
@@ -1451,10 +1064,7 @@
         "east": 1595,
         "north": 1597
       },
-      "id": 1596,
-      "area": {
-        "id": 28
-      }
+      "id": 1596
     },
     {
       "name": "Cavalry Gate",
@@ -1463,10 +1073,7 @@
         "south": 1596,
         "north": 1598
       },
-      "id": 1597,
-      "area": {
-        "id": 28
-      }
+      "id": 1597
     },
     {
       "name": "Training Grounds",
@@ -1475,20 +1082,14 @@
         "east": 1600,
         "north": 1599
       },
-      "id": 1598,
-      "area": {
-        "id": 28
-      }
+      "id": 1598
     },
     {
       "name": "Combat Training",
       "exits": {
         "south": 1598
       },
-      "id": 1599,
-      "area": {
-        "id": 28
-      }
+      "id": 1599
     },
     {
       "name": "Post Exchange",
@@ -1498,20 +1099,14 @@
         "east": 1601,
         "north": 1603
       },
-      "id": 1600,
-      "area": {
-        "id": 28
-      }
+      "id": 1600
     },
     {
       "name": "Stockade",
       "exits": {
         "west": 1600
       },
-      "id": 1601,
-      "area": {
-        "id": 28
-      }
+      "id": 1601
     },
     {
       "name": "Infirmary",
@@ -1519,10 +1114,7 @@
         "east": 1605,
         "north": 1600
       },
-      "id": 1602,
-      "area": {
-        "id": 28
-      }
+      "id": 1602
     },
     {
       "name": "Soldiers' Tent",
@@ -1530,50 +1122,35 @@
         "east": 1604,
         "south": 1600
       },
-      "id": 1603,
-      "area": {
-        "id": 28
-      }
+      "id": 1603
     },
     {
       "name": "Soldiers' Tent",
       "exits": {
         "west": 1603
       },
-      "id": 1604,
-      "area": {
-        "id": 28
-      }
+      "id": 1604
     },
     {
       "name": "You move the partition to the side and walk into the back of the tent.",
       "exits": {
         "west": 1602
       },
-      "id": 1605,
-      "area": {
-        "id": 28
-      }
+      "id": 1605
     },
     {
       "name": "Sithicus",
       "exits": {
         "south": 1514
       },
-      "id": 1621,
-      "area": {
-        "id": 28
-      }
+      "id": 1621
     },
     {
       "name": "Mother Whitman's Confections Shop",
       "exits": {
         "south": 1511
       },
-      "id": 1622,
-      "area": {
-        "id": 28
-      }
+      "id": 1622
     },
     {
       "name": "Livestock Lot",
@@ -1581,40 +1158,28 @@
         "south": 1510,
         "north": 1643
       },
-      "id": 1623,
-      "area": {
-        "id": 28
-      }
+      "id": 1623
     },
     {
       "name": "Saul's formal wear",
       "exits": {
         "south": 1509
       },
-      "id": 1624,
-      "area": {
-        "id": 28
-      }
+      "id": 1624
     },
     {
       "name": "Quicksilver Delivery Service",
       "exits": {
         "east": 1405
       },
-      "id": 1625,
-      "area": {
-        "id": 28
-      }
+      "id": 1625
     },
     {
       "name": "Jusonah's Pawn and Polearms",
       "exits": {
         "east": 1404
       },
-      "id": 1626,
-      "area": {
-        "id": 28
-      }
+      "id": 1626
     },
     {
       "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
@@ -1622,10 +1187,7 @@
         "west": 1404,
         "south": 1637
       },
-      "id": 1627,
-      "area": {
-        "id": 28
-      }
+      "id": 1627
     },
     {
       "name": "Zomar's Dry Goods",
@@ -1633,30 +1195,21 @@
         "east": 1403,
         "down": 1629
       },
-      "id": 1628,
-      "area": {
-        "id": 28
-      }
+      "id": 1628
     },
     {
       "name": "The Art of Darkness",
       "exits": {
         "up": 1628
       },
-      "id": 1629,
-      "area": {
-        "id": 28
-      }
+      "id": 1629
     },
     {
       "name": "Burrow's Map Shop",
       "exits": {
         "west": 1403
       },
-      "id": 1630,
-      "area": {
-        "id": 28
-      }
+      "id": 1630
     },
     {
       "name": "Muddy Lane",
@@ -1664,20 +1217,14 @@
         "east": 1402,
         "west": 1632
       },
-      "id": 1631,
-      "area": {
-        "id": 28
-      }
+      "id": 1631
     },
     {
       "name": "Muddy Lane",
       "exits": {
         "east": 1631
       },
-      "id": 1632,
-      "area": {
-        "id": 28
-      }
+      "id": 1632
     },
     {
       "name": "Muddy Lane",
@@ -1685,60 +1232,42 @@
         "east": 1634,
         "west": 1402
       },
-      "id": 1633,
-      "area": {
-        "id": 28
-      }
+      "id": 1633
     },
     {
       "name": "Farm Road",
       "exits": {
         "west": 1633
       },
-      "id": 1634,
-      "area": {
-        "id": 28
-      }
+      "id": 1634
     },
     {
       "name": "West Ready Room",
       "exits": {
         "east": 1401
       },
-      "id": 1635,
-      "area": {
-        "id": 28
-      }
+      "id": 1635
     },
     {
       "name": "East Ready Room",
       "exits": {
         "west": 1401
       },
-      "id": 1636,
-      "area": {
-        "id": 28
-      }
+      "id": 1636
     },
     {
       "name": "Player Appreciation Week Discussions",
       "exits": {
         "north": 1627
       },
-      "id": 1637,
-      "area": {
-        "id": 28
-      }
+      "id": 1637
     },
     {
       "name": "Mudball Arena Entrance",
       "exits": {
         "up": 1583
       },
-      "id": 1653,
-      "area": {
-        "id": 28
-      }
+      "id": 1653
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/nature-preserve.json
+++ b/maps/nature-preserve.json
@@ -8,30 +8,21 @@
       "exits": {
         "west": 433
       },
-      "id": 432,
-      "area": {
-        "id": 5
-      }
+      "id": 432
     },
     {
       "name": "Waterfall",
       "exits": {
         "east": 432
       },
-      "id": 433,
-      "area": {
-        "id": 5
-      }
+      "id": 433
     },
     {
       "name": "",
       "exits": {
         "north": 435
       },
-      "id": 434,
-      "area": {
-        "id": 5
-      }
+      "id": 434
     },
     {
       "name": "Canopy Trail",
@@ -39,10 +30,7 @@
         "west": 436,
         "south": 434
       },
-      "id": 435,
-      "area": {
-        "id": 5
-      }
+      "id": 435
     },
     {
       "name": "Canopy Trail",
@@ -50,10 +38,7 @@
         "east": 435,
         "west": 437
       },
-      "id": 436,
-      "area": {
-        "id": 5
-      }
+      "id": 436
     },
     {
       "name": "Canopy Trail",
@@ -61,10 +46,7 @@
         "east": 436,
         "west": 438
       },
-      "id": 437,
-      "area": {
-        "id": 5
-      }
+      "id": 437
     },
     {
       "name": "Canopy Trail",
@@ -73,10 +55,7 @@
         "east": 437,
         "south": 440
       },
-      "id": 438,
-      "area": {
-        "id": 5
-      }
+      "id": 438
     },
     {
       "name": "Canopy Trail",
@@ -84,10 +63,7 @@
         "east": 438,
         "west": 445
       },
-      "id": 439,
-      "area": {
-        "id": 5
-      }
+      "id": 439
     },
     {
       "name": "Nature Preserve",
@@ -95,10 +71,7 @@
         "south": 441,
         "north": 438
       },
-      "id": 440,
-      "area": {
-        "id": 5
-      }
+      "id": 440
     },
     {
       "name": "Tropical Forest",
@@ -106,10 +79,7 @@
         "south": 442,
         "north": 440
       },
-      "id": 441,
-      "area": {
-        "id": 5
-      }
+      "id": 441
     },
     {
       "name": "Nature Preserve",
@@ -118,30 +88,21 @@
         "east": 444,
         "north": 441
       },
-      "id": 442,
-      "area": {
-        "id": 5
-      }
+      "id": 442
     },
     {
       "name": "Bird Sanctuary",
       "exits": {
         "east": 442
       },
-      "id": 443,
-      "area": {
-        "id": 5
-      }
+      "id": 443
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "west": 442
       },
-      "id": 444,
-      "area": {
-        "id": 5
-      }
+      "id": 444
     },
     {
       "name": "Canopy Trail",
@@ -150,10 +111,7 @@
         "east": 439,
         "north": 446
       },
-      "id": 445,
-      "area": {
-        "id": 5
-      }
+      "id": 445
     },
     {
       "name": "Entrance to Queen's Meadow",
@@ -161,10 +119,7 @@
         "south": 445,
         "north": 447
       },
-      "id": 446,
-      "area": {
-        "id": 5
-      }
+      "id": 446
     },
     {
       "name": "Queen's Meadow",
@@ -172,10 +127,7 @@
         "south": 446,
         "north": 448
       },
-      "id": 447,
-      "area": {
-        "id": 5
-      }
+      "id": 447
     },
     {
       "name": "Queen's Meadow",
@@ -183,10 +135,7 @@
         "south": 447,
         "north": 449
       },
-      "id": 448,
-      "area": {
-        "id": 5
-      }
+      "id": 448
     },
     {
       "name": "Queen's Meadow",
@@ -195,10 +144,7 @@
         "south": 448,
         "north": 494
       },
-      "id": 449,
-      "area": {
-        "id": 5
-      }
+      "id": 449
     },
     {
       "name": "Nature Preserve",
@@ -206,10 +152,7 @@
         "east": 449,
         "west": 451
       },
-      "id": 450,
-      "area": {
-        "id": 5
-      }
+      "id": 450
     },
     {
       "name": "Nature Preserve",
@@ -217,10 +160,7 @@
         "east": 450,
         "west": 452
       },
-      "id": 451,
-      "area": {
-        "id": 5
-      }
+      "id": 451
     },
     {
       "name": "Nature Preserve",
@@ -228,10 +168,7 @@
         "east": 451,
         "west": 453
       },
-      "id": 452,
-      "area": {
-        "id": 5
-      }
+      "id": 452
     },
     {
       "name": "Nature Preserve",
@@ -240,20 +177,14 @@
         "east": 452,
         "north": 454
       },
-      "id": 453,
-      "area": {
-        "id": 5
-      }
+      "id": 453
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "south": 453
       },
-      "id": 454,
-      "area": {
-        "id": 5
-      }
+      "id": 454
     },
     {
       "name": "Nature Preserve",
@@ -261,10 +192,7 @@
         "south": 456,
         "north": 453
       },
-      "id": 455,
-      "area": {
-        "id": 5
-      }
+      "id": 455
     },
     {
       "name": "Nature Preserve",
@@ -272,10 +200,7 @@
         "west": 457,
         "north": 455
       },
-      "id": 456,
-      "area": {
-        "id": 5
-      }
+      "id": 456
     },
     {
       "name": "Nature Preserve",
@@ -283,10 +208,7 @@
         "east": 456,
         "west": 458
       },
-      "id": 457,
-      "area": {
-        "id": 5
-      }
+      "id": 457
     },
     {
       "name": "Nature Preserve",
@@ -294,10 +216,7 @@
         "east": 457,
         "north": 459
       },
-      "id": 458,
-      "area": {
-        "id": 5
-      }
+      "id": 458
     },
     {
       "name": "Nature Preserve",
@@ -305,10 +224,7 @@
         "south": 458,
         "north": 460
       },
-      "id": 459,
-      "area": {
-        "id": 5
-      }
+      "id": 459
     },
     {
       "name": "Nature Preserve",
@@ -317,10 +233,7 @@
         "south": 459,
         "north": 461
       },
-      "id": 460,
-      "area": {
-        "id": 5
-      }
+      "id": 460
     },
     {
       "name": "Nature Preserve",
@@ -329,10 +242,7 @@
         "east": 462,
         "south": 460
       },
-      "id": 461,
-      "area": {
-        "id": 5
-      }
+      "id": 461
     },
     {
       "name": "Nature Preserve",
@@ -340,20 +250,14 @@
         "west": 461,
         "north": 464
       },
-      "id": 462,
-      "area": {
-        "id": 5
-      }
+      "id": 462
     },
     {
       "name": "Sink Hole",
       "exits": {
         "east": 461
       },
-      "id": 463,
-      "area": {
-        "id": 5
-      }
+      "id": 463
     },
     {
       "name": "Nature Preserve",
@@ -362,10 +266,7 @@
         "east": 465,
         "south": 462
       },
-      "id": 464,
-      "area": {
-        "id": 5
-      }
+      "id": 464
     },
     {
       "name": "Nature Preserve",
@@ -373,10 +274,7 @@
         "west": 464,
         "north": 466
       },
-      "id": 465,
-      "area": {
-        "id": 5
-      }
+      "id": 465
     },
     {
       "name": "Nature Preserve",
@@ -384,10 +282,7 @@
         "east": 467,
         "south": 465
       },
-      "id": 466,
-      "area": {
-        "id": 5
-      }
+      "id": 466
     },
     {
       "name": "Nature Preserve",
@@ -395,10 +290,7 @@
         "east": 468,
         "west": 466
       },
-      "id": 467,
-      "area": {
-        "id": 5
-      }
+      "id": 467
     },
     {
       "name": "Nature Preserve",
@@ -406,10 +298,7 @@
         "east": 469,
         "west": 467
       },
-      "id": 468,
-      "area": {
-        "id": 5
-      }
+      "id": 468
     },
     {
       "name": "Nature Preserve",
@@ -417,10 +306,7 @@
         "east": 470,
         "west": 468
       },
-      "id": 469,
-      "area": {
-        "id": 5
-      }
+      "id": 469
     },
     {
       "name": "Queen's Meadow",
@@ -429,10 +315,7 @@
         "south": 493,
         "north": 471
       },
-      "id": 470,
-      "area": {
-        "id": 5
-      }
+      "id": 470
     },
     {
       "name": "Tropical Landscape",
@@ -440,10 +323,7 @@
         "south": 470,
         "north": 472
       },
-      "id": 471,
-      "area": {
-        "id": 5
-      }
+      "id": 471
     },
     {
       "name": "Nature Preserve",
@@ -451,10 +331,7 @@
         "south": 471,
         "north": 473
       },
-      "id": 472,
-      "area": {
-        "id": 5
-      }
+      "id": 472
     },
     {
       "name": "Nature Preserve",
@@ -463,10 +340,7 @@
         "east": 474,
         "south": 472
       },
-      "id": 473,
-      "area": {
-        "id": 5
-      }
+      "id": 473
     },
     {
       "name": "Nature Preserve",
@@ -474,20 +348,14 @@
         "east": 475,
         "west": 473
       },
-      "id": 474,
-      "area": {
-        "id": 5
-      }
+      "id": 474
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "west": 474
       },
-      "id": 475,
-      "area": {
-        "id": 5
-      }
+      "id": 475
     },
     {
       "name": "Nature Preserve",
@@ -495,10 +363,7 @@
         "northwest": 477,
         "east": 473
       },
-      "id": 476,
-      "area": {
-        "id": 5
-      }
+      "id": 476
     },
     {
       "name": "Nature Preserve",
@@ -507,10 +372,7 @@
         "southeast": 476,
         "north": 490
       },
-      "id": 477,
-      "area": {
-        "id": 5
-      }
+      "id": 477
     },
     {
       "name": "Nature Preserve",
@@ -518,10 +380,7 @@
         "west": 479,
         "northeast": 477
       },
-      "id": 478,
-      "area": {
-        "id": 5
-      }
+      "id": 478
     },
     {
       "name": "Nature Preserve",
@@ -530,10 +389,7 @@
         "east": 478,
         "south": 487
       },
-      "id": 479,
-      "area": {
-        "id": 5
-      }
+      "id": 479
     },
     {
       "name": "Nature Preserve",
@@ -541,10 +397,7 @@
         "east": 479,
         "west": 481
       },
-      "id": 480,
-      "area": {
-        "id": 5
-      }
+      "id": 480
     },
     {
       "name": "Nature Preserve",
@@ -552,10 +405,7 @@
         "east": 480,
         "south": 482
       },
-      "id": 481,
-      "area": {
-        "id": 5
-      }
+      "id": 481
     },
     {
       "name": "Nature Preserve",
@@ -564,20 +414,14 @@
         "south": 484,
         "north": 481
       },
-      "id": 482,
-      "area": {
-        "id": 5
-      }
+      "id": 482
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "east": 482
       },
-      "id": 483,
-      "area": {
-        "id": 5
-      }
+      "id": 483
     },
     {
       "name": "Nature Preserve",
@@ -585,10 +429,7 @@
         "south": 485,
         "north": 482
       },
-      "id": 484,
-      "area": {
-        "id": 5
-      }
+      "id": 484
     },
     {
       "name": "Nature Preserve",
@@ -596,10 +437,7 @@
         "south": 486,
         "north": 484
       },
-      "id": 485,
-      "area": {
-        "id": 5
-      }
+      "id": 485
     },
     {
       "name": "Nature Preserve",
@@ -607,10 +445,7 @@
         "east": 464,
         "north": 485
       },
-      "id": 486,
-      "area": {
-        "id": 5
-      }
+      "id": 486
     },
     {
       "name": "Nature Preserve",
@@ -618,10 +453,7 @@
         "south": 488,
         "north": 479
       },
-      "id": 487,
-      "area": {
-        "id": 5
-      }
+      "id": 487
     },
     {
       "name": "Nature Preserve",
@@ -629,20 +461,14 @@
         "east": 489,
         "north": 487
       },
-      "id": 488,
-      "area": {
-        "id": 5
-      }
+      "id": 488
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "west": 488
       },
-      "id": 489,
-      "area": {
-        "id": 5
-      }
+      "id": 489
     },
     {
       "name": "Nature Preserve",
@@ -650,10 +476,7 @@
         "south": 477,
         "north": 491
       },
-      "id": 490,
-      "area": {
-        "id": 5
-      }
+      "id": 490
     },
     {
       "name": "Nature Preserve",
@@ -661,20 +484,14 @@
         "east": 492,
         "south": 490
       },
-      "id": 491,
-      "area": {
-        "id": 5
-      }
+      "id": 491
     },
     {
       "name": "A Hollowed Tree",
       "exits": {
         "west": 491
       },
-      "id": 492,
-      "area": {
-        "id": 5
-      }
+      "id": 492
     },
     {
       "name": "Queen's Meadow",
@@ -682,10 +499,7 @@
         "south": 494,
         "north": 470
       },
-      "id": 493,
-      "area": {
-        "id": 5
-      }
+      "id": 493
     },
     {
       "name": "Queen's Meadow",
@@ -693,20 +507,14 @@
         "south": 449,
         "north": 493
       },
-      "id": 494,
-      "area": {
-        "id": 5
-      }
+      "id": 494
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "east": 460
       },
-      "id": 495,
-      "area": {
-        "id": 5
-      }
+      "id": 495
     },
     {
       "name": "Canopy Trail",
@@ -714,10 +522,7 @@
         "east": 445,
         "west": 497
       },
-      "id": 496,
-      "area": {
-        "id": 5
-      }
+      "id": 496
     },
     {
       "name": "Canopy Trail",
@@ -726,10 +531,7 @@
         "east": 496,
         "south": 501
       },
-      "id": 497,
-      "area": {
-        "id": 5
-      }
+      "id": 497
     },
     {
       "name": "Canopy Trail",
@@ -737,10 +539,7 @@
         "east": 497,
         "north": 499
       },
-      "id": 498,
-      "area": {
-        "id": 5
-      }
+      "id": 498
     },
     {
       "name": "Nature Preserve",
@@ -748,20 +547,14 @@
         "east": 500,
         "south": 498
       },
-      "id": 499,
-      "area": {
-        "id": 5
-      }
+      "id": 499
     },
     {
       "name": "Dragon's Den",
       "exits": {
         "west": 499
       },
-      "id": 500,
-      "area": {
-        "id": 5
-      }
+      "id": 500
     },
     {
       "name": "Nature Preserve",
@@ -769,10 +562,7 @@
         "south": 502,
         "north": 497
       },
-      "id": 501,
-      "area": {
-        "id": 5
-      }
+      "id": 501
     },
     {
       "name": "Nature Preserve",
@@ -781,30 +571,21 @@
         "east": 503,
         "north": 501
       },
-      "id": 502,
-      "area": {
-        "id": 5
-      }
+      "id": 502
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "west": 502
       },
-      "id": 503,
-      "area": {
-        "id": 5
-      }
+      "id": 503
     },
     {
       "name": "Nature Preserve",
       "exits": {
         "east": 502
       },
-      "id": 504,
-      "area": {
-        "id": 5
-      }
+      "id": 504
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/promenade-des-trafficants.json
+++ b/maps/promenade-des-trafficants.json
@@ -9,10 +9,7 @@
         "south": 1147,
         "north": 1170
       },
-      "id": 1169,
-      "area": {
-        "id": 22
-      }
+      "id": 1169
     },
     {
       "name": "The Promenade's gate",
@@ -20,10 +17,7 @@
         "south": 1169,
         "north": 1171
       },
-      "id": 1170,
-      "area": {
-        "id": 22
-      }
+      "id": 1170
     },
     {
       "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
@@ -32,10 +26,7 @@
         "east": 1184,
         "north": 1172
       },
-      "id": 1171,
-      "area": {
-        "id": 22
-      }
+      "id": 1171
     },
     {
       "name": "Moonlit Promenade",
@@ -44,20 +35,14 @@
         "south": 1171,
         "north": 1174
       },
-      "id": 1172,
-      "area": {
-        "id": 22
-      }
+      "id": 1172
     },
     {
       "name": "Mekalar's Outdoor Gear",
       "exits": {
         "east": 1172
       },
-      "id": 1173,
-      "area": {
-        "id": 22
-      }
+      "id": 1173
     },
     {
       "name": "Moonlit Promenade",
@@ -66,10 +51,7 @@
         "east": 1183,
         "north": 1175
       },
-      "id": 1174,
-      "area": {
-        "id": 22
-      }
+      "id": 1174
     },
     {
       "name": "Middle of the moonlit Promenade",
@@ -77,10 +59,7 @@
         "south": 1174,
         "north": 1176
       },
-      "id": 1175,
-      "area": {
-        "id": 22
-      }
+      "id": 1175
     },
     {
       "name": "Moonlit Promenade",
@@ -88,10 +67,7 @@
         "south": 1175,
         "north": 1177
       },
-      "id": 1176,
-      "area": {
-        "id": 22
-      }
+      "id": 1176
     },
     {
       "name": "Moonlit Promenade",
@@ -100,10 +76,7 @@
         "south": 1176,
         "north": 1178
       },
-      "id": 1177,
-      "area": {
-        "id": 22
-      }
+      "id": 1177
     },
     {
       "name": "Moonlit Promenade",
@@ -111,10 +84,7 @@
         "south": 1177,
         "north": 1179
       },
-      "id": 1178,
-      "area": {
-        "id": 22
-      }
+      "id": 1178
     },
     {
       "name": "Northern end of the moonlit Promenade",
@@ -123,60 +93,42 @@
         "south": 1178,
         "north": 1180
       },
-      "id": 1179,
-      "area": {
-        "id": 22
-      }
+      "id": 1179
     },
     {
       "name": "Enchanter's Store",
       "exits": {
         "south": 1179
       },
-      "id": 1180,
-      "area": {
-        "id": 22
-      }
+      "id": 1180
     },
     {
       "name": "Gere's Petshop",
       "exits": {
         "east": 1179
       },
-      "id": 1181,
-      "area": {
-        "id": 22
-      }
+      "id": 1181
     },
     {
       "name": "Carpenter's shop",
       "exits": {
         "east": 1177
       },
-      "id": 1182,
-      "area": {
-        "id": 22
-      }
+      "id": 1182
     },
     {
       "name": "Roget's Furrier",
       "exits": {
         "west": 1174
       },
-      "id": 1183,
-      "area": {
-        "id": 22
-      }
+      "id": 1183
     },
     {
       "name": "Volshev's Advertising Agency",
       "exits": {
         "west": 1171
       },
-      "id": 1184,
-      "area": {
-        "id": 22
-      }
+      "id": 1184
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/pylus.json
+++ b/maps/pylus.json
@@ -8,10 +8,7 @@
       "exits": {
         "south": 1206
       },
-      "id": 1205,
-      "area": {
-        "id": 24
-      }
+      "id": 1205
     },
     {
       "name": "Pylus road",
@@ -19,10 +16,7 @@
         "south": 1207,
         "north": 1205
       },
-      "id": 1206,
-      "area": {
-        "id": 24
-      }
+      "id": 1206
     },
     {
       "name": "Pylus road",
@@ -31,10 +25,7 @@
         "east": 1212,
         "north": 1206
       },
-      "id": 1207,
-      "area": {
-        "id": 24
-      }
+      "id": 1207
     },
     {
       "name": "Pylus road",
@@ -43,10 +34,7 @@
         "south": 1213,
         "north": 1207
       },
-      "id": 1208,
-      "area": {
-        "id": 24
-      }
+      "id": 1208
     },
     {
       "name": "Freemason's",
@@ -55,40 +43,28 @@
         "east": 1208,
         "north": 1211
       },
-      "id": 1209,
-      "area": {
-        "id": 24
-      }
+      "id": 1209
     },
     {
       "name": "Apprentice's",
       "exits": {
         "north": 1209
       },
-      "id": 1210,
-      "area": {
-        "id": 24
-      }
+      "id": 1210
     },
     {
       "name": "Master stonemason's",
       "exits": {
         "south": 1209
       },
-      "id": 1211,
-      "area": {
-        "id": 24
-      }
+      "id": 1211
     },
     {
       "name": "Mausoleum entrance",
       "exits": {
         "west": 1207
       },
-      "id": 1212,
-      "area": {
-        "id": 24
-      }
+      "id": 1212
     },
     {
       "name": "Pylus road",
@@ -96,10 +72,7 @@
         "south": 1214,
         "north": 1208
       },
-      "id": 1213,
-      "area": {
-        "id": 24
-      }
+      "id": 1213
     },
     {
       "name": "Pylus road",
@@ -109,10 +82,7 @@
         "east": 1219,
         "north": 1213
       },
-      "id": 1214,
-      "area": {
-        "id": 24
-      }
+      "id": 1214
     },
     {
       "name": "Pylus road",
@@ -122,40 +92,28 @@
         "southeast": 1217,
         "north": 1214
       },
-      "id": 1215,
-      "area": {
-        "id": 24
-      }
+      "id": 1215
     },
     {
       "name": "Porch",
       "exits": {
         "northeast": 1215
       },
-      "id": 1216,
-      "area": {
-        "id": 24
-      }
+      "id": 1216
     },
     {
       "name": "Sanity's Requiem",
       "exits": {
         "northwest": 1215
       },
-      "id": 1217,
-      "area": {
-        "id": 24
-      }
+      "id": 1217
     },
     {
       "name": "Hall of Bacchus",
       "exits": {
         "east": 1214
       },
-      "id": 1218,
-      "area": {
-        "id": 24
-      }
+      "id": 1218
     },
     {
       "name": "Triage",
@@ -163,10 +121,7 @@
         "west": 1214,
         "north": 1220
       },
-      "id": 1219,
-      "area": {
-        "id": 24
-      }
+      "id": 1219
     },
     {
       "name": "Waiting room",
@@ -174,20 +129,14 @@
         "east": 1221,
         "south": 1219
       },
-      "id": 1220,
-      "area": {
-        "id": 24
-      }
+      "id": 1220
     },
     {
       "name": "Operating room",
       "exits": {
         "west": 1220
       },
-      "id": 1221,
-      "area": {
-        "id": 24
-      }
+      "id": 1221
     },
     {
       "name": "Pylus road checkpoint",
@@ -195,10 +144,7 @@
         "east": 1289,
         "west": 1215
       },
-      "id": 1222,
-      "area": {
-        "id": 24
-      }
+      "id": 1222
     },
     {
       "name": "Iola square",
@@ -207,10 +153,7 @@
         "south": 1227,
         "north": 1225
       },
-      "id": 1224,
-      "area": {
-        "id": 24
-      }
+      "id": 1224
     },
     {
       "name": "Iola way",
@@ -219,10 +162,7 @@
         "south": 1224,
         "north": 1226
       },
-      "id": 1225,
-      "area": {
-        "id": 24
-      }
+      "id": 1225
     },
     {
       "name": "Iola way",
@@ -230,10 +170,7 @@
         "south": 1225,
         "north": 1248
       },
-      "id": 1226,
-      "area": {
-        "id": 24
-      }
+      "id": 1226
     },
     {
       "name": "Iola way",
@@ -243,10 +180,7 @@
         "east": 1246,
         "north": 1224
       },
-      "id": 1227,
-      "area": {
-        "id": 24
-      }
+      "id": 1227
     },
     {
       "name": "Iola way",
@@ -256,10 +190,7 @@
         "east": 1243,
         "north": 1227
       },
-      "id": 1228,
-      "area": {
-        "id": 24
-      }
+      "id": 1228
     },
     {
       "name": "Iola bridge",
@@ -268,10 +199,7 @@
         "east": 1231,
         "north": 1228
       },
-      "id": 1229,
-      "area": {
-        "id": 24
-      }
+      "id": 1229
     },
     {
       "name": "Large field",
@@ -279,10 +207,7 @@
         "west": 1239,
         "northeast": 1229
       },
-      "id": 1230,
-      "area": {
-        "id": 24
-      }
+      "id": 1230
     },
     {
       "name": "Polema street",
@@ -291,20 +216,14 @@
         "east": 1233,
         "south": 1232
       },
-      "id": 1231,
-      "area": {
-        "id": 24
-      }
+      "id": 1231
     },
     {
       "name": "Gay house",
       "exits": {
         "north": 1231
       },
-      "id": 1232,
-      "area": {
-        "id": 24
-      }
+      "id": 1232
     },
     {
       "name": "Polema street",
@@ -314,20 +233,14 @@
         "east": 1235,
         "north": 1238
       },
-      "id": 1233,
-      "area": {
-        "id": 24
-      }
+      "id": 1233
     },
     {
       "name": "Short house",
       "exits": {
         "north": 1233
       },
-      "id": 1234,
-      "area": {
-        "id": 24
-      }
+      "id": 1234
     },
     {
       "name": "Polema street",
@@ -336,40 +249,28 @@
         "east": 1237,
         "north": 1236
       },
-      "id": 1235,
-      "area": {
-        "id": 24
-      }
+      "id": 1235
     },
     {
       "name": "Bright house",
       "exits": {
         "south": 1235
       },
-      "id": 1236,
-      "area": {
-        "id": 24
-      }
+      "id": 1236
     },
     {
       "name": "Foyer",
       "exits": {
         "west": 1235
       },
-      "id": 1237,
-      "area": {
-        "id": 24
-      }
+      "id": 1237
     },
     {
       "name": "Tall house",
       "exits": {
         "south": 1233
       },
-      "id": 1238,
-      "area": {
-        "id": 24
-      }
+      "id": 1238
     },
     {
       "name": "Gymnasium foyer",
@@ -378,20 +279,14 @@
         "east": 1230,
         "south": 1241
       },
-      "id": 1239,
-      "area": {
-        "id": 24
-      }
+      "id": 1239
     },
     {
       "name": "Changing room",
       "exits": {
         "east": 1239
       },
-      "id": 1240,
-      "area": {
-        "id": 24
-      }
+      "id": 1240
     },
     {
       "name": "Gymnasium hallway",
@@ -399,30 +294,21 @@
         "south": 1242,
         "north": 1239
       },
-      "id": 1241,
-      "area": {
-        "id": 24
-      }
+      "id": 1241
     },
     {
       "name": "Natatorium",
       "exits": {
         "north": 1241
       },
-      "id": 1242,
-      "area": {
-        "id": 24
-      }
+      "id": 1242
     },
     {
       "name": "Vegetable seller's",
       "exits": {
         "west": 1228
       },
-      "id": 1243,
-      "area": {
-        "id": 24
-      }
+      "id": 1243
     },
     {
       "name": "Herbarium",
@@ -430,40 +316,28 @@
         "east": 1228,
         "south": 1245
       },
-      "id": 1244,
-      "area": {
-        "id": 24
-      }
+      "id": 1244
     },
     {
       "name": "Herb garden",
       "exits": {
         "north": 1244
       },
-      "id": 1245,
-      "area": {
-        "id": 24
-      }
+      "id": 1245
     },
     {
       "name": "Butcher shop",
       "exits": {
         "west": 1227
       },
-      "id": 1246,
-      "area": {
-        "id": 24
-      }
+      "id": 1246
     },
     {
       "name": "Guild/Shop Space for rent",
       "exits": {
         "east": 1227
       },
-      "id": 1247,
-      "area": {
-        "id": 24
-      }
+      "id": 1247
     },
     {
       "name": "Iola way",
@@ -472,10 +346,7 @@
         "east": 1252,
         "south": 1226
       },
-      "id": 1248,
-      "area": {
-        "id": 24
-      }
+      "id": 1248
     },
     {
       "name": "Garden entry",
@@ -483,10 +354,7 @@
         "east": 1248,
         "north": 1250
       },
-      "id": 1249,
-      "area": {
-        "id": 24
-      }
+      "id": 1249
     },
     {
       "name": "Garden clearing",
@@ -494,10 +362,7 @@
         "west": 1251,
         "south": 1249
       },
-      "id": 1250,
-      "area": {
-        "id": 24
-      }
+      "id": 1250
     },
     {
       "name": "Entry to akademos",
@@ -505,10 +370,7 @@
         "east": 1250,
         "west": 1374
       },
-      "id": 1251,
-      "area": {
-        "id": 24
-      }
+      "id": 1251
     },
     {
       "name": "Ithsma street",
@@ -516,10 +378,7 @@
         "east": 1253,
         "west": 1248
       },
-      "id": 1252,
-      "area": {
-        "id": 24
-      }
+      "id": 1252
     },
     {
       "name": "Ithsma street",
@@ -528,10 +387,7 @@
         "east": 1255,
         "south": 1254
       },
-      "id": 1253,
-      "area": {
-        "id": 24
-      }
+      "id": 1253
     },
     {
       "name": "Short path",
@@ -539,10 +395,7 @@
         "south": 1375,
         "north": 1253
       },
-      "id": 1254,
-      "area": {
-        "id": 24
-      }
+      "id": 1254
     },
     {
       "name": "Ithsma street",
@@ -551,10 +404,7 @@
         "east": 1389,
         "north": 1256
       },
-      "id": 1255,
-      "area": {
-        "id": 24
-      }
+      "id": 1255
     },
     {
       "name": "Before the Palace",
@@ -562,10 +412,7 @@
         "south": 1255,
         "north": 1257
       },
-      "id": 1256,
-      "area": {
-        "id": 24
-      }
+      "id": 1256
     },
     {
       "name": "Threshold to the Grand Rotunda",
@@ -573,10 +420,7 @@
         "south": 1256,
         "north": 1258
       },
-      "id": 1257,
-      "area": {
-        "id": 24
-      }
+      "id": 1257
     },
     {
       "name": "Grand Rotunda",
@@ -585,10 +429,7 @@
         "east": 1362,
         "south": 1257
       },
-      "id": 1258,
-      "area": {
-        "id": 24
-      }
+      "id": 1258
     },
     {
       "name": "Administrative hallway",
@@ -597,20 +438,14 @@
         "east": 1258,
         "north": 1260
       },
-      "id": 1259,
-      "area": {
-        "id": 24
-      }
+      "id": 1259
     },
     {
       "name": "Office of the Magistrate",
       "exits": {
         "south": 1259
       },
-      "id": 1260,
-      "area": {
-        "id": 24
-      }
+      "id": 1260
     },
     {
       "name": "Administrative hallway",
@@ -619,20 +454,14 @@
         "east": 1259,
         "south": 1391
       },
-      "id": 1261,
-      "area": {
-        "id": 24
-      }
+      "id": 1261
     },
     {
       "name": "Royal Throne Room",
       "exits": {
         "east": 1261
       },
-      "id": 1262,
-      "area": {
-        "id": 24
-      }
+      "id": 1262
     },
     {
       "name": "Gate of Triumph",
@@ -642,30 +471,21 @@
         "east": 1224,
         "north": 1291
       },
-      "id": 1289,
-      "area": {
-        "id": 24
-      }
+      "id": 1289
     },
     {
       "name": "Southern niche",
       "exits": {
         "north": 1289
       },
-      "id": 1290,
-      "area": {
-        "id": 24
-      }
+      "id": 1290
     },
     {
       "name": "Northern niche",
       "exits": {
         "south": 1289
       },
-      "id": 1291,
-      "area": {
-        "id": 24
-      }
+      "id": 1291
     },
     {
       "name": "Guard Post",
@@ -674,10 +494,7 @@
         "east": 1392,
         "north": 1395
       },
-      "id": 1362,
-      "area": {
-        "id": 24
-      }
+      "id": 1362
     },
     {
       "name": "Doorway",
@@ -685,10 +502,7 @@
         "east": 1225,
         "west": 1364
       },
-      "id": 1363,
-      "area": {
-        "id": 24
-      }
+      "id": 1363
     },
     {
       "name": "Statued hallway",
@@ -696,10 +510,7 @@
         "east": 1363,
         "west": 1365
       },
-      "id": 1364,
-      "area": {
-        "id": 24
-      }
+      "id": 1364
     },
     {
       "name": "Hallway",
@@ -708,20 +519,14 @@
         "east": 1364,
         "north": 1367
       },
-      "id": 1365,
-      "area": {
-        "id": 24
-      }
+      "id": 1365
     },
     {
       "name": "Captain's office",
       "exits": {
         "east": 1365
       },
-      "id": 1366,
-      "area": {
-        "id": 24
-      }
+      "id": 1366
     },
     {
       "name": "Courtyard",
@@ -729,10 +534,7 @@
         "south": 1365,
         "north": 1368
       },
-      "id": 1367,
-      "area": {
-        "id": 24
-      }
+      "id": 1367
     },
     {
       "name": "Courtyard",
@@ -740,10 +542,7 @@
         "south": 1367,
         "north": 1369
       },
-      "id": 1368,
-      "area": {
-        "id": 24
-      }
+      "id": 1368
     },
     {
       "name": "Hallway",
@@ -753,20 +552,14 @@
         "east": 1371,
         "south": 1368
       },
-      "id": 1369,
-      "area": {
-        "id": 24
-      }
+      "id": 1369
     },
     {
       "name": "West wing",
       "exits": {
         "east": 1369
       },
-      "id": 1370,
-      "area": {
-        "id": 24
-      }
+      "id": 1370
     },
     {
       "name": "East wing",
@@ -774,40 +567,28 @@
         "west": 1369,
         "south": 1372
       },
-      "id": 1371,
-      "area": {
-        "id": 24
-      }
+      "id": 1371
     },
     {
       "name": "East wing hallway",
       "exits": {
         "north": 1371
       },
-      "id": 1372,
-      "area": {
-        "id": 24
-      }
+      "id": 1372
     },
     {
       "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
       "exits": {
         "down": 1369
       },
-      "id": 1373,
-      "area": {
-        "id": 24
-      }
+      "id": 1373
     },
     {
       "name": "Akademos",
       "exits": {
         "east": 1251
       },
-      "id": 1374,
-      "area": {
-        "id": 24
-      }
+      "id": 1374
     },
     {
       "name": "Temple entry",
@@ -815,10 +596,7 @@
         "south": 1376,
         "north": 1254
       },
-      "id": 1375,
-      "area": {
-        "id": 24
-      }
+      "id": 1375
     },
     {
       "name": "Temple rotunda",
@@ -828,10 +606,7 @@
         "east": 1384,
         "north": 1375
       },
-      "id": 1376,
-      "area": {
-        "id": 24
-      }
+      "id": 1376
     },
     {
       "name": "Temple hallway",
@@ -839,10 +614,7 @@
         "south": 1378,
         "north": 1376
       },
-      "id": 1377,
-      "area": {
-        "id": 24
-      }
+      "id": 1377
     },
     {
       "name": "End of temple hallway",
@@ -851,30 +623,21 @@
         "east": 1379,
         "north": 1377
       },
-      "id": 1378,
-      "area": {
-        "id": 24
-      }
+      "id": 1378
     },
     {
       "name": "Folio depository",
       "exits": {
         "west": 1378
       },
-      "id": 1379,
-      "area": {
-        "id": 24
-      }
+      "id": 1379
     },
     {
       "name": "Reliquary",
       "exits": {
         "east": 1378
       },
-      "id": 1380,
-      "area": {
-        "id": 24
-      }
+      "id": 1380
     },
     {
       "name": "Hall of Peace",
@@ -882,10 +645,7 @@
         "east": 1376,
         "west": 1382
       },
-      "id": 1381,
-      "area": {
-        "id": 24
-      }
+      "id": 1381
     },
     {
       "name": "Hall of Peace",
@@ -894,20 +654,14 @@
         "east": 1381,
         "south": 1387
       },
-      "id": 1382,
-      "area": {
-        "id": 24
-      }
+      "id": 1382
     },
     {
       "name": "Rotunda of Peace",
       "exits": {
         "east": 1382
       },
-      "id": 1383,
-      "area": {
-        "id": 24
-      }
+      "id": 1383
     },
     {
       "name": "Hall of War",
@@ -916,10 +670,7 @@
         "east": 1385,
         "south": 1388
       },
-      "id": 1384,
-      "area": {
-        "id": 24
-      }
+      "id": 1384
     },
     {
       "name": "Hall of War",
@@ -927,40 +678,28 @@
         "east": 1386,
         "west": 1384
       },
-      "id": 1385,
-      "area": {
-        "id": 24
-      }
+      "id": 1385
     },
     {
       "name": "Rotunda of War",
       "exits": {
         "west": 1385
       },
-      "id": 1386,
-      "area": {
-        "id": 24
-      }
+      "id": 1386
     },
     {
       "name": "Chapel of Peace",
       "exits": {
         "north": 1382
       },
-      "id": 1387,
-      "area": {
-        "id": 24
-      }
+      "id": 1387
     },
     {
       "name": "Chapel of War",
       "exits": {
         "north": 1384
       },
-      "id": 1388,
-      "area": {
-        "id": 24
-      }
+      "id": 1388
     },
     {
       "name": "Ithsma street",
@@ -968,30 +707,21 @@
         "east": 1390,
         "west": 1255
       },
-      "id": 1389,
-      "area": {
-        "id": 24
-      }
+      "id": 1389
     },
     {
       "name": "End of Ithsma street",
       "exits": {
         "west": 1389
       },
-      "id": 1390,
-      "area": {
-        "id": 24
-      }
+      "id": 1390
     },
     {
       "name": "Office of the Secretary",
       "exits": {
         "north": 1261
       },
-      "id": 1391,
-      "area": {
-        "id": 24
-      }
+      "id": 1391
     },
     {
       "name": "Formal gardens",
@@ -1000,30 +730,21 @@
         "east": 1393,
         "south": 1394
       },
-      "id": 1392,
-      "area": {
-        "id": 24
-      }
+      "id": 1392
     },
     {
       "name": "A private corner in the garden",
       "exits": {
         "west": 1392
       },
-      "id": 1393,
-      "area": {
-        "id": 24
-      }
+      "id": 1393
     },
     {
       "name": "A private corner in the garden",
       "exits": {
         "north": 1392
       },
-      "id": 1394,
-      "area": {
-        "id": 24
-      }
+      "id": 1394
     },
     {
       "name": "Residential hallway",
@@ -1031,10 +752,7 @@
         "east": 1396,
         "south": 1362
       },
-      "id": 1395,
-      "area": {
-        "id": 24
-      }
+      "id": 1395
     },
     {
       "name": "Residential hallway",
@@ -1043,10 +761,7 @@
         "east": 1397,
         "north": 1398
       },
-      "id": 1396,
-      "area": {
-        "id": 24
-      }
+      "id": 1396
     },
     {
       "name": "The harem",
@@ -1054,10 +769,7 @@
         "west": 1396,
         "north": 1400
       },
-      "id": 1397,
-      "area": {
-        "id": 24
-      }
+      "id": 1397
     },
     {
       "name": "The Royal Chambers",
@@ -1065,30 +777,21 @@
         "west": 1399,
         "south": 1396
       },
-      "id": 1398,
-      "area": {
-        "id": 24
-      }
+      "id": 1398
     },
     {
       "name": "The royal dressing room",
       "exits": {
         "east": 1398
       },
-      "id": 1399,
-      "area": {
-        "id": 24
-      }
+      "id": 1399
     },
     {
       "name": "The Consort's chambers",
       "exits": {
         "south": 1397
       },
-      "id": 1400,
-      "area": {
-        "id": 24
-      }
+      "id": 1400
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/wheatfield.json
+++ b/maps/wheatfield.json
@@ -10,10 +10,7 @@
         "southeast": 1641,
         "south": 1640
       },
-      "id": 1638,
-      "area": {
-        "id": 31
-      }
+      "id": 1638
     },
     {
       "name": "Road Through a Wheatfield",
@@ -24,10 +21,7 @@
         "east": 1649,
         "west": 1638
       },
-      "id": 1639,
-      "area": {
-        "id": 31
-      }
+      "id": 1639
     },
     {
       "name": "Wheatfield",
@@ -40,10 +34,7 @@
         "east": 1641,
         "north": 1638
       },
-      "id": 1640,
-      "area": {
-        "id": 31
-      }
+      "id": 1640
     },
     {
       "name": "Road Through A Wheatfield",
@@ -56,10 +47,7 @@
         "east": 1648,
         "north": 1639
       },
-      "id": 1641,
-      "area": {
-        "id": 31
-      }
+      "id": 1641
     },
     {
       "name": "Wheatfield",
@@ -70,10 +58,7 @@
         "east": 1646,
         "north": 1641
       },
-      "id": 1642,
-      "area": {
-        "id": 31
-      }
+      "id": 1642
     },
     {
       "name": "Wheatfield",
@@ -85,10 +70,7 @@
         "east": 1642,
         "north": 1640
       },
-      "id": 1643,
-      "area": {
-        "id": 31
-      }
+      "id": 1643
     },
     {
       "name": "Wheatfield",
@@ -97,10 +79,7 @@
         "east": 1643,
         "north": 1645
       },
-      "id": 1644,
-      "area": {
-        "id": 31
-      }
+      "id": 1644
     },
     {
       "name": "Wheatfield",
@@ -109,10 +88,7 @@
         "southeast": 1643,
         "south": 1644
       },
-      "id": 1645,
-      "area": {
-        "id": 31
-      }
+      "id": 1645
     },
     {
       "name": "Wheatfield",
@@ -121,20 +97,14 @@
         "east": 1647,
         "north": 1648
       },
-      "id": 1646,
-      "area": {
-        "id": 31
-      }
+      "id": 1646
     },
     {
       "name": "Wheatfield",
       "exits": {
         "west": 1646
       },
-      "id": 1647,
-      "area": {
-        "id": 31
-      }
+      "id": 1647
     },
     {
       "name": "Road Through a Wheatfield",
@@ -145,10 +115,7 @@
         "west": 1641,
         "north": 1649
       },
-      "id": 1648,
-      "area": {
-        "id": 31
-      }
+      "id": 1648
     },
     {
       "name": "Wheatfield",
@@ -157,10 +124,7 @@
         "west": 1639,
         "south": 1648
       },
-      "id": 1649,
-      "area": {
-        "id": 31
-      }
+      "id": 1649
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"


### PR DESCRIPTION
### Motivation
- Remove redundant `"area": { "id": # }` metadata from room objects across the map JSON files to simplify map data.
- Keep `moraldecay.json` unchanged as an explicit exception.

### Description
- A Python cleanup script scanned `maps/*.json` (skipping `moraldecay.json`) and removed any `"area"` key whose value is exactly an object of the form `{ "id": <int>}` from all nested objects.
- Each modified JSON was reserialized with `json.dumps(..., indent=2)` to preserve valid formatting; 37 map files were updated.
- Changes were staged and committed with the message `Remove area id references from map files`.

### Testing
- The cleanup script parsed each JSON file with `json.loads` and rewrote it with `json.dumps`, which validates that the resulting files are syntactically valid JSON and succeeded for all processed files.  
- `git status` was used to confirm the set of modified files and `git commit` completed successfully.  
- No unit or integration tests were run because this is a data-only cleanup.  
- Manual spot-checks were performed by inspecting diffs for several files to confirm `"area": { "id" : # }` entries were removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8a3296808327b02dff4822fbc7bf)