### PR TITLE
Reformat map room entries to put `id`/`name` on one line and group `exits`

### DIFF
--- a/maps/anshelm.json
+++ b/maps/anshelm.json
@@ -4,897 +4,448 @@
   },
   "rooms": [
     {
-      "name": "Before the Anshelm Gatehouse",
-      "exits": {
-        "north": 236
-      },
-      "id": 235
-    },
-    {
-      "name": "Under the Anshelmish Gatehouse",
-      "exits": {
-        "west": 1143,
-        "south": 235,
-        "north": 237
-      },
-      "id": 236
-    },
-    {
-      "name": "Southern end of Rue du Nord",
-      "exits": {
-        "southwest": 1135,
-        "south": 236,
-        "southeast": 1154,
-        "north": 238
-      },
-      "id": 237
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "west": 413,
-        "south": 237,
-        "north": 239
-      },
-      "id": 238
-    },
-    {
-      "name": "Intersection of Rue du Nord and Beitel Straat",
-      "exits": {
-        "south": 238,
-        "west": 414,
-        "east": 1185,
-        "north": 240
-      },
-      "id": 239
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 239,
-        "west": 415,
-        "east": 1192,
-        "north": 241
-      },
-      "id": 240
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "west": 416,
-        "south": 240,
-        "north": 242
-      },
-      "id": 241
-    },
-    {
-      "name": "Gateway to Middle Bailey",
-      "exits": {
-        "south": 241,
-        "north": 243
-      },
-      "id": 242
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 242,
-        "north": 244
-      },
-      "id": 243
-    },
-    {
-      "name": "Western intersection of Rue du Nord and Kirsch Lane",
-      "exits": {
-        "west": 245,
-        "east": 250,
-        "south": 243
-      },
-      "id": 244
-    },
-    {
-      "name": "Kirsch Lane",
-      "exits": {
-        "east": 244,
-        "west": 246
-      },
-      "id": 245
-    },
-    {
-      "name": "Kirsch Lane",
-      "exits": {
-        "west": 247,
-        "east": 245,
-        "south": 249
-      },
-      "id": 246
-    },
-    {
-      "name": "Western end of Kirsch Lane",
-      "exits": {
-        "east": 246,
-        "south": 248
-      },
-      "id": 247
-    },
-    {
-      "name": "Construction site",
-      "exits": {
-        "north": 247
-      },
-      "id": 248
-    },
-    {
-      "name": "Kaneohe Armory",
-      "exits": {
-        "north": 246
-      },
-      "id": 249
-    },
-    {
-      "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
-      "exits": {
-        "west": 244,
-        "east": 283,
-        "north": 251
-      },
-      "id": 250
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 250,
-        "east": 1193,
-        "north": 252
-      },
-      "id": 251
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 251,
-        "north": 253
-      },
-      "id": 252
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 252,
-        "north": 254
-      },
-      "id": 253
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 253,
-        "north": 255
-      },
-      "id": 254
-    },
-    {
-      "name": "Central Square on the Rue du Nord",
-      "exits": {
-        "south": 254,
-        "west": 1195,
-        "east": 1194,
-        "north": 256
-      },
-      "id": 255
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 255,
-        "north": 257
-      },
-      "id": 256
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 256,
-        "north": 258
-      },
-      "id": 257
-    },
-    {
-      "name": "Intersection of Rue du Nord and East Geld Strasse",
-      "exits": {
-        "west": 259,
-        "east": 281,
-        "south": 257
-      },
-      "id": 258
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "east": 258,
-        "west": 260
-      },
-      "id": 259
-    },
-    {
-      "name": "Intersection of Rue du Nord and West Geld Strasse",
-      "exits": {
-        "west": 261,
-        "east": 259,
-        "north": 264
-      },
-      "id": 260
-    },
-    {
-      "name": "Geld Strasse",
-      "exits": {
-        "east": 260,
-        "west": 262
-      },
-      "id": 261
-    },
-    {
-      "name": "Geld Strasse",
-      "exits": {
-        "east": 261,
-        "west": 263
-      },
-      "id": 262
-    },
-    {
-      "name": "Western end of Geld Strasse",
-      "exits": {
-        "east": 262
-      },
-      "id": 263
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 260,
-        "north": 265
-      },
-      "id": 264
-    },
-    {
-      "name": "Gateway to Upper Bailey",
-      "exits": {
-        "south": 264,
-        "west": 282,
-        "east": 1198,
-        "north": 266
-      },
-      "id": 265
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 265,
-        "north": 267
-      },
-      "id": 266
-    },
-    {
-      "name": "Intersection of Rue du Nord and Kasernegade",
-      "exits": {
-        "south": 266,
-        "west": 268,
-        "east": 276,
-        "north": 273
-      },
-      "id": 267
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "east": 267,
-        "west": 269
-      },
-      "id": 268
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "east": 268,
-        "west": 270
-      },
-      "id": 269
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "west": 271,
-        "east": 269,
-        "south": 1199
-      },
-      "id": 270
-    },
-    {
-      "name": "Western end of Kasernegade",
-      "exits": {
-        "east": 270,
-        "north": 272
-      },
-      "id": 271
-    },
-    {
-      "name": "Construction site",
-      "exits": {
-        "south": 271
-      },
-      "id": 272
-    },
-    {
-      "name": "Rue du Nord",
-      "exits": {
-        "south": 267,
-        "northwest": 1202,
-        "north": 274
-      },
-      "id": 273
-    },
-    {
-      "name": "Under the Town Gate",
-      "exits": {
-        "south": 273,
-        "north": 275
-      },
-      "id": 274
-    },
-    {
-      "name": "Before the Anshelm Town Gate",
-      "exits": {
-        "south": 274
-      },
-      "id": 275
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "west": 267,
-        "east": 277,
-        "north": 1200
-      },
-      "id": 276
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "east": 278,
-        "west": 276
-      },
-      "id": 277
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "east": 279,
-        "west": 277
-      },
-      "id": 278
-    },
-    {
-      "name": "Kasernegade",
-      "exits": {
-        "east": 280,
-        "west": 278
-      },
-      "id": 279
-    },
-    {
-      "name": "Eastern end of Kasernegade",
-      "exits": {
-        "west": 279,
-        "south": 1201
-      },
-      "id": 280
-    },
-    {
-      "name": "Geld Strasse",
-      "exits": {
-        "west": 258,
-        "east": 1328,
-        "north": 1197
-      },
-      "id": 281
-    },
-    {
-      "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
-      "exits": {
-        "east": 265
-      },
-      "id": 282
-    },
-    {
-      "name": "Kirsch Lane",
-      "exits": {
-        "west": 250,
-        "east": 284,
-        "north": 1326
-      },
-      "id": 283
-    },
-    {
-      "name": "Kirsch Lane",
-      "exits": {
-        "west": 283,
-        "east": 285,
-        "north": 1327
-      },
-      "id": 284
-    },
-    {
-      "name": "Eastern end of Kirsch Lane",
-      "exits": {
-        "west": 284
-      },
-      "id": 285
-    },
-    {
-      "name": "Hawaiian Ryan's",
-      "exits": {
-        "east": 238,
-        "north": 414
-      },
-      "id": 413
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "south": 413,
-        "west": 1147,
-        "east": 239,
-        "north": 415
-      },
-      "id": 414
-    },
-    {
-      "name": "Club Femme Nu",
-      "exits": {
-        "east": 240,
-        "south": 414
-      },
-      "id": 415
-    },
-    {
-      "name": "Western Guard Post",
-      "exits": {
-        "up": 1136,
-        "northeast": 237
-      },
-      "id": 1135
-    },
-    {
-      "name": "Arleg bows to you.",
-      "exits": {
-        "down": 1135,
-        "up": 1137
-      },
-      "id": 1136
-    },
-    {
-      "name": "Second Floor Landing",
-      "exits": {
-        "down": 1136,
-        "east": 1142,
-        "up": 1138
-      },
-      "id": 1137
-    },
-    {
-      "name": "Third Floor Passage",
-      "exits": {
-        "down": 1137,
-        "east": 1144,
-        "up": 1139
-      },
-      "id": 1138
-    },
-    {
-      "name": "Western Spire Stairwell",
-      "exits": {
-        "down": 1138,
-        "up": 1140
-      },
-      "id": 1139
-    },
-    {
-      "name": "Roof of the Western Spire",
-      "exits": {
-        "down": 1139
-      },
-      "id": 1140
-    },
-    {
-      "name": "Western Stairwell",
-      "exits": {
-        "up": 1137
-      },
-      "id": 1141
-    },
-    {
-      "name": "Killing Room",
-      "exits": {
-        "east": 1153,
-        "west": 1137
-      },
-      "id": 1142
-    },
-    {
-      "name": "Anshelm Lounge",
-      "exits": {
-        "east": 236,
-        "west": 1204
-      },
-      "id": 1143
-    },
-    {
-      "name": "Gatehouse Mess Hall",
-      "exits": {
-        "east": 1145,
-        "west": 1138
-      },
-      "id": 1144
-    },
-    {
-      "name": "Gatehouse Barracks",
-      "exits": {
-        "east": 1146,
-        "west": 1144
-      },
-      "id": 1145
-    },
-    {
-      "name": "Third Floor Passage",
-      "exits": {
-        "up": 1151,
-        "west": 1145
-      },
-      "id": 1146
-    },
-    {
-      "name": "Beitel Straad at the Promenade",
-      "exits": {
-        "west": 1150,
-        "east": 414,
-        "north": 1169
-      },
-      "id": 1147
-    },
-    {
-      "name": "Eastern Stairwell",
-      "exits": {
-        "down": 1149
-      },
-      "id": 1148
-    },
-    {
-      "name": "Base of the Eastern Stairwell",
-      "exits": {
-        "up": 1148
-      },
-      "id": 1149
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "west": 1157,
-        "east": 1147,
-        "south": 1168
-      },
-      "id": 1150
-    },
-    {
-      "name": "Eastern Spire Stairwell",
-      "exits": {
-        "down": 1149,
-        "up": 1152
-      },
-      "id": 1151
-    },
-    {
-      "name": "Roof of the Eastern Spire",
-      "exits": {
-        "down": 1151
-      },
-      "id": 1152
-    },
-    {
-      "name": "Tider bows to you.",
-      "exits": {
-        "west": 1142
-      },
-      "id": 1153
-    },
-    {
-      "name": "Eastern Guard Post",
-      "exits": {
-        "northwest": 237,
-        "east": 1155
-      },
-      "id": 1154
-    },
-    {
-      "name": "Ganran bows to you.",
-      "exits": {
-        "up": 1158,
-        "down": 1156,
-        "west": 1154
-      },
-      "id": 1155
-    },
-    {
-      "name": "Gatehouse Armoury",
-      "exits": {
-        "up": 1155
-      },
-      "id": 1156
-    },
-    {
-      "name": "Western end of Beitel Straad",
-      "exits": {
-        "east": 1150,
-        "north": 1164
-      },
-      "id": 1157
-    },
-    {
-      "name": "Eastern Stairwell",
-      "exits": {
-        "down": 1155,
-        "up": 1159
-      },
-      "id": 1158
-    },
-    {
-      "name": "Olotia bows to you.",
-      "exits": {
-        "down": 1158,
-        "west": 1160
-      },
-      "id": 1159
-    },
-    {
-      "name": "Tiran bows to you.",
-      "exits": {
-        "east": 1159,
-        "west": 1161
-      },
-      "id": 1160
-    },
-    {
-      "name": "Killing Room",
-      "exits": {
-        "east": 1160,
-        "west": 1162
-      },
-      "id": 1161
-    },
-    {
-      "name": "Second Floor Landing",
-      "exits": {
-        "east": 1161,
-        "down": 1163
-      },
-      "id": 1162
-    },
-    {
-      "name": "Western Stairwell",
-      "exits": {
-        "down": 1135,
-        "up": 1162
-      },
-      "id": 1163
-    },
-    {
-      "name": "The Inner Bailey",
-      "exits": {
-        "north": 1150
-      },
-      "id": 1168
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "west": 239,
-        "east": 1186,
-        "north": 1191
-      },
-      "id": 1185
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "west": 1185,
-        "east": 1187,
-        "north": 1190
-      },
-      "id": 1186
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "east": 1188,
-        "west": 1186
-      },
-      "id": 1187
-    },
-    {
-      "name": "Beitel Straad",
-      "exits": {
-        "east": 1189,
-        "west": 1187
-      },
-      "id": 1188
-    },
-    {
-      "name": "Eastern end of Beitel Straad",
-      "exits": {
-        "west": 1188
-      },
-      "id": 1189
-    },
-    {
-      "name": "The Banana Hammock",
-      "exits": {
-        "west": 1191,
-        "south": 1186
-      },
-      "id": 1190
-    },
+      "id": 235, "name": "Before the Anshelm Gatehouse",
+      "exits": { "north": 236 }
+    },
+    {
+      "id": 236, "name": "Under the Anshelmish Gatehouse",
+      "exits": { "west": 1143, "south": 235, "north": 237 }
+    },
+    {
+      "id": 237, "name": "Southern end of Rue du Nord",
+      "exits": { "southwest": 1135, "south": 236, "southeast": 1154, "north": 238 }
+    },
+    {
+      "id": 238, "name": "Rue du Nord",
+      "exits": { "west": 413, "south": 237, "north": 239 }
+    },
+    {
+      "id": 239, "name": "Intersection of Rue du Nord and Beitel Straat",
+      "exits": { "south": 238, "west": 414, "east": 1185, "north": 240 }
+    },
+    {
+      "id": 240, "name": "Rue du Nord",
+      "exits": { "south": 239, "west": 415, "east": 1192, "north": 241 }
+    },
+    {
+      "id": 241, "name": "Rue du Nord",
+      "exits": { "west": 416, "south": 240, "north": 242 }
+    },
+    {
+      "id": 242, "name": "Gateway to Middle Bailey",
+      "exits": { "south": 241, "north": 243 }
+    },
+    {
+      "id": 243, "name": "Rue du Nord",
+      "exits": { "south": 242, "north": 244 }
+    },
+    {
+      "id": 244, "name": "Western intersection of Rue du Nord and Kirsch Lane",
+      "exits": { "west": 245, "east": 250, "south": 243 }
+    },
+    {
+      "id": 245, "name": "Kirsch Lane",
+      "exits": { "east": 244, "west": 246 }
+    },
+    {
+      "id": 246, "name": "Kirsch Lane",
+      "exits": { "west": 247, "east": 245, "south": 249 }
+    },
+    {
+      "id": 247, "name": "Western end of Kirsch Lane",
+      "exits": { "east": 246, "south": 248 }
+    },
+    {
+      "id": 248, "name": "Construction site",
+      "exits": { "north": 247 }
+    },
+    {
+      "id": 249, "name": "Kaneohe Armory",
+      "exits": { "north": 246 }
+    },
+    {
+      "id": 250, "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
+      "exits": { "west": 244, "east": 283, "north": 251 }
+    },
+    {
+      "id": 251, "name": "Rue du Nord",
+      "exits": { "south": 250, "east": 1193, "north": 252 }
+    },
+    {
+      "id": 252, "name": "Rue du Nord",
+      "exits": { "south": 251, "north": 253 }
+    },
+    {
+      "id": 253, "name": "Rue du Nord",
+      "exits": { "south": 252, "north": 254 }
+    },
+    {
+      "id": 254, "name": "Rue du Nord",
+      "exits": { "south": 253, "north": 255 }
+    },
+    {
+      "id": 255, "name": "Central Square on the Rue du Nord",
+      "exits": { "south": 254, "west": 1195, "east": 1194, "north": 256 }
+    },
+    {
+      "id": 256, "name": "Rue du Nord",
+      "exits": { "south": 255, "north": 257 }
+    },
+    {
+      "id": 257, "name": "Rue du Nord",
+      "exits": { "south": 256, "north": 258 }
+    },
+    {
+      "id": 258, "name": "Intersection of Rue du Nord and East Geld Strasse",
+      "exits": { "west": 259, "east": 281, "south": 257 }
+    },
+    {
+      "id": 259, "name": "Rue du Nord",
+      "exits": { "east": 258, "west": 260 }
+    },
+    {
+      "id": 260, "name": "Intersection of Rue du Nord and West Geld Strasse",
+      "exits": { "west": 261, "east": 259, "north": 264 }
+    },
+    {
+      "id": 261, "name": "Geld Strasse",
+      "exits": { "east": 260, "west": 262 }
+    },
+    {
+      "id": 262, "name": "Geld Strasse",
+      "exits": { "east": 261, "west": 263 }
+    },
+    {
+      "id": 263, "name": "Western end of Geld Strasse",
+      "exits": { "east": 262 }
+    },
+    {
+      "id": 264, "name": "Rue du Nord",
+      "exits": { "south": 260, "north": 265 }
+    },
+    {
+      "id": 265, "name": "Gateway to Upper Bailey",
+      "exits": { "south": 264, "west": 282, "east": 1198, "north": 266 }
+    },
+    {
+      "id": 266, "name": "Rue du Nord",
+      "exits": { "south": 265, "north": 267 }
+    },
+    {
+      "id": 267, "name": "Intersection of Rue du Nord and Kasernegade",
+      "exits": { "south": 266, "west": 268, "east": 276, "north": 273 }
+    },
+    {
+      "id": 268, "name": "Kasernegade",
+      "exits": { "east": 267, "west": 269 }
+    },
+    {
+      "id": 269, "name": "Kasernegade",
+      "exits": { "east": 268, "west": 270 }
+    },
+    {
+      "id": 270, "name": "Kasernegade",
+      "exits": { "west": 271, "east": 269, "south": 1199 }
+    },
+    {
+      "id": 271, "name": "Western end of Kasernegade",
+      "exits": { "east": 270, "north": 272 }
+    },
+    {
+      "id": 272, "name": "Construction site",
+      "exits": { "south": 271 }
+    },
+    {
+      "id": 273, "name": "Rue du Nord",
+      "exits": { "south": 267, "northwest": 1202, "north": 274 }
+    },
+    {
+      "id": 274, "name": "Under the Town Gate",
+      "exits": { "south": 273, "north": 275 }
+    },
+    {
+      "id": 275, "name": "Before the Anshelm Town Gate",
+      "exits": { "south": 274 }
+    },
+    {
+      "id": 276, "name": "Kasernegade",
+      "exits": { "west": 267, "east": 277, "north": 1200 }
+    },
+    {
+      "id": 277, "name": "Kasernegade",
+      "exits": { "east": 278, "west": 276 }
+    },
+    {
+      "id": 278, "name": "Kasernegade",
+      "exits": { "east": 279, "west": 277 }
+    },
+    {
+      "id": 279, "name": "Kasernegade",
+      "exits": { "east": 280, "west": 278 }
+    },
+    {
+      "id": 280, "name": "Eastern end of Kasernegade",
+      "exits": { "west": 279, "south": 1201 }
+    },
+    {
+      "id": 281, "name": "Geld Strasse",
+      "exits": { "west": 258, "east": 1328, "north": 1197 }
+    },
+    {
+      "id": 282, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "exits": { "east": 265 }
+    },
+    {
+      "id": 283, "name": "Kirsch Lane",
+      "exits": { "west": 250, "east": 284, "north": 1326 }
+    },
+    {
+      "id": 284, "name": "Kirsch Lane",
+      "exits": { "west": 283, "east": 285, "north": 1327 }
+    },
+    {
+      "id": 285, "name": "Eastern end of Kirsch Lane",
+      "exits": { "west": 284 }
+    },
+    {
+      "id": 413, "name": "Hawaiian Ryan's",
+      "exits": { "east": 238, "north": 414 }
+    },
+    {
+      "id": 414, "name": "Beitel Straad",
+      "exits": { "south": 413, "west": 1147, "east": 239, "north": 415 }
+    },
+    {
+      "id": 415, "name": "Club Femme Nu",
+      "exits": { "east": 240, "south": 414 }
+    },
+    {
+      "id": 1135, "name": "Western Guard Post",
+      "exits": { "up": 1136, "northeast": 237 }
+    },
+    {
+      "id": 1136, "name": "Arleg bows to you.",
+      "exits": { "down": 1135, "up": 1137 }
+    },
+    {
+      "id": 1137, "name": "Second Floor Landing",
+      "exits": { "down": 1136, "east": 1142, "up": 1138 }
+    },
+    {
+      "id": 1138, "name": "Third Floor Passage",
+      "exits": { "down": 1137, "east": 1144, "up": 1139 }
+    },
+    {
+      "id": 1139, "name": "Western Spire Stairwell",
+      "exits": { "down": 1138, "up": 1140 }
+    },
+    {
+      "id": 1140, "name": "Roof of the Western Spire",
+      "exits": { "down": 1139 }
+    },
+    {
+      "id": 1141, "name": "Western Stairwell",
+      "exits": { "up": 1137 }
+    },
+    {
+      "id": 1142, "name": "Killing Room",
+      "exits": { "east": 1153, "west": 1137 }
+    },
+    {
+      "id": 1143, "name": "Anshelm Lounge",
+      "exits": { "east": 236, "west": 1204 }
+    },
+    {
+      "id": 1144, "name": "Gatehouse Mess Hall",
+      "exits": { "east": 1145, "west": 1138 }
+    },
+    {
+      "id": 1145, "name": "Gatehouse Barracks",
+      "exits": { "east": 1146, "west": 1144 }
+    },
+    {
+      "id": 1146, "name": "Third Floor Passage",
+      "exits": { "up": 1151, "west": 1145 }
+    },
+    {
+      "id": 1147, "name": "Beitel Straad at the Promenade",
+      "exits": { "west": 1150, "east": 414, "north": 1169 }
+    },
+    {
+      "id": 1148, "name": "Eastern Stairwell",
+      "exits": { "down": 1149 }
+    },
+    {
+      "id": 1149, "name": "Base of the Eastern Stairwell",
+      "exits": { "up": 1148 }
+    },
+    {
+      "id": 1150, "name": "Beitel Straad",
+      "exits": { "west": 1157, "east": 1147, "south": 1168 }
+    },
+    {
+      "id": 1151, "name": "Eastern Spire Stairwell",
+      "exits": { "down": 1149, "up": 1152 }
+    },
+    {
+      "id": 1152, "name": "Roof of the Eastern Spire",
+      "exits": { "down": 1151 }
+    },
+    {
+      "id": 1153, "name": "Tider bows to you.",
+      "exits": { "west": 1142 }
+    },
+    {
+      "id": 1154, "name": "Eastern Guard Post",
+      "exits": { "northwest": 237, "east": 1155 }
+    },
+    {
+      "id": 1155, "name": "Ganran bows to you.",
+      "exits": { "up": 1158, "down": 1156, "west": 1154 }
+    },
+    {
+      "id": 1156, "name": "Gatehouse Armoury",
+      "exits": { "up": 1155 }
+    },
+    {
+      "id": 1157, "name": "Western end of Beitel Straad",
+      "exits": { "east": 1150, "north": 1164 }
+    },
+    {
+      "id": 1158, "name": "Eastern Stairwell",
+      "exits": { "down": 1155, "up": 1159 }
+    },
+    {
+      "id": 1159, "name": "Olotia bows to you.",
+      "exits": { "down": 1158, "west": 1160 }
+    },
+    {
+      "id": 1160, "name": "Tiran bows to you.",
+      "exits": { "east": 1159, "west": 1161 }
+    },
+    {
+      "id": 1161, "name": "Killing Room",
+      "exits": { "east": 1160, "west": 1162 }
+    },
+    {
+      "id": 1162, "name": "Second Floor Landing",
+      "exits": { "east": 1161, "down": 1163 }
+    },
+    {
+      "id": 1163, "name": "Western Stairwell",
+      "exits": { "down": 1135, "up": 1162 }
+    },
+    {
+      "id": 1168, "name": "The Inner Bailey",
+      "exits": { "north": 1150 }
+    },
+    {
+      "id": 1185, "name": "Beitel Straad",
+      "exits": { "west": 239, "east": 1186, "north": 1191 }
+    },
+    {
+      "id": 1186, "name": "Beitel Straad",
+      "exits": { "west": 1185, "east": 1187, "north": 1190 }
+    },
+    {
+      "id": 1187, "name": "Beitel Straad",
+      "exits": { "east": 1188, "west": 1186 }
+    },
+    {
+      "id": 1188, "name": "Beitel Straad",
+      "exits": { "east": 1189, "west": 1187 }
+    },
+    {
+      "id": 1189, "name": "Eastern end of Beitel Straad",
+      "exits": { "west": 1188 }
+    },
+    {
+      "id": 1190, "name": "The Banana Hammock",
+      "exits": { "west": 1191, "south": 1186 }
+    },
     {
-      "name": "Jack's Bistro",
-      "exits": {
-        "east": 1190,
-        "south": 1185
-      },
-      "id": 1191
+      "id": 1191, "name": "Jack's Bistro",
+      "exits": { "east": 1190, "south": 1185 }
     },
     {
-      "name": "Second Bank of Anshelm",
-      "exits": {
-        "west": 240
-      },
-      "id": 1192
+      "id": 1192, "name": "Second Bank of Anshelm",
+      "exits": { "west": 240 }
     },
     {
-      "name": "The Anshelmish General Store",
-      "exits": {
-        "west": 251
-      },
-      "id": 1193
+      "id": 1193, "name": "The Anshelmish General Store",
+      "exits": { "west": 251 }
     },
     {
-      "name": "Construction site",
-      "exits": {
-        "west": 255
-      },
-      "id": 1194
+      "id": 1194, "name": "Construction site",
+      "exits": { "west": 255 }
     },
     {
-      "name": "Anshelmish Keep's drawbridge",
-      "exits": {
-        "east": 255,
-        "west": 1196
-      },
-      "id": 1195
+      "id": 1195, "name": "Anshelmish Keep's drawbridge",
+      "exits": { "east": 255, "west": 1196 }
     },
     {
-      "name": "Construction site",
-      "exits": {
-        "east": 1195
-      },
-      "id": 1196
+      "id": 1196, "name": "Construction site",
+      "exits": { "east": 1195 }
     },
     {
-      "name": "Private Entry",
-      "exits": {
-        "south": 281
-      },
-      "id": 1197
+      "id": 1197, "name": "Private Entry",
+      "exits": { "south": 281 }
     },
     {
-      "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
-      "exits": {
-        "west": 265
-      },
-      "id": 1198
+      "id": 1198, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "exits": { "west": 265 }
     },
     {
-      "name": "Armourer's Shack",
-      "exits": {
-        "north": 270
-      },
-      "id": 1199
+      "id": 1199, "name": "Armourer's Shack",
+      "exits": { "north": 270 }
     },
     {
-      "name": "Construction site",
-      "exits": {
-        "south": 276
-      },
-      "id": 1200
+      "id": 1200, "name": "Construction site",
+      "exits": { "south": 276 }
     },
     {
-      "name": "Construction site",
-      "exits": {
-        "north": 280
-      },
-      "id": 1201
+      "id": 1201, "name": "Construction site",
+      "exits": { "north": 280 }
     },
     {
-      "name": "Construction site",
-      "exits": {
-        "southeast": 273
-      },
-      "id": 1202
+      "id": 1202, "name": "Construction site",
+      "exits": { "southeast": 273 }
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "exits": {
-        "east": 1143
-      },
-      "id": 1204
+      "id": 1204, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "east": 1143 }
     },
     {
-      "name": "La Cosa Nostra",
-      "exits": {
-        "south": 283
-      },
-      "id": 1326
+      "id": 1326, "name": "La Cosa Nostra",
+      "exits": { "south": 283 }
     },
     {
-      "name": "Anshelm Stables",
-      "exits": {
-        "south": 284
-      },
-      "id": 1327
+      "id": 1327, "name": "Anshelm Stables",
+      "exits": { "south": 284 }
     },
     {
-      "name": "Eastern end of Geld Strasse",
-      "exits": {
-        "east": 1329,
-        "west": 281
-      },
-      "id": 1328
+      "id": 1328, "name": "Eastern end of Geld Strasse",
+      "exits": { "east": 1329, "west": 281 }
     },
     {
-      "name": "With a little strain, you are able to pull open the heavy doors and enter",
-      "exits": {
-        "east": 1330,
-        "west": 1328
-      },
-      "id": 1329
+      "id": 1329, "name": "With a little strain, you are able to pull open the heavy doors and enter",
+      "exits": { "east": 1330, "west": 1328 }
     },
     {
-      "name": "Naive",
-      "exits": {
-        "south": 1332,
-        "west": 1329,
-        "east": 1331,
-        "north": 1333
-      },
-      "id": 1330
+      "id": 1330, "name": "Naive",
+      "exits": { "south": 1332, "west": 1329, "east": 1331, "north": 1333 }
     },
     {
-      "name": "Altar of the Rose",
-      "exits": {
-        "west": 1330
-      },
-      "id": 1331
+      "id": 1331, "name": "Altar of the Rose",
+      "exits": { "west": 1330 }
     },
     {
-      "name": "Southern statuary",
-      "exits": {
-        "north": 1330
-      },
-      "id": 1332
+      "id": 1332, "name": "Southern statuary",
+      "exits": { "north": 1330 }
     },
     {
-      "name": "Northern statuary",
-      "exits": {
-        "south": 1330
-      },
-      "id": 1333
+      "id": 1333, "name": "Northern statuary",
+      "exits": { "south": 1330 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/anthill.json
+++ b/maps/anthill.json
@@ -4,555 +4,275 @@
   },
   "rooms": [
     {
-      "name": "Inside the Anthill",
-      "exits": {
-        "up": 1806,
-        "down": 1744,
-        "north": 1740
-      },
-      "id": 1723
-    },
-    {
-      "name": "Inside the Anthill",
-      "exits": {
-        "southwest": 1741,
-        "southeast": 1743,
-        "south": 1723
-      },
-      "id": 1740
-    },
-    {
-      "name": "Inside the Anthill",
-      "exits": {
-        "southeast": 1742,
-        "northeast": 1740
-      },
-      "id": 1741
-    },
-    {
-      "name": "Inside the Anthill",
-      "exits": {
-        "northwest": 1741,
-        "northeast": 1743
-      },
-      "id": 1742
-    },
-    {
-      "name": "Inside the Anthill",
-      "exits": {
-        "northwest": 1740,
-        "southwest": 1742
-      },
-      "id": 1743
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southeast": 1751,
-        "up": 1723,
-        "southwest": 1750,
-        "northeast": 1745,
-        "down": 1754,
-        "northwest": 1747
-      },
-      "id": 1744
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southwest": 1744,
-        "south": 1746
-      },
-      "id": 1745
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "north": 1745
-      },
-      "id": 1746
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southwest": 1749,
-        "northeast": 1748,
-        "southeast": 1744
-      },
-      "id": 1747
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southwest": 1747
-      },
-      "id": 1748
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "northeast": 1747
-      },
-      "id": 1749
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "northeast": 1744
-      },
-      "id": 1750
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southwest": 1753,
-        "northeast": 1752,
-        "northwest": 1744
-      },
-      "id": 1751
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "southwest": 1751
-      },
-      "id": 1752
-    },
-    {
-      "name": "In the Heart of the Anthill",
-      "exits": {
-        "northeast": 1751
-      },
-      "id": 1753
+      "id": 1723, "name": "Inside the Anthill",
+      "exits": { "up": 1806, "down": 1744, "north": 1740 }
     },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "up": 1744,
-        "east": 1758,
-        "south": 1755
-      },
-      "id": 1754
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southeast": 1756,
-        "north": 1754
-      },
-      "id": 1755
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1755,
-        "southwest": 1757
-      },
-      "id": 1756
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northeast": 1756
-      },
-      "id": 1757
+    {
+      "id": 1740, "name": "Inside the Anthill",
+      "exits": { "southwest": 1741, "southeast": 1743, "south": 1723 }
+    },
+    {
+      "id": 1741, "name": "Inside the Anthill",
+      "exits": { "southeast": 1742, "northeast": 1740 }
+    },
+    {
+      "id": 1742, "name": "Inside the Anthill",
+      "exits": { "northwest": 1741, "northeast": 1743 }
+    },
+    {
+      "id": 1743, "name": "Inside the Anthill",
+      "exits": { "northwest": 1740, "southwest": 1742 }
+    },
+    {
+      "id": 1744, "name": "In the Heart of the Anthill",
+      "exits": { "southeast": 1751, "up": 1723, "southwest": 1750, "northeast": 1745, "down": 1754, "northwest": 1747 }
+    },
+    {
+      "id": 1745, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1744, "south": 1746 }
+    },
+    {
+      "id": 1746, "name": "In the Heart of the Anthill",
+      "exits": { "north": 1745 }
+    },
+    {
+      "id": 1747, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1749, "northeast": 1748, "southeast": 1744 }
+    },
+    {
+      "id": 1748, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1747 }
+    },
+    {
+      "id": 1749, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1747 }
+    },
+    {
+      "id": 1750, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1744 }
+    },
+    {
+      "id": 1751, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1753, "northeast": 1752, "northwest": 1744 }
+    },
+    {
+      "id": 1752, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1751 }
+    },
+    {
+      "id": 1753, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1751 }
+    },
+    {
+      "id": 1754, "name": "At the Base of the Anthill",
+      "exits": { "up": 1744, "east": 1758, "south": 1755 }
+    },
+    {
+      "id": 1755, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1756, "north": 1754 }
+    },
+    {
+      "id": 1756, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1755, "southwest": 1757 }
+    },
+    {
+      "id": 1757, "name": "At the Base of the Anthill",
+      "exits": { "northeast": 1756 }
+    },
+    {
+      "id": 1758, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1763, "northeast": 1759, "northwest": 1762, "west": 1754 }
+    },
+    {
+      "id": 1759, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1760, "southwest": 1758 }
+    },
+    {
+      "id": 1760, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1762, "northwest": 1761, "southeast": 1759 }
+    },
+    {
+      "id": 1761, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1760 }
+    },
+    {
+      "id": 1762, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1765, "northeast": 1760, "southeast": 1758 }
+    },
+    {
+      "id": 1763, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1758, "northeast": 1764 }
+    },
+    {
+      "id": 1764, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1763 }
+    },
+    {
+      "id": 1765, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1766, "northeast": 1762 }
+    },
+    {
+      "id": 1766, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1767, "northeast": 1770, "southeast": 1765 }
+    },
+    {
+      "id": 1767, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1768, "northeast": 1766 }
+    },
+    {
+      "id": 1768, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1767, "southeast": 1769 }
+    },
+    {
+      "id": 1769, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1768 }
+    },
+    {
+      "id": 1770, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1766 }
+    },
+    {
+      "id": 1771, "name": "Beneath the Anthill",
+      "exits": { "south": 1798, "west": 1772, "east": 1782, "north": 1797 }
+    },
+    {
+      "id": 1772, "name": "Beneath the Anthill",
+      "exits": { "northwest": 1773, "east": 1771 }
+    },
+    {
+      "id": 1773, "name": "Beneath the Anthill",
+      "exits": { "east": 1774, "southeast": 1772, "south": 1791 }
+    },
+    {
+      "id": 1774, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1775, "west": 1773, "north": 1783 }
+    },
+    {
+      "id": 1775, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1774, "east": 1776 }
+    },
+    {
+      "id": 1776, "name": "Beneath the Anthill",
+      "exits": { "west": 1775, "south": 1777 }
+    },
+    {
+      "id": 1777, "name": "Beneath the Anthill",
+      "exits": { "south": 1782, "west": 1797, "northeast": 1778, "east": 1799, "north": 1776 }
+    },
+    {
+      "id": 1778, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1777, "east": 1779 }
+    },
+    {
+      "id": 1779, "name": "Beneath the Anthill",
+      "exits": { "west": 1778, "south": 1780 }
+    },
+    {
+      "id": 1780, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1781, "south": 1803, "north": 1779 }
+    },
+    {
+      "id": 1781, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1780, "west": 1782, "south": 1800 }
+    },
+    {
+      "id": 1782, "name": "Beneath the Anthill",
+      "exits": { "west": 1771, "east": 1781, "north": 1777 }
+    },
+    {
+      "id": 1783, "name": "Beneath the Anthill",
+      "exits": { "west": 1784, "south": 1774 }
+    },
+    {
+      "id": 1784, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1785, "east": 1783 }
+    },
+    {
+      "id": 1785, "name": "Beneath the Anthill",
+      "exits": { "west": 1786, "northeast": 1784 }
+    },
+    {
+      "id": 1786, "name": "Beneath the Anthill",
+      "exits": { "east": 1785, "south": 1787 }
+    },
+    {
+      "id": 1787, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1788, "north": 1786 }
+    },
+    {
+      "id": 1788, "name": "Near the Queen's Lair",
+      "exits": { "northeast": 1787, "north": 1789 }
+    },
+    {
+      "id": 1789, "name": "Near the Queen's Lair",
+      "exits": { "south": 1788, "north": 1790 }
     },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southeast": 1763,
-        "northeast": 1759,
-        "northwest": 1762,
-        "west": 1754
-      },
-      "id": 1758
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1760,
-        "southwest": 1758
-      },
-      "id": 1759
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southwest": 1762,
-        "northwest": 1761,
-        "southeast": 1759
-      },
-      "id": 1760
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southeast": 1760
-      },
-      "id": 1761
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southwest": 1765,
-        "northeast": 1760,
-        "southeast": 1758
-      },
-      "id": 1762
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1758,
-        "northeast": 1764
-      },
-      "id": 1763
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southwest": 1763
-      },
-      "id": 1764
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1766,
-        "northeast": 1762
-      },
-      "id": 1765
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southwest": 1767,
-        "northeast": 1770,
-        "southeast": 1765
-      },
-      "id": 1766
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southeast": 1768,
-        "northeast": 1766
-      },
-      "id": 1767
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1767,
-        "southeast": 1769
-      },
-      "id": 1768
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "northwest": 1768
-      },
-      "id": 1769
-    },
-    {
-      "name": "At the Base of the Anthill",
-      "exits": {
-        "southwest": 1766
-      },
-      "id": 1770
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "south": 1798,
-        "west": 1772,
-        "east": 1782,
-        "north": 1797
-      },
-      "id": 1771
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "northwest": 1773,
-        "east": 1771
-      },
-      "id": 1772
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "east": 1774,
-        "southeast": 1772,
-        "south": 1791
-      },
-      "id": 1773
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "northeast": 1775,
-        "west": 1773,
-        "north": 1783
-      },
-      "id": 1774
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1774,
-        "east": 1776
-      },
-      "id": 1775
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1775,
-        "south": 1777
-      },
-      "id": 1776
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "south": 1782,
-        "west": 1797,
-        "northeast": 1778,
-        "east": 1799,
-        "north": 1776
-      },
-      "id": 1777
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1777,
-        "east": 1779
-      },
-      "id": 1778
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1778,
-        "south": 1780
-      },
-      "id": 1779
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1781,
-        "south": 1803,
-        "north": 1779
-      },
-      "id": 1780
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "northeast": 1780,
-        "west": 1782,
-        "south": 1800
-      },
-      "id": 1781
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1771,
-        "east": 1781,
-        "north": 1777
-      },
-      "id": 1782
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1784,
-        "south": 1774
-      },
-      "id": 1783
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1785,
-        "east": 1783
-      },
-      "id": 1784
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1786,
-        "northeast": 1784
-      },
-      "id": 1785
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "east": 1785,
-        "south": 1787
-      },
-      "id": 1786
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1788,
-        "north": 1786
-      },
-      "id": 1787
-    },
-    {
-      "name": "Near the Queen's Lair",
-      "exits": {
-        "northeast": 1787,
-        "north": 1789
-      },
-      "id": 1788
-    },
-    {
-      "name": "Near the Queen's Lair",
-      "exits": {
-        "south": 1788,
-        "north": 1790
-      },
-      "id": 1789
-    },
-    {
-      "name": "The Ant Lair",
-      "exits": {
-        "south": 1789
-      },
-      "id": 1790
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "south": 1792,
-        "southeast": 1796,
-        "north": 1773
-      },
-      "id": 1791
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1793,
-        "east": 1796,
-        "north": 1791
-      },
-      "id": 1792
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "east": 1792,
-        "north": 1794
-      },
-      "id": 1793
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "southwest": 1795,
-        "south": 1793
-      },
-      "id": 1794
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "northeast": 1794
-      },
-      "id": 1795
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "northwest": 1791,
-        "west": 1792
-      },
-      "id": 1796
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "east": 1777,
-        "south": 1771
-      },
-      "id": 1797
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "north": 1771
-      },
-      "id": 1798
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1777
-      },
-      "id": 1799
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1801,
-        "east": 1802,
-        "north": 1781
-      },
-      "id": 1800
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "east": 1800
-      },
-      "id": 1801
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1800,
-        "north": 1803
-      },
-      "id": 1802
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "south": 1802,
-        "east": 1804,
-        "north": 1780
-      },
-      "id": 1803
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "west": 1803,
-        "north": 1805
-      },
-      "id": 1804
-    },
-    {
-      "name": "Beneath the Anthill",
-      "exits": {
-        "south": 1804
-      },
-      "id": 1805
-    },
-    {
-      "name": "At the top of the anthill.",
-      "id": 1806
+    {
+      "id": 1790, "name": "The Ant Lair",
+      "exits": { "south": 1789 }
+    },
+    {
+      "id": 1791, "name": "Beneath the Anthill",
+      "exits": { "south": 1792, "southeast": 1796, "north": 1773 }
+    },
+    {
+      "id": 1792, "name": "Beneath the Anthill",
+      "exits": { "west": 1793, "east": 1796, "north": 1791 }
+    },
+    {
+      "id": 1793, "name": "Beneath the Anthill",
+      "exits": { "east": 1792, "north": 1794 }
+    },
+    {
+      "id": 1794, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1795, "south": 1793 }
+    },
+    {
+      "id": 1795, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1794 }
+    },
+    {
+      "id": 1796, "name": "Beneath the Anthill",
+      "exits": { "northwest": 1791, "west": 1792 }
+    },
+    {
+      "id": 1797, "name": "Beneath the Anthill",
+      "exits": { "east": 1777, "south": 1771 }
+    },
+    {
+      "id": 1798, "name": "Beneath the Anthill",
+      "exits": { "north": 1771 }
+    },
+    {
+      "id": 1799, "name": "Beneath the Anthill",
+      "exits": { "west": 1777 }
+    },
+    {
+      "id": 1800, "name": "Beneath the Anthill",
+      "exits": { "west": 1801, "east": 1802, "north": 1781 }
+    },
+    {
+      "id": 1801, "name": "Beneath the Anthill",
+      "exits": { "east": 1800 }
+    },
+    {
+      "id": 1802, "name": "Beneath the Anthill",
+      "exits": { "west": 1800, "north": 1803 }
+    },
+    {
+      "id": 1803, "name": "Beneath the Anthill",
+      "exits": { "south": 1802, "east": 1804, "north": 1780 }
+    },
+    {
+      "id": 1804, "name": "Beneath the Anthill",
+      "exits": { "west": 1803, "north": 1805 }
+    },
+    {
+      "id": 1805, "name": "Beneath the Anthill",
+      "exits": { "south": 1804 }
+    },
+    {
+      "id": 1806, "name": "At the top of the anthill."
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area10.json
+++ b/maps/area10.json
@@ -4,183 +4,92 @@
   },
   "rooms": [
     {
-      "name": "Entryway",
-      "exits": {
-        "south": 201,
-        "north": 932
-      },
-      "id": 931
+      "id": 931, "name": "Entryway",
+      "exits": { "south": 201, "north": 932 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 931,
-        "west": 933,
-        "east": 934,
-        "north": 937
-      },
-      "id": 932
+      "id": 932, "name": "Hallway",
+      "exits": { "south": 931, "west": 933, "east": 934, "north": 937 }
     },
     {
-      "name": "Corner",
-      "exits": {
-        "east": 932,
-        "north": 939
-      },
-      "id": 933
+      "id": 933, "name": "Corner",
+      "exits": { "east": 932, "north": 939 }
     },
     {
-      "name": "Corner",
-      "exits": {
-        "west": 932,
-        "north": 935
-      },
-      "id": 934
+      "id": 934, "name": "Corner",
+      "exits": { "west": 932, "north": 935 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 934,
-        "east": 945,
-        "north": 936
-      },
-      "id": 935
+      "id": 935, "name": "Hallway",
+      "exits": { "south": 934, "east": 945, "north": 936 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 935,
-        "east": 946,
-        "north": 947
-      },
-      "id": 936
+      "id": 936, "name": "Hallway",
+      "exits": { "south": 935, "east": 946, "north": 947 }
     },
     {
-      "name": "Courtyard",
-      "exits": {
-        "south": 932,
-        "north": 938
-      },
-      "id": 937
+      "id": 937, "name": "Courtyard",
+      "exits": { "south": 932, "north": 938 }
     },
     {
-      "name": "Courtyard",
-      "exits": {
-        "south": 937,
-        "north": 941
-      },
-      "id": 938
+      "id": 938, "name": "Courtyard",
+      "exits": { "south": 937, "north": 941 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "west": 942,
-        "south": 933,
-        "north": 940
-      },
-      "id": 939
+      "id": 939, "name": "Hallway",
+      "exits": { "west": 942, "south": 933, "north": 940 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "west": 943,
-        "south": 939,
-        "north": 944
-      },
-      "id": 940
+      "id": 940, "name": "Hallway",
+      "exits": { "west": 943, "south": 939, "north": 944 }
     },
     {
-      "name": "Archway",
-      "exits": {
-        "south": 938,
-        "west": 944,
-        "east": 947,
-        "north": 948
-      },
-      "id": 941
+      "id": 941, "name": "Archway",
+      "exits": { "south": 938, "west": 944, "east": 947, "north": 948 }
     },
     {
-      "name": "Quarters",
-      "exits": {
-        "east": 939
-      },
-      "id": 942
+      "id": 942, "name": "Quarters",
+      "exits": { "east": 939 }
     },
     {
-      "name": "Quarters",
-      "exits": {
-        "east": 940
-      },
-      "id": 943
+      "id": 943, "name": "Quarters",
+      "exits": { "east": 940 }
     },
     {
-      "name": "Corner",
-      "exits": {
-        "east": 941,
-        "south": 940
-      },
-      "id": 944
+      "id": 944, "name": "Corner",
+      "exits": { "east": 941, "south": 940 }
     },
     {
-      "name": "Quarters",
-      "exits": {
-        "west": 935
-      },
-      "id": 945
+      "id": 945, "name": "Quarters",
+      "exits": { "west": 935 }
     },
     {
-      "name": "Quarters",
-      "exits": {
-        "west": 936
-      },
-      "id": 946
+      "id": 946, "name": "Quarters",
+      "exits": { "west": 936 }
     },
     {
-      "name": "Corner",
-      "exits": {
-        "west": 941,
-        "south": 936
-      },
-      "id": 947
+      "id": 947, "name": "Corner",
+      "exits": { "west": 941, "south": 936 }
     },
     {
-      "name": "Temple Chamber",
-      "exits": {
-        "south": 941,
-        "west": 951,
-        "east": 952,
-        "north": 949
-      },
-      "id": 948
+      "id": 948, "name": "Temple Chamber",
+      "exits": { "south": 941, "west": 951, "east": 952, "north": 949 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 948,
-        "north": 950
-      },
-      "id": 949
+      "id": 949, "name": "Hallway",
+      "exits": { "south": 948, "north": 950 }
     },
     {
-      "name": "Library",
-      "exits": {
-        "south": 949
-      },
-      "id": 950
+      "id": 950, "name": "Library",
+      "exits": { "south": 949 }
     },
     {
-      "name": "Kitchen",
-      "exits": {
-        "east": 948
-      },
-      "id": 951
+      "id": 951, "name": "Kitchen",
+      "exits": { "east": 948 }
     },
     {
-      "name": "Storage",
-      "exits": {
-        "west": 948
-      },
-      "id": 952
+      "id": 952, "name": "Storage",
+      "exits": { "west": 948 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area11.json
+++ b/maps/area11.json
@@ -4,194 +4,96 @@
   },
   "rooms": [
     {
-      "name": "Entrance of a village",
-      "exits": {
-        "west": 859,
-        "east": 877,
-        "south": 131
-      },
-      "id": 858
+      "id": 858, "name": "Entrance of a village",
+      "exits": { "west": 859, "east": 877, "south": 131 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "east": 858,
-        "northwest": 860,
-        "north": 864
-      },
-      "id": 859
+      "id": 859, "name": "On a dusty path",
+      "exits": { "east": 858, "northwest": 860, "north": 864 }
     },
     {
-      "name": "A living room made of glass",
-      "exits": {
-        "southwest": 863,
-        "northwest": 861,
-        "southeast": 859
-      },
-      "id": 860
+      "id": 860, "name": "A living room made of glass",
+      "exits": { "southwest": 863, "northwest": 861, "southeast": 859 }
     },
     {
-      "name": "A kitchen made of glass",
-      "exits": {
-        "southwest": 862,
-        "southeast": 860
-      },
-      "id": 861
+      "id": 861, "name": "A kitchen made of glass",
+      "exits": { "southwest": 862, "southeast": 860 }
     },
     {
-      "name": "Sylvia's workroom",
-      "exits": {
-        "southeast": 863,
-        "northeast": 861
-      },
-      "id": 862
+      "id": 862, "name": "Sylvia's workroom",
+      "exits": { "southeast": 863, "northeast": 861 }
     },
     {
-      "name": "A bedroom made of glass",
-      "exits": {
-        "northwest": 862,
-        "northeast": 860
-      },
-      "id": 863
+      "id": 863, "name": "A bedroom made of glass",
+      "exits": { "northwest": 862, "northeast": 860 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "south": 859,
-        "north": 865
-      },
-      "id": 864
+      "id": 864, "name": "On a dusty path",
+      "exits": { "south": 859, "north": 865 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "east": 868,
-        "northwest": 866,
-        "south": 864
-      },
-      "id": 865
+      "id": 865, "name": "On a dusty path",
+      "exits": { "east": 868, "northwest": 866, "south": 864 }
     },
     {
-      "name": "Inside a small home",
-      "exits": {
-        "southeast": 865,
-        "west": 867
-      },
-      "id": 866
+      "id": 866, "name": "Inside a small home",
+      "exits": { "southeast": 865, "west": 867 }
     },
     {
-      "name": "A large kitchen",
-      "exits": {
-        "east": 866
-      },
-      "id": 867
+      "id": 867, "name": "A large kitchen",
+      "exits": { "east": 866 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "west": 865,
-        "east": 875,
-        "north": 869
-      },
-      "id": 868
+      "id": 868, "name": "On a dusty path",
+      "exits": { "west": 865, "east": 875, "north": 869 }
     },
     {
-      "name": "Bottom floor of the silo",
-      "exits": {
-        "up": 870,
-        "south": 868
-      },
-      "id": 869
+      "id": 869, "name": "Bottom floor of the silo",
+      "exits": { "up": 870, "south": 868 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "west": 868,
-        "south": 876
-      },
-      "id": 875
+      "id": 875, "name": "On a dusty path",
+      "exits": { "west": 868, "south": 876 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "south": 877,
-        "east": 953,
-        "north": 875
-      },
-      "id": 876
+      "id": 876, "name": "On a dusty path",
+      "exits": { "south": 877, "east": 953, "north": 875 }
     },
     {
-      "name": "On a dusty path",
-      "exits": {
-        "west": 858,
-        "north": 876
-      },
-      "id": 877
+      "id": 877, "name": "On a dusty path",
+      "exits": { "west": 858, "north": 876 }
     },
     {
-      "name": "On the porch",
-      "exits": {
-        "east": 954,
-        "west": 876
-      },
-      "id": 953
+      "id": 953, "name": "On the porch",
+      "exits": { "east": 954, "west": 876 }
     },
     {
-      "name": "In the sitting room",
-      "exits": {
-        "west": 953,
-        "east": 955,
-        "south": 958
-      },
-      "id": 954
+      "id": 954, "name": "In the sitting room",
+      "exits": { "west": 953, "east": 955, "south": 958 }
     },
     {
-      "name": "In the kitchen",
-      "exits": {
-        "west": 954,
-        "south": 956
-      },
-      "id": 955
+      "id": 955, "name": "In the kitchen",
+      "exits": { "west": 954, "south": 956 }
     },
     {
-      "name": "In the dining room",
-      "exits": {
-        "west": 958,
-        "east": 957,
-        "north": 955
-      },
-      "id": 956
+      "id": 956, "name": "In the dining room",
+      "exits": { "west": 958, "east": 957, "north": 955 }
     },
     {
-      "name": "You leave the farmhouse and enter the backyard.",
-      "exits": {
-        "east": 959,
-        "west": 956
-      },
-      "id": 957
+      "id": 957, "name": "You leave the farmhouse and enter the backyard.",
+      "exits": { "east": 959, "west": 956 }
     },
     {
-      "name": "In the study",
-      "exits": {
-        "east": 956,
-        "north": 954
-      },
-      "id": 958
+      "id": 958, "name": "In the study",
+      "exits": { "east": 956, "north": 954 }
     },
     {
-      "name": "In a shed",
-      "exits": {
-        "up": 960,
-        "west": 957
-      },
-      "id": 959
+      "id": 959, "name": "In a shed",
+      "exits": { "up": 960, "west": 957 }
     },
     {
-      "name": "Above the shed",
-      "exits": {
-        "down": 959
-      },
-      "id": 960
+      "id": 960, "name": "Above the shed",
+      "exits": { "down": 959 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area12.json
+++ b/maps/area12.json
@@ -4,99 +4,52 @@
   },
   "rooms": [
     {
-      "name": "Cemetery Lane.",
-      "exits": {
-        "south": 128,
-        "north": 882
-      },
-      "id": 881
+      "id": 881, "name": "Cemetery Lane.",
+      "exits": { "south": 128, "north": 882 }
     },
     {
-      "name": "Cemetery Lane.",
-      "exits": {
-        "south": 881,
-        "north": 883
-      },
-      "id": 882
+      "id": 882, "name": "Cemetery Lane.",
+      "exits": { "south": 881, "north": 883 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "east": 884,
-        "south": 882
-      },
-      "id": 883
+      "id": 883, "name": "A cemetery.",
+      "exits": { "east": 884, "south": 882 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "west": 883,
-        "north": 885
-      },
-      "id": 884
+      "id": 884, "name": "A cemetery.",
+      "exits": { "west": 883, "north": 885 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "west": 886,
-        "south": 884
-      },
-      "id": 885
+      "id": 885, "name": "A cemetery.",
+      "exits": { "west": 886, "south": 884 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "east": 885,
-        "north": 887
-      },
-      "id": 886
+      "id": 886, "name": "A cemetery.",
+      "exits": { "east": 885, "north": 887 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "south": 886,
-        "west": 889,
-        "east": 892,
-        "north": 888
-      },
-      "id": 887
+      "id": 887, "name": "A cemetery.",
+      "exits": { "south": 886, "west": 889, "east": 892, "north": 888 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "south": 887
-      },
-      "id": 888
+      "id": 888, "name": "A cemetery.",
+      "exits": { "south": 887 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "east": 887,
-        "south": 890
-      },
-      "id": 889
+      "id": 889, "name": "A cemetery.",
+      "exits": { "east": 887, "south": 890 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "south": 891,
-        "north": 889
-      },
-      "id": 890
+      "id": 890, "name": "A cemetery.",
+      "exits": { "south": 891, "north": 889 }
     },
     {
-      "name": "Thieves Guild",
-      "exits": {
-        "north": 890
-      },
-      "id": 891
+      "id": 891, "name": "Thieves Guild",
+      "exits": { "north": 890 }
     },
     {
-      "name": "A cemetery.",
-      "exits": {
-        "west": 887
-      },
-      "id": 892
+      "id": 892, "name": "A cemetery.",
+      "exits": { "west": 887 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area13.json
+++ b/maps/area13.json
@@ -4,129 +4,64 @@
   },
   "rooms": [
     {
-      "name": "Foyer",
-      "exits": {
-        "west": 98,
-        "up": 1011,
-        "south": 1010,
-        "east": 1001,
-        "north": 1009
-      },
-      "id": 1000
+      "id": 1000, "name": "Foyer",
+      "exits": { "west": 98, "up": 1011, "south": 1010, "east": 1001, "north": 1009 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "northeast": 1008,
-        "east": 1002,
-        "west": 1000
-      },
-      "id": 1001
+      "id": 1001, "name": "Hallway",
+      "exits": { "northeast": 1008, "east": 1002, "west": 1000 }
     },
     {
-      "name": "Ballroom",
-      "exits": {
-        "south": 1007,
-        "west": 1001,
-        "east": 1003,
-        "north": 1014
-      },
-      "id": 1002
+      "id": 1002, "name": "Ballroom",
+      "exits": { "south": 1007, "west": 1001, "east": 1003, "north": 1014 }
     },
     {
-      "name": "Dance Floor",
-      "exits": {
-        "west": 1002,
-        "east": 1004,
-        "south": 1006
-      },
-      "id": 1003
+      "id": 1003, "name": "Dance Floor",
+      "exits": { "west": 1002, "east": 1004, "south": 1006 }
     },
     {
-      "name": "Gaston's table",
-      "exits": {
-        "west": 1003,
-        "south": 1005,
-        "north": 1013
-      },
-      "id": 1004
+      "id": 1004, "name": "Gaston's table",
+      "exits": { "west": 1003, "south": 1005, "north": 1013 }
     },
     {
-      "name": "Dance Floor",
-      "exits": {
-        "west": 1006,
-        "south": 1012,
-        "north": 1004
-      },
-      "id": 1005
+      "id": 1005, "name": "Dance Floor",
+      "exits": { "west": 1006, "south": 1012, "north": 1004 }
     },
     {
-      "name": "Dance Floor",
-      "exits": {
-        "west": 1007,
-        "east": 1005,
-        "north": 1003
-      },
-      "id": 1006
+      "id": 1006, "name": "Dance Floor",
+      "exits": { "west": 1007, "east": 1005, "north": 1003 }
     },
     {
-      "name": "Buffet table",
-      "exits": {
-        "east": 1006,
-        "north": 1002
-      },
-      "id": 1007
+      "id": 1007, "name": "Buffet table",
+      "exits": { "east": 1006, "north": 1002 }
     },
     {
-      "name": "Kitchen",
-      "exits": {
-        "southwest": 1001
-      },
-      "id": 1008
+      "id": 1008, "name": "Kitchen",
+      "exits": { "southwest": 1001 }
     },
     {
-      "name": "Library",
-      "exits": {
-        "south": 1000
-      },
-      "id": 1009
+      "id": 1009, "name": "Library",
+      "exits": { "south": 1000 }
     },
     {
-      "name": "Map Room",
-      "exits": {
-        "north": 1000
-      },
-      "id": 1010
+      "id": 1010, "name": "Map Room",
+      "exits": { "north": 1000 }
     },
     {
-      "name": "House of Clan Lord Gaston",
-      "exits": {
-        "down": 1000
-      },
-      "id": 1011
+      "id": 1011, "name": "House of Clan Lord Gaston",
+      "exits": { "down": 1000 }
     },
     {
-      "name": "Deck",
-      "exits": {
-        "north": 1005
-      },
-      "id": 1012
+      "id": 1012, "name": "Deck",
+      "exits": { "north": 1005 }
     },
     {
-      "name": "Bandstand",
-      "exits": {
-        "west": 1014,
-        "south": 1004
-      },
-      "id": 1013
+      "id": 1013, "name": "Bandstand",
+      "exits": { "west": 1014, "south": 1004 }
     },
     {
-      "name": "Dark corner",
-      "exits": {
-        "east": 1013,
-        "south": 1002
-      },
-      "id": 1014
+      "id": 1014, "name": "Dark corner",
+      "exits": { "east": 1013, "south": 1002 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area14.json
+++ b/maps/area14.json
@@ -4,93 +4,48 @@
   },
   "rooms": [
     {
-      "name": "Headquarter Entrance",
-      "exits": {
-        "south": 74,
-        "east": 1017,
-        "north": 1020
-      },
-      "id": 1018
+      "id": 1018, "name": "Headquarter Entrance",
+      "exits": { "south": 74, "east": 1017, "north": 1020 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1018,
-        "north": 1021
-      },
-      "id": 1020
+      "id": 1020, "name": "Hallway",
+      "exits": { "south": 1018, "north": 1021 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1020,
-        "east": 1022,
-        "north": 1024
-      },
-      "id": 1021
+      "id": 1021, "name": "Hallway",
+      "exits": { "south": 1020, "east": 1022, "north": 1024 }
     },
     {
-      "name": "Bunk Area",
-      "exits": {
-        "west": 1021,
-        "south": 1023
-      },
-      "id": 1022
+      "id": 1022, "name": "Bunk Area",
+      "exits": { "west": 1021, "south": 1023 }
     },
     {
-      "name": "Banquet Hall",
-      "exits": {
-        "north": 1022
-      },
-      "id": 1023
+      "id": 1023, "name": "Banquet Hall",
+      "exits": { "north": 1022 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1021,
-        "east": 1029,
-        "north": 1025
-      },
-      "id": 1024
+      "id": 1024, "name": "Hallway",
+      "exits": { "south": 1021, "east": 1029, "north": 1025 }
     },
     {
-      "name": "Ready Room",
-      "exits": {
-        "south": 1024,
-        "east": 1028,
-        "north": 1026
-      },
-      "id": 1025
+      "id": 1025, "name": "Ready Room",
+      "exits": { "south": 1024, "east": 1028, "north": 1026 }
     },
     {
-      "name": "Outer Wall",
-      "exits": {
-        "east": 1027,
-        "south": 1025
-      },
-      "id": 1026
+      "id": 1026, "name": "Outer Wall",
+      "exits": { "east": 1027, "south": 1025 }
     },
     {
-      "name": "Outer Wall",
-      "exits": {
-        "east": 963,
-        "west": 1026
-      },
-      "id": 1027
+      "id": 1027, "name": "Outer Wall",
+      "exits": { "east": 963, "west": 1026 }
     },
     {
-      "name": "Armoury",
-      "exits": {
-        "west": 1025
-      },
-      "id": 1028
+      "id": 1028, "name": "Armoury",
+      "exits": { "west": 1025 }
     },
     {
-      "name": "Strategist's Room",
-      "exits": {
-        "west": 1024
-      },
-      "id": 1029
+      "id": 1029, "name": "Strategist's Room",
+      "exits": { "west": 1024 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area16.json
+++ b/maps/area16.json
@@ -4,19 +4,14 @@
   },
   "rooms": [
     {
-      "name": "Southwest Tower",
-      "id": 1036
+      "id": 1036, "name": "Southwest Tower"
     },
     {
-      "name": "Empty Closet",
-      "id": 1037
+      "id": 1037, "name": "Empty Closet"
     },
     {
-      "name": "Thief Hideout Entrance",
-      "exits": {
-        "up": 1037
-      },
-      "id": 1038
+      "id": 1038, "name": "Thief Hideout Entrance",
+      "exits": { "up": 1037 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area17.json
+++ b/maps/area17.json
@@ -4,322 +4,160 @@
   },
   "rooms": [
     {
-      "name": "Guard Post",
-      "exits": {
-        "east": 1049,
-        "north": 1040
-      },
-      "id": 1039
+      "id": 1039, "name": "Guard Post",
+      "exits": { "east": 1049, "north": 1040 }
     },
     {
-      "name": "A bend in the hallway",
-      "exits": {
-        "east": 1041,
-        "south": 1039
-      },
-      "id": 1040
+      "id": 1040, "name": "A bend in the hallway",
+      "exits": { "east": 1041, "south": 1039 }
     },
     {
-      "name": "Cobwebs brush against the left side of your face as you walk through them.",
-      "exits": {
-        "east": 1042,
-        "west": 1040
-      },
-      "id": 1041
+      "id": 1041, "name": "Cobwebs brush against the left side of your face as you walk through them.",
+      "exits": { "east": 1042, "west": 1040 }
     },
     {
-      "name": "The Great Hall",
-      "exits": {
-        "east": 1043,
-        "west": 1041
-      },
-      "id": 1042
+      "id": 1042, "name": "The Great Hall",
+      "exits": { "east": 1043, "west": 1041 }
     },
     {
-      "name": "A bend in the hallway",
-      "exits": {
-        "west": 1042,
-        "south": 1044
-      },
-      "id": 1043
+      "id": 1043, "name": "A bend in the hallway",
+      "exits": { "west": 1042, "south": 1044 }
     },
     {
-      "name": "Barrack",
-      "exits": {
-        "west": 1045,
-        "south": 1046,
-        "north": 1043
-      },
-      "id": 1044
+      "id": 1044, "name": "Barrack",
+      "exits": { "west": 1045, "south": 1046, "north": 1043 }
     },
     {
-      "name": "First floor landing",
-      "exits": {
-        "east": 1044,
-        "up": 1050
-      },
-      "id": 1045
+      "id": 1045, "name": "First floor landing",
+      "exits": { "east": 1044, "up": 1050 }
     },
     {
-      "name": "Barrack",
-      "exits": {
-        "south": 1047,
-        "north": 1044
-      },
-      "id": 1046
+      "id": 1046, "name": "Barrack",
+      "exits": { "south": 1047, "north": 1044 }
     },
     {
-      "name": "Staging Room",
-      "exits": {
-        "west": 1048,
-        "north": 1046
-      },
-      "id": 1047
+      "id": 1047, "name": "Staging Room",
+      "exits": { "west": 1048, "north": 1046 }
     },
     {
-      "name": "Sally Port",
-      "exits": {
-        "east": 1047
-      },
-      "id": 1048
+      "id": 1048, "name": "Sally Port",
+      "exits": { "east": 1047 }
     },
     {
-      "name": "An office",
-      "exits": {
-        "west": 1039
-      },
-      "id": 1049
+      "id": 1049, "name": "An office",
+      "exits": { "west": 1039 }
     },
     {
-      "name": "Second floor landing",
-      "exits": {
-        "up": 1051,
-        "down": 1045,
-        "north": 1069
-      },
-      "id": 1050
+      "id": 1050, "name": "Second floor landing",
+      "exits": { "up": 1051, "down": 1045, "north": 1069 }
     },
     {
-      "name": "Third floor landing",
-      "exits": {
-        "down": 1050,
-        "up": 1052,
-        "east": 1065,
-        "north": 1064
-      },
-      "id": 1051
+      "id": 1051, "name": "Third floor landing",
+      "exits": { "down": 1050, "up": 1052, "east": 1065, "north": 1064 }
     },
     {
-      "name": "Stairwell",
-      "exits": {
-        "west": 1060,
-        "down": 1051,
-        "south": 1053,
-        "east": 1059,
-        "north": 1057
-      },
-      "id": 1052
+      "id": 1052, "name": "Stairwell",
+      "exits": { "west": 1060, "down": 1051, "south": 1053, "east": 1059, "north": 1057 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "south": 1054,
-        "east": 1056,
-        "north": 1052
-      },
-      "id": 1053
+      "id": 1053, "name": "Northeast Tower Roof",
+      "exits": { "south": 1054, "east": 1056, "north": 1052 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "east": 1055,
-        "north": 1053
-      },
-      "id": 1054
+      "id": 1054, "name": "Northeast Tower Roof",
+      "exits": { "east": 1055, "north": 1053 }
     },
     {
-      "name": "Southeast corner of roof",
-      "exits": {
-        "west": 1054,
-        "north": 1056
-      },
-      "id": 1055
+      "id": 1055, "name": "Southeast corner of roof",
+      "exits": { "west": 1054, "north": 1056 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "west": 1053,
-        "south": 1055,
-        "north": 1059
-      },
-      "id": 1056
+      "id": 1056, "name": "Northeast Tower Roof",
+      "exits": { "west": 1053, "south": 1055, "north": 1059 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "east": 1058,
-        "south": 1052
-      },
-      "id": 1057
+      "id": 1057, "name": "Northeast Tower Roof",
+      "exits": { "east": 1058, "south": 1052 }
     },
     {
-      "name": "Northeast corner of roof",
-      "exits": {
-        "west": 1057,
-        "south": 1059
-      },
-      "id": 1058
+      "id": 1058, "name": "Northeast corner of roof",
+      "exits": { "west": 1057, "south": 1059 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "west": 1052,
-        "south": 1056,
-        "north": 1058
-      },
-      "id": 1059
+      "id": 1059, "name": "Northeast Tower Roof",
+      "exits": { "west": 1052, "south": 1056, "north": 1058 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "west": 1063,
-        "east": 1052,
-        "north": 1061
-      },
-      "id": 1060
+      "id": 1060, "name": "Northeast Tower Roof",
+      "exits": { "west": 1063, "east": 1052, "north": 1061 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "west": 1062,
-        "south": 1060
-      },
-      "id": 1061
+      "id": 1061, "name": "Northeast Tower Roof",
+      "exits": { "west": 1062, "south": 1060 }
     },
     {
-      "name": "Northwest corner of roof",
-      "exits": {
-        "east": 1061,
-        "south": 1063
-      },
-      "id": 1062
+      "id": 1062, "name": "Northwest corner of roof",
+      "exits": { "east": 1061, "south": 1063 }
     },
     {
-      "name": "Northeast Tower Roof",
-      "exits": {
-        "east": 1060,
-        "north": 1062
-      },
-      "id": 1063
+      "id": 1063, "name": "Northeast Tower Roof",
+      "exits": { "east": 1060, "north": 1062 }
     },
     {
-      "name": "Guard Post",
-      "exits": {
-        "south": 1051
-      },
-      "id": 1064
+      "id": 1064, "name": "Guard Post",
+      "exits": { "south": 1051 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "west": 1051,
-        "south": 1066
-      },
-      "id": 1065
+      "id": 1065, "name": "Hallway",
+      "exits": { "west": 1051, "south": 1066 }
     },
     {
-      "name": "Hall",
-      "exits": {
-        "south": 1067,
-        "north": 1065
-      },
-      "id": 1066
+      "id": 1066, "name": "Hall",
+      "exits": { "south": 1067, "north": 1065 }
     },
     {
-      "name": "War Room",
-      "exits": {
-        "west": 1068,
-        "north": 1066
-      },
-      "id": 1067
+      "id": 1067, "name": "War Room",
+      "exits": { "west": 1068, "north": 1066 }
     },
     {
-      "name": "Portal Chamber",
-      "exits": {
-        "east": 1067
-      },
-      "id": 1068
+      "id": 1068, "name": "Portal Chamber",
+      "exits": { "east": 1067 }
     },
     {
-      "name": "Guard Post",
-      "exits": {
-        "west": 1070,
-        "east": 1072,
-        "south": 1050
-      },
-      "id": 1069
+      "id": 1069, "name": "Guard Post",
+      "exits": { "west": 1070, "east": 1072, "south": 1050 }
     },
     {
-      "name": "Prison Wing",
-      "exits": {
-        "west": 1071,
-        "east": 1069,
-        "south": 1077
-      },
-      "id": 1070
+      "id": 1070, "name": "Prison Wing",
+      "exits": { "west": 1071, "east": 1069, "south": 1077 }
     },
     {
-      "name": "Prison cell",
-      "exits": {
-        "east": 1070
-      },
-      "id": 1071
+      "id": 1071, "name": "Prison cell",
+      "exits": { "east": 1070 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "west": 1069,
-        "south": 1073
-      },
-      "id": 1072
+      "id": 1072, "name": "Hallway",
+      "exits": { "west": 1069, "south": 1073 }
     },
     {
-      "name": "An alarm sounds as you pass the threshold of the magic barrier.",
-      "exits": {
-        "south": 1074,
-        "north": 1072
-      },
-      "id": 1073
+      "id": 1073, "name": "An alarm sounds as you pass the threshold of the magic barrier.",
+      "exits": { "south": 1074, "north": 1072 }
     },
     {
-      "name": "Witch's Workroom",
-      "exits": {
-        "west": 1075,
-        "south": 1076,
-        "north": 1073
-      },
-      "id": 1074
+      "id": 1074, "name": "Witch's Workroom",
+      "exits": { "west": 1075, "south": 1076, "north": 1073 }
     },
     {
-      "name": "Library",
-      "exits": {
-        "east": 1074
-      },
-      "id": 1075
+      "id": 1075, "name": "Library",
+      "exits": { "east": 1074 }
     },
     {
-      "name": "Morgue",
-      "exits": {
-        "north": 1074
-      },
-      "id": 1076
+      "id": 1076, "name": "Morgue",
+      "exits": { "north": 1074 }
     },
     {
-      "name": "Prison cell",
-      "exits": {
-        "north": 1070
-      },
-      "id": 1077
+      "id": 1077, "name": "Prison cell",
+      "exits": { "north": 1070 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area18.json
+++ b/maps/area18.json
@@ -4,43 +4,24 @@
   },
   "rooms": [
     {
-      "name": "House of Clan Lord Bracknar",
-      "exits": {
-        "west": 1080,
-        "up": 1081,
-        "south": 1079,
-        "east": 76,
-        "north": 1078
-      },
-      "id": 77
+      "id": 77, "name": "House of Clan Lord Bracknar",
+      "exits": { "west": 1080, "up": 1081, "south": 1079, "east": 76, "north": 1078 }
     },
     {
-      "name": "Lord's Stable",
-      "exits": {
-        "south": 77
-      },
-      "id": 1078
+      "id": 1078, "name": "Lord's Stable",
+      "exits": { "south": 77 }
     },
     {
-      "name": "Kitchen",
-      "exits": {
-        "north": 77
-      },
-      "id": 1079
+      "id": 1079, "name": "Kitchen",
+      "exits": { "north": 77 }
     },
     {
-      "name": "Bracknar's Garden",
-      "exits": {
-        "east": 77
-      },
-      "id": 1080
+      "id": 1080, "name": "Bracknar's Garden",
+      "exits": { "east": 77 }
     },
     {
-      "name": "House of Clan Lord Bracknar",
-      "exits": {
-        "down": 77
-      },
-      "id": 1081
+      "id": 1081, "name": "House of Clan Lord Bracknar",
+      "exits": { "down": 77 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area19.json
+++ b/maps/area19.json
@@ -4,107 +4,56 @@
   },
   "rooms": [
     {
-      "name": "Gatehouse",
-      "exits": {
-        "up": 1083,
-        "east": 87,
-        "west": 1084
-      },
-      "id": 1082
+      "id": 1082, "name": "Gatehouse",
+      "exits": { "up": 1083, "east": 87, "west": 1084 }
     },
     {
-      "name": "Blockhouse",
-      "exits": {
-        "down": 1082
-      },
-      "id": 1083
+      "id": 1083, "name": "Blockhouse",
+      "exits": { "down": 1082 }
     },
     {
-      "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
-      "exits": {
-        "south": 1087,
-        "west": 1085,
-        "east": 1082,
-        "north": 1092
-      },
-      "id": 1084
+      "id": 1084, "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
+      "exits": { "south": 1087, "west": 1085, "east": 1082, "north": 1092 }
     },
     {
-      "name": "Eastern bailey",
-      "exits": {
-        "east": 1084,
-        "west": 1086
-      },
-      "id": 1085
+      "id": 1085, "name": "Eastern bailey",
+      "exits": { "east": 1084, "west": 1086 }
     },
     {
-      "name": "Western bailey",
-      "exits": {
-        "south": 1871,
-        "east": 1085,
-        "north": 1870
-      },
-      "id": 1086
+      "id": 1086, "name": "Western bailey",
+      "exits": { "south": 1871, "east": 1085, "north": 1870 }
     },
     {
-      "name": "Long hallway",
-      "exits": {
-        "west": 1089,
-        "south": 1088,
-        "north": 1084
-      },
-      "id": 1087
+      "id": 1087, "name": "Long hallway",
+      "exits": { "west": 1089, "south": 1088, "north": 1084 }
     },
     {
-      "name": "Passage",
-      "exits": {
-        "up": 1090,
-        "north": 1087
-      },
-      "id": 1088
+      "id": 1088, "name": "Passage",
+      "exits": { "up": 1090, "north": 1087 }
     },
     {
-      "name": "Sun Court",
-      "exits": {
-        "east": 1087
-      },
-      "id": 1089
+      "id": 1089, "name": "Sun Court",
+      "exits": { "east": 1087 }
     },
     {
-      "name": "Stairwell",
-      "exits": {
-        "down": 1088,
-        "up": 1091
-      },
-      "id": 1090
+      "id": 1090, "name": "Stairwell",
+      "exits": { "down": 1088, "up": 1091 }
     },
     {
-      "name": "Southeast Watchtower",
-      "exits": {
-        "down": 1090
-      },
-      "id": 1091
+      "id": 1091, "name": "Southeast Watchtower",
+      "exits": { "down": 1090 }
     },
     {
-      "name": "Long hallway",
-      "exits": {
-        "south": 1084
-      },
-      "id": 1092
+      "id": 1092, "name": "Long hallway",
+      "exits": { "south": 1084 }
     },
     {
-      "name": "Armoury",
-      "exits": {
-        "south": 1086
-      },
-      "id": 1870
+      "id": 1870, "name": "Armoury",
+      "exits": { "south": 1086 }
     },
     {
-      "name": "Stables",
-      "exits": {
-        "north": 1086
-      },
-      "id": 1871
+      "id": 1871, "name": "Stables",
+      "exits": { "north": 1086 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area20.json
+++ b/maps/area20.json
@@ -4,211 +4,108 @@
   },
   "rooms": [
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "up": 1098,
-        "east": 1100,
-        "south": 1101
-      },
-      "id": 1099
+      "id": 1099, "name": "Crypt of the Honored Dead",
+      "exits": { "up": 1098, "east": 1100, "south": 1101 }
     },
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "northeast": 1103,
-        "southeast": 1102,
-        "west": 1099
-      },
-      "id": 1100
+      "id": 1100, "name": "Crypt of the Honored Dead",
+      "exits": { "northeast": 1103, "southeast": 1102, "west": 1099 }
     },
     {
-      "name": "Crypt of the Honored Dead.",
-      "exits": {
-        "north": 1099
-      },
-      "id": 1101
+      "id": 1101, "name": "Crypt of the Honored Dead.",
+      "exits": { "north": 1099 }
     },
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "northwest": 1100,
-        "southeast": 1115
-      },
-      "id": 1102
+      "id": 1102, "name": "Crypt of the Honored Dead",
+      "exits": { "northwest": 1100, "southeast": 1115 }
     },
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "southwest": 1100,
-        "northeast": 1104
-      },
-      "id": 1103
+      "id": 1103, "name": "Crypt of the Honored Dead",
+      "exits": { "southwest": 1100, "northeast": 1104 }
     },
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "southwest": 1103,
-        "east": 1105
-      },
-      "id": 1104
+      "id": 1104, "name": "Crypt of the Honored Dead",
+      "exits": { "southwest": 1103, "east": 1105 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1108,
-        "west": 1104,
-        "east": 1106,
-        "north": 1107
-      },
-      "id": 1105
+      "id": 1105, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1108, "west": 1104, "east": 1106, "north": 1107 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1111,
-        "west": 1105,
-        "east": 1110,
-        "north": 1109
-      },
-      "id": 1106
+      "id": 1106, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1111, "west": 1105, "east": 1110, "north": 1109 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1105
-      },
-      "id": 1107
+      "id": 1107, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1105 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "north": 1105
-      },
-      "id": 1108
+      "id": 1108, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1105 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1106
-      },
-      "id": 1109
+      "id": 1109, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1106 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1113,
-        "west": 1106,
-        "east": 1114,
-        "north": 1112
-      },
-      "id": 1110
+      "id": 1110, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1113, "west": 1106, "east": 1114, "north": 1112 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "north": 1106
-      },
-      "id": 1111
+      "id": 1111, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1106 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "south": 1110
-      },
-      "id": 1112
+      "id": 1112, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1110 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "north": 1110
-      },
-      "id": 1113
+      "id": 1113, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1110 }
     },
     {
-      "name": "Battle of the Sand Gargoyles",
-      "exits": {
-        "west": 1110
-      },
-      "id": 1114
+      "id": 1114, "name": "Battle of the Sand Gargoyles",
+      "exits": { "west": 1110 }
     },
     {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "northwest": 1102,
-        "east": 1116
-      },
-      "id": 1115
+      "id": 1115, "name": "Crypt of the Honored Dead",
+      "exits": { "northwest": 1102, "east": 1116 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "south": 1123,
-        "west": 1115,
-        "east": 1117,
-        "north": 1124
-      },
-      "id": 1116
+      "id": 1116, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1123, "west": 1115, "east": 1117, "north": 1124 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "south": 1121,
-        "west": 1116,
-        "east": 1118,
-        "north": 1122
-      },
-      "id": 1117
+      "id": 1117, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1121, "west": 1116, "east": 1118, "north": 1122 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "west": 1117,
-        "south": 1119,
-        "north": 1120
-      },
-      "id": 1118
+      "id": 1118, "name": "Battle of Maiden's Kiss",
+      "exits": { "west": 1117, "south": 1119, "north": 1120 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "north": 1118
-      },
-      "id": 1119
+      "id": 1119, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1118 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "south": 1118
-      },
-      "id": 1120
+      "id": 1120, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1118 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "north": 1117
-      },
-      "id": 1121
+      "id": 1121, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1117 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "south": 1117
-      },
-      "id": 1122
+      "id": 1122, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1117 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "north": 1116
-      },
-      "id": 1123
+      "id": 1123, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1116 }
     },
     {
-      "name": "Battle of Maiden's Kiss",
-      "exits": {
-        "south": 1116
-      },
-      "id": 1124
+      "id": 1124, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1116 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area21.json
+++ b/maps/area21.json
@@ -4,35 +4,20 @@
   },
   "rooms": [
     {
-      "name": "Living room",
-      "exits": {
-        "south": 1157,
-        "northeast": 1167,
-        "northwest": 1165,
-        "north": 1166
-      },
-      "id": 1164
+      "id": 1164, "name": "Living room",
+      "exits": { "south": 1157, "northeast": 1167, "northwest": 1165, "north": 1166 }
     },
     {
-      "name": "You brush aside the blanket and duck to pass through the small door.",
-      "exits": {
-        "southeast": 1164
-      },
-      "id": 1165
+      "id": 1165, "name": "You brush aside the blanket and duck to pass through the small door.",
+      "exits": { "southeast": 1164 }
     },
     {
-      "name": "You feel strange walking into the kitchen - that's where women belong.",
-      "exits": {
-        "south": 1164
-      },
-      "id": 1166
+      "id": 1166, "name": "You feel strange walking into the kitchen - that's where women belong.",
+      "exits": { "south": 1164 }
     },
     {
-      "name": "You brush aside the blanket and duck to pass through the small door.",
-      "exits": {
-        "southwest": 1164
-      },
-      "id": 1167
+      "id": 1167, "name": "You brush aside the blanket and duck to pass through the small door.",
+      "exits": { "southwest": 1164 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area23.json
+++ b/maps/area23.json
@@ -4,35 +4,20 @@
   },
   "rooms": [
     {
-      "name": "City Unemployment Office",
-      "exits": {
-        "south": 1203,
-        "west": 417,
-        "east": 241,
-        "north": 418
-      },
-      "id": 416
+      "id": 416, "name": "City Unemployment Office",
+      "exits": { "south": 1203, "west": 417, "east": 241, "north": 418 }
     },
     {
-      "name": "City Unemployment Office",
-      "exits": {
-        "east": 416
-      },
-      "id": 417
+      "id": 417, "name": "City Unemployment Office",
+      "exits": { "east": 416 }
     },
     {
-      "name": "City Unemployment Office",
-      "exits": {
-        "south": 416
-      },
-      "id": 418
+      "id": 418, "name": "City Unemployment Office",
+      "exits": { "south": 416 }
     },
     {
-      "name": "City Unemployment Office",
-      "exits": {
-        "north": 416
-      },
-      "id": 1203
+      "id": 1203, "name": "City Unemployment Office",
+      "exits": { "north": 416 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area25.json
+++ b/maps/area25.json
@@ -4,218 +4,112 @@
   },
   "rooms": [
     {
-      "name": "A short entryway",
-      "exits": {
-        "north": 1263
-      },
-      "id": 1223
+      "id": 1223, "name": "A short entryway",
+      "exits": { "north": 1263 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1223,
-        "west": 1276,
-        "east": 1278,
-        "north": 1264
-      },
-      "id": 1263
+      "id": 1263, "name": "Hallway",
+      "exits": { "south": 1223, "west": 1276, "east": 1278, "north": 1264 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1263,
-        "north": 1265
-      },
-      "id": 1264
+      "id": 1264, "name": "Hallway",
+      "exits": { "south": 1263, "north": 1265 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1264,
-        "east": 1275,
-        "north": 1266
-      },
-      "id": 1265
+      "id": 1265, "name": "Hallway",
+      "exits": { "south": 1264, "east": 1275, "north": 1266 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 1265,
-        "west": 1271,
-        "east": 1273,
-        "north": 1267
-      },
-      "id": 1266
+      "id": 1266, "name": "Hallway",
+      "exits": { "south": 1265, "west": 1271, "east": 1273, "north": 1267 }
     },
     {
-      "name": "End of Hallway",
-      "exits": {
-        "west": 1268,
-        "east": 1269,
-        "south": 1266
-      },
-      "id": 1267
+      "id": 1267, "name": "End of Hallway",
+      "exits": { "west": 1268, "east": 1269, "south": 1266 }
     },
     {
-      "name": "Munchkin Romper Room",
-      "exits": {
-        "east": 1267
-      },
-      "id": 1268
+      "id": 1268, "name": "Munchkin Romper Room",
+      "exits": { "east": 1267 }
     },
     {
-      "name": "Mages' Barracks",
-      "exits": {
-        "east": 1270,
-        "west": 1267
-      },
-      "id": 1269
+      "id": 1269, "name": "Mages' Barracks",
+      "exits": { "east": 1270, "west": 1267 }
     },
     {
-      "name": "Munchkin Library",
-      "exits": {
-        "west": 1269
-      },
-      "id": 1270
+      "id": 1270, "name": "Munchkin Library",
+      "exits": { "west": 1269 }
     },
     {
-      "name": "Munchkin Mess Hall",
-      "exits": {
-        "east": 1266,
-        "west": 1272
-      },
-      "id": 1271
+      "id": 1271, "name": "Munchkin Mess Hall",
+      "exits": { "east": 1266, "west": 1272 }
     },
     {
-      "name": "Kitchen",
-      "exits": {
-        "east": 1271
-      },
-      "id": 1272
+      "id": 1272, "name": "Kitchen",
+      "exits": { "east": 1271 }
     },
     {
-      "name": "Fighters' Barracks",
-      "exits": {
-        "east": 1274,
-        "west": 1266
-      },
-      "id": 1273
+      "id": 1273, "name": "Fighters' Barracks",
+      "exits": { "east": 1274, "west": 1266 }
     },
     {
-      "name": "Fighters' Barracks",
-      "exits": {
-        "west": 1273,
-        "south": 1288
-      },
-      "id": 1274
+      "id": 1274, "name": "Fighters' Barracks",
+      "exits": { "west": 1273, "south": 1288 }
     },
     {
-      "name": "Munchkin Smithy",
-      "exits": {
-        "west": 1265
-      },
-      "id": 1275
+      "id": 1275, "name": "Munchkin Smithy",
+      "exits": { "west": 1265 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "east": 1263,
-        "west": 1277
-      },
-      "id": 1276
+      "id": 1276, "name": "Hallway",
+      "exits": { "east": 1263, "west": 1277 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "west": 1281,
-        "east": 1276,
-        "south": 1280
-      },
-      "id": 1277
+      "id": 1277, "name": "Hallway",
+      "exits": { "west": 1281, "east": 1276, "south": 1280 }
     },
     {
-      "name": "Narrow Hallway",
-      "exits": {
-        "west": 1263,
-        "east": 1279,
-        "north": 1286
-      },
-      "id": 1278
+      "id": 1278, "name": "Narrow Hallway",
+      "exits": { "west": 1263, "east": 1279, "north": 1286 }
     },
     {
-      "name": "End of Narrow Hallway",
-      "exits": {
-        "west": 1278,
-        "north": 1287
-      },
-      "id": 1279
+      "id": 1279, "name": "End of Narrow Hallway",
+      "exits": { "west": 1278, "north": 1287 }
     },
     {
-      "name": "A Dark Tunnel",
-      "exits": {
-        "south": 1284,
-        "north": 1277
-      },
-      "id": 1280
+      "id": 1280, "name": "A Dark Tunnel",
+      "exits": { "south": 1284, "north": 1277 }
     },
     {
-      "name": "End of Hallway",
-      "exits": {
-        "south": 1282,
-        "east": 1277,
-        "north": 1283
-      },
-      "id": 1281
+      "id": 1281, "name": "End of Hallway",
+      "exits": { "south": 1282, "east": 1277, "north": 1283 }
     },
     {
-      "name": "Munchkin Leader's Quarters",
-      "exits": {
-        "north": 1281
-      },
-      "id": 1282
+      "id": 1282, "name": "Munchkin Leader's Quarters",
+      "exits": { "north": 1281 }
     },
     {
-      "name": "Munchkin Leader's Harem",
-      "exits": {
-        "south": 1281
-      },
-      "id": 1283
+      "id": 1283, "name": "Munchkin Leader's Harem",
+      "exits": { "south": 1281 }
     },
     {
-      "name": "A Dark Tunnel",
-      "exits": {
-        "northeast": 1285,
-        "north": 1280
-      },
-      "id": 1284
+      "id": 1284, "name": "A Dark Tunnel",
+      "exits": { "northeast": 1285, "north": 1280 }
     },
     {
-      "name": "A Dark Tunnel",
-      "exits": {
-        "southwest": 1284
-      },
-      "id": 1285
+      "id": 1285, "name": "A Dark Tunnel",
+      "exits": { "southwest": 1284 }
     },
     {
-      "name": "Dank Cell",
-      "exits": {
-        "south": 1278
-      },
-      "id": 1286
+      "id": 1286, "name": "Dank Cell",
+      "exits": { "south": 1278 }
     },
     {
-      "name": "Dank Cell",
-      "exits": {
-        "south": 1279
-      },
-      "id": 1287
+      "id": 1287, "name": "Dank Cell",
+      "exits": { "south": 1279 }
     },
     {
-      "name": "The Lollipop Guild",
-      "exits": {
-        "north": 1274
-      },
-      "id": 1288
+      "id": 1288, "name": "The Lollipop Guild",
+      "exits": { "north": 1274 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area27.json
+++ b/maps/area27.json
@@ -4,43 +4,24 @@
   },
   "rooms": [
     {
-      "name": "Tiled Entryway",
-      "exits": {
-        "west": 1336,
-        "south": 1335
-      },
-      "id": 1334
+      "id": 1334, "name": "Tiled Entryway",
+      "exits": { "west": 1336, "south": 1335 }
     },
     {
-      "name": "Inside of Bracknar Gate",
-      "exits": {
-        "south": 261,
-        "north": 1334
-      },
-      "id": 1335
+      "id": 1335, "name": "Inside of Bracknar Gate",
+      "exits": { "south": 261, "north": 1334 }
     },
     {
-      "name": "Sitting Room",
-      "exits": {
-        "east": 1334,
-        "north": 1337
-      },
-      "id": 1336
+      "id": 1336, "name": "Sitting Room",
+      "exits": { "east": 1334, "north": 1337 }
     },
     {
-      "name": "Guarded hallway",
-      "exits": {
-        "south": 1336,
-        "north": 1361
-      },
-      "id": 1337
+      "id": 1337, "name": "Guarded hallway",
+      "exits": { "south": 1336, "north": 1361 }
     },
     {
-      "name": "Clan Lord's Private Chambers",
-      "exits": {
-        "south": 1337
-      },
-      "id": 1361
+      "id": 1361, "name": "Clan Lord's Private Chambers",
+      "exits": { "south": 1337 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area29.json
+++ b/maps/area29.json
@@ -4,609 +4,268 @@
   },
   "rooms": [
     {
-      "name": "Light forest",
-      "exits": {
-        "west": 1492,
-        "east": 1496,
-        "south": 1441
-      },
-      "id": 1440
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1442,
-        "west": 1493,
-        "east": 1495,
-        "north": 1440
-      },
-      "id": 1441
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1475,
-        "west": 1494,
-        "east": 1443,
-        "north": 1441
-      },
-      "id": 1442
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1476,
-        "west": 1442,
-        "east": 1444,
-        "north": 1495
-      },
-      "id": 1443
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1477,
-        "west": 1443,
-        "east": 1445,
-        "north": 1498
-      },
-      "id": 1444
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1444,
-        "east": 1446,
-        "south": 1460
-      },
-      "id": 1445
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "west": 1445,
-        "east": 1447,
-        "south": 1459
-      },
-      "id": 1446
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "west": 1446,
-        "east": 1449,
-        "south": 1452
-      },
-      "id": 1447
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "east": 1450,
-        "west": 1447
-      },
-      "id": 1449
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "east": 1451,
-        "west": 1449
-      },
-      "id": 1450
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1450
-      },
-      "id": 1451
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1459,
-        "south": 1453,
-        "north": 1447
-      },
-      "id": 1452
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1458,
-        "south": 1454,
-        "north": 1452
-      },
-      "id": 1453
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "west": 1457,
-        "south": 1455,
-        "north": 1453
-      },
-      "id": 1454
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1456,
-        "north": 1454
-      },
-      "id": 1455
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1499,
-        "west": 1463,
-        "east": 1455,
-        "north": 1457
-      },
-      "id": 1456
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1456,
-        "west": 1462,
-        "east": 1454,
-        "north": 1458
-      },
-      "id": 1457
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1457,
-        "west": 1461,
-        "east": 1453,
-        "north": 1459
-      },
-      "id": 1458
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "south": 1458,
-        "west": 1460,
-        "east": 1452,
-        "north": 1446
-      },
-      "id": 1459
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "south": 1461,
-        "west": 1477,
-        "east": 1459,
-        "north": 1445
-      },
-      "id": 1460
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "south": 1462,
-        "west": 1478,
-        "east": 1458,
-        "north": 1460
-      },
-      "id": 1461
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1463,
-        "west": 1479,
-        "east": 1457,
-        "north": 1461
-      },
-      "id": 1462
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1464,
-        "west": 1480,
-        "east": 1456,
-        "north": 1462
-      },
-      "id": 1463
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "west": 1465,
-        "east": 1499,
-        "north": 1463
-      },
-      "id": 1464
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "west": 1466,
-        "east": 1464,
-        "north": 1480
-      },
-      "id": 1465
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "west": 1467,
-        "east": 1465,
-        "north": 1481
-      },
-      "id": 1466
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "west": 1468,
-        "east": 1466,
-        "north": 1482
-      },
-      "id": 1467
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "east": 1467,
-        "west": 1469
-      },
-      "id": 1468
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "east": 1468,
-        "north": 1470
-      },
-      "id": 1469
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1469,
-        "north": 1471
-      },
-      "id": 1470
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1470,
-        "east": 1484,
-        "north": 1472
-      },
-      "id": 1471
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1471,
-        "east": 1485,
-        "north": 1473
-      },
-      "id": 1472
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1472,
-        "east": 1474,
-        "north": 1489
-      },
-      "id": 1473
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1485,
-        "west": 1473,
-        "east": 1475,
-        "north": 1494
-      },
-      "id": 1474
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1486,
-        "west": 1474,
-        "east": 1476,
-        "north": 1442
-      },
-      "id": 1475
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1487,
-        "west": 1475,
-        "east": 1477,
-        "north": 1443
-      },
-      "id": 1476
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1478,
-        "west": 1476,
-        "east": 1460,
-        "north": 1444
-      },
-      "id": 1477
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1479,
-        "west": 1487,
-        "east": 1461,
-        "north": 1477
-      },
-      "id": 1478
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1480,
-        "west": 1488,
-        "east": 1462,
-        "north": 1478
-      },
-      "id": 1479
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1465,
-        "west": 1481,
-        "east": 1463,
-        "north": 1479
-      },
-      "id": 1480
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1466,
-        "west": 1482,
-        "east": 1480,
-        "north": 1488
-      },
-      "id": 1481
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1467,
-        "east": 1481,
-        "north": 1483
-      },
-      "id": 1482
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1482,
-        "west": 1484,
-        "east": 1488,
-        "north": 1486
-      },
-      "id": 1483
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "west": 1471,
-        "east": 1483,
-        "north": 1485
-      },
-      "id": 1484
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1484,
-        "west": 1472,
-        "east": 1486,
-        "north": 1474
-      },
-      "id": 1485
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1483,
-        "west": 1485,
-        "east": 1487,
-        "north": 1475
-      },
-      "id": 1486
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1488,
-        "west": 1486,
-        "east": 1478,
-        "north": 1476
-      },
-      "id": 1487
-    },
-    {
-      "name": "Dense forest",
-      "exits": {
-        "south": 1481,
-        "west": 1483,
-        "east": 1479,
-        "north": 1487
-      },
-      "id": 1488
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1473,
-        "east": 1494,
-        "north": 1490
-      },
-      "id": 1489
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "south": 1489,
-        "east": 1493,
-        "north": 1491
-      },
-      "id": 1490
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "down": 1506,
-        "east": 1492,
-        "south": 1490
-      },
-      "id": 1491
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "west": 1491,
-        "east": 1440,
-        "south": 1493
-      },
-      "id": 1492
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1494,
-        "west": 1490,
-        "east": 1441,
-        "north": 1492
-      },
-      "id": 1493
-    },
-    {
-      "name": "The Valley",
-      "exits": {
-        "south": 1474,
-        "west": 1489,
-        "east": 1442,
-        "north": 1493
-      },
-      "id": 1494
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "south": 1443,
-        "west": 1441,
-        "east": 1498,
-        "north": 1496
-      },
-      "id": 1495
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1440,
-        "east": 1497,
-        "south": 1495
-      },
-      "id": 1496
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1496,
-        "south": 1498
-      },
-      "id": 1497
-    },
-    {
-      "name": "Light forest",
-      "exits": {
-        "west": 1495,
-        "south": 1444,
-        "north": 1497
-      },
-      "id": 1498
-    },
-    {
-      "name": "Meadow",
-      "exits": {
-        "west": 1464,
-        "south": 1505,
-        "north": 1456
-      },
-      "id": 1499
-    },
-    {
-      "name": "Path",
-      "exits": {
-        "south": 1501,
-        "west": 1503,
-        "east": 1473,
-        "north": 1504
-      },
-      "id": 1500
-    },
-    {
-      "name": "Forest",
-      "exits": {
-        "west": 1502,
-        "north": 1500
-      },
-      "id": 1501
-    },
-    {
-      "name": "Beach",
-      "exits": {
-        "east": 1501,
-        "north": 1503
-      },
-      "id": 1502
-    },
-    {
-      "name": "Beach",
-      "exits": {
-        "east": 1500,
-        "south": 1502
-      },
-      "id": 1503
-    },
-    {
-      "name": "Lighthouse Base",
-      "exits": {
-        "south": 1500
-      },
-      "id": 1504
-    },
-    {
-      "name": "Mountain Range",
-      "exits": {
-        "north": 1499
-      },
-      "id": 1505
-    },
-    {
-      "name": "Mine Entrance",
-      "exits": {
-        "up": 1491
-      },
-      "id": 1506
+      "id": 1440, "name": "Light forest",
+      "exits": { "west": 1492, "east": 1496, "south": 1441 }
+    },
+    {
+      "id": 1441, "name": "Light forest",
+      "exits": { "south": 1442, "west": 1493, "east": 1495, "north": 1440 }
+    },
+    {
+      "id": 1442, "name": "The Valley",
+      "exits": { "south": 1475, "west": 1494, "east": 1443, "north": 1441 }
+    },
+    {
+      "id": 1443, "name": "The Valley",
+      "exits": { "south": 1476, "west": 1442, "east": 1444, "north": 1495 }
+    },
+    {
+      "id": 1444, "name": "The Valley",
+      "exits": { "south": 1477, "west": 1443, "east": 1445, "north": 1498 }
+    },
+    {
+      "id": 1445, "name": "Light forest",
+      "exits": { "west": 1444, "east": 1446, "south": 1460 }
+    },
+    {
+      "id": 1446, "name": "Meadow",
+      "exits": { "west": 1445, "east": 1447, "south": 1459 }
+    },
+    {
+      "id": 1447, "name": "Meadow",
+      "exits": { "west": 1446, "east": 1449, "south": 1452 }
+    },
+    {
+      "id": 1449, "name": "Light forest",
+      "exits": { "east": 1450, "west": 1447 }
+    },
+    {
+      "id": 1450, "name": "Light forest",
+      "exits": { "east": 1451, "west": 1449 }
+    },
+    {
+      "id": 1451, "name": "Light forest",
+      "exits": { "west": 1450 }
+    },
+    {
+      "id": 1452, "name": "Light forest",
+      "exits": { "west": 1459, "south": 1453, "north": 1447 }
+    },
+    {
+      "id": 1453, "name": "Light forest",
+      "exits": { "west": 1458, "south": 1454, "north": 1452 }
+    },
+    {
+      "id": 1454, "name": "Dense forest",
+      "exits": { "west": 1457, "south": 1455, "north": 1453 }
+    },
+    {
+      "id": 1455, "name": "Light forest",
+      "exits": { "west": 1456, "north": 1454 }
+    },
+    {
+      "id": 1456, "name": "Dense forest",
+      "exits": { "south": 1499, "west": 1463, "east": 1455, "north": 1457 }
+    },
+    {
+      "id": 1457, "name": "Dense forest",
+      "exits": { "south": 1456, "west": 1462, "east": 1454, "north": 1458 }
+    },
+    {
+      "id": 1458, "name": "Light forest",
+      "exits": { "south": 1457, "west": 1461, "east": 1453, "north": 1459 }
+    },
+    {
+      "id": 1459, "name": "Meadow",
+      "exits": { "south": 1458, "west": 1460, "east": 1452, "north": 1446 }
+    },
+    {
+      "id": 1460, "name": "Meadow",
+      "exits": { "south": 1461, "west": 1477, "east": 1459, "north": 1445 }
+    },
+    {
+      "id": 1461, "name": "Meadow",
+      "exits": { "south": 1462, "west": 1478, "east": 1458, "north": 1460 }
+    },
+    {
+      "id": 1462, "name": "Dense forest",
+      "exits": { "south": 1463, "west": 1479, "east": 1457, "north": 1461 }
+    },
+    {
+      "id": 1463, "name": "Dense forest",
+      "exits": { "south": 1464, "west": 1480, "east": 1456, "north": 1462 }
+    },
+    {
+      "id": 1464, "name": "Mountain Range",
+      "exits": { "west": 1465, "east": 1499, "north": 1463 }
+    },
+    {
+      "id": 1465, "name": "Mountain Range",
+      "exits": { "west": 1466, "east": 1464, "north": 1480 }
+    },
+    {
+      "id": 1466, "name": "Mountain Range",
+      "exits": { "west": 1467, "east": 1465, "north": 1481 }
+    },
+    {
+      "id": 1467, "name": "Mountain Range",
+      "exits": { "west": 1468, "east": 1466, "north": 1482 }
+    },
+    {
+      "id": 1468, "name": "Mountain Range",
+      "exits": { "east": 1467, "west": 1469 }
+    },
+    {
+      "id": 1469, "name": "Mountain Range",
+      "exits": { "east": 1468, "north": 1470 }
+    },
+    {
+      "id": 1470, "name": "Mountain Range",
+      "exits": { "south": 1469, "north": 1471 }
+    },
+    {
+      "id": 1471, "name": "Mountain Range",
+      "exits": { "south": 1470, "east": 1484, "north": 1472 }
+    },
+    {
+      "id": 1472, "name": "Mountain Range",
+      "exits": { "south": 1471, "east": 1485, "north": 1473 }
+    },
+    {
+      "id": 1473, "name": "Mountain Range",
+      "exits": { "south": 1472, "east": 1474, "north": 1489 }
+    },
+    {
+      "id": 1474, "name": "Light forest",
+      "exits": { "south": 1485, "west": 1473, "east": 1475, "north": 1494 }
+    },
+    {
+      "id": 1475, "name": "Light forest",
+      "exits": { "south": 1486, "west": 1474, "east": 1476, "north": 1442 }
+    },
+    {
+      "id": 1476, "name": "Light forest",
+      "exits": { "south": 1487, "west": 1475, "east": 1477, "north": 1443 }
+    },
+    {
+      "id": 1477, "name": "The Valley",
+      "exits": { "south": 1478, "west": 1476, "east": 1460, "north": 1444 }
+    },
+    {
+      "id": 1478, "name": "The Valley",
+      "exits": { "south": 1479, "west": 1487, "east": 1461, "north": 1477 }
+    },
+    {
+      "id": 1479, "name": "The Valley",
+      "exits": { "south": 1480, "west": 1488, "east": 1462, "north": 1478 }
+    },
+    {
+      "id": 1480, "name": "The Valley",
+      "exits": { "south": 1465, "west": 1481, "east": 1463, "north": 1479 }
+    },
+    {
+      "id": 1481, "name": "Dense forest",
+      "exits": { "south": 1466, "west": 1482, "east": 1480, "north": 1488 }
+    },
+    {
+      "id": 1482, "name": "Dense forest",
+      "exits": { "south": 1467, "east": 1481, "north": 1483 }
+    },
+    {
+      "id": 1483, "name": "Dense forest",
+      "exits": { "south": 1482, "west": 1484, "east": 1488, "north": 1486 }
+    },
+    {
+      "id": 1484, "name": "Dense forest",
+      "exits": { "west": 1471, "east": 1483, "north": 1485 }
+    },
+    {
+      "id": 1485, "name": "Light forest",
+      "exits": { "south": 1484, "west": 1472, "east": 1486, "north": 1474 }
+    },
+    {
+      "id": 1486, "name": "Light forest",
+      "exits": { "south": 1483, "west": 1485, "east": 1487, "north": 1475 }
+    },
+    {
+      "id": 1487, "name": "Light forest",
+      "exits": { "south": 1488, "west": 1486, "east": 1478, "north": 1476 }
+    },
+    {
+      "id": 1488, "name": "Dense forest",
+      "exits": { "south": 1481, "west": 1483, "east": 1479, "north": 1487 }
+    },
+    {
+      "id": 1489, "name": "Mountain Range",
+      "exits": { "south": 1473, "east": 1494, "north": 1490 }
+    },
+    {
+      "id": 1490, "name": "Mountain Range",
+      "exits": { "south": 1489, "east": 1493, "north": 1491 }
+    },
+    {
+      "id": 1491, "name": "Mountain Range",
+      "exits": { "down": 1506, "east": 1492, "south": 1490 }
+    },
+    {
+      "id": 1492, "name": "The Valley",
+      "exits": { "west": 1491, "east": 1440, "south": 1493 }
+    },
+    {
+      "id": 1493, "name": "The Valley",
+      "exits": { "south": 1494, "west": 1490, "east": 1441, "north": 1492 }
+    },
+    {
+      "id": 1494, "name": "The Valley",
+      "exits": { "south": 1474, "west": 1489, "east": 1442, "north": 1493 }
+    },
+    {
+      "id": 1495, "name": "Light forest",
+      "exits": { "south": 1443, "west": 1441, "east": 1498, "north": 1496 }
+    },
+    {
+      "id": 1496, "name": "Light forest",
+      "exits": { "west": 1440, "east": 1497, "south": 1495 }
+    },
+    {
+      "id": 1497, "name": "Light forest",
+      "exits": { "west": 1496, "south": 1498 }
+    },
+    {
+      "id": 1498, "name": "Light forest",
+      "exits": { "west": 1495, "south": 1444, "north": 1497 }
+    },
+    {
+      "id": 1499, "name": "Meadow",
+      "exits": { "west": 1464, "south": 1505, "north": 1456 }
+    },
+    {
+      "id": 1500, "name": "Path",
+      "exits": { "south": 1501, "west": 1503, "east": 1473, "north": 1504 }
+    },
+    {
+      "id": 1501, "name": "Forest",
+      "exits": { "west": 1502, "north": 1500 }
+    },
+    {
+      "id": 1502, "name": "Beach",
+      "exits": { "east": 1501, "north": 1503 }
+    },
+    {
+      "id": 1503, "name": "Beach",
+      "exits": { "east": 1500, "south": 1502 }
+    },
+    {
+      "id": 1504, "name": "Lighthouse Base",
+      "exits": { "south": 1500 }
+    },
+    {
+      "id": 1505, "name": "Mountain Range",
+      "exits": { "north": 1499 }
+    },
+    {
+      "id": 1506, "name": "Mine Entrance",
+      "exits": { "up": 1491 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area32.json
+++ b/maps/area32.json
@@ -4,292 +4,148 @@
   },
   "rooms": [
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1651,
-        "west": 1673
-      },
-      "id": 1650
+      "id": 1650, "name": "North Moat",
+      "exits": { "east": 1651, "west": 1673 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1652,
-        "west": 1650
-      },
-      "id": 1651
+      "id": 1651, "name": "North Moat",
+      "exits": { "east": 1652, "west": 1650 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1654,
-        "west": 1651
-      },
-      "id": 1652
+      "id": 1652, "name": "North Moat",
+      "exits": { "east": 1654, "west": 1651 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "west": 1652,
-        "south": 1655
-      },
-      "id": 1654
+      "id": 1654, "name": "North Moat",
+      "exits": { "west": 1652, "south": 1655 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1656,
-        "north": 1654
-      },
-      "id": 1655
+      "id": 1655, "name": "East Moat",
+      "exits": { "south": 1656, "north": 1654 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1657,
-        "north": 1655
-      },
-      "id": 1656
+      "id": 1656, "name": "East Moat",
+      "exits": { "south": 1657, "north": 1655 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1658,
-        "north": 1656
-      },
-      "id": 1657
+      "id": 1657, "name": "East Moat",
+      "exits": { "south": 1658, "north": 1656 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1659,
-        "north": 1657
-      },
-      "id": 1658
+      "id": 1658, "name": "East Moat",
+      "exits": { "south": 1659, "north": 1657 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1660,
-        "north": 1658
-      },
-      "id": 1659
+      "id": 1659, "name": "East Moat",
+      "exits": { "south": 1660, "north": 1658 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1661,
-        "north": 1659
-      },
-      "id": 1660
+      "id": 1660, "name": "East Moat",
+      "exits": { "south": 1661, "north": 1659 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1662,
-        "north": 1660
-      },
-      "id": 1661
+      "id": 1661, "name": "East Moat",
+      "exits": { "south": 1662, "north": 1660 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1663,
-        "north": 1661
-      },
-      "id": 1662
+      "id": 1662, "name": "East Moat",
+      "exits": { "south": 1663, "north": 1661 }
     },
     {
-      "name": "East Moat",
-      "exits": {
-        "south": 1664,
-        "north": 1662
-      },
-      "id": 1663
+      "id": 1663, "name": "East Moat",
+      "exits": { "south": 1664, "north": 1662 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "west": 1665,
-        "north": 1663
-      },
-      "id": 1664
+      "id": 1664, "name": "South Moat",
+      "exits": { "west": 1665, "north": 1663 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1664,
-        "west": 1666
-      },
-      "id": 1665
+      "id": 1665, "name": "South Moat",
+      "exits": { "east": 1664, "west": 1666 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1665,
-        "west": 1667
-      },
-      "id": 1666
+      "id": 1666, "name": "South Moat",
+      "exits": { "east": 1665, "west": 1667 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1666,
-        "west": 1668
-      },
-      "id": 1667
+      "id": 1667, "name": "South Moat",
+      "exits": { "east": 1666, "west": 1668 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1667,
-        "west": 1669
-      },
-      "id": 1668
+      "id": 1668, "name": "South Moat",
+      "exits": { "east": 1667, "west": 1669 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1668,
-        "west": 1670
-      },
-      "id": 1669
+      "id": 1669, "name": "South Moat",
+      "exits": { "east": 1668, "west": 1670 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1669,
-        "west": 1671
-      },
-      "id": 1670
+      "id": 1670, "name": "South Moat",
+      "exits": { "east": 1669, "west": 1671 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1670,
-        "west": 1672
-      },
-      "id": 1671
+      "id": 1671, "name": "South Moat",
+      "exits": { "east": 1670, "west": 1672 }
     },
     {
-      "name": "South Moat",
-      "exits": {
-        "east": 1671,
-        "north": 1686
-      },
-      "id": 1672
+      "id": 1672, "name": "South Moat",
+      "exits": { "east": 1671, "north": 1686 }
     },
     {
-      "name": "North Moat - Under Draw Bridge",
-      "exits": {
-        "east": 1650,
-        "west": 1674
-      },
-      "id": 1673
+      "id": 1673, "name": "North Moat - Under Draw Bridge",
+      "exits": { "east": 1650, "west": 1674 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1673,
-        "west": 1675
-      },
-      "id": 1674
+      "id": 1674, "name": "North Moat",
+      "exits": { "east": 1673, "west": 1675 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1674,
-        "west": 1676
-      },
-      "id": 1675
+      "id": 1675, "name": "North Moat",
+      "exits": { "east": 1674, "west": 1676 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1675,
-        "west": 1677
-      },
-      "id": 1676
+      "id": 1676, "name": "North Moat",
+      "exits": { "east": 1675, "west": 1677 }
     },
     {
-      "name": "North Moat",
-      "exits": {
-        "east": 1676,
-        "south": 1678
-      },
-      "id": 1677
+      "id": 1677, "name": "North Moat",
+      "exits": { "east": 1676, "south": 1678 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1679,
-        "north": 1677
-      },
-      "id": 1678
+      "id": 1678, "name": "West Moat",
+      "exits": { "south": 1679, "north": 1677 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1680,
-        "north": 1678
-      },
-      "id": 1679
+      "id": 1679, "name": "West Moat",
+      "exits": { "south": 1680, "north": 1678 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1681,
-        "north": 1679
-      },
-      "id": 1680
+      "id": 1680, "name": "West Moat",
+      "exits": { "south": 1681, "north": 1679 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1682,
-        "north": 1680
-      },
-      "id": 1681
+      "id": 1681, "name": "West Moat",
+      "exits": { "south": 1682, "north": 1680 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1683,
-        "north": 1681
-      },
-      "id": 1682
+      "id": 1682, "name": "West Moat",
+      "exits": { "south": 1683, "north": 1681 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1684,
-        "north": 1682
-      },
-      "id": 1683
+      "id": 1683, "name": "West Moat",
+      "exits": { "south": 1684, "north": 1682 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1685,
-        "north": 1683
-      },
-      "id": 1684
+      "id": 1684, "name": "West Moat",
+      "exits": { "south": 1685, "north": 1683 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1686,
-        "north": 1684
-      },
-      "id": 1685
+      "id": 1685, "name": "West Moat",
+      "exits": { "south": 1686, "north": 1684 }
     },
     {
-      "name": "West Moat",
-      "exits": {
-        "south": 1672,
-        "north": 1685
-      },
-      "id": 1686
+      "id": 1686, "name": "West Moat",
+      "exits": { "south": 1672, "north": 1685 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area33.json
+++ b/maps/area33.json
@@ -4,464 +4,212 @@
   },
   "rooms": [
     {
-      "name": "Oak Treehouse landing",
-      "exits": {
-        "southwest": 1725,
-        "northeast": 1726,
-        "southeast": 1724
-      },
-      "id": 990
+      "id": 990, "name": "Oak Treehouse landing",
+      "exits": { "southwest": 1725, "northeast": 1726, "southeast": 1724 }
     },
     {
-      "name": "Gate to the Village Green",
-      "exits": {
-        "east": 1693,
-        "south": 1688
-      },
-      "id": 1687
+      "id": 1687, "name": "Gate to the Village Green",
+      "exits": { "east": 1693, "south": 1688 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1689,
-        "east": 1694,
-        "north": 1687
-      },
-      "id": 1688
+      "id": 1688, "name": "Northwest Green",
+      "exits": { "south": 1689, "east": 1694, "north": 1687 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1699,
-        "east": 1690,
-        "north": 1688
-      },
-      "id": 1689
+      "id": 1689, "name": "Northwest Green",
+      "exits": { "south": 1699, "east": 1690, "north": 1688 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1700,
-        "west": 1689,
-        "east": 1691,
-        "north": 1694
-      },
-      "id": 1690
+      "id": 1690, "name": "Northwest Green",
+      "exits": { "south": 1700, "west": 1689, "east": 1691, "north": 1694 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1701,
-        "west": 1690,
-        "east": 1692,
-        "north": 1704
-      },
-      "id": 1691
+      "id": 1691, "name": "Northwest Green",
+      "exits": { "south": 1701, "west": 1690, "east": 1692, "north": 1704 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "south": 1702,
-        "west": 1691,
-        "east": 1706,
-        "north": 1703
-      },
-      "id": 1692
+      "id": 1692, "name": "Northeast Green",
+      "exits": { "south": 1702, "west": 1691, "east": 1706, "north": 1703 }
     },
     {
-      "name": "Northwestern Green",
-      "exits": {
-        "west": 1687,
-        "east": 1695,
-        "south": 1694
-      },
-      "id": 1693
+      "id": 1693, "name": "Northwestern Green",
+      "exits": { "west": 1687, "east": 1695, "south": 1694 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1690,
-        "west": 1688,
-        "east": 1704,
-        "north": 1693
-      },
-      "id": 1694
+      "id": 1694, "name": "Northwest Green",
+      "exits": { "south": 1690, "west": 1688, "east": 1704, "north": 1693 }
     },
     {
-      "name": "Northwestern Green",
-      "exits": {
-        "west": 1693,
-        "east": 1696,
-        "south": 1704
-      },
-      "id": 1695
+      "id": 1695, "name": "Northwestern Green",
+      "exits": { "west": 1693, "east": 1696, "south": 1704 }
     },
     {
-      "name": "Northeastern Green",
-      "exits": {
-        "west": 1695,
-        "east": 1697,
-        "south": 1703
-      },
-      "id": 1696
+      "id": 1696, "name": "Northeastern Green",
+      "exits": { "west": 1695, "east": 1697, "south": 1703 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "west": 1696,
-        "east": 1698,
-        "south": 1705
-      },
-      "id": 1697
+      "id": 1697, "name": "Northeast Green",
+      "exits": { "west": 1696, "east": 1698, "south": 1705 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "west": 1697,
-        "south": 1710
-      },
-      "id": 1698
+      "id": 1698, "name": "Northeast Green",
+      "exits": { "west": 1697, "south": 1710 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1713,
-        "east": 1700,
-        "north": 1689
-      },
-      "id": 1699
+      "id": 1699, "name": "Southwest Green",
+      "exits": { "south": 1713, "east": 1700, "north": 1689 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1712,
-        "west": 1699,
-        "east": 1701,
-        "north": 1690
-      },
-      "id": 1700
+      "id": 1700, "name": "Southwest Green",
+      "exits": { "south": 1712, "west": 1699, "east": 1701, "north": 1690 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1711,
-        "west": 1700,
-        "east": 1702,
-        "north": 1691
-      },
-      "id": 1701
+      "id": 1701, "name": "Southwest Green",
+      "exits": { "south": 1711, "west": 1700, "east": 1702, "north": 1691 }
     },
     {
-      "name": "Southeast Green",
-      "exits": {
-        "south": 1714,
-        "west": 1701,
-        "east": 1707,
-        "north": 1692
-      },
-      "id": 1702
+      "id": 1702, "name": "Southeast Green",
+      "exits": { "south": 1714, "west": 1701, "east": 1707, "north": 1692 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "south": 1692,
-        "west": 1704,
-        "east": 1705,
-        "north": 1696
-      },
-      "id": 1703
+      "id": 1703, "name": "Northeast Green",
+      "exits": { "south": 1692, "west": 1704, "east": 1705, "north": 1696 }
     },
     {
-      "name": "Northwest Green",
-      "exits": {
-        "south": 1691,
-        "west": 1694,
-        "east": 1703,
-        "north": 1695
-      },
-      "id": 1704
+      "id": 1704, "name": "Northwest Green",
+      "exits": { "south": 1691, "west": 1694, "east": 1703, "north": 1695 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "south": 1706,
-        "west": 1703,
-        "east": 1710,
-        "north": 1697
-      },
-      "id": 1705
+      "id": 1705, "name": "Northeast Green",
+      "exits": { "south": 1706, "west": 1703, "east": 1710, "north": 1697 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "south": 1707,
-        "west": 1692,
-        "east": 1709,
-        "north": 1705
-      },
-      "id": 1706
+      "id": 1706, "name": "Northeast Green",
+      "exits": { "south": 1707, "west": 1692, "east": 1709, "north": 1705 }
     },
     {
-      "name": "Ruins in the Southeast Green",
-      "exits": {
-        "south": 1715,
-        "west": 1702,
-        "east": 1708,
-        "north": 1706
-      },
-      "id": 1707
+      "id": 1707, "name": "Ruins in the Southeast Green",
+      "exits": { "south": 1715, "west": 1702, "east": 1708, "north": 1706 }
     },
     {
-      "name": "Ruins in the Southeast Green",
-      "exits": {
-        "west": 1707,
-        "south": 1716,
-        "north": 1709
-      },
-      "id": 1708
+      "id": 1708, "name": "Ruins in the Southeast Green",
+      "exits": { "west": 1707, "south": 1716, "north": 1709 }
     },
     {
-      "name": "Northeastern Green",
-      "exits": {
-        "west": 1706,
-        "south": 1708,
-        "north": 1710
-      },
-      "id": 1709
+      "id": 1709, "name": "Northeastern Green",
+      "exits": { "west": 1706, "south": 1708, "north": 1710 }
     },
     {
-      "name": "Northeast Green",
-      "exits": {
-        "south": 1709,
-        "west": 1705,
-        "east": 1722,
-        "north": 1698
-      },
-      "id": 1710
+      "id": 1710, "name": "Northeast Green",
+      "exits": { "south": 1709, "west": 1705, "east": 1722, "north": 1698 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1717,
-        "west": 1712,
-        "east": 1714,
-        "north": 1701
-      },
-      "id": 1711
+      "id": 1711, "name": "Southwest Green",
+      "exits": { "south": 1717, "west": 1712, "east": 1714, "north": 1701 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1718,
-        "west": 1713,
-        "east": 1711,
-        "north": 1700
-      },
-      "id": 1712
+      "id": 1712, "name": "Southwest Green",
+      "exits": { "south": 1718, "west": 1713, "east": 1711, "north": 1700 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "south": 1719,
-        "east": 1712,
-        "north": 1699
-      },
-      "id": 1713
+      "id": 1713, "name": "Southwest Green",
+      "exits": { "south": 1719, "east": 1712, "north": 1699 }
     },
     {
-      "name": "Southeast Green",
-      "exits": {
-        "west": 1711,
-        "east": 1715,
-        "north": 1702
-      },
-      "id": 1714
+      "id": 1714, "name": "Southeast Green",
+      "exits": { "west": 1711, "east": 1715, "north": 1702 }
     },
     {
-      "name": "Southeast Green",
-      "exits": {
-        "west": 1714,
-        "east": 1716,
-        "north": 1707
-      },
-      "id": 1715
+      "id": 1715, "name": "Southeast Green",
+      "exits": { "west": 1714, "east": 1716, "north": 1707 }
     },
     {
-      "name": "Southeast Green",
-      "exits": {
-        "west": 1715,
-        "north": 1708
-      },
-      "id": 1716
+      "id": 1716, "name": "Southeast Green",
+      "exits": { "west": 1715, "north": 1708 }
     },
     {
-      "name": "Southwest Green",
-      "exits": {
-        "west": 1718,
-        "north": 1711
-      },
-      "id": 1717
+      "id": 1717, "name": "Southwest Green",
+      "exits": { "west": 1718, "north": 1711 }
     },
     {
-      "name": "Dark Southwest Green",
-      "exits": {
-        "south": 1721,
-        "west": 1719,
-        "east": 1717,
-        "north": 1712
-      },
-      "id": 1718
+      "id": 1718, "name": "Dark Southwest Green",
+      "exits": { "south": 1721, "west": 1719, "east": 1717, "north": 1712 }
     },
     {
-      "name": "Dark Southwest Green",
-      "exits": {
-        "south": 1720,
-        "east": 1718,
-        "north": 1713
-      },
-      "id": 1719
+      "id": 1719, "name": "Dark Southwest Green",
+      "exits": { "south": 1720, "east": 1718, "north": 1713 }
     },
     {
-      "name": "Dark Southwest Green",
-      "exits": {
-        "east": 1721,
-        "north": 1719
-      },
-      "id": 1720
+      "id": 1720, "name": "Dark Southwest Green",
+      "exits": { "east": 1721, "north": 1719 }
     },
     {
-      "name": "Dark Southwest Green",
-      "exits": {
-        "west": 1720,
-        "north": 1718
-      },
-      "id": 1721
+      "id": 1721, "name": "Dark Southwest Green",
+      "exits": { "west": 1720, "north": 1718 }
     },
     {
-      "name": "The Herb Exchange",
-      "exits": {
-        "west": 1710
-      },
-      "id": 1722
+      "id": 1722, "name": "The Herb Exchange",
+      "exits": { "west": 1710 }
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
-      "exits": {
-        "northwest": 990,
-        "southeast": 1729
-      },
-      "id": 1724
+      "id": 1724, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "northwest": 990, "southeast": 1729 }
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
-      "exits": {
-        "southwest": 1728,
-        "northeast": 990
-      },
-      "id": 1725
+      "id": 1725, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "southwest": 1728, "northeast": 990 }
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
-      "exits": {
-        "southwest": 990,
-        "northeast": 1727
-      },
-      "id": 1726
+      "id": 1726, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "southwest": 990, "northeast": 1727 }
     },
     {
-      "name": "Living Quarters in the Oak",
-      "exits": {
-        "southwest": 1726
-      },
-      "id": 1727
+      "id": 1727, "name": "Living Quarters in the Oak",
+      "exits": { "southwest": 1726 }
     },
     {
-      "name": "Living Quarters in the Oak",
-      "exits": {
-        "northeast": 1725
-      },
-      "id": 1728
+      "id": 1728, "name": "Living Quarters in the Oak",
+      "exits": { "northeast": 1725 }
     },
     {
-      "name": "Oak Treehouse Gazebo",
-      "exits": {
-        "northwest": 1724,
-        "east": 1730
-      },
-      "id": 1729
+      "id": 1729, "name": "Oak Treehouse Gazebo",
+      "exits": { "northwest": 1724, "east": 1730 }
     },
     {
-      "name": "Long Rope Bridge",
-      "exits": {
-        "east": 1731,
-        "west": 1729
-      },
-      "id": 1730
+      "id": 1730, "name": "Long Rope Bridge",
+      "exits": { "east": 1731, "west": 1729 }
     },
     {
-      "name": "The rope bridge sways underfoot, but you maintain your balance.",
-      "exits": {
-        "west": 1730,
-        "northeast": 1732,
-        "east": 1733,
-        "south": 1734
-      },
-      "id": 1731
+      "id": 1731, "name": "The rope bridge sways underfoot, but you maintain your balance.",
+      "exits": { "west": 1730, "northeast": 1732, "east": 1733, "south": 1734 }
     },
     {
-      "name": "You push open the door and proceed northeast into the large room.",
-      "exits": {
-        "southwest": 1731
-      },
-      "id": 1732
+      "id": 1732, "name": "You push open the door and proceed northeast into the large room.",
+      "exits": { "southwest": 1731 }
     },
     {
-      "name": "You push open the door to the private quarters.",
-      "exits": {
-        "west": 1731
-      },
-      "id": 1733
+      "id": 1733, "name": "You push open the door to the private quarters.",
+      "exits": { "west": 1731 }
     },
     {
-      "name": "Gingerly, you step out onto the taunt rope bridge.",
-      "exits": {
-        "south": 1735,
-        "north": 1731
-      },
-      "id": 1734
+      "id": 1734, "name": "Gingerly, you step out onto the taunt rope bridge.",
+      "exits": { "south": 1735, "north": 1731 }
     },
     {
-      "name": "You scurry across the swinging rope bridge.",
-      "exits": {
-        "southeast": 1736,
-        "north": 1734
-      },
-      "id": 1735
+      "id": 1735, "name": "You scurry across the swinging rope bridge.",
+      "exits": { "southeast": 1736, "north": 1734 }
     },
     {
-      "name": "Tel'Quesir Throne Room",
-      "exits": {
-        "northeast": 1738,
-        "northwest": 1735,
-        "southeast": 1737
-      },
-      "id": 1736
+      "id": 1736, "name": "Tel'Quesir Throne Room",
+      "exits": { "northeast": 1738, "northwest": 1735, "southeast": 1737 }
     },
     {
-      "name": "White Chapel",
-      "exits": {
-        "northwest": 1736,
-        "north": 1738
-      },
-      "id": 1737
+      "id": 1737, "name": "White Chapel",
+      "exits": { "northwest": 1736, "north": 1738 }
     },
     {
-      "name": "Hall of Ministers",
-      "exits": {
-        "southwest": 1736,
-        "south": 1737
-      },
-      "id": 1738
+      "id": 1738, "name": "Hall of Ministers",
+      "exits": { "southwest": 1736, "south": 1737 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area36.json
+++ b/maps/area36.json
@@ -4,82 +4,44 @@
   },
   "rooms": [
     {
-      "name": "You are just inside the entrace to a large cave",
-      "exits": {
-        "east": 1825
-      },
-      "id": 1824
+      "id": 1824, "name": "You are just inside the entrace to a large cave",
+      "exits": { "east": 1825 }
     },
     {
-      "name": "A wide tunnel",
-      "exits": {
-        "west": 1824,
-        "south": 1826,
-        "north": 1827
-      },
-      "id": 1825
+      "id": 1825, "name": "A wide tunnel",
+      "exits": { "west": 1824, "south": 1826, "north": 1827 }
     },
     {
-      "name": "A den",
-      "exits": {
-        "north": 1825
-      },
-      "id": 1826
+      "id": 1826, "name": "A den",
+      "exits": { "north": 1825 }
     },
     {
-      "name": "A tunnel",
-      "exits": {
-        "south": 1825,
-        "north": 1828
-      },
-      "id": 1827
+      "id": 1827, "name": "A tunnel",
+      "exits": { "south": 1825, "north": 1828 }
     },
     {
-      "name": "A bend in the tunnel",
-      "exits": {
-        "east": 1829,
-        "south": 1827
-      },
-      "id": 1828
+      "id": 1828, "name": "A bend in the tunnel",
+      "exits": { "east": 1829, "south": 1827 }
     },
     {
-      "name": "A tunnel",
-      "exits": {
-        "east": 1830,
-        "west": 1828
-      },
-      "id": 1829
+      "id": 1829, "name": "A tunnel",
+      "exits": { "east": 1830, "west": 1828 }
     },
     {
-      "name": "T-intersection",
-      "exits": {
-        "west": 1829,
-        "south": 1831,
-        "north": 1833
-      },
-      "id": 1830
+      "id": 1830, "name": "T-intersection",
+      "exits": { "west": 1829, "south": 1831, "north": 1833 }
     },
     {
-      "name": "The widening tunnel",
-      "exits": {
-        "east": 1832,
-        "north": 1830
-      },
-      "id": 1831
+      "id": 1831, "name": "The widening tunnel",
+      "exits": { "east": 1832, "north": 1830 }
     },
     {
-      "name": "A large chamber",
-      "exits": {
-        "west": 1831
-      },
-      "id": 1832
+      "id": 1832, "name": "A large chamber",
+      "exits": { "west": 1831 }
     },
     {
-      "name": "A small chamber",
-      "exits": {
-        "south": 1830
-      },
-      "id": 1833
+      "id": 1833, "name": "A small chamber",
+      "exits": { "south": 1830 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area38.json
+++ b/maps/area38.json
@@ -4,51 +4,28 @@
   },
   "rooms": [
     {
-      "name": "You cross the sharply arching bridge.",
-      "exits": {
-        "south": 1861,
-        "north": 1864
-      },
-      "id": 1863
+      "id": 1863, "name": "You cross the sharply arching bridge.",
+      "exits": { "south": 1861, "north": 1864 }
     },
     {
-      "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
-      "exits": {
-        "south": 1863,
-        "north": 1865
-      },
-      "id": 1864
+      "id": 1864, "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
+      "exits": { "south": 1863, "north": 1865 }
     },
     {
-      "name": "You step down into the sandy courtyard.",
-      "exits": {
-        "south": 1864,
-        "north": 1866
-      },
-      "id": 1865
+      "id": 1865, "name": "You step down into the sandy courtyard.",
+      "exits": { "south": 1864, "north": 1866 }
     },
     {
-      "name": "Northwest Training Yard",
-      "exits": {
-        "south": 1865,
-        "north": 1867
-      },
-      "id": 1866
+      "id": 1866, "name": "Northwest Training Yard",
+      "exits": { "south": 1865, "north": 1867 }
     },
     {
-      "name": "You step up onto the boardwalk that rings the practice yard.",
-      "exits": {
-        "south": 1866,
-        "north": 1868
-      },
-      "id": 1867
+      "id": 1867, "name": "You step up onto the boardwalk that rings the practice yard.",
+      "exits": { "south": 1866, "north": 1868 }
     },
     {
-      "name": "You slide back the fusumi with a flick of your hand.",
-      "exits": {
-        "south": 1867
-      },
-      "id": 1868
+      "id": 1868, "name": "You slide back the fusumi with a flick of your hand.",
+      "exits": { "south": 1867 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area6.json
+++ b/maps/area6.json
@@ -4,26 +4,16 @@
   },
   "rooms": [
     {
-      "name": "Entrance to Gorge",
-      "exits": {
-        "north": 507
-      },
-      "id": 506
+      "id": 506, "name": "Entrance to Gorge",
+      "exits": { "north": 507 }
     },
     {
-      "name": "Narrow Gorge",
-      "exits": {
-        "west": 508,
-        "south": 506
-      },
-      "id": 507
+      "id": 507, "name": "Narrow Gorge",
+      "exits": { "west": 508, "south": 506 }
     },
     {
-      "name": "Old Guard Room",
-      "exits": {
-        "east": 507
-      },
-      "id": 508
+      "id": 508, "name": "Old Guard Room",
+      "exits": { "east": 507 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area7.json
+++ b/maps/area7.json
@@ -4,408 +4,210 @@
   },
   "rooms": [
     {
-      "name": "",
-      "id": 509
+      "id": 509, "name": ""
     },
     {
-      "name": "Barbarian Clearing",
-      "exits": {
-        "north": 511
-      },
-      "id": 510
+      "id": 510, "name": "Barbarian Clearing",
+      "exits": { "north": 511 }
     },
     {
-      "name": "Underground Pond",
-      "exits": {
-        "southwest": 512,
-        "west": 518,
-        "south": 510
-      },
-      "id": 511
+      "id": 511, "name": "Underground Pond",
+      "exits": { "southwest": 512, "west": 518, "south": 510 }
     },
     {
-      "name": "Cave Passage",
-      "exits": {
-        "south": 513,
-        "northeast": 511
-      },
-      "id": 512
+      "id": 512, "name": "Cave Passage",
+      "exits": { "south": 513, "northeast": 511 }
     },
     {
-      "name": "Cave Passage",
-      "exits": {
-        "south": 515,
-        "north": 512
-      },
-      "id": 513
+      "id": 513, "name": "Cave Passage",
+      "exits": { "south": 515, "north": 512 }
     },
     {
-      "name": "You begin to climb into the pit, and the descent seems simple enough.",
-      "id": 514
+      "id": 514, "name": "You begin to climb into the pit, and the descent seems simple enough."
     },
     {
-      "name": "Bottom of a Deep Dark Pit",
-      "exits": {
-        "east": 516,
-        "north": 513
-      },
-      "id": 515
+      "id": 515, "name": "Bottom of a Deep Dark Pit",
+      "exits": { "east": 516, "north": 513 }
     },
     {
-      "name": "Dark Barricade",
-      "exits": {
-        "east": 517,
-        "west": 515
-      },
-      "id": 516
+      "id": 516, "name": "Dark Barricade",
+      "exits": { "east": 517, "west": 515 }
     },
     {
-      "name": "Corridor",
-      "exits": {
-        "east": 519,
-        "west": 516
-      },
-      "id": 517
+      "id": 517, "name": "Corridor",
+      "exits": { "east": 519, "west": 516 }
     },
     {
-      "name": "Cave Passage",
-      "exits": {
-        "southwest": 1292,
-        "east": 511
-      },
-      "id": 518
+      "id": 518, "name": "Cave Passage",
+      "exits": { "southwest": 1292, "east": 511 }
     },
     {
-      "name": "Passage Way",
-      "exits": {
-        "south": 520,
-        "west": 517,
-        "east": 523,
-        "north": 521
-      },
-      "id": 519
+      "id": 519, "name": "Passage Way",
+      "exits": { "south": 520, "west": 517, "east": 523, "north": 521 }
     },
     {
-      "name": "Barracks",
-      "exits": {
-        "north": 519
-      },
-      "id": 520
+      "id": 520, "name": "Barracks",
+      "exits": { "north": 519 }
     },
     {
-      "name": "Mess Hall",
-      "exits": {
-        "south": 519,
-        "north": 522
-      },
-      "id": 521
+      "id": 521, "name": "Mess Hall",
+      "exits": { "south": 519, "north": 522 }
     },
     {
-      "name": "Kitchen",
-      "exits": {
-        "south": 521
-      },
-      "id": 522
+      "id": 522, "name": "Kitchen",
+      "exits": { "south": 521 }
     },
     {
-      "name": "Passage Way",
-      "exits": {
-        "south": 524,
-        "west": 519,
-        "east": 1295,
-        "north": 1294
-      },
-      "id": 523
+      "id": 523, "name": "Passage Way",
+      "exits": { "south": 524, "west": 519, "east": 1295, "north": 1294 }
     },
     {
-      "name": "Passage Way",
-      "exits": {
-        "south": 525,
-        "north": 523
-      },
-      "id": 524
+      "id": 524, "name": "Passage Way",
+      "exits": { "south": 525, "north": 523 }
     },
     {
-      "name": "Passage Way",
-      "exits": {
-        "west": 1293,
-        "south": 526,
-        "north": 524
-      },
-      "id": 525
+      "id": 525, "name": "Passage Way",
+      "exits": { "west": 1293, "south": 526, "north": 524 }
     },
     {
-      "name": "Circular room",
-      "exits": {
-        "north": 525
-      },
-      "id": 526
+      "id": 526, "name": "Circular room",
+      "exits": { "north": 525 }
     },
     {
-      "name": "Cave Waterfall",
-      "exits": {
-        "northeast": 518
-      },
-      "id": 1292
+      "id": 1292, "name": "Cave Waterfall",
+      "exits": { "northeast": 518 }
     },
     {
-      "name": "Throne Room",
-      "exits": {
-        "east": 525
-      },
-      "id": 1293
+      "id": 1293, "name": "Throne Room",
+      "exits": { "east": 525 }
     },
     {
-      "name": "Mess Hall",
-      "exits": {
-        "south": 523
-      },
-      "id": 1294
+      "id": 1294, "name": "Mess Hall",
+      "exits": { "south": 523 }
     },
     {
-      "name": "New Tunnel",
-      "exits": {
-        "east": 1296,
-        "west": 523
-      },
-      "id": 1295
+      "id": 1295, "name": "New Tunnel",
+      "exits": { "east": 1296, "west": 523 }
     },
     {
-      "name": "New Tunnel",
-      "exits": {
-        "west": 1295
-      },
-      "id": 1296
+      "id": 1296, "name": "New Tunnel",
+      "exits": { "west": 1295 }
     },
     {
-      "name": "New Tunnel",
-      "exits": {
-        "south": 1299,
-        "west": 1298,
-        "east": 1301,
-        "north": 1300
-      },
-      "id": 1297
+      "id": 1297, "name": "New Tunnel",
+      "exits": { "south": 1299, "west": 1298, "east": 1301, "north": 1300 }
     },
     {
-      "name": "You pass through the door and it closes and locks behind you.",
-      "exits": {
-        "east": 1297
-      },
-      "id": 1298
+      "id": 1298, "name": "You pass through the door and it closes and locks behind you.",
+      "exits": { "east": 1297 }
     },
     {
-      "name": "Nursery",
-      "exits": {
-        "north": 1297
-      },
-      "id": 1299
+      "id": 1299, "name": "Nursery",
+      "exits": { "north": 1297 }
     },
     {
-      "name": "Barracks",
-      "exits": {
-        "south": 1297
-      },
-      "id": 1300
+      "id": 1300, "name": "Barracks",
+      "exits": { "south": 1297 }
     },
     {
-      "name": "New Tunnel: Checkpoint",
-      "exits": {
-        "east": 1302,
-        "west": 1297
-      },
-      "id": 1301
+      "id": 1301, "name": "New Tunnel: Checkpoint",
+      "exits": { "east": 1302, "west": 1297 }
     },
     {
-      "name": "Top of the mine shaft",
-      "exits": {
-        "down": 1303,
-        "west": 1301
-      },
-      "id": 1302
+      "id": 1302, "name": "Top of the mine shaft",
+      "exits": { "down": 1303, "west": 1301 }
     },
     {
-      "name": "You let up on the ropes, and the counterweight slowly glides you down the",
-      "exits": {
-        "down": 1304,
-        "up": 1302
-      },
-      "id": 1303
+      "id": 1303, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "exits": { "down": 1304, "up": 1302 }
     },
     {
-      "name": "You let up on the ropes, and the counterweight slowly glides you down the",
-      "exits": {
-        "southwest": 1305,
-        "up": 1303,
-        "east": 1320,
-        "north": 1311
-      },
-      "id": 1304
+      "id": 1304, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "exits": { "southwest": 1305, "up": 1303, "east": 1320, "north": 1311 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southwest": 1306,
-        "northeast": 1304,
-        "southeast": 1309
-      },
-      "id": 1305
+      "id": 1305, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1306, "northeast": 1304, "southeast": 1309 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northeast": 1305,
-        "northwest": 1308,
-        "southeast": 1307
-      },
-      "id": 1306
+      "id": 1306, "name": "Twisting Tunnel",
+      "exits": { "northeast": 1305, "northwest": 1308, "southeast": 1307 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northwest": 1306
-      },
-      "id": 1307
+      "id": 1307, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1306 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southeast": 1306
-      },
-      "id": 1308
+      "id": 1308, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1306 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northwest": 1305,
-        "northeast": 1310
-      },
-      "id": 1309
+      "id": 1309, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1305, "northeast": 1310 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southwest": 1309
-      },
-      "id": 1310
+      "id": 1310, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1309 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "south": 1304,
-        "northeast": 1312
-      },
-      "id": 1311
+      "id": 1311, "name": "Twisting Tunnel",
+      "exits": { "south": 1304, "northeast": 1312 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southwest": 1311,
-        "north": 1313
-      },
-      "id": 1312
+      "id": 1312, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1311, "north": 1313 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "east": 1314,
-        "northwest": 1316,
-        "south": 1312
-      },
-      "id": 1313
+      "id": 1313, "name": "Twisting Tunnel",
+      "exits": { "east": 1314, "northwest": 1316, "south": 1312 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southeast": 1315,
-        "west": 1313
-      },
-      "id": 1314
+      "id": 1314, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1315, "west": 1313 }
     },
     {
-      "name": "Your left arm is now in full health.",
-      "exits": {
-        "northwest": 1314
-      },
-      "id": 1315
+      "id": 1315, "name": "Your left arm is now in full health.",
+      "exits": { "northwest": 1314 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northeast": 1319,
-        "southeast": 1313,
-        "north": 1317
-      },
-      "id": 1316
+      "id": 1316, "name": "Twisting Tunnel",
+      "exits": { "northeast": 1319, "southeast": 1313, "north": 1317 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northwest": 1318,
-        "south": 1316
-      },
-      "id": 1317
+      "id": 1317, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1318, "south": 1316 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southeast": 1317
-      },
-      "id": 1318
+      "id": 1318, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1317 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southwest": 1316
-      },
-      "id": 1319
+      "id": 1319, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1316 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "west": 1304,
-        "northeast": 1321
-      },
-      "id": 1320
+      "id": 1320, "name": "Twisting Tunnel",
+      "exits": { "west": 1304, "northeast": 1321 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "southwest": 1320,
-        "west": 1325,
-        "southeast": 1322,
-        "north": 1324
-      },
-      "id": 1321
+      "id": 1321, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1320, "west": 1325, "southeast": 1322, "north": 1324 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "northwest": 1321,
-        "east": 1323
-      },
-      "id": 1322
+      "id": 1322, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1321, "east": 1323 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "west": 1322
-      },
-      "id": 1323
+      "id": 1323, "name": "Twisting Tunnel",
+      "exits": { "west": 1322 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "south": 1321
-      },
-      "id": 1324
+      "id": 1324, "name": "Twisting Tunnel",
+      "exits": { "south": 1321 }
     },
     {
-      "name": "Twisting Tunnel",
-      "exits": {
-        "east": 1321
-      },
-      "id": 1325
+      "id": 1325, "name": "Twisting Tunnel",
+      "exits": { "east": 1321 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/area8.json
+++ b/maps/area8.json
@@ -4,747 +4,296 @@
   },
   "rooms": [
     {
-      "name": "The start of a forest path",
-      "exits": {
-        "northeast": 530
-      },
-      "id": 529
-    },
-    {
-      "name": "The start of a forest path",
-      "exits": {
-        "southwest": 529,
-        "northeast": 531,
-        "northwest": 532
-      },
-      "id": 530
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 530,
-        "northeast": 539,
-        "east": 551
-      },
-      "id": 531
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 535,
-        "northeast": 578,
-        "southeast": 530,
-        "north": 533
-      },
-      "id": 532
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 534,
-        "south": 532,
-        "southwest": 535,
-        "northeast": 596,
-        "east": 578,
-        "north": 591
-      },
-      "id": 533
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "south": 535,
-        "west": 536,
-        "northeast": 591,
-        "east": 533,
-        "north": 592
-      },
-      "id": 534
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "northeast": 533,
-        "east": 532,
-        "north": 534
-      },
-      "id": 535
-    },
-    {
-      "name": "River Bank",
-      "exits": {
-        "southwest": 537,
-        "northeast": 592,
-        "east": 534
-      },
-      "id": 536
-    },
-    {
-      "name": "River Bank",
-      "exits": {
-        "southwest": 538,
-        "northeast": 536
-      },
-      "id": 537
-    },
-    {
-      "name": "Gryphon Nest",
-      "exits": {
-        "northeast": 537
-      },
-      "id": 538
-    },
-    {
-      "name": "A clearing in the forest",
-      "exits": {
-        "southwest": 531,
-        "northeast": 540,
-        "east": 550,
-        "south": 551
-      },
-      "id": 539
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 539,
-        "northeast": 541,
-        "east": 549,
-        "south": 550
-      },
-      "id": 540
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "south": 549,
-        "southwest": 540,
-        "northeast": 542,
-        "east": 548,
-        "west": 575
-      },
-      "id": 541
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "southwest": 541,
-        "northeast": 543,
-        "east": 547,
-        "south": 548
-      },
-      "id": 542
-    },
-    {
-      "name": "A dark forest",
-      "exits": {
-        "southwest": 542,
-        "northeast": 544,
-        "east": 546,
-        "south": 547
-      },
-      "id": 543
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "southwest": 543,
-        "east": 545,
-        "south": 546
-      },
-      "id": 544
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "southwest": 546,
-        "west": 544,
-        "east": 558,
-        "south": 557
-      },
-      "id": 545
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "west": 543,
-        "south": 556,
-        "southwest": 547,
-        "northeast": 545,
-        "east": 557,
-        "north": 544
-      },
-      "id": 546
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 542,
-        "south": 555,
-        "southwest": 548,
-        "northeast": 546,
-        "east": 556,
-        "north": 543
-      },
-      "id": 547
-    },
-    {
-      "name": "A path in the forest",
-      "exits": {
-        "west": 541,
-        "south": 554,
-        "southwest": 549,
-        "northeast": 547,
-        "east": 555,
-        "north": 542
-      },
-      "id": 548
-    },
-    {
-      "name": "A clearing in the forest",
-      "exits": {
-        "west": 540,
-        "south": 553,
-        "southwest": 550,
-        "northeast": 548,
-        "east": 554,
-        "north": 541
-      },
-      "id": 549
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "west": 539,
-        "south": 552,
-        "southwest": 551,
-        "northeast": 549,
-        "east": 553,
-        "north": 540
-      },
-      "id": 550
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "south": 576,
-        "west": 531,
-        "northeast": 550,
-        "east": 552,
-        "north": 539
-      },
-      "id": 551
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 551,
-        "northeast": 553,
-        "east": 565,
-        "north": 550
-      },
-      "id": 552
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 550,
-        "south": 565,
-        "southwest": 552,
-        "northeast": 554,
-        "east": 564,
-        "north": 549
-      },
-      "id": 553
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 549,
-        "south": 564,
-        "southwest": 553,
-        "northeast": 555,
-        "east": 563,
-        "north": 548
-      },
-      "id": 554
-    },
-    {
-      "name": "A path through the forest",
-      "exits": {
-        "west": 548,
-        "south": 563,
-        "southwest": 554,
-        "northeast": 556,
-        "east": 562,
-        "north": 547
-      },
-      "id": 555
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 547,
-        "south": 562,
-        "southwest": 555,
-        "northeast": 557,
-        "east": 561,
-        "north": 546
-      },
-      "id": 556
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "west": 546,
-        "south": 561,
-        "southwest": 556,
-        "northeast": 558,
-        "east": 560,
-        "north": 545
-      },
-      "id": 557
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 557,
-        "west": 545,
-        "east": 559,
-        "south": 560
-      },
-      "id": 558
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 560,
-        "west": 558,
-        "south": 573
-      },
-      "id": 559
-    },
-    {
-      "name": "A path in the forest",
-      "exits": {
-        "west": 557,
-        "south": 572,
-        "southwest": 561,
-        "northeast": 559,
-        "east": 573,
-        "north": 558
-      },
-      "id": 560
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 556,
-        "south": 571,
-        "southwest": 562,
-        "northeast": 560,
-        "east": 572,
-        "north": 557
-      },
-      "id": 561
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 555,
-        "south": 570,
-        "southwest": 563,
-        "northeast": 561,
-        "east": 571,
-        "north": 556
-      },
-      "id": 562
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "west": 554,
-        "south": 569,
-        "southwest": 564,
-        "northeast": 562,
-        "east": 570,
-        "north": 555
-      },
-      "id": 563
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 553,
-        "south": 568,
-        "southwest": 565,
-        "northeast": 563,
-        "east": 569,
-        "north": 554
-      },
-      "id": 564
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 552,
-        "south": 574,
-        "southwest": 566,
-        "northeast": 564,
-        "east": 568,
-        "north": 553
-      },
-      "id": 565
-    },
-    {
-      "name": "A dark forest glade",
-      "exits": {
-        "southwest": 567,
-        "northeast": 565
-      },
-      "id": 566
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 601,
-        "northeast": 566
-      },
-      "id": 567
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 574,
-        "northeast": 569,
-        "west": 565,
-        "north": 564
-      },
-      "id": 568
-    },
-    {
-      "name": "A path through the forest",
-      "exits": {
-        "southwest": 568,
-        "northeast": 570,
-        "west": 564,
-        "north": 563
-      },
-      "id": 569
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "southwest": 569,
-        "northeast": 571,
-        "west": 563,
-        "north": 562
-      },
-      "id": 570
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 570,
-        "northeast": 572,
-        "west": 562,
-        "north": 561
-      },
-      "id": 571
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 571,
-        "northeast": 573,
-        "west": 561,
-        "north": 560
-      },
-      "id": 572
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 572,
-        "west": 560,
-        "north": 559
-      },
-      "id": 573
-    },
-    {
-      "name": "Forest Glade",
-      "exits": {
-        "northeast": 568,
-        "north": 565
-      },
-      "id": 574
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "east": 541
-      },
-      "id": 575
-    },
-    {
-      "name": "The start of a forest path",
-      "exits": {
-        "southwest": 577,
-        "north": 551
-      },
-      "id": 576
-    },
-    {
-      "name": "The start of a forest path",
-      "exits": {
-        "northeast": 576
-      },
-      "id": 577
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 533,
-        "southwest": 532,
-        "northeast": 579,
-        "east": 600,
-        "north": 596
-      },
-      "id": 578
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 578,
-        "northeast": 580,
-        "west": 596,
-        "north": 597
-      },
-      "id": 579
-    },
-    {
-      "name": "A clearing in the forest",
-      "exits": {
-        "southwest": 579,
-        "northeast": 581,
-        "west": 597,
-        "north": 598
-      },
-      "id": 580
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 580,
-        "northeast": 582,
-        "west": 598,
-        "north": 585
-      },
-      "id": 581
-    },
-    {
-      "name": "Forest Mound",
-      "exits": {
-        "west": 585,
-        "southwest": 581,
-        "northeast": 583,
-        "east": 599,
-        "north": 584
-      },
-      "id": 582
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "southwest": 582,
-        "west": 584
-      },
-      "id": 583
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "southwest": 585,
-        "west": 586,
-        "east": 583,
-        "south": 582
-      },
-      "id": 584
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "south": 581,
-        "west": 595,
-        "northeast": 584,
-        "east": 582,
-        "north": 586
-      },
-      "id": 585
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "southwest": 588,
-        "west": 587,
-        "east": 584,
-        "south": 585
-      },
-      "id": 586
-    },
-    {
-      "name": "A river bank",
-      "exits": {
-        "southwest": 595,
-        "east": 586,
-        "south": 588
-      },
-      "id": 587
-    },
-    {
-      "name": "A dark forest glade",
-      "exits": {
-        "west": 595,
-        "south": 598,
-        "southwest": 589,
-        "northeast": 586,
-        "east": 589,
-        "north": 587
-      },
-      "id": 588
-    },
-    {
-      "name": "A forest glade",
-      "exits": {
-        "west": 594,
-        "south": 597,
-        "southwest": 590,
-        "northeast": 588,
-        "east": 598,
-        "north": 595
-      },
-      "id": 589
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "west": 593,
-        "south": 596,
-        "southwest": 591,
-        "northeast": 589,
-        "east": 597,
-        "north": 594
-      },
-      "id": 590
-    },
-    {
-      "name": "A forest",
-      "exits": {
-        "west": 592,
-        "south": 533,
-        "southwest": 534,
-        "northeast": 590,
-        "east": 596,
-        "north": 593
-      },
-      "id": 591
-    },
-    {
-      "name": "A river bank",
-      "exits": {
-        "southwest": 536,
-        "northeast": 593,
-        "east": 591,
-        "south": 534
-      },
-      "id": 592
-    },
-    {
-      "name": "A river bank",
-      "exits": {
-        "southwest": 592,
-        "northeast": 594,
-        "east": 590,
-        "south": 591
-      },
-      "id": 593
-    },
-    {
-      "name": "A riverbank",
-      "exits": {
-        "southwest": 593,
-        "northeast": 595,
-        "east": 589,
-        "south": 590
-      },
-      "id": 594
-    },
-    {
-      "name": "A river bank",
-      "exits": {
-        "southwest": 594,
-        "northeast": 587,
-        "east": 585,
-        "south": 589
-      },
-      "id": 595
-    },
-    {
-      "name": "A path through the forest",
-      "exits": {
-        "west": 591,
-        "south": 578,
-        "southwest": 533,
-        "northeast": 597,
-        "east": 579,
-        "north": 590
-      },
-      "id": 596
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 590,
-        "south": 579,
-        "southwest": 596,
-        "northeast": 598,
-        "east": 580,
-        "north": 589
-      },
-      "id": 597
-    },
-    {
-      "name": "A forest path",
-      "exits": {
-        "west": 589,
-        "south": 580,
-        "southwest": 597,
-        "northeast": 589,
-        "east": 581,
-        "north": 588
-      },
-      "id": 598
-    },
-    {
-      "name": "A small clearing",
-      "exits": {
-        "west": 582
-      },
-      "id": 599
-    },
-    {
-      "name": "Druids Guild",
-      "exits": {
-        "west": 578
-      },
-      "id": 600
-    },
-    {
-      "name": "Large home",
-      "exits": {
-        "east": 567
-      },
-      "id": 601
+      "id": 529, "name": "The start of a forest path",
+      "exits": { "northeast": 530 }
+    },
+    {
+      "id": 530, "name": "The start of a forest path",
+      "exits": { "southwest": 529, "northeast": 531, "northwest": 532 }
+    },
+    {
+      "id": 531, "name": "A forest path",
+      "exits": { "southwest": 530, "northeast": 539, "east": 551 }
+    },
+    {
+      "id": 532, "name": "A forest path",
+      "exits": { "west": 535, "northeast": 578, "southeast": 530, "north": 533 }
+    },
+    {
+      "id": 533, "name": "A forest path",
+      "exits": { "west": 534, "south": 532, "southwest": 535, "northeast": 596, "east": 578, "north": 591 }
+    },
+    {
+      "id": 534, "name": "A forest path",
+      "exits": { "south": 535, "west": 536, "northeast": 591, "east": 533, "north": 592 }
+    },
+    {
+      "id": 535, "name": "A forest path",
+      "exits": { "northeast": 533, "east": 532, "north": 534 }
+    },
+    {
+      "id": 536, "name": "River Bank",
+      "exits": { "southwest": 537, "northeast": 592, "east": 534 }
+    },
+    {
+      "id": 537, "name": "River Bank",
+      "exits": { "southwest": 538, "northeast": 536 }
+    },
+    {
+      "id": 538, "name": "Gryphon Nest",
+      "exits": { "northeast": 537 }
+    },
+    {
+      "id": 539, "name": "A clearing in the forest",
+      "exits": { "southwest": 531, "northeast": 540, "east": 550, "south": 551 }
+    },
+    {
+      "id": 540, "name": "A forest path",
+      "exits": { "southwest": 539, "northeast": 541, "east": 549, "south": 550 }
+    },
+    {
+      "id": 541, "name": "A forest path",
+      "exits": { "south": 549, "southwest": 540, "northeast": 542, "east": 548, "west": 575 }
+    },
+    {
+      "id": 542, "name": "A forest",
+      "exits": { "southwest": 541, "northeast": 543, "east": 547, "south": 548 }
+    },
+    {
+      "id": 543, "name": "A dark forest",
+      "exits": { "southwest": 542, "northeast": 544, "east": 546, "south": 547 }
+    },
+    {
+      "id": 544, "name": "A forest",
+      "exits": { "southwest": 543, "east": 545, "south": 546 }
+    },
+    {
+      "id": 545, "name": "A forest glade",
+      "exits": { "southwest": 546, "west": 544, "east": 558, "south": 557 }
+    },
+    {
+      "id": 546, "name": "A forest glade",
+      "exits": { "west": 543, "south": 556, "southwest": 547, "northeast": 545, "east": 557, "north": 544 }
+    },
+    {
+      "id": 547, "name": "A forest path",
+      "exits": { "west": 542, "south": 555, "southwest": 548, "northeast": 546, "east": 556, "north": 543 }
+    },
+    {
+      "id": 548, "name": "A path in the forest",
+      "exits": { "west": 541, "south": 554, "southwest": 549, "northeast": 547, "east": 555, "north": 542 }
+    },
+    {
+      "id": 549, "name": "A clearing in the forest",
+      "exits": { "west": 540, "south": 553, "southwest": 550, "northeast": 548, "east": 554, "north": 541 }
+    },
+    {
+      "id": 550, "name": "A forest",
+      "exits": { "west": 539, "south": 552, "southwest": 551, "northeast": 549, "east": 553, "north": 540 }
+    },
+    {
+      "id": 551, "name": "A forest path",
+      "exits": { "south": 576, "west": 531, "northeast": 550, "east": 552, "north": 539 }
+    },
+    {
+      "id": 552, "name": "A forest path",
+      "exits": { "west": 551, "northeast": 553, "east": 565, "north": 550 }
+    },
+    {
+      "id": 553, "name": "A forest path",
+      "exits": { "west": 550, "south": 565, "southwest": 552, "northeast": 554, "east": 564, "north": 549 }
+    },
+    {
+      "id": 554, "name": "A forest path",
+      "exits": { "west": 549, "south": 564, "southwest": 553, "northeast": 555, "east": 563, "north": 548 }
+    },
+    {
+      "id": 555, "name": "A path through the forest",
+      "exits": { "west": 548, "south": 563, "southwest": 554, "northeast": 556, "east": 562, "north": 547 }
+    },
+    {
+      "id": 556, "name": "A forest path",
+      "exits": { "west": 547, "south": 562, "southwest": 555, "northeast": 557, "east": 561, "north": 546 }
+    },
+    {
+      "id": 557, "name": "A forest",
+      "exits": { "west": 546, "south": 561, "southwest": 556, "northeast": 558, "east": 560, "north": 545 }
+    },
+    {
+      "id": 558, "name": "A forest path",
+      "exits": { "southwest": 557, "west": 545, "east": 559, "south": 560 }
+    },
+    {
+      "id": 559, "name": "A forest path",
+      "exits": { "southwest": 560, "west": 558, "south": 573 }
+    },
+    {
+      "id": 560, "name": "A path in the forest",
+      "exits": { "west": 557, "south": 572, "southwest": 561, "northeast": 559, "east": 573, "north": 558 }
+    },
+    {
+      "id": 561, "name": "A forest path",
+      "exits": { "west": 556, "south": 571, "southwest": 562, "northeast": 560, "east": 572, "north": 557 }
+    },
+    {
+      "id": 562, "name": "A forest path",
+      "exits": { "west": 555, "south": 570, "southwest": 563, "northeast": 561, "east": 571, "north": 556 }
+    },
+    {
+      "id": 563, "name": "A forest",
+      "exits": { "west": 554, "south": 569, "southwest": 564, "northeast": 562, "east": 570, "north": 555 }
+    },
+    {
+      "id": 564, "name": "A forest path",
+      "exits": { "west": 553, "south": 568, "southwest": 565, "northeast": 563, "east": 569, "north": 554 }
+    },
+    {
+      "id": 565, "name": "A forest path",
+      "exits": { "west": 552, "south": 574, "southwest": 566, "northeast": 564, "east": 568, "north": 553 }
+    },
+    {
+      "id": 566, "name": "A dark forest glade",
+      "exits": { "southwest": 567, "northeast": 565 }
+    },
+    {
+      "id": 567, "name": "A forest path",
+      "exits": { "west": 601, "northeast": 566 }
+    },
+    {
+      "id": 568, "name": "A forest path",
+      "exits": { "southwest": 574, "northeast": 569, "west": 565, "north": 564 }
+    },
+    {
+      "id": 569, "name": "A path through the forest",
+      "exits": { "southwest": 568, "northeast": 570, "west": 564, "north": 563 }
+    },
+    {
+      "id": 570, "name": "A forest glade",
+      "exits": { "southwest": 569, "northeast": 571, "west": 563, "north": 562 }
+    },
+    {
+      "id": 571, "name": "A forest path",
+      "exits": { "southwest": 570, "northeast": 572, "west": 562, "north": 561 }
+    },
+    {
+      "id": 572, "name": "A forest path",
+      "exits": { "southwest": 571, "northeast": 573, "west": 561, "north": 560 }
+    },
+    {
+      "id": 573, "name": "A forest path",
+      "exits": { "southwest": 572, "west": 560, "north": 559 }
+    },
+    {
+      "id": 574, "name": "Forest Glade",
+      "exits": { "northeast": 568, "north": 565 }
+    },
+    {
+      "id": 575, "name": "A forest",
+      "exits": { "east": 541 }
+    },
+    {
+      "id": 576, "name": "The start of a forest path",
+      "exits": { "southwest": 577, "north": 551 }
+    },
+    {
+      "id": 577, "name": "The start of a forest path",
+      "exits": { "northeast": 576 }
+    },
+    {
+      "id": 578, "name": "A forest path",
+      "exits": { "west": 533, "southwest": 532, "northeast": 579, "east": 600, "north": 596 }
+    },
+    {
+      "id": 579, "name": "A forest path",
+      "exits": { "southwest": 578, "northeast": 580, "west": 596, "north": 597 }
+    },
+    {
+      "id": 580, "name": "A clearing in the forest",
+      "exits": { "southwest": 579, "northeast": 581, "west": 597, "north": 598 }
+    },
+    {
+      "id": 581, "name": "A forest path",
+      "exits": { "southwest": 580, "northeast": 582, "west": 598, "north": 585 }
+    },
+    {
+      "id": 582, "name": "Forest Mound",
+      "exits": { "west": 585, "southwest": 581, "northeast": 583, "east": 599, "north": 584 }
+    },
+    {
+      "id": 583, "name": "A forest path",
+      "exits": { "southwest": 582, "west": 584 }
+    },
+    {
+      "id": 584, "name": "A forest glade",
+      "exits": { "southwest": 585, "west": 586, "east": 583, "south": 582 }
+    },
+    {
+      "id": 585, "name": "A forest path",
+      "exits": { "south": 581, "west": 595, "northeast": 584, "east": 582, "north": 586 }
+    },
+    {
+      "id": 586, "name": "A forest glade",
+      "exits": { "southwest": 588, "west": 587, "east": 584, "south": 585 }
+    },
+    {
+      "id": 587, "name": "A river bank",
+      "exits": { "southwest": 595, "east": 586, "south": 588 }
+    },
+    {
+      "id": 588, "name": "A dark forest glade",
+      "exits": { "west": 595, "south": 598, "southwest": 589, "northeast": 586, "east": 589, "north": 587 }
+    },
+    {
+      "id": 589, "name": "A forest glade",
+      "exits": { "west": 594, "south": 597, "southwest": 590, "northeast": 588, "east": 598, "north": 595 }
+    },
+    {
+      "id": 590, "name": "A forest",
+      "exits": { "west": 593, "south": 596, "southwest": 591, "northeast": 589, "east": 597, "north": 594 }
+    },
+    {
+      "id": 591, "name": "A forest",
+      "exits": { "west": 592, "south": 533, "southwest": 534, "northeast": 590, "east": 596, "north": 593 }
+    },
+    {
+      "id": 592, "name": "A river bank",
+      "exits": { "southwest": 536, "northeast": 593, "east": 591, "south": 534 }
+    },
+    {
+      "id": 593, "name": "A river bank",
+      "exits": { "southwest": 592, "northeast": 594, "east": 590, "south": 591 }
+    },
+    {
+      "id": 594, "name": "A riverbank",
+      "exits": { "southwest": 593, "northeast": 595, "east": 589, "south": 590 }
+    },
+    {
+      "id": 595, "name": "A river bank",
+      "exits": { "southwest": 594, "northeast": 587, "east": 585, "south": 589 }
+    },
+    {
+      "id": 596, "name": "A path through the forest",
+      "exits": { "west": 591, "south": 578, "southwest": 533, "northeast": 597, "east": 579, "north": 590 }
+    },
+    {
+      "id": 597, "name": "A forest path",
+      "exits": { "west": 590, "south": 579, "southwest": 596, "northeast": 598, "east": 580, "north": 589 }
+    },
+    {
+      "id": 598, "name": "A forest path",
+      "exits": { "west": 589, "south": 580, "southwest": 597, "northeast": 589, "east": 581, "north": 588 }
+    },
+    {
+      "id": 599, "name": "A small clearing",
+      "exits": { "west": 582 }
+    },
+    {
+      "id": 600, "name": "Druids Guild",
+      "exits": { "west": 578 }
+    },
+    {
+      "id": 601, "name": "Large home",
+      "exits": { "east": 567 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/balin.json
+++ b/maps/balin.json
@@ -4,1039 +4,518 @@
   },
   "rooms": [
     {
-      "name": "Ocean before Beachhead",
-      "exits": {
-        "north": 606
-      },
-      "id": 605
-    },
-    {
-      "name": "A sandy beachhead",
-      "exits": {
-        "south": 605,
-        "west": 623,
-        "east": 626,
-        "north": 607
-      },
-      "id": 606
-    },
-    {
-      "name": "A narrow path between the dunes",
-      "exits": {
-        "south": 606,
-        "east": 628,
-        "north": 608
-      },
-      "id": 607
-    },
-    {
-      "name": "A Dune Path",
-      "exits": {
-        "south": 607,
-        "north": 609
-      },
-      "id": 608
-    },
-    {
-      "name": "The City Gate",
-      "exits": {
-        "south": 608,
-        "west": 631,
-        "east": 634,
-        "north": 610
-      },
-      "id": 609
-    },
-    {
-      "name": "Intersection of Silver Street and Balin Road",
-      "exits": {
-        "south": 609,
-        "west": 635,
-        "east": 660,
-        "north": 611
-      },
-      "id": 610
-    },
-    {
-      "name": "Silver Street",
-      "exits": {
-        "south": 610,
-        "east": 713,
-        "north": 612
-      },
-      "id": 611
-    },
-    {
-      "name": "Silver Street",
-      "exits": {
-        "south": 611,
-        "east": 674,
-        "north": 613
-      },
-      "id": 612
-    },
-    {
-      "name": "Silver Street",
-      "exits": {
-        "south": 612,
-        "west": 675,
-        "east": 676,
-        "north": 614
-      },
-      "id": 613
-    },
-    {
-      "name": "A Grand Plaza",
-      "exits": {
-        "south": 613,
-        "west": 678,
-        "east": 677,
-        "north": 615
-      },
-      "id": 614
-    },
-    {
-      "name": "Silver Street",
-      "exits": {
-        "west": 688,
-        "south": 614,
-        "north": 616
-      },
-      "id": 615
-    },
-    {
-      "name": "Silver Street",
-      "exits": {
-        "south": 615,
-        "east": 689,
-        "north": 617
-      },
-      "id": 616
+      "id": 605, "name": "Ocean before Beachhead",
+      "exits": { "north": 606 }
     },
     {
-      "name": "Silver Street",
-      "exits": {
-        "west": 690,
-        "south": 616,
-        "north": 618
-      },
-      "id": 617
+      "id": 606, "name": "A sandy beachhead",
+      "exits": { "south": 605, "west": 623, "east": 626, "north": 607 }
     },
     {
-      "name": "Silver Street",
-      "exits": {
-        "south": 617,
-        "west": 622,
-        "east": 691,
-        "north": 619
-      },
-      "id": 618
+      "id": 607, "name": "A narrow path between the dunes",
+      "exits": { "south": 606, "east": 628, "north": 608 }
     },
     {
-      "name": "End of Silver Street",
-      "exits": {
-        "east": 620,
-        "south": 618
-      },
-      "id": 619
+      "id": 608, "name": "A Dune Path",
+      "exits": { "south": 607, "north": 609 }
     },
     {
-      "name": "Island smeltery",
-      "exits": {
-        "east": 621,
-        "west": 619
-      },
-      "id": 620
+      "id": 609, "name": "The City Gate",
+      "exits": { "south": 608, "west": 631, "east": 634, "north": 610 }
     },
     {
-      "name": "Repair Shop",
-      "exits": {
-        "west": 620
-      },
-      "id": 621
+      "id": 610, "name": "Intersection of Silver Street and Balin Road",
+      "exits": { "south": 609, "west": 635, "east": 660, "north": 611 }
     },
     {
-      "name": "A Bloody Arena.",
-      "id": 622
+      "id": 611, "name": "Silver Street",
+      "exits": { "south": 610, "east": 713, "north": 612 }
     },
     {
-      "name": "Western Part of Beach",
-      "exits": {
-        "east": 606,
-        "west": 624
-      },
-      "id": 623
+      "id": 612, "name": "Silver Street",
+      "exits": { "south": 611, "east": 674, "north": 613 }
     },
     {
-      "name": "East of the waterfall",
-      "exits": {
-        "east": 623,
-        "west": 625
-      },
-      "id": 624
+      "id": 613, "name": "Silver Street",
+      "exits": { "south": 612, "west": 675, "east": 676, "north": 614 }
     },
     {
-      "name": "The base of a waterfall",
-      "exits": {
-        "east": 624
-      },
-      "id": 625
-    },
+      "id": 614, "name": "A Grand Plaza",
+      "exits": { "south": 613, "west": 678, "east": 677, "north": 615 }
+    },
+    {
+      "id": 615, "name": "Silver Street",
+      "exits": { "west": 688, "south": 614, "north": 616 }
+    },
+    {
+      "id": 616, "name": "Silver Street",
+      "exits": { "south": 615, "east": 689, "north": 617 }
+    },
+    {
+      "id": 617, "name": "Silver Street",
+      "exits": { "west": 690, "south": 616, "north": 618 }
+    },
+    {
+      "id": 618, "name": "Silver Street",
+      "exits": { "south": 617, "west": 622, "east": 691, "north": 619 }
+    },
+    {
+      "id": 619, "name": "End of Silver Street",
+      "exits": { "east": 620, "south": 618 }
+    },
+    {
+      "id": 620, "name": "Island smeltery",
+      "exits": { "east": 621, "west": 619 }
+    },
+    {
+      "id": 621, "name": "Repair Shop",
+      "exits": { "west": 620 }
+    },
+    {
+      "id": 622, "name": "A Bloody Arena."
+    },
+    {
+      "id": 623, "name": "Western Part of Beach",
+      "exits": { "east": 606, "west": 624 }
+    },
+    {
+      "id": 624, "name": "East of the waterfall",
+      "exits": { "east": 623, "west": 625 }
+    },
+    {
+      "id": 625, "name": "The base of a waterfall",
+      "exits": { "east": 624 }
+    },
+    {
+      "id": 626, "name": "Ruins",
+      "exits": { "east": 627, "west": 606 }
+    },
+    {
+      "id": 627, "name": "Eastern Beach",
+      "exits": { "west": 626 }
+    },
+    {
+      "id": 628, "name": "A valley between two large dunes",
+      "exits": { "east": 629, "west": 607 }
+    },
+    {
+      "id": 629, "name": "A desert plain",
+      "exits": { "west": 628, "north": 630 }
+    },
+    {
+      "id": 630, "name": "A dead end",
+      "exits": { "south": 629 }
+    },
+    {
+      "id": 631, "name": "Guard Room",
+      "exits": { "east": 609, "west": 632 }
+    },
+    {
+      "id": 632, "name": "Armoury",
+      "exits": { "east": 631, "west": 633 }
+    },
+    {
+      "id": 633, "name": "Elderoak's Quarters",
+      "exits": { "east": 632 }
+    },
+    {
+      "id": 634, "name": "A guard house",
+      "exits": { "west": 609 }
+    },
+    {
+      "id": 635, "name": "Balin Road",
+      "exits": { "northwest": 719, "south": 717, "northeast": 718, "east": 610, "west": 636 }
+    },
+    {
+      "id": 636, "name": "Balin Road",
+      "exits": { "southwest": 722, "east": 635, "southeast": 721, "west": 637 }
+    },
+    {
+      "id": 637, "name": "West End of Balin Road",
+      "exits": { "west": 638, "northeast": 720, "east": 636, "south": 723 }
+    },
+    {
+      "id": 638, "name": "Tunnel Under Canal",
+      "exits": { "east": 637, "west": 639 }
+    },
+    {
+      "id": 639, "name": "South End of Highland Avenue",
+      "exits": { "east": 638, "west": 640 }
+    },
+    {
+      "id": 640, "name": "Highland Avenue",
+      "exits": { "south": 657, "east": 639, "north": 641 }
+    },
+    {
+      "id": 641, "name": "Highland Avenue",
+      "exits": { "south": 640, "north": 642 }
+    },
+    {
+      "id": 642, "name": "Highland Avenue",
+      "exits": { "west": 643, "south": 641 }
+    },
+    {
+      "id": 643, "name": "Highland Avenue",
+      "exits": { "south": 647, "east": 642, "north": 644 }
+    },
+    {
+      "id": 644, "name": "Highland Avenue",
+      "exits": { "south": 643, "west": 646, "east": 648, "north": 645 }
+    },
+    {
+      "id": 645, "name": "Dwarven Hut",
+      "exits": { "south": 644 }
+    },
+    {
+      "id": 646, "name": "You trundle past the facade and arrive on a beautiful street.",
+      "exits": { "east": 644 }
+    },
+    {
+      "id": 647, "name": "Gnome Hut",
+      "exits": { "north": 643 }
+    },
+    {
+      "id": 648, "name": "Highland Avenue",
+      "exits": { "south": 651, "west": 644, "east": 649, "north": 650 }
+    },
+    {
+      "id": 649, "name": "Dwarven Home",
+      "exits": { "west": 648 }
+    },
+    {
+      "id": 650, "name": "Highland Avenue",
+      "exits": { "west": 652, "south": 648 }
+    },
+    {
+      "id": 651, "name": "Dwarven Shack",
+      "exits": { "north": 648 }
+    },
+    {
+      "id": 652, "name": "Highland Avenue",
+      "exits": { "west": 653, "east": 650, "north": 654 }
+    },
+    {
+      "id": 653, "name": "Dwarven Home",
+      "exits": { "east": 652, "south": 656 }
+    },
+    {
+      "id": 654, "name": "Highland Avenue",
+      "exits": { "south": 652, "north": 655 }
+    },
+    {
+      "id": 655, "name": "House of Balin",
+      "exits": { "west": 712, "south": 654 }
+    },
+    {
+      "id": 656, "name": "Dwarven Home",
+      "exits": { "north": 653 }
+    },
+    {
+      "id": 657, "name": "Keep Of Alcibiades",
+      "exits": { "west": 659, "east": 658, "north": 640 }
+    },
+    {
+      "id": 658, "name": "Study",
+      "exits": { "west": 657 }
+    },
+    {
+      "id": 659, "name": "Bedroom:",
+      "exits": { "east": 657 }
+    },
+    {
+      "id": 660, "name": "Balin Road",
+      "exits": { "east": 661, "west": 610 }
+    },
     {
-      "name": "Ruins",
-      "exits": {
-        "east": 627,
-        "west": 606
-      },
-      "id": 626
-    },
+      "id": 661, "name": "Balin Road",
+      "exits": { "west": 660, "east": 662, "south": 673 }
+    },
+    {
+      "id": 662, "name": "Balin Road",
+      "exits": { "west": 661, "east": 663, "north": 672 }
+    },
+    {
+      "id": 663, "name": "Balin Road",
+      "exits": { "south": 670, "west": 662, "east": 664, "north": 671 }
+    },
+    {
+      "id": 664, "name": "Balin Road",
+      "exits": { "south": 667, "west": 663, "east": 665, "north": 668 }
+    },
+    {
+      "id": 665, "name": "East End of Balin Road",
+      "exits": { "west": 664, "south": 666 }
+    },
+    {
+      "id": 666, "name": "Arched Gates",
+      "exits": { "north": 665 }
+    },
+    {
+      "id": 667, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 664 }
+    },
+    {
+      "id": 668, "name": "Island Historical Society",
+      "exits": { "south": 664, "north": 669 }
+    },
     {
-      "name": "Eastern Beach",
-      "exits": {
-        "west": 626
-      },
-      "id": 627
-    },
-    {
-      "name": "A valley between two large dunes",
-      "exits": {
-        "east": 629,
-        "west": 607
-      },
-      "id": 628
-    },
-    {
-      "name": "A desert plain",
-      "exits": {
-        "west": 628,
-        "north": 630
-      },
-      "id": 629
-    },
-    {
-      "name": "A dead end",
-      "exits": {
-        "south": 629
-      },
-      "id": 630
-    },
-    {
-      "name": "Guard Room",
-      "exits": {
-        "east": 609,
-        "west": 632
-      },
-      "id": 631
-    },
-    {
-      "name": "Armoury",
-      "exits": {
-        "east": 631,
-        "west": 633
-      },
-      "id": 632
-    },
-    {
-      "name": "Elderoak's Quarters",
-      "exits": {
-        "east": 632
-      },
-      "id": 633
-    },
-    {
-      "name": "A guard house",
-      "exits": {
-        "west": 609
-      },
-      "id": 634
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "northwest": 719,
-        "south": 717,
-        "northeast": 718,
-        "east": 610,
-        "west": 636
-      },
-      "id": 635
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "southwest": 722,
-        "east": 635,
-        "southeast": 721,
-        "west": 637
-      },
-      "id": 636
-    },
-    {
-      "name": "West End of Balin Road",
-      "exits": {
-        "west": 638,
-        "northeast": 720,
-        "east": 636,
-        "south": 723
-      },
-      "id": 637
+      "id": 669, "name": "Office",
+      "exits": { "south": 668 }
     },
-    {
-      "name": "Tunnel Under Canal",
-      "exits": {
-        "east": 637,
-        "west": 639
-      },
-      "id": 638
+    {
+      "id": 670, "name": "Elven Mercantile",
+      "exits": { "north": 663 }
+    },
+    {
+      "id": 671, "name": "Temple Shop",
+      "exits": { "west": 672, "south": 663 }
+    },
+    {
+      "id": 672, "name": "Temple Plaza",
+      "exits": { "west": 715, "east": 671, "south": 662 }
+    },
+    {
+      "id": 673, "name": "Seed Shop",
+      "exits": { "north": 661 }
+    },
+    {
+      "id": 674, "name": "City Pastry Shop",
+      "exits": { "west": 612 }
+    },
+    {
+      "id": 675, "name": "Soylent Green",
+      "exits": { "east": 613 }
     },
-    {
-      "name": "South End of Highland Avenue",
-      "exits": {
-        "east": 638,
-        "west": 640
-      },
-      "id": 639
+    {
+      "id": 676, "name": "Mariner's Revenge",
+      "exits": { "west": 613, "north": 677 }
     },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 657,
-        "east": 639,
-        "north": 641
-      },
-      "id": 640
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 640,
-        "north": 642
-      },
-      "id": 641
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "west": 643,
-        "south": 641
-      },
-      "id": 642
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 647,
-        "east": 642,
-        "north": 644
-      },
-      "id": 643
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 643,
-        "west": 646,
-        "east": 648,
-        "north": 645
-      },
-      "id": 644
-    },
-    {
-      "name": "Dwarven Hut",
-      "exits": {
-        "south": 644
-      },
-      "id": 645
-    },
-    {
-      "name": "You trundle past the facade and arrive on a beautiful street.",
-      "exits": {
-        "east": 644
-      },
-      "id": 646
-    },
-    {
-      "name": "Gnome Hut",
-      "exits": {
-        "north": 643
-      },
-      "id": 647
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 651,
-        "west": 644,
-        "east": 649,
-        "north": 650
-      },
-      "id": 648
-    },
-    {
-      "name": "Dwarven Home",
-      "exits": {
-        "west": 648
-      },
-      "id": 649
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "west": 652,
-        "south": 648
-      },
-      "id": 650
-    },
-    {
-      "name": "Dwarven Shack",
-      "exits": {
-        "north": 648
-      },
-      "id": 651
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "west": 653,
-        "east": 650,
-        "north": 654
-      },
-      "id": 652
-    },
-    {
-      "name": "Dwarven Home",
-      "exits": {
-        "east": 652,
-        "south": 656
-      },
-      "id": 653
-    },
-    {
-      "name": "Highland Avenue",
-      "exits": {
-        "south": 652,
-        "north": 655
-      },
-      "id": 654
-    },
-    {
-      "name": "House of Balin",
-      "exits": {
-        "west": 712,
-        "south": 654
-      },
-      "id": 655
-    },
-    {
-      "name": "Dwarven Home",
-      "exits": {
-        "north": 653
-      },
-      "id": 656
-    },
-    {
-      "name": "Keep Of Alcibiades",
-      "exits": {
-        "west": 659,
-        "east": 658,
-        "north": 640
-      },
-      "id": 657
-    },
-    {
-      "name": "Study",
-      "exits": {
-        "west": 657
-      },
-      "id": 658
-    },
-    {
-      "name": "Bedroom:",
-      "exits": {
-        "east": 657
-      },
-      "id": 659
+    {
+      "id": 677, "name": "Gate House",
+      "exits": { "south": 676, "west": 614, "east": 693, "north": 686 }
     },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "east": 661,
-        "west": 610
-      },
-      "id": 660
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "west": 660,
-        "east": 662,
-        "south": 673
-      },
-      "id": 661
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "west": 661,
-        "east": 663,
-        "north": 672
-      },
-      "id": 662
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "south": 670,
-        "west": 662,
-        "east": 664,
-        "north": 671
-      },
-      "id": 663
-    },
-    {
-      "name": "Balin Road",
-      "exits": {
-        "south": 667,
-        "west": 663,
-        "east": 665,
-        "north": 668
-      },
-      "id": 664
-    },
-    {
-      "name": "East End of Balin Road",
-      "exits": {
-        "west": 664,
-        "south": 666
-      },
-      "id": 665
-    },
-    {
-      "name": "Arched Gates",
-      "exits": {
-        "north": 665
-      },
-      "id": 666
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 664
-      },
-      "id": 667
-    },
-    {
-      "name": "Island Historical Society",
-      "exits": {
-        "south": 664,
-        "north": 669
-      },
-      "id": 668
-    },
-    {
-      "name": "Office",
-      "exits": {
-        "south": 668
-      },
-      "id": 669
-    },
-    {
-      "name": "Elven Mercantile",
-      "exits": {
-        "north": 663
-      },
-      "id": 670
-    },
-    {
-      "name": "Temple Shop",
-      "exits": {
-        "west": 672,
-        "south": 663
-      },
-      "id": 671
-    },
-    {
-      "name": "Temple Plaza",
-      "exits": {
-        "west": 715,
-        "east": 671,
-        "south": 662
-      },
-      "id": 672
-    },
-    {
-      "name": "Seed Shop",
-      "exits": {
-        "north": 661
-      },
-      "id": 673
-    },
-    {
-      "name": "City Pastry Shop",
-      "exits": {
-        "west": 612
-      },
-      "id": 674
-    },
-    {
-      "name": "Soylent Green",
-      "exits": {
-        "east": 613
-      },
-      "id": 675
+    {
+      "id": 678, "name": "Gate House",
+      "exits": { "east": 614, "west": 679 }
     },
-    {
-      "name": "Mariner's Revenge",
-      "exits": {
-        "west": 613,
-        "north": 677
-      },
-      "id": 676
+    {
+      "id": 679, "name": "Foyer",
+      "exits": { "south": 684, "east": 678, "north": 680 }
     },
-    {
-      "name": "Gate House",
-      "exits": {
-        "south": 676,
-        "west": 614,
-        "east": 693,
-        "north": 686
-      },
-      "id": 677
+    {
+      "id": 680, "name": "Hallway",
+      "exits": { "south": 679, "north": 681 }
     },
     {
-      "name": "Gate House",
-      "exits": {
-        "east": 614,
-        "west": 679
-      },
-      "id": 678
+      "id": 681, "name": "Audience Hall",
+      "exits": { "west": 682, "south": 680 }
     },
     {
-      "name": "Foyer",
-      "exits": {
-        "south": 684,
-        "east": 678,
-        "north": 680
-      },
-      "id": 679
+      "id": 682, "name": "Council Chamber",
+      "exits": { "east": 681, "west": 683 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 679,
-        "north": 681
-      },
-      "id": 680
+      "id": 683, "name": "Trophy Room",
+      "exits": { "east": 682 }
     },
     {
-      "name": "Audience Hall",
-      "exits": {
-        "west": 682,
-        "south": 680
-      },
-      "id": 681
+      "id": 684, "name": "Hallway",
+      "exits": { "south": 685, "north": 679 }
     },
     {
-      "name": "Council Chamber",
-      "exits": {
-        "east": 681,
-        "west": 683
-      },
-      "id": 682
+      "id": 685, "name": "Lady Roland's Bedroom",
+      "exits": { "north": 684 }
     },
     {
-      "name": "Trophy Room",
-      "exits": {
-        "east": 682
-      },
-      "id": 683
+      "id": 686, "name": "RIIS",
+      "exits": { "down": 687, "south": 677 }
     },
     {
-      "name": "Hallway",
-      "exits": {
-        "south": 685,
-        "north": 679
-      },
-      "id": 684
+      "id": 687, "name": "Crack of Doom",
+      "exits": { "up": 686 }
     },
     {
-      "name": "Lady Roland's Bedroom",
-      "exits": {
-        "north": 684
-      },
-      "id": 685
+      "id": 688, "name": "Rhian's Potion Shop",
+      "exits": { "east": 615 }
     },
     {
-      "name": "RIIS",
-      "exits": {
-        "down": 687,
-        "south": 677
-      },
-      "id": 686
+      "id": 689, "name": "Alchemist Shop",
+      "exits": { "west": 616 }
     },
     {
-      "name": "Crack of Doom",
-      "exits": {
-        "up": 686
-      },
-      "id": 687
+      "id": 690, "name": "Entrance to the Hall of Records",
+      "exits": { "east": 617 }
     },
     {
-      "name": "Rhian's Potion Shop",
-      "exits": {
-        "east": 615
-      },
-      "id": 688
+      "id": 691, "name": "Power System Generator",
+      "exits": { "east": 692, "west": 618 }
     },
     {
-      "name": "Alchemist Shop",
-      "exits": {
-        "west": 616
-      },
-      "id": 689
+      "id": 692, "name": "Power System Internals",
+      "exits": { "west": 691 }
     },
     {
-      "name": "Entrance to the Hall of Records",
-      "exits": {
-        "east": 617
-      },
-      "id": 690
+      "id": 693, "name": "Entryway",
+      "exits": { "west": 677, "south": 694, "north": 696 }
     },
     {
-      "name": "Power System Generator",
-      "exits": {
-        "east": 692,
-        "west": 618
-      },
-      "id": 691
+      "id": 694, "name": "South Corridor",
+      "exits": { "south": 695, "north": 693 }
     },
     {
-      "name": "Power System Internals",
-      "exits": {
-        "west": 691
-      },
-      "id": 692
+      "id": 695, "name": "Guard Post",
+      "exits": { "north": 694 }
     },
     {
-      "name": "Entryway",
-      "exits": {
-        "west": 677,
-        "south": 694,
-        "north": 696
-      },
-      "id": 693
+      "id": 696, "name": "North Corridor",
+      "exits": { "south": 693, "north": 697 }
     },
     {
-      "name": "South Corridor",
-      "exits": {
-        "south": 695,
-        "north": 693
-      },
-      "id": 694
+      "id": 697, "name": "Guard Room",
+      "exits": { "east": 698, "south": 696 }
     },
     {
-      "name": "Guard Post",
-      "exits": {
-        "north": 694
-      },
-      "id": 695
-    },
-    {
-      "name": "North Corridor",
-      "exits": {
-        "south": 693,
-        "north": 697
-      },
-      "id": 696
-    },
-    {
-      "name": "Guard Room",
-      "exits": {
-        "east": 698,
-        "south": 696
-      },
-      "id": 697
-    },
-    {
-      "name": "West Harem",
-      "exits": {
-        "east": 699,
-        "west": 697
-      },
-      "id": 698
+      "id": 698, "name": "West Harem",
+      "exits": { "east": 699, "west": 697 }
     },
     {
-      "name": "East Harem",
-      "exits": {
-        "east": 700,
-        "west": 698
-      },
-      "id": 699
+      "id": 699, "name": "East Harem",
+      "exits": { "east": 700, "west": 698 }
     },
     {
-      "name": "Bedchamber",
-      "exits": {
-        "east": 701,
-        "west": 699
-      },
-      "id": 700
+      "id": 700, "name": "Bedchamber",
+      "exits": { "east": 701, "west": 699 }
     },
     {
-      "name": "Entryway",
-      "exits": {
-        "west": 700,
-        "south": 702
-      },
-      "id": 701
+      "id": 701, "name": "Entryway",
+      "exits": { "west": 700, "south": 702 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "south": 703,
-        "east": 708,
-        "north": 701
-      },
-      "id": 702
+      "id": 702, "name": "Turkish Bath",
+      "exits": { "south": 703, "east": 708, "north": 701 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "south": 704,
-        "east": 707,
-        "north": 702
-      },
-      "id": 703
+      "id": 703, "name": "Turkish Bath",
+      "exits": { "south": 704, "east": 707, "north": 702 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "south": 705,
-        "east": 706,
-        "north": 703
-      },
-      "id": 704
+      "id": 704, "name": "Turkish Bath",
+      "exits": { "south": 705, "east": 706, "north": 703 }
     },
     {
-      "name": "South Entryway",
-      "exits": {
-        "north": 704
-      },
-      "id": 705
+      "id": 705, "name": "South Entryway",
+      "exits": { "north": 704 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "west": 704,
-        "south": 710,
-        "north": 707
-      },
-      "id": 706
+      "id": 706, "name": "Turkish Bath",
+      "exits": { "west": 704, "south": 710, "north": 707 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "west": 703,
-        "south": 706,
-        "north": 708
-      },
-      "id": 707
+      "id": 707, "name": "Turkish Bath",
+      "exits": { "west": 703, "south": 706, "north": 708 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "west": 702,
-        "south": 707,
-        "north": 709
-      },
-      "id": 708
+      "id": 708, "name": "Turkish Bath",
+      "exits": { "west": 702, "south": 707, "north": 709 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "south": 708
-      },
-      "id": 709
+      "id": 709, "name": "Turkish Bath",
+      "exits": { "south": 708 }
     },
     {
-      "name": "Turkish Bath",
-      "exits": {
-        "north": 706
-      },
-      "id": 710
+      "id": 710, "name": "Turkish Bath",
+      "exits": { "north": 706 }
     },
     {
-      "name": "The hermit says: Is there anything you would like to talk about?",
-      "id": 711
+      "id": 711, "name": "The hermit says: Is there anything you would like to talk about?"
     },
     {
-      "name": "Hermit's Chamber",
-      "exits": {
-        "east": 655
-      },
-      "id": 712
+      "id": 712, "name": "Hermit's Chamber",
+      "exits": { "east": 655 }
     },
     {
-      "name": "Temple",
-      "exits": {
-        "west": 611,
-        "east": 714,
-        "north": 716
-      },
-      "id": 713
+      "id": 713, "name": "Temple",
+      "exits": { "west": 611, "east": 714, "north": 716 }
     },
     {
-      "name": "Central Chamber",
-      "exits": {
-        "east": 715,
-        "west": 713
-      },
-      "id": 714
+      "id": 714, "name": "Central Chamber",
+      "exits": { "east": 715, "west": 713 }
     },
     {
-      "name": "Eastern Chamber",
-      "exits": {
-        "east": 672,
-        "west": 714
-      },
-      "id": 715
+      "id": 715, "name": "Eastern Chamber",
+      "exits": { "east": 672, "west": 714 }
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "exits": {
-        "south": 713
-      },
-      "id": 716
+      "id": 716, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 713 }
     },
     {
-      "name": "Poison Shop",
-      "exits": {
-        "north": 635
-      },
-      "id": 717
+      "id": 717, "name": "Poison Shop",
+      "exits": { "north": 635 }
     },
     {
-      "name": "Taxidermist",
-      "exits": {
-        "southwest": 635
-      },
-      "id": 718
+      "id": 718, "name": "Taxidermist",
+      "exits": { "southwest": 635 }
     },
     {
-      "name": "Weaver's",
-      "exits": {
-        "southeast": 635
-      },
-      "id": 719
+      "id": 719, "name": "Weaver's",
+      "exits": { "southeast": 635 }
     },
     {
-      "name": "Foyer of House of Ill Repute",
-      "exits": {
-        "southwest": 637
-      },
-      "id": 720
+      "id": 720, "name": "Foyer of House of Ill Repute",
+      "exits": { "southwest": 637 }
     },
     {
-      "name": "Balin Road Pub",
-      "exits": {
-        "northwest": 636
-      },
-      "id": 721
+      "id": 721, "name": "Balin Road Pub",
+      "exits": { "northwest": 636 }
     },
     {
-      "name": "Wheelwright",
-      "exits": {
-        "northeast": 636
-      },
-      "id": 722
+      "id": 722, "name": "Wheelwright",
+      "exits": { "northeast": 636 }
     },
     {
-      "name": "Crowded Thoroughfare",
-      "exits": {
-        "south": 724,
-        "north": 637
-      },
-      "id": 723
+      "id": 723, "name": "Crowded Thoroughfare",
+      "exits": { "south": 724, "north": 637 }
     },
     {
-      "name": "Archway of Servitude",
-      "exits": {
-        "south": 725,
-        "north": 723
-      },
-      "id": 724
+      "id": 724, "name": "Archway of Servitude",
+      "exits": { "south": 725, "north": 723 }
     },
     {
-      "name": "Bazaar Crossroad",
-      "exits": {
-        "west": 726,
-        "east": 729,
-        "north": 724
-      },
-      "id": 725
+      "id": 725, "name": "Bazaar Crossroad",
+      "exits": { "west": 726, "east": 729, "north": 724 }
     },
     {
-      "name": "Western District",
-      "exits": {
-        "east": 725,
-        "south": 727
-      },
-      "id": 726
+      "id": 726, "name": "Western District",
+      "exits": { "east": 725, "south": 727 }
     },
     {
-      "name": "Western District",
-      "exits": {
-        "south": 728,
-        "north": 726
-      },
-      "id": 727
+      "id": 727, "name": "Western District",
+      "exits": { "south": 728, "north": 726 }
     },
     {
-      "name": "Western slave bazaar",
-      "exits": {
-        "east": 732,
-        "north": 727
-      },
-      "id": 728
+      "id": 728, "name": "Western slave bazaar",
+      "exits": { "east": 732, "north": 727 }
     },
     {
-      "name": "Eastern District",
-      "exits": {
-        "west": 725,
-        "south": 730
-      },
-      "id": 729
+      "id": 729, "name": "Eastern District",
+      "exits": { "west": 725, "south": 730 }
     },
     {
-      "name": "Eastern District",
-      "exits": {
-        "south": 731,
-        "north": 729
-      },
-      "id": 730
+      "id": 730, "name": "Eastern District",
+      "exits": { "south": 731, "north": 729 }
     },
     {
-      "name": "Eastern slave bazaar",
-      "exits": {
-        "west": 732,
-        "north": 730
-      },
-      "id": 731
+      "id": 731, "name": "Eastern slave bazaar",
+      "exits": { "west": 732, "north": 730 }
     },
     {
-      "name": "Central slave bazaar",
-      "exits": {
-        "west": 728,
-        "east": 731,
-        "south": 733
-      },
-      "id": 732
+      "id": 732, "name": "Central slave bazaar",
+      "exits": { "west": 728, "east": 731, "south": 733 }
     },
     {
-      "name": "Administrative hallway",
-      "exits": {
-        "north": 732
-      },
-      "id": 733
+      "id": 733, "name": "Administrative hallway",
+      "exits": { "north": 732 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/candera.json
+++ b/maps/candera.json
@@ -4,1332 +4,660 @@
   },
   "rooms": [
     {
-      "name": "North Gate",
-      "exits": {
-        "west": 56,
-        "east": 2,
-        "south": 57
-      },
-      "id": 1
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 3,
-        "west": 1
-      },
-      "id": 2
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 4,
-        "west": 2
-      },
-      "id": 3
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 5,
-        "west": 3
-      },
-      "id": 4
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 6,
-        "west": 4
-      },
-      "id": 5
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 7,
-        "west": 5
-      },
-      "id": 6
-    },
-    {
-      "name": "Entrance to the Northeast Tower",
-      "exits": {
-        "east": 8,
-        "west": 6
-      },
-      "id": 7
-    },
-    {
-      "name": "Northeast Corner",
-      "exits": {
-        "west": 7,
-        "south": 9
-      },
-      "id": 8
-    },
-    {
-      "name": "Entrance to the Northeast Tower",
-      "exits": {
-        "south": 10,
-        "north": 8
-      },
-      "id": 9
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 11,
-        "north": 9
-      },
-      "id": 10
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 12,
-        "north": 10
-      },
-      "id": 11
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 13,
-        "north": 11
-      },
-      "id": 12
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 14,
-        "north": 12
-      },
-      "id": 13
+      "id": 1, "name": "North Gate",
+      "exits": { "west": 56, "east": 2, "south": 57 }
     },
     {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 15,
-        "north": 13
-      },
-      "id": 14
+      "id": 2, "name": "New Outer Wall",
+      "exits": { "east": 3, "west": 1 }
     },
     {
-      "name": "East Wall Guard Station",
-      "exits": {
-        "south": 16,
-        "east": 973,
-        "north": 14
-      },
-      "id": 15
+      "id": 3, "name": "New Outer Wall",
+      "exits": { "east": 4, "west": 2 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 17,
-        "north": 15
-      },
-      "id": 16
+    {
+      "id": 4, "name": "New Outer Wall",
+      "exits": { "east": 5, "west": 3 }
+    },
+    {
+      "id": 5, "name": "New Outer Wall",
+      "exits": { "east": 6, "west": 4 }
+    },
+    {
+      "id": 6, "name": "New Outer Wall",
+      "exits": { "east": 7, "west": 5 }
+    },
+    {
+      "id": 7, "name": "Entrance to the Northeast Tower",
+      "exits": { "east": 8, "west": 6 }
+    },
+    {
+      "id": 8, "name": "Northeast Corner",
+      "exits": { "west": 7, "south": 9 }
+    },
+    {
+      "id": 9, "name": "Entrance to the Northeast Tower",
+      "exits": { "south": 10, "north": 8 }
+    },
+    {
+      "id": 10, "name": "New Outer Wall",
+      "exits": { "south": 11, "north": 9 }
+    },
+    {
+      "id": 11, "name": "New Outer Wall",
+      "exits": { "south": 12, "north": 10 }
+    },
+    {
+      "id": 12, "name": "New Outer Wall",
+      "exits": { "south": 13, "north": 11 }
+    },
+    {
+      "id": 13, "name": "New Outer Wall",
+      "exits": { "south": 14, "north": 12 }
+    },
+    {
+      "id": 14, "name": "New Outer Wall",
+      "exits": { "south": 15, "north": 13 }
+    },
+    {
+      "id": 15, "name": "East Wall Guard Station",
+      "exits": { "south": 16, "east": 973, "north": 14 }
+    },
+    {
+      "id": 16, "name": "New Outer Wall",
+      "exits": { "south": 17, "north": 15 }
+    },
+    {
+      "id": 17, "name": "New Outer Wall",
+      "exits": { "south": 18, "north": 16 }
+    },
+    {
+      "id": 18, "name": "New Outer Wall",
+      "exits": { "south": 19, "north": 17 }
+    },
+    {
+      "id": 19, "name": "New Outer Wall",
+      "exits": { "south": 20, "north": 18 }
+    },
+    {
+      "id": 20, "name": "New Outer Wall",
+      "exits": { "south": 21, "north": 19 }
+    },
+    {
+      "id": 21, "name": "New Outer Wall",
+      "exits": { "south": 22, "north": 20 }
+    },
+    {
+      "id": 22, "name": "New Outer Wall",
+      "exits": { "west": 23, "north": 21 }
+    },
+    {
+      "id": 23, "name": "New Outer Wall",
+      "exits": { "east": 22, "west": 24 }
+    },
+    {
+      "id": 24, "name": "New Outer Wall",
+      "exits": { "east": 23, "west": 25 }
+    },
+    {
+      "id": 25, "name": "New Outer Wall",
+      "exits": { "east": 24, "west": 26 }
+    },
+    {
+      "id": 26, "name": "New Outer Wall",
+      "exits": { "east": 25, "west": 27 }
+    },
+    {
+      "id": 27, "name": "New Outer Wall",
+      "exits": { "east": 26, "west": 28 }
+    },
+    {
+      "id": 28, "name": "New Outer Wall",
+      "exits": { "east": 27, "west": 29 }
+    },
+    {
+      "id": 29, "name": "South Wall Guard Station",
+      "exits": { "west": 30, "east": 28, "south": 1030 }
+    },
+    {
+      "id": 30, "name": "New Outer Wall",
+      "exits": { "east": 29, "west": 31 }
+    },
+    {
+      "id": 31, "name": "New Outer Wall",
+      "exits": { "east": 30, "west": 32 }
+    },
+    {
+      "id": 32, "name": "New Outer Wall",
+      "exits": { "east": 31, "west": 33 }
+    },
+    {
+      "id": 33, "name": "New Outer Wall",
+      "exits": { "east": 32, "west": 34 }
+    },
+    {
+      "id": 34, "name": "New Outer Wall",
+      "exits": { "east": 33, "west": 35 }
+    },
+    {
+      "id": 35, "name": "New Outer Wall",
+      "exits": { "east": 34, "west": 36 }
+    },
+    {
+      "id": 36, "name": "Southwest Corner",
+      "exits": { "east": 35, "north": 37 }
+    },
+    {
+      "id": 37, "name": "New Outer Wall",
+      "exits": { "south": 36, "north": 38 }
+    },
+    {
+      "id": 38, "name": "New Outer Wall",
+      "exits": { "south": 37, "north": 39 }
+    },
+    {
+      "id": 39, "name": "New Outer Wall",
+      "exits": { "south": 38, "north": 40 }
+    },
+    {
+      "id": 40, "name": "New Outer Wall",
+      "exits": { "south": 39, "north": 41 }
+    },
+    {
+      "id": 41, "name": "New Outer Wall",
+      "exits": { "south": 40, "north": 42 }
+    },
+    {
+      "id": 42, "name": "New Outer Wall",
+      "exits": { "south": 41, "north": 43 }
+    },
+    {
+      "id": 43, "name": "West Wall Guard Station",
+      "exits": { "west": 1033, "south": 42, "north": 44 }
+    },
+    {
+      "id": 44, "name": "New Outer Wall",
+      "exits": { "south": 43, "north": 45 }
+    },
+    {
+      "id": 45, "name": "New Outer Wall",
+      "exits": { "south": 44, "north": 46 }
+    },
+    {
+      "id": 46, "name": "New Outer Wall",
+      "exits": { "south": 45, "north": 47 }
+    },
+    {
+      "id": 47, "name": "New Outer Wall",
+      "exits": { "south": 46, "north": 48 }
+    },
+    {
+      "id": 48, "name": "New Outer Wall",
+      "exits": { "south": 47, "north": 49 }
+    },
+    {
+      "id": 49, "name": "Entrance to the Northwest Tower",
+      "exits": { "south": 48, "north": 50 }
+    },
+    {
+      "id": 50, "name": "Northwest Corner",
+      "exits": { "east": 51, "south": 49 }
+    },
+    {
+      "id": 51, "name": "Entrance to the Northwest Tower",
+      "exits": { "east": 52, "west": 50 }
+    },
+    {
+      "id": 52, "name": "New Outer Wall",
+      "exits": { "east": 53, "west": 51 }
+    },
+    {
+      "id": 53, "name": "New Outer Wall",
+      "exits": { "east": 54, "west": 52 }
+    },
+    {
+      "id": 54, "name": "New Outer Wall",
+      "exits": { "east": 55, "west": 53 }
+    },
+    {
+      "id": 55, "name": "New Outer Wall",
+      "exits": { "east": 56, "west": 54 }
+    },
+    {
+      "id": 56, "name": "New Outer Wall",
+      "exits": { "east": 1, "west": 55 }
+    },
+    {
+      "id": 57, "name": "Warrior's Walk",
+      "exits": { "south": 58, "west": 963, "east": 964, "north": 1 }
+    },
+    {
+      "id": 58, "name": "Warrior's Walk",
+      "exits": { "south": 59, "west": 965, "east": 966, "north": 57 }
+    },
+    {
+      "id": 59, "name": "Warrior's Walk",
+      "exits": { "west": 967, "south": 60, "north": 58 }
+    },
+    {
+      "id": 60, "name": "Warrior's Walk",
+      "exits": { "south": 61, "west": 968, "east": 969, "north": 59 }
+    },
+    {
+      "id": 61, "name": "Warrior's Walk",
+      "exits": { "west": 970, "south": 62, "north": 60 }
+    },
+    {
+      "id": 62, "name": "Warrior's Walk",
+      "exits": { "south": 63, "west": 971, "east": 972, "north": 61 }
+    },
+    {
+      "id": 63, "name": "Canderan Well",
+      "exits": { "south": 64, "west": 72, "east": 94, "north": 62 }
+    },
+    {
+      "id": 64, "name": "Warrior's Walk",
+      "exits": { "south": 65, "west": 429, "east": 427, "north": 63 }
+    },
+    {
+      "id": 65, "name": "Warrior's Walk",
+      "exits": { "south": 66, "west": 430, "east": 1015, "north": 64 }
+    },
+    {
+      "id": 66, "name": "Warrior's Walk",
+      "exits": { "south": 67, "north": 65 }
+    },
+    {
+      "id": 67, "name": "Warrior's Walk",
+      "exits": { "south": 68, "north": 66 }
+    },
+    {
+      "id": 68, "name": "Warrior's Walk",
+      "exits": { "south": 69, "east": 431, "north": 67 }
+    },
+    {
+      "id": 69, "name": "House of Lord Candera",
+      "exits": { "up": 1134, "west": 70, "east": 71, "north": 68 }
+    },
+    {
+      "id": 70, "name": "House of Lord Candera",
+      "exits": { "east": 69 }
+    },
+    {
+      "id": 71, "name": "House of Lord Candera",
+      "exits": { "west": 69 }
+    },
+    {
+      "id": 72, "name": "Clansmen Way",
+      "exits": { "west": 73, "east": 63, "south": 429 }
+    },
+    {
+      "id": 73, "name": "Clansmen Way",
+      "exits": { "south": 1016, "west": 74, "east": 72, "north": 1017 }
+    },
+    {
+      "id": 74, "name": "Clansmen Way",
+      "exits": { "south": 1019, "west": 75, "east": 73, "north": 1018 }
+    },
+    {
+      "id": 75, "name": "Clansmen Way",
+      "exits": { "west": 76, "east": 74, "south": 1095 }
+    },
+    {
+      "id": 76, "name": "Clansmen Way",
+      "exits": { "south": 78, "west": 77, "east": 75, "north": 86 }
+    },
+    {
+      "id": 78, "name": "Zoman's Flat",
+      "exits": { "south": 79, "north": 76 }
+    },
+    {
+      "id": 79, "name": "Zoman's Flat",
+      "exits": { "south": 80, "east": 1096, "north": 78 }
+    },
+    {
+      "id": 80, "name": "Zoman's Flat",
+      "exits": { "south": 81, "north": 79 }
+    },
+    {
+      "id": 81, "name": "Zoman's Flat",
+      "exits": { "south": 82, "north": 80 }
+    },
+    {
+      "id": 82, "name": "Zoman's Flat",
+      "exits": { "south": 83, "west": 1097, "east": 1098, "north": 81 }
+    },
+    {
+      "id": 83, "name": "Temple of Air",
+      "exits": { "west": 84, "east": 85, "north": 82 }
+    },
+    {
+      "id": 84, "name": "Temple of Air",
+      "exits": { "east": 83, "up": 1130 }
+    },
+    {
+      "id": 85, "name": "Temple of Air",
+      "exits": { "up": 1131, "west": 83 }
+    },
+    {
+      "id": 86, "name": "Suran's Flat",
+      "exits": { "south": 76, "north": 87 }
+    },
+    {
+      "id": 87, "name": "Suran's Flat",
+      "exits": { "west": 1082, "south": 86, "north": 88 }
+    },
+    {
+      "id": 88, "name": "Suran's Flat",
+      "exits": { "south": 87, "north": 89 }
+    },
+    {
+      "id": 89, "name": "Suran's Flat",
+      "exits": { "south": 88, "north": 90 }
+    },
+    {
+      "id": 90, "name": "Suran's Flat",
+      "exits": { "south": 89, "west": 1093, "east": 1094, "north": 91 }
+    },
+    {
+      "id": 91, "name": "Temple of Water",
+      "exits": { "west": 92, "east": 93, "south": 90 }
+    },
+    {
+      "id": 92, "name": "Temple of Water",
+      "exits": { "east": 91, "up": 1132 }
+    },
+    {
+      "id": 93, "name": "Temple of Water",
+      "exits": { "up": 1133, "west": 91 }
+    },
+    {
+      "id": 94, "name": "Clansmen Way",
+      "exits": { "south": 427, "west": 63, "east": 95, "north": 972 }
+    },
+    {
+      "id": 95, "name": "Clansmen Way",
+      "exits": { "west": 94, "east": 96, "south": 975 }
+    },
+    {
+      "id": 96, "name": "Clansmen Way",
+      "exits": { "south": 976, "west": 95, "east": 97, "north": 977 }
+    },
+    {
+      "id": 97, "name": "Clansmen Way",
+      "exits": { "west": 96, "east": 98, "north": 428 }
+    },
+    {
+      "id": 98, "name": "Clansmen Way",
+      "exits": { "south": 99, "west": 97, "east": 1000, "north": 107 }
+    },
+    {
+      "id": 99, "name": "Fallah's Flat:",
+      "exits": { "south": 100, "north": 98 }
+    },
+    {
+      "id": 100, "name": "Fallah's Flat:",
+      "exits": { "south": 101, "west": 505, "east": 997, "north": 99 }
+    },
+    {
+      "id": 101, "name": "Fallah's Flat",
+      "exits": { "south": 102, "north": 100 }
+    },
+    {
+      "id": 102, "name": "Fallah's Flat",
+      "exits": { "south": 103, "north": 101 }
+    },
+    {
+      "id": 103, "name": "Fallah's Flat:",
+      "exits": { "south": 104, "west": 998, "east": 999, "north": 102 }
+    },
+    {
+      "id": 104, "name": "Temple of Earth",
+      "exits": { "west": 105, "east": 106, "north": 103 }
+    },
+    {
+      "id": 105, "name": "Temple of Earth",
+      "exits": { "east": 104, "up": 1127 }
+    },
+    {
+      "id": 106, "name": "Temple of Earth",
+      "exits": { "up": 1126, "west": 104 }
+    },
+    {
+      "id": 107, "name": "Phaekads Flat:",
+      "exits": { "south": 98, "north": 108 }
+    },
+    {
+      "id": 108, "name": "Phaekads Flat:",
+      "exits": { "south": 107, "north": 109 }
+    },
+    {
+      "id": 109, "name": "Phaekads Flat",
+      "exits": { "south": 108, "north": 110 }
+    },
+    {
+      "id": 110, "name": "Phaekads Flat",
+      "exits": { "south": 109, "north": 111 }
+    },
+    {
+      "id": 111, "name": "Phaekads Flat:",
+      "exits": { "south": 110, "east": 996, "north": 112 }
+    },
+    {
+      "id": 112, "name": "Temple of Fire",
+      "exits": { "west": 113, "east": 114, "south": 111 }
+    },
+    {
+      "id": 113, "name": "Temple of Fire",
+      "exits": { "east": 112, "up": 1129 }
+    },
+    {
+      "id": 114, "name": "Temple of Fire",
+      "exits": { "up": 1128, "west": 112 }
+    },
+    {
+      "id": 427, "name": "The Rabbit's Hole",
+      "exits": { "west": 64, "north": 94 }
+    },
+    {
+      "id": 428, "name": "6 Feet Under",
+      "exits": { "west": 977, "south": 97 }
+    },
+    {
+      "id": 429, "name": "Morbid Curiosity",
+      "exits": { "east": 64, "north": 72 }
+    },
+    {
+      "id": 430, "name": "Scribe",
+      "exits": { "east": 65 }
+    },
+    {
+      "id": 431, "name": "Servants Quarters",
+      "exits": { "west": 68 }
+    },
+    {
+      "id": 505, "name": "Slave Auction:",
+      "exits": { "east": 100 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 18,
-        "north": 16
-      },
-      "id": 17
+    {
+      "id": 963, "name": "Eastern Entrance",
+      "exits": { "east": 57, "west": 1027 }
+    },
+    {
+      "id": 964, "name": "Widow's House",
+      "exits": { "west": 57 }
+    },
+    {
+      "id": 965, "name": "A Jeweler's Shop",
+      "exits": { "east": 58 }
+    },
+    {
+      "id": 966, "name": "Farmer's Smith",
+      "exits": { "east": 989, "west": 58 }
+    },
+    {
+      "id": 967, "name": "Candera Information Bureau",
+      "exits": { "east": 59, "north": 1125 }
+    },
+    {
+      "id": 968, "name": "Lizard Skin Trader",
+      "exits": { "east": 60 }
+    },
+    {
+      "id": 969, "name": "Shaman's Shack",
+      "exits": { "west": 60 }
+    },
+    {
+      "id": 970, "name": "Silk Shop",
+      "exits": { "east": 61 }
+    },
+    {
+      "id": 971, "name": "Barbarian's Guild",
+      "exits": { "east": 62 }
+    },
+    {
+      "id": 972, "name": "Trader's Shack",
+      "exits": { "west": 62, "south": 94 }
+    },
+    {
+      "id": 973, "name": "East Wall Guard Station",
+      "exits": { "west": 15, "south": 974, "north": 986 }
+    },
+    {
+      "id": 974, "name": "Living Quarters",
+      "exits": { "north": 973 }
+    },
+    {
+      "id": 975, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 95 }
+    },
+    {
+      "id": 976, "name": "Back Alley",
+      "exits": { "north": 96 }
+    },
+    {
+      "id": 986, "name": "Sleeping Quarters",
+      "exits": { "south": 973 }
+    },
+    {
+      "id": 996, "name": "Candera Priest's Hut",
+      "exits": { "west": 111 }
+    },
+    {
+      "id": 997, "name": "Pillow Shop:",
+      "exits": { "west": 100 }
+    },
+    {
+      "id": 998, "name": "Relic Shop:",
+      "exits": { "east": 103 }
+    },
+    {
+      "id": 999, "name": "Butcher Shop:",
+      "exits": { "west": 103 }
+    },
+    {
+      "id": 1015, "name": "Snake Charmer",
+      "exits": { "west": 65 }
+    },
+    {
+      "id": 1016, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 73 }
+    },
+    {
+      "id": 1017, "name": "Kaimuki Q's",
+      "exits": { "west": 1018, "south": 73 }
+    },
+    {
+      "id": 1019, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 74 }
+    },
+    {
+      "id": 1030, "name": "South Wall Guard Station",
+      "exits": { "west": 1031, "east": 1032, "north": 29 }
+    },
+    {
+      "id": 1031, "name": "Living Quarters",
+      "exits": { "east": 1030 }
+    },
+    {
+      "id": 1032, "name": "Sleeping Quarters",
+      "exits": { "west": 1030 }
+    },
+    {
+      "id": 1033, "name": "West Wall Guard Station",
+      "exits": { "south": 1034, "east": 43, "north": 1035 }
+    },
+    {
+      "id": 1034, "name": "Living Quarters",
+      "exits": { "north": 1033 }
+    },
+    {
+      "id": 1035, "name": "Sleeping Quarters",
+      "exits": { "south": 1033 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 19,
-        "north": 17
-      },
-      "id": 18
+    {
+      "id": 1093, "name": "Goondala's Flowers",
+      "exits": { "east": 90 }
+    },
+    {
+      "id": 1094, "name": "Weapon Master's Shop",
+      "exits": { "west": 90 }
+    },
+    {
+      "id": 1095, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 75 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 20,
-        "north": 18
-      },
-      "id": 19
+    {
+      "id": 1096, "name": "Alchemist's Shop",
+      "exits": { "west": 79 }
+    },
+    {
+      "id": 1097, "name": "Canderan Guard House",
+      "exits": { "east": 82 }
+    },
+    {
+      "id": 1098, "name": "Crypt of the Honored Dead",
+      "exits": { "down": 1099, "west": 82 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 21,
-        "north": 19
-      },
-      "id": 20
+    {
+      "id": 1125, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 967 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 22,
-        "north": 20
-      },
-      "id": 21
+    {
+      "id": 1126, "name": "Temple of Earth",
+      "exits": { "down": 106 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "west": 23,
-        "north": 21
-      },
-      "id": 22
+    {
+      "id": 1127, "name": "Temple of Earth",
+      "exits": { "down": 105 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 22,
-        "west": 24
-      },
-      "id": 23
+    {
+      "id": 1128, "name": "Temple of Fire",
+      "exits": { "down": 114 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 23,
-        "west": 25
-      },
-      "id": 24
+    {
+      "id": 1129, "name": "Temple of Fire",
+      "exits": { "down": 113 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 24,
-        "west": 26
-      },
-      "id": 25
+    {
+      "id": 1130, "name": "Temple of Air",
+      "exits": { "down": 84 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 25,
-        "west": 27
-      },
-      "id": 26
+    {
+      "id": 1131, "name": "Temple of Air",
+      "exits": { "down": 85 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 26,
-        "west": 28
-      },
-      "id": 27
+    {
+      "id": 1132, "name": "Temple of Water",
+      "exits": { "down": 92 }
     },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 27,
-        "west": 29
-      },
-      "id": 28
+    {
+      "id": 1133, "name": "Temple of Water",
+      "exits": { "down": 93 }
     },
-    {
-      "name": "South Wall Guard Station",
-      "exits": {
-        "west": 30,
-        "east": 28,
-        "south": 1030
-      },
-      "id": 29
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 29,
-        "west": 31
-      },
-      "id": 30
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 30,
-        "west": 32
-      },
-      "id": 31
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 31,
-        "west": 33
-      },
-      "id": 32
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 32,
-        "west": 34
-      },
-      "id": 33
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 33,
-        "west": 35
-      },
-      "id": 34
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 34,
-        "west": 36
-      },
-      "id": 35
-    },
-    {
-      "name": "Southwest Corner",
-      "exits": {
-        "east": 35,
-        "north": 37
-      },
-      "id": 36
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 36,
-        "north": 38
-      },
-      "id": 37
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 37,
-        "north": 39
-      },
-      "id": 38
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 38,
-        "north": 40
-      },
-      "id": 39
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 39,
-        "north": 41
-      },
-      "id": 40
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 40,
-        "north": 42
-      },
-      "id": 41
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 41,
-        "north": 43
-      },
-      "id": 42
-    },
-    {
-      "name": "West Wall Guard Station",
-      "exits": {
-        "west": 1033,
-        "south": 42,
-        "north": 44
-      },
-      "id": 43
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 43,
-        "north": 45
-      },
-      "id": 44
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 44,
-        "north": 46
-      },
-      "id": 45
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 45,
-        "north": 47
-      },
-      "id": 46
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 46,
-        "north": 48
-      },
-      "id": 47
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "south": 47,
-        "north": 49
-      },
-      "id": 48
-    },
-    {
-      "name": "Entrance to the Northwest Tower",
-      "exits": {
-        "south": 48,
-        "north": 50
-      },
-      "id": 49
-    },
-    {
-      "name": "Northwest Corner",
-      "exits": {
-        "east": 51,
-        "south": 49
-      },
-      "id": 50
-    },
-    {
-      "name": "Entrance to the Northwest Tower",
-      "exits": {
-        "east": 52,
-        "west": 50
-      },
-      "id": 51
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 53,
-        "west": 51
-      },
-      "id": 52
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 54,
-        "west": 52
-      },
-      "id": 53
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 55,
-        "west": 53
-      },
-      "id": 54
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 56,
-        "west": 54
-      },
-      "id": 55
-    },
-    {
-      "name": "New Outer Wall",
-      "exits": {
-        "east": 1,
-        "west": 55
-      },
-      "id": 56
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 58,
-        "west": 963,
-        "east": 964,
-        "north": 1
-      },
-      "id": 57
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 59,
-        "west": 965,
-        "east": 966,
-        "north": 57
-      },
-      "id": 58
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "west": 967,
-        "south": 60,
-        "north": 58
-      },
-      "id": 59
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 61,
-        "west": 968,
-        "east": 969,
-        "north": 59
-      },
-      "id": 60
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "west": 970,
-        "south": 62,
-        "north": 60
-      },
-      "id": 61
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 63,
-        "west": 971,
-        "east": 972,
-        "north": 61
-      },
-      "id": 62
-    },
-    {
-      "name": "Canderan Well",
-      "exits": {
-        "south": 64,
-        "west": 72,
-        "east": 94,
-        "north": 62
-      },
-      "id": 63
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 65,
-        "west": 429,
-        "east": 427,
-        "north": 63
-      },
-      "id": 64
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 66,
-        "west": 430,
-        "east": 1015,
-        "north": 64
-      },
-      "id": 65
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 67,
-        "north": 65
-      },
-      "id": 66
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 68,
-        "north": 66
-      },
-      "id": 67
-    },
-    {
-      "name": "Warrior's Walk",
-      "exits": {
-        "south": 69,
-        "east": 431,
-        "north": 67
-      },
-      "id": 68
-    },
-    {
-      "name": "House of Lord Candera",
-      "exits": {
-        "up": 1134,
-        "west": 70,
-        "east": 71,
-        "north": 68
-      },
-      "id": 69
-    },
-    {
-      "name": "House of Lord Candera",
-      "exits": {
-        "east": 69
-      },
-      "id": 70
-    },
-    {
-      "name": "House of Lord Candera",
-      "exits": {
-        "west": 69
-      },
-      "id": 71
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "west": 73,
-        "east": 63,
-        "south": 429
-      },
-      "id": 72
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 1016,
-        "west": 74,
-        "east": 72,
-        "north": 1017
-      },
-      "id": 73
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 1019,
-        "west": 75,
-        "east": 73,
-        "north": 1018
-      },
-      "id": 74
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "west": 76,
-        "east": 74,
-        "south": 1095
-      },
-      "id": 75
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 78,
-        "west": 77,
-        "east": 75,
-        "north": 86
-      },
-      "id": 76
-    },
-    {
-      "name": "Zoman's Flat",
-      "exits": {
-        "south": 79,
-        "north": 76
-      },
-      "id": 78
-    },
-    {
-      "name": "Zoman's Flat",
-      "exits": {
-        "south": 80,
-        "east": 1096,
-        "north": 78
-      },
-      "id": 79
-    },
-    {
-      "name": "Zoman's Flat",
-      "exits": {
-        "south": 81,
-        "north": 79
-      },
-      "id": 80
-    },
-    {
-      "name": "Zoman's Flat",
-      "exits": {
-        "south": 82,
-        "north": 80
-      },
-      "id": 81
-    },
-    {
-      "name": "Zoman's Flat",
-      "exits": {
-        "south": 83,
-        "west": 1097,
-        "east": 1098,
-        "north": 81
-      },
-      "id": 82
-    },
-    {
-      "name": "Temple of Air",
-      "exits": {
-        "west": 84,
-        "east": 85,
-        "north": 82
-      },
-      "id": 83
-    },
-    {
-      "name": "Temple of Air",
-      "exits": {
-        "east": 83,
-        "up": 1130
-      },
-      "id": 84
-    },
-    {
-      "name": "Temple of Air",
-      "exits": {
-        "up": 1131,
-        "west": 83
-      },
-      "id": 85
-    },
-    {
-      "name": "Suran's Flat",
-      "exits": {
-        "south": 76,
-        "north": 87
-      },
-      "id": 86
-    },
-    {
-      "name": "Suran's Flat",
-      "exits": {
-        "west": 1082,
-        "south": 86,
-        "north": 88
-      },
-      "id": 87
-    },
-    {
-      "name": "Suran's Flat",
-      "exits": {
-        "south": 87,
-        "north": 89
-      },
-      "id": 88
-    },
-    {
-      "name": "Suran's Flat",
-      "exits": {
-        "south": 88,
-        "north": 90
-      },
-      "id": 89
-    },
-    {
-      "name": "Suran's Flat",
-      "exits": {
-        "south": 89,
-        "west": 1093,
-        "east": 1094,
-        "north": 91
-      },
-      "id": 90
-    },
-    {
-      "name": "Temple of Water",
-      "exits": {
-        "west": 92,
-        "east": 93,
-        "south": 90
-      },
-      "id": 91
-    },
-    {
-      "name": "Temple of Water",
-      "exits": {
-        "east": 91,
-        "up": 1132
-      },
-      "id": 92
-    },
-    {
-      "name": "Temple of Water",
-      "exits": {
-        "up": 1133,
-        "west": 91
-      },
-      "id": 93
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 427,
-        "west": 63,
-        "east": 95,
-        "north": 972
-      },
-      "id": 94
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "west": 94,
-        "east": 96,
-        "south": 975
-      },
-      "id": 95
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 976,
-        "west": 95,
-        "east": 97,
-        "north": 977
-      },
-      "id": 96
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "west": 96,
-        "east": 98,
-        "north": 428
-      },
-      "id": 97
-    },
-    {
-      "name": "Clansmen Way",
-      "exits": {
-        "south": 99,
-        "west": 97,
-        "east": 1000,
-        "north": 107
-      },
-      "id": 98
-    },
-    {
-      "name": "Fallah's Flat:",
-      "exits": {
-        "south": 100,
-        "north": 98
-      },
-      "id": 99
-    },
-    {
-      "name": "Fallah's Flat:",
-      "exits": {
-        "south": 101,
-        "west": 505,
-        "east": 997,
-        "north": 99
-      },
-      "id": 100
-    },
-    {
-      "name": "Fallah's Flat",
-      "exits": {
-        "south": 102,
-        "north": 100
-      },
-      "id": 101
-    },
-    {
-      "name": "Fallah's Flat",
-      "exits": {
-        "south": 103,
-        "north": 101
-      },
-      "id": 102
-    },
-    {
-      "name": "Fallah's Flat:",
-      "exits": {
-        "south": 104,
-        "west": 998,
-        "east": 999,
-        "north": 102
-      },
-      "id": 103
-    },
-    {
-      "name": "Temple of Earth",
-      "exits": {
-        "west": 105,
-        "east": 106,
-        "north": 103
-      },
-      "id": 104
-    },
-    {
-      "name": "Temple of Earth",
-      "exits": {
-        "east": 104,
-        "up": 1127
-      },
-      "id": 105
-    },
-    {
-      "name": "Temple of Earth",
-      "exits": {
-        "up": 1126,
-        "west": 104
-      },
-      "id": 106
-    },
-    {
-      "name": "Phaekads Flat:",
-      "exits": {
-        "south": 98,
-        "north": 108
-      },
-      "id": 107
-    },
-    {
-      "name": "Phaekads Flat:",
-      "exits": {
-        "south": 107,
-        "north": 109
-      },
-      "id": 108
-    },
-    {
-      "name": "Phaekads Flat",
-      "exits": {
-        "south": 108,
-        "north": 110
-      },
-      "id": 109
-    },
-    {
-      "name": "Phaekads Flat",
-      "exits": {
-        "south": 109,
-        "north": 111
-      },
-      "id": 110
-    },
-    {
-      "name": "Phaekads Flat:",
-      "exits": {
-        "south": 110,
-        "east": 996,
-        "north": 112
-      },
-      "id": 111
-    },
-    {
-      "name": "Temple of Fire",
-      "exits": {
-        "west": 113,
-        "east": 114,
-        "south": 111
-      },
-      "id": 112
-    },
-    {
-      "name": "Temple of Fire",
-      "exits": {
-        "east": 112,
-        "up": 1129
-      },
-      "id": 113
-    },
-    {
-      "name": "Temple of Fire",
-      "exits": {
-        "up": 1128,
-        "west": 112
-      },
-      "id": 114
-    },
-    {
-      "name": "The Rabbit's Hole",
-      "exits": {
-        "west": 64,
-        "north": 94
-      },
-      "id": 427
-    },
-    {
-      "name": "6 Feet Under",
-      "exits": {
-        "west": 977,
-        "south": 97
-      },
-      "id": 428
-    },
-    {
-      "name": "Morbid Curiosity",
-      "exits": {
-        "east": 64,
-        "north": 72
-      },
-      "id": 429
-    },
-    {
-      "name": "Scribe",
-      "exits": {
-        "east": 65
-      },
-      "id": 430
-    },
-    {
-      "name": "Servants Quarters",
-      "exits": {
-        "west": 68
-      },
-      "id": 431
-    },
-    {
-      "name": "Slave Auction:",
-      "exits": {
-        "east": 100
-      },
-      "id": 505
-    },
-    {
-      "name": "Eastern Entrance",
-      "exits": {
-        "east": 57,
-        "west": 1027
-      },
-      "id": 963
-    },
-    {
-      "name": "Widow's House",
-      "exits": {
-        "west": 57
-      },
-      "id": 964
-    },
-    {
-      "name": "A Jeweler's Shop",
-      "exits": {
-        "east": 58
-      },
-      "id": 965
-    },
-    {
-      "name": "Farmer's Smith",
-      "exits": {
-        "east": 989,
-        "west": 58
-      },
-      "id": 966
-    },
-    {
-      "name": "Candera Information Bureau",
-      "exits": {
-        "east": 59,
-        "north": 1125
-      },
-      "id": 967
-    },
-    {
-      "name": "Lizard Skin Trader",
-      "exits": {
-        "east": 60
-      },
-      "id": 968
-    },
-    {
-      "name": "Shaman's Shack",
-      "exits": {
-        "west": 60
-      },
-      "id": 969
-    },
-    {
-      "name": "Silk Shop",
-      "exits": {
-        "east": 61
-      },
-      "id": 970
-    },
-    {
-      "name": "Barbarian's Guild",
-      "exits": {
-        "east": 62
-      },
-      "id": 971
-    },
-    {
-      "name": "Trader's Shack",
-      "exits": {
-        "west": 62,
-        "south": 94
-      },
-      "id": 972
-    },
-    {
-      "name": "East Wall Guard Station",
-      "exits": {
-        "west": 15,
-        "south": 974,
-        "north": 986
-      },
-      "id": 973
-    },
-    {
-      "name": "Living Quarters",
-      "exits": {
-        "north": 973
-      },
-      "id": 974
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 95
-      },
-      "id": 975
-    },
-    {
-      "name": "Back Alley",
-      "exits": {
-        "north": 96
-      },
-      "id": 976
-    },
-    {
-      "name": "Sleeping Quarters",
-      "exits": {
-        "south": 973
-      },
-      "id": 986
-    },
-    {
-      "name": "Candera Priest's Hut",
-      "exits": {
-        "west": 111
-      },
-      "id": 996
-    },
-    {
-      "name": "Pillow Shop:",
-      "exits": {
-        "west": 100
-      },
-      "id": 997
-    },
-    {
-      "name": "Relic Shop:",
-      "exits": {
-        "east": 103
-      },
-      "id": 998
-    },
-    {
-      "name": "Butcher Shop:",
-      "exits": {
-        "west": 103
-      },
-      "id": 999
-    },
-    {
-      "name": "Snake Charmer",
-      "exits": {
-        "west": 65
-      },
-      "id": 1015
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 73
-      },
-      "id": 1016
-    },
-    {
-      "name": "Kaimuki Q's",
-      "exits": {
-        "west": 1018,
-        "south": 73
-      },
-      "id": 1017
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 74
-      },
-      "id": 1019
-    },
-    {
-      "name": "South Wall Guard Station",
-      "exits": {
-        "west": 1031,
-        "east": 1032,
-        "north": 29
-      },
-      "id": 1030
-    },
-    {
-      "name": "Living Quarters",
-      "exits": {
-        "east": 1030
-      },
-      "id": 1031
-    },
-    {
-      "name": "Sleeping Quarters",
-      "exits": {
-        "west": 1030
-      },
-      "id": 1032
-    },
-    {
-      "name": "West Wall Guard Station",
-      "exits": {
-        "south": 1034,
-        "east": 43,
-        "north": 1035
-      },
-      "id": 1033
-    },
-    {
-      "name": "Living Quarters",
-      "exits": {
-        "north": 1033
-      },
-      "id": 1034
-    },
-    {
-      "name": "Sleeping Quarters",
-      "exits": {
-        "south": 1033
-      },
-      "id": 1035
-    },
-    {
-      "name": "Goondala's Flowers",
-      "exits": {
-        "east": 90
-      },
-      "id": 1093
-    },
-    {
-      "name": "Weapon Master's Shop",
-      "exits": {
-        "west": 90
-      },
-      "id": 1094
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 75
-      },
-      "id": 1095
-    },
-    {
-      "name": "Alchemist's Shop",
-      "exits": {
-        "west": 79
-      },
-      "id": 1096
-    },
-    {
-      "name": "Canderan Guard House",
-      "exits": {
-        "east": 82
-      },
-      "id": 1097
-    },
-    {
-      "name": "Crypt of the Honored Dead",
-      "exits": {
-        "down": 1099,
-        "west": 82
-      },
-      "id": 1098
-    },
-    {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "exits": {
-        "south": 967
-      },
-      "id": 1125
-    },
-    {
-      "name": "Temple of Earth",
-      "exits": {
-        "down": 106
-      },
-      "id": 1126
-    },
-    {
-      "name": "Temple of Earth",
-      "exits": {
-        "down": 105
-      },
-      "id": 1127
-    },
-    {
-      "name": "Temple of Fire",
-      "exits": {
-        "down": 114
-      },
-      "id": 1128
-    },
-    {
-      "name": "Temple of Fire",
-      "exits": {
-        "down": 113
-      },
-      "id": 1129
-    },
-    {
-      "name": "Temple of Air",
-      "exits": {
-        "down": 84
-      },
-      "id": 1130
-    },
-    {
-      "name": "Temple of Air",
-      "exits": {
-        "down": 85
-      },
-      "id": 1131
-    },
-    {
-      "name": "Temple of Water",
-      "exits": {
-        "down": 92
-      },
-      "id": 1132
-    },
-    {
-      "name": "Temple of Water",
-      "exits": {
-        "down": 93
-      },
-      "id": 1133
-    },
-    {
-      "name": "House of Lord Candera",
-      "exits": {
-        "down": 69
-      },
-      "id": 1134
+    {
+      "id": 1134, "name": "House of Lord Candera",
+      "exits": { "down": 69 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/chikurin-forest.json
+++ b/maps/chikurin-forest.json
@@ -4,301 +4,120 @@
   },
   "rooms": [
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "northeast": 1858,
-        "northwest": 1835,
-        "north": 1856
-      },
-      "id": 1834
+      "id": 1834, "name": "Chikurin Forest Path",
+      "exits": { "northeast": 1858, "northwest": 1835, "north": 1856 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "east": 1856,
-        "northeast": 1857,
-        "southeast": 1834,
-        "north": 1836
-      },
-      "id": 1835
+      "id": 1835, "name": "Bamboo Forest",
+      "exits": { "east": 1856, "northeast": 1857, "southeast": 1834, "north": 1836 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "northwest": 1837,
-        "south": 1835,
-        "northeast": 1862,
-        "east": 1857,
-        "north": 1855
-      },
-      "id": 1836
+      "id": 1836, "name": "Bamboo Forest",
+      "exits": { "northwest": 1837, "south": 1835, "northeast": 1862, "east": 1857, "north": 1855 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "east": 1855,
-        "northeast": 1851,
-        "southeast": 1836,
-        "north": 1838
-      },
-      "id": 1837
+      "id": 1837, "name": "Bamboo Forest",
+      "exits": { "east": 1855, "northeast": 1851, "southeast": 1836, "north": 1838 }
     },
     {
-      "name": "Calm Clearing in the Bamboo Forest",
-      "exits": {
-        "southeast": 1855,
-        "south": 1837,
-        "northeast": 1850,
-        "east": 1851,
-        "north": 1839
-      },
-      "id": 1838
+      "id": 1838, "name": "Calm Clearing in the Bamboo Forest",
+      "exits": { "southeast": 1855, "south": 1837, "northeast": 1850, "east": 1851, "north": 1839 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "east": 1850,
-        "northeast": 1840,
-        "southeast": 1851,
-        "south": 1838
-      },
-      "id": 1839
+      "id": 1839, "name": "Bamboo Forest",
+      "exits": { "east": 1850, "northeast": 1840, "southeast": 1851, "south": 1838 }
     },
     {
-      "name": "Bamboo Forest, Near a Pond",
-      "exits": {
-        "southeast": 1849,
-        "south": 1850,
-        "southwest": 1839,
-        "northeast": 1842,
-        "east": 1846,
-        "north": 1841
-      },
-      "id": 1840
+      "id": 1840, "name": "Bamboo Forest, Near a Pond",
+      "exits": { "southeast": 1849, "south": 1850, "southwest": 1839, "northeast": 1842, "east": 1846, "north": 1841 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "east": 1842,
-        "southeast": 1846,
-        "south": 1840
-      },
-      "id": 1841
+      "id": 1841, "name": "Bamboo Forest",
+      "exits": { "east": 1842, "southeast": 1846, "south": 1840 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "south": 1846,
-        "west": 1841,
-        "east": 1845,
-        "north": 1843
-      },
-      "id": 1842
+      "id": 1842, "name": "Chikurin Forest Path",
+      "exits": { "south": 1846, "west": 1841, "east": 1845, "north": 1843 }
     },
     {
-      "name": "Chikurin Path, south of Semai Pass",
-      "exits": {
-        "south": 1842,
-        "north": 1844
-      },
-      "id": 1843
+      "id": 1843, "name": "Chikurin Path, south of Semai Pass",
+      "exits": { "south": 1842, "north": 1844 }
     },
     {
-      "name": "Heading north, you enter the narrow Semai Pass.",
-      "exits": {
-        "south": 1843
-      },
-      "id": 1844
+      "id": 1844, "name": "Heading north, you enter the narrow Semai Pass.",
+      "exits": { "south": 1843 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "southwest": 1846,
-        "west": 1842,
-        "south": 1848
-      },
-      "id": 1845
+      "id": 1845, "name": "Bamboo Forest",
+      "exits": { "southwest": 1846, "west": 1842, "south": 1848 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "southeast": 1847,
-        "west": 1840,
-        "northwest": 1841,
-        "south": 1849,
-        "southwest": 1850,
-        "northeast": 1845,
-        "east": 1848,
-        "north": 1842
-      },
-      "id": 1846
+      "id": 1846, "name": "Chikurin Forest Path",
+      "exits": { "southeast": 1847, "west": 1840, "northwest": 1841, "south": 1849, "southwest": 1850, "northeast": 1845, "east": 1848, "north": 1842 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "northwest": 1846,
-        "south": 1853,
-        "west": 1849,
-        "east": 1852,
-        "north": 1848
-      },
-      "id": 1847
+      "id": 1847, "name": "Bamboo Forest",
+      "exits": { "northwest": 1846, "south": 1853, "west": 1849, "east": 1852, "north": 1848 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "northwest": 1842,
-        "south": 1847,
-        "southwest": 1849,
-        "west": 1846,
-        "southeast": 1852,
-        "north": 1845
-      },
-      "id": 1848
+      "id": 1848, "name": "Bamboo Forest",
+      "exits": { "northwest": 1842, "south": 1847, "southwest": 1849, "west": 1846, "southeast": 1852, "north": 1845 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "southeast": 1853,
-        "south": 1854,
-        "southwest": 1851,
-        "west": 1850,
-        "north": 1846
-      },
-      "id": 1849
+      "id": 1849, "name": "Chikurin Forest Path",
+      "exits": { "southeast": 1853, "south": 1854, "southwest": 1851, "west": 1850, "north": 1846 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "west": 1839,
-        "south": 1851,
-        "southwest": 1838,
-        "northeast": 1846,
-        "east": 1849,
-        "north": 1840
-      },
-      "id": 1850
+      "id": 1850, "name": "Bamboo Forest",
+      "exits": { "west": 1839, "south": 1851, "southwest": 1838, "northeast": 1846, "east": 1849, "north": 1840 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "southeast": 1862,
-        "west": 1838,
-        "northwest": 1839,
-        "south": 1855,
-        "southwest": 1837,
-        "northeast": 1849,
-        "east": 1854,
-        "north": 1850
-      },
-      "id": 1851
+      "id": 1851, "name": "Bamboo Forest",
+      "exits": { "southeast": 1862, "west": 1838, "northwest": 1839, "south": 1855, "southwest": 1837, "northeast": 1849, "east": 1854, "north": 1850 }
     },
     {
-      "name": "Bamboo Forest, North of a Monastery",
-      "exits": {
-        "northwest": 1848,
-        "west": 1847
-      },
-      "id": 1852
+      "id": 1852, "name": "Bamboo Forest, North of a Monastery",
+      "exits": { "northwest": 1848, "west": 1847 }
     },
     {
-      "name": "Bamboo Forest, West of a Monastery",
-      "exits": {
-        "northwest": 1849,
-        "south": 1860,
-        "southwest": 1862,
-        "west": 1854,
-        "north": 1847
-      },
-      "id": 1853
+      "id": 1853, "name": "Bamboo Forest, West of a Monastery",
+      "exits": { "northwest": 1849, "south": 1860, "southwest": 1862, "west": 1854, "north": 1847 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "south": 1862,
-        "southwest": 1855,
-        "west": 1851,
-        "east": 1853,
-        "north": 1849
-      },
-      "id": 1854
+      "id": 1854, "name": "Chikurin Forest Path",
+      "exits": { "south": 1862, "southwest": 1855, "west": 1851, "east": 1853, "north": 1849 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "southeast": 1857,
-        "northwest": 1838,
-        "south": 1836,
-        "west": 1837,
-        "northeast": 1854,
-        "east": 1862,
-        "north": 1851
-      },
-      "id": 1855
+      "id": 1855, "name": "Bamboo Forest",
+      "exits": { "southeast": 1857, "northwest": 1838, "south": 1836, "west": 1837, "northeast": 1854, "east": 1862, "north": 1851 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "south": 1834,
-        "west": 1835,
-        "east": 1858,
-        "north": 1857
-      },
-      "id": 1856
+      "id": 1856, "name": "Chikurin Forest Path",
+      "exits": { "south": 1834, "west": 1835, "east": 1858, "north": 1857 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "north": 1862
-      },
-      "id": 1857
+      "id": 1857, "name": "Chikurin Forest Path",
+      "exits": { "north": 1862 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "southwest": 1834,
-        "west": 1856,
-        "northwest": 1857,
-        "north": 1859
-      },
-      "id": 1858
+      "id": 1858, "name": "Bamboo Forest",
+      "exits": { "southwest": 1834, "west": 1856, "northwest": 1857, "north": 1859 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "west": 1857,
-        "south": 1858,
-        "northwest": 1862,
-        "north": 1860
-      },
-      "id": 1859
+      "id": 1859, "name": "Bamboo Forest",
+      "exits": { "west": 1857, "south": 1858, "northwest": 1862, "north": 1860 }
     },
     {
-      "name": "Bamboo Forest",
-      "exits": {
-        "south": 1859,
-        "southwest": 1857,
-        "west": 1862,
-        "east": 1861,
-        "north": 1853
-      },
-      "id": 1860
+      "id": 1860, "name": "Bamboo Forest",
+      "exits": { "south": 1859, "southwest": 1857, "west": 1862, "east": 1861, "north": 1853 }
     },
     {
-      "name": "Bamboo Forest, South of a Monastery",
-      "exits": {
-        "southwest": 1859,
-        "west": 1860,
-        "north": 1863
-      },
-      "id": 1861
+      "id": 1861, "name": "Bamboo Forest, South of a Monastery",
+      "exits": { "southwest": 1859, "west": 1860, "north": 1863 }
     },
     {
-      "name": "Chikurin Forest Path",
-      "exits": {
-        "south": 1857
-      },
-      "id": 1862
+      "id": 1862, "name": "Chikurin Forest Path",
+      "exits": { "south": 1857 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/crimsonaxe-mine.json
+++ b/maps/crimsonaxe-mine.json
@@ -4,136 +4,72 @@
   },
   "rooms": [
     {
-      "name": "Moist cavern",
-      "exits": {
-        "down": 1809,
-        "up": 1808
-      },
-      "id": 1807
+      "id": 1807, "name": "Moist cavern",
+      "exits": { "down": 1809, "up": 1808 }
     },
     {
-      "name": "Crack in the mountainside",
-      "exits": {
-        "down": 1807
-      },
-      "id": 1808
+      "id": 1808, "name": "Crack in the mountainside",
+      "exits": { "down": 1807 }
     },
     {
-      "name": "Giant cavern",
-      "exits": {
-        "up": 1807,
-        "west": 1810
-      },
-      "id": 1809
+      "id": 1809, "name": "Giant cavern",
+      "exits": { "up": 1807, "west": 1810 }
     },
     {
-      "name": "Bright niche",
-      "exits": {
-        "east": 1809
-      },
-      "id": 1810
+      "id": 1810, "name": "Bright niche",
+      "exits": { "east": 1809 }
     },
     {
-      "name": "The ore lift",
-      "exits": {
-        "south": 1812
-      },
-      "id": 1811
+      "id": 1811, "name": "The ore lift",
+      "exits": { "south": 1812 }
     },
     {
-      "name": "The Crimsonaxe mine",
-      "exits": {
-        "west": 1813,
-        "south": 1815,
-        "north": 1811
-      },
-      "id": 1812
+      "id": 1812, "name": "The Crimsonaxe mine",
+      "exits": { "west": 1813, "south": 1815, "north": 1811 }
     },
     {
-      "name": "A guard point",
-      "exits": {
-        "south": 1814,
-        "east": 1812,
-        "north": 1823
-      },
-      "id": 1813
+      "id": 1813, "name": "A guard point",
+      "exits": { "south": 1814, "east": 1812, "north": 1823 }
     },
     {
-      "name": "The immense stone slab moves suprisingly easily.",
-      "exits": {
-        "north": 1813
-      },
-      "id": 1814
+      "id": 1814, "name": "The immense stone slab moves suprisingly easily.",
+      "exits": { "north": 1813 }
     },
     {
-      "name": "The Crimsonaxe mine",
-      "exits": {
-        "south": 1816,
-        "east": 1821,
-        "north": 1812
-      },
-      "id": 1815
+      "id": 1815, "name": "The Crimsonaxe mine",
+      "exits": { "south": 1816, "east": 1821, "north": 1812 }
     },
     {
-      "name": "A bend in the tunnel.",
-      "exits": {
-        "southeast": 1817,
-        "north": 1815
-      },
-      "id": 1816
+      "id": 1816, "name": "A bend in the tunnel.",
+      "exits": { "southeast": 1817, "north": 1815 }
     },
     {
-      "name": "A mine shaft.",
-      "exits": {
-        "northwest": 1816,
-        "east": 1818,
-        "up": 1820
-      },
-      "id": 1817
+      "id": 1817, "name": "A mine shaft.",
+      "exits": { "northwest": 1816, "east": 1818, "up": 1820 }
     },
     {
-      "name": "A guard house.",
-      "exits": {
-        "up": 1819,
-        "west": 1817
-      },
-      "id": 1818
+      "id": 1818, "name": "A guard house.",
+      "exits": { "up": 1819, "west": 1817 }
     },
     {
-      "name": "A sentry room",
-      "exits": {
-        "down": 1818
-      },
-      "id": 1819
+      "id": 1819, "name": "A sentry room",
+      "exits": { "down": 1818 }
     },
     {
-      "name": "A darkened entrance.",
-      "exits": {
-        "down": 1817
-      },
-      "id": 1820
+      "id": 1820, "name": "A darkened entrance.",
+      "exits": { "down": 1817 }
     },
     {
-      "name": "Mine catering",
-      "exits": {
-        "west": 1815,
-        "north": 1822
-      },
-      "id": 1821
+      "id": 1821, "name": "Mine catering",
+      "exits": { "west": 1815, "north": 1822 }
     },
     {
-      "name": "A smelly crevice.",
-      "exits": {
-        "south": 1821
-      },
-      "id": 1822
+      "id": 1822, "name": "A smelly crevice.",
+      "exits": { "south": 1821 }
     },
     {
-      "name": "The immense stone slab moves suprisingly easily.",
-      "exits": {
-        "south": 1813
-      },
-      "id": 1823
+      "id": 1823, "name": "The immense stone slab moves suprisingly easily.",
+      "exits": { "south": 1813 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/exedoria.json
+++ b/maps/exedoria.json
@@ -4,1208 +4,604 @@
   },
   "rooms": [
     {
-      "name": "Entrance to Exedoria",
-      "exits": {
-        "east": 287
-      },
-      "id": 286
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "west": 286,
-        "east": 288,
-        "south": 330
-      },
-      "id": 287
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "south": 368,
-        "west": 287,
-        "east": 289,
-        "north": 367
-      },
-      "id": 288
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "west": 288,
-        "east": 290,
-        "south": 366
-      },
-      "id": 289
-    },
-    {
-      "name": "Monument Circle, Main Street",
-      "exits": {
-        "south": 299,
-        "west": 289,
-        "east": 291,
-        "north": 369
-      },
-      "id": 290
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "south": 298,
-        "west": 290,
-        "east": 292,
-        "north": 370
-      },
-      "id": 291
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "west": 291,
-        "east": 293,
-        "south": 383
-      },
-      "id": 292
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "east": 294,
-        "west": 292
-      },
-      "id": 293
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "east": 295,
-        "west": 293
-      },
-      "id": 294
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "east": 296,
-        "west": 294
-      },
-      "id": 295
-    },
-    {
-      "name": "Main Street",
-      "exits": {
-        "east": 297,
-        "west": 295
-      },
-      "id": 296
-    },
-    {
-      "name": "Corigan Court Intersection",
-      "exits": {
-        "west": 296
-      },
-      "id": 297
-    },
-    {
-      "name": "City Hall",
-      "exits": {
-        "north": 291
-      },
-      "id": 298
-    },
-    {
-      "name": "Eithel Sirion",
-      "exits": {
-        "south": 300,
-        "north": 290
-      },
-      "id": 299
-    },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "south": 301,
-        "west": 302,
-        "east": 385,
-        "north": 299
-      },
-      "id": 300
-    },
-    {
-      "name": "Frenchie's II",
-      "exits": {
-        "north": 300
-      },
-      "id": 301
-    },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "west": 303,
-        "east": 300,
-        "south": 392
-      },
-      "id": 302
-    },
-    {
-      "name": "Middle of Brapnor Road",
-      "exits": {
-        "west": 304,
-        "east": 302,
-        "south": 329
-      },
-      "id": 303
-    },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "west": 305,
-        "east": 303,
-        "north": 330
-      },
-      "id": 304
-    },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "west": 306,
-        "east": 304,
-        "north": 393
-      },
-      "id": 305
-    },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "east": 305,
-        "west": 307
-      },
-      "id": 306
-    },
-    {
-      "name": "End of Brapnor Road",
-      "exits": {
-        "east": 306,
-        "northwest": 331,
-        "south": 308
-      },
-      "id": 307
-    },
-    {
-      "name": "Beginning of Lilu Lane",
-      "exits": {
-        "south": 309,
-        "north": 307
-      },
-      "id": 308
-    },
-    {
-      "name": "Lilu Lane",
-      "exits": {
-        "south": 310,
-        "north": 308
-      },
-      "id": 309
-    },
-    {
-      "name": "Middle of Lilu Lane",
-      "exits": {
-        "west": 355,
-        "south": 311,
-        "north": 309
-      },
-      "id": 310
-    },
-    {
-      "name": "Lilu Lane",
-      "exits": {
-        "south": 312,
-        "north": 310
-      },
-      "id": 311
-    },
-    {
-      "name": "End of Lilu Lane",
-      "exits": {
-        "west": 354,
-        "south": 313,
-        "north": 311
-      },
-      "id": 312
-    },
-    {
-      "name": "Beginning of Embassy Row",
-      "exits": {
-        "east": 314,
-        "north": 312
-      },
-      "id": 313
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "west": 313,
-        "east": 315,
-        "south": 322
-      },
-      "id": 314
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "south": 320,
-        "west": 314,
-        "east": 316,
-        "north": 321
-      },
-      "id": 315
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "south": 318,
-        "west": 315,
-        "east": 317,
-        "north": 319
-      },
-      "id": 316
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "west": 316,
-        "east": 323,
-        "north": 333
-      },
-      "id": 317
-    },
-    {
-      "name": "A Dark Hole in the Ground",
-      "exits": {
-        "north": 316
-      },
-      "id": 318
-    },
-    {
-      "name": "Guard Post for Gnome Embassy",
-      "exits": {
-        "south": 316,
-        "north": 926
-      },
-      "id": 319
-    },
-    {
-      "name": "Before a round door",
-      "exits": {
-        "north": 315
-      },
-      "id": 320
-    },
-    {
-      "name": "Junk yard",
-      "exits": {
-        "south": 315
-      },
-      "id": 321
-    },
-    {
-      "name": "Elven Embassy checkpoint",
-      "exits": {
-        "north": 314
-      },
-      "id": 322
-    },
-    {
-      "name": "End of Embassy Row",
-      "exits": {
-        "west": 317,
-        "north": 324
-      },
-      "id": 323
-    },
-    {
-      "name": "Southern end of alley",
-      "exits": {
-        "south": 323,
-        "north": 325
-      },
-      "id": 324
-    },
-    {
-      "name": "Bend in an alley",
-      "exits": {
-        "west": 326,
-        "south": 324
-      },
-      "id": 325
-    },
-    {
-      "name": "A bend in the alley",
-      "exits": {
-        "east": 325,
-        "north": 327
-      },
-      "id": 326
-    },
-    {
-      "name": "Dark and narrow alley",
-      "exits": {
-        "south": 326,
-        "north": 328
-      },
-      "id": 327
-    },
-    {
-      "name": "Dark alley",
-      "exits": {
-        "south": 327,
-        "north": 329
-      },
-      "id": 328
-    },
-    {
-      "name": "Alley entrance",
-      "exits": {
-        "south": 328,
-        "north": 303
-      },
-      "id": 329
-    },
-    {
-      "name": "The Excalibur, a closed guild",
-      "exits": {
-        "south": 304,
-        "north": 287
-      },
-      "id": 330
-    },
-    {
-      "name": "Foyer of the Exedorian Inn",
-      "exits": {
-        "southeast": 307,
-        "west": 332
-      },
-      "id": 331
-    },
-    {
-      "name": "Exedorian saloon",
-      "exits": {
-        "east": 331
-      },
-      "id": 332
-    },
-    {
-      "name": "Before the Dwarven Embassy",
-      "exits": {
-        "south": 317,
-        "north": 920
-      },
-      "id": 333
-    },
-    {
-      "name": "Keen Street West",
-      "exits": {
-        "east": 335
-      },
-      "id": 334
-    },
-    {
-      "name": "Keen Street",
-      "exits": {
-        "east": 336,
-        "west": 334
-      },
-      "id": 335
-    },
-    {
-      "name": "Keen Street",
-      "exits": {
-        "west": 335,
-        "east": 337,
-        "north": 602
-      },
-      "id": 336
-    },
-    {
-      "name": "Keen Street",
-      "exits": {
-        "west": 336,
-        "east": 338,
-        "south": 603
-      },
-      "id": 337
-    },
-    {
-      "name": "East Keen Street Bridge",
-      "exits": {
-        "west": 337,
-        "east": 339,
-        "north": 604
-      },
-      "id": 338
-    },
-    {
-      "name": "Keen Street Bridge",
-      "exits": {
-        "east": 340,
-        "west": 338
-      },
-      "id": 339
-    },
-    {
-      "name": "Keen Street",
-      "exits": {
-        "west": 339,
-        "east": 341,
-        "south": 343
-      },
-      "id": 340
-    },
-    {
-      "name": "Keen Street East",
-      "exits": {
-        "west": 340,
-        "north": 342
-      },
-      "id": 341
-    },
-    {
-      "name": "Guard Post",
-      "exits": {
-        "south": 341,
-        "north": 350
-      },
-      "id": 342
-    },
-    {
-      "name": "Statued lawn",
-      "exits": {
-        "south": 344,
-        "north": 340
-      },
-      "id": 343
-    },
-    {
-      "name": "Statued lawn",
-      "exits": {
-        "south": 345,
-        "north": 343
-      },
-      "id": 344
-    },
-    {
-      "name": "Manicured lawn",
-      "exits": {
-        "south": 346,
-        "north": 344
-      },
-      "id": 345
-    },
-    {
-      "name": "Cavernous foyer",
-      "exits": {
-        "west": 348,
-        "east": 347,
-        "north": 345
-      },
-      "id": 346
-    },
-    {
-      "name": "Icy room",
-      "exits": {
-        "west": 346
-      },
-      "id": 347
-    },
-    {
-      "name": "Cold hallway",
-      "exits": {
-        "east": 346,
-        "south": 349
-      },
-      "id": 348
-    },
-    {
-      "name": "Snowy cave",
-      "exits": {
-        "north": 348
-      },
-      "id": 349
-    },
-    {
-      "name": "With no gate guard present, you are able to enter the walled estate",
-      "exits": {
-        "south": 342,
-        "north": 351
-      },
-      "id": 350
-    },
-    {
-      "name": "Foyer",
-      "exits": {
-        "east": 352,
-        "south": 350
-      },
-      "id": 351
-    },
-    {
-      "name": "Wood-paneled Hallway",
-      "exits": {
-        "west": 351,
-        "north": 353
-      },
-      "id": 352
-    },
-    {
-      "name": "Busy Kitchen",
-      "exits": {
-        "south": 352
-      },
-      "id": 353
-    },
-    {
-      "name": "Mom's General Store",
-      "exits": {
-        "east": 312
-      },
-      "id": 354
-    },
-    {
-      "name": "Drawbridge",
-      "exits": {
-        "east": 310,
-        "west": 356
-      },
-      "id": 355
-    },
-    {
-      "name": "Library's entrance",
-      "exits": {
-        "south": 357,
-        "west": 361,
-        "east": 355,
-        "north": 362
-      },
-      "id": 356
+      "id": 286, "name": "Entrance to Exedoria",
+      "exits": { "east": 287 }
     },
     {
-      "name": "Cobblestoned hallway",
-      "exits": {
-        "south": 358,
-        "east": 360,
-        "north": 356
-      },
-      "id": 357
+      "id": 287, "name": "Main Street",
+      "exits": { "west": 286, "east": 288, "south": 330 }
     },
-    {
-      "name": "A bend in the hallway",
-      "exits": {
-        "west": 359,
-        "north": 357
-      },
-      "id": 358
+    {
+      "id": 288, "name": "Main Street",
+      "exits": { "south": 368, "west": 287, "east": 289, "north": 367 }
+    },
+    {
+      "id": 289, "name": "Main Street",
+      "exits": { "west": 288, "east": 290, "south": 366 }
+    },
+    {
+      "id": 290, "name": "Monument Circle, Main Street",
+      "exits": { "south": 299, "west": 289, "east": 291, "north": 369 }
+    },
+    {
+      "id": 291, "name": "Main Street",
+      "exits": { "south": 298, "west": 290, "east": 292, "north": 370 }
+    },
+    {
+      "id": 292, "name": "Main Street",
+      "exits": { "west": 291, "east": 293, "south": 383 }
+    },
+    {
+      "id": 293, "name": "Main Street",
+      "exits": { "east": 294, "west": 292 }
+    },
+    {
+      "id": 294, "name": "Main Street",
+      "exits": { "east": 295, "west": 293 }
+    },
+    {
+      "id": 295, "name": "Main Street",
+      "exits": { "east": 296, "west": 294 }
+    },
+    {
+      "id": 296, "name": "Main Street",
+      "exits": { "east": 297, "west": 295 }
+    },
+    {
+      "id": 297, "name": "Corigan Court Intersection",
+      "exits": { "west": 296 }
+    },
+    {
+      "id": 298, "name": "City Hall",
+      "exits": { "north": 291 }
+    },
+    {
+      "id": 299, "name": "Eithel Sirion",
+      "exits": { "south": 300, "north": 290 }
+    },
+    {
+      "id": 300, "name": "Brapnor Road",
+      "exits": { "south": 301, "west": 302, "east": 385, "north": 299 }
+    },
+    {
+      "id": 301, "name": "Frenchie's II",
+      "exits": { "north": 300 }
+    },
+    {
+      "id": 302, "name": "Brapnor Road",
+      "exits": { "west": 303, "east": 300, "south": 392 }
+    },
+    {
+      "id": 303, "name": "Middle of Brapnor Road",
+      "exits": { "west": 304, "east": 302, "south": 329 }
+    },
+    {
+      "id": 304, "name": "Brapnor Road",
+      "exits": { "west": 305, "east": 303, "north": 330 }
+    },
+    {
+      "id": 305, "name": "Brapnor Road",
+      "exits": { "west": 306, "east": 304, "north": 393 }
+    },
+    {
+      "id": 306, "name": "Brapnor Road",
+      "exits": { "east": 305, "west": 307 }
+    },
+    {
+      "id": 307, "name": "End of Brapnor Road",
+      "exits": { "east": 306, "northwest": 331, "south": 308 }
+    },
+    {
+      "id": 308, "name": "Beginning of Lilu Lane",
+      "exits": { "south": 309, "north": 307 }
+    },
+    {
+      "id": 309, "name": "Lilu Lane",
+      "exits": { "south": 310, "north": 308 }
+    },
+    {
+      "id": 310, "name": "Middle of Lilu Lane",
+      "exits": { "west": 355, "south": 311, "north": 309 }
+    },
+    {
+      "id": 311, "name": "Lilu Lane",
+      "exits": { "south": 312, "north": 310 }
+    },
+    {
+      "id": 312, "name": "End of Lilu Lane",
+      "exits": { "west": 354, "south": 313, "north": 311 }
+    },
+    {
+      "id": 313, "name": "Beginning of Embassy Row",
+      "exits": { "east": 314, "north": 312 }
+    },
+    {
+      "id": 314, "name": "Embassy Row",
+      "exits": { "west": 313, "east": 315, "south": 322 }
+    },
+    {
+      "id": 315, "name": "Embassy Row",
+      "exits": { "south": 320, "west": 314, "east": 316, "north": 321 }
+    },
+    {
+      "id": 316, "name": "Embassy Row",
+      "exits": { "south": 318, "west": 315, "east": 317, "north": 319 }
+    },
+    {
+      "id": 317, "name": "Embassy Row",
+      "exits": { "west": 316, "east": 323, "north": 333 }
+    },
+    {
+      "id": 318, "name": "A Dark Hole in the Ground",
+      "exits": { "north": 316 }
+    },
+    {
+      "id": 319, "name": "Guard Post for Gnome Embassy",
+      "exits": { "south": 316, "north": 926 }
+    },
+    {
+      "id": 320, "name": "Before a round door",
+      "exits": { "north": 315 }
+    },
+    {
+      "id": 321, "name": "Junk yard",
+      "exits": { "south": 315 }
+    },
+    {
+      "id": 322, "name": "Elven Embassy checkpoint",
+      "exits": { "north": 314 }
+    },
+    {
+      "id": 323, "name": "End of Embassy Row",
+      "exits": { "west": 317, "north": 324 }
+    },
+    {
+      "id": 324, "name": "Southern end of alley",
+      "exits": { "south": 323, "north": 325 }
+    },
+    {
+      "id": 325, "name": "Bend in an alley",
+      "exits": { "west": 326, "south": 324 }
+    },
+    {
+      "id": 326, "name": "A bend in the alley",
+      "exits": { "east": 325, "north": 327 }
+    },
+    {
+      "id": 327, "name": "Dark and narrow alley",
+      "exits": { "south": 326, "north": 328 }
+    },
+    {
+      "id": 328, "name": "Dark alley",
+      "exits": { "south": 327, "north": 329 }
+    },
+    {
+      "id": 329, "name": "Alley entrance",
+      "exits": { "south": 328, "north": 303 }
+    },
+    {
+      "id": 330, "name": "The Excalibur, a closed guild",
+      "exits": { "south": 304, "north": 287 }
+    },
+    {
+      "id": 331, "name": "Foyer of the Exedorian Inn",
+      "exits": { "southeast": 307, "west": 332 }
+    },
+    {
+      "id": 332, "name": "Exedorian saloon",
+      "exits": { "east": 331 }
+    },
+    {
+      "id": 333, "name": "Before the Dwarven Embassy",
+      "exits": { "south": 317, "north": 920 }
+    },
+    {
+      "id": 334, "name": "Keen Street West",
+      "exits": { "east": 335 }
+    },
+    {
+      "id": 335, "name": "Keen Street",
+      "exits": { "east": 336, "west": 334 }
+    },
+    {
+      "id": 336, "name": "Keen Street",
+      "exits": { "west": 335, "east": 337, "north": 602 }
+    },
+    {
+      "id": 337, "name": "Keen Street",
+      "exits": { "west": 336, "east": 338, "south": 603 }
+    },
+    {
+      "id": 338, "name": "East Keen Street Bridge",
+      "exits": { "west": 337, "east": 339, "north": 604 }
+    },
+    {
+      "id": 339, "name": "Keen Street Bridge",
+      "exits": { "east": 340, "west": 338 }
+    },
+    {
+      "id": 340, "name": "Keen Street",
+      "exits": { "west": 339, "east": 341, "south": 343 }
+    },
+    {
+      "id": 341, "name": "Keen Street East",
+      "exits": { "west": 340, "north": 342 }
+    },
+    {
+      "id": 342, "name": "Guard Post",
+      "exits": { "south": 341, "north": 350 }
+    },
+    {
+      "id": 343, "name": "Statued lawn",
+      "exits": { "south": 344, "north": 340 }
+    },
+    {
+      "id": 344, "name": "Statued lawn",
+      "exits": { "south": 345, "north": 343 }
+    },
+    {
+      "id": 345, "name": "Manicured lawn",
+      "exits": { "south": 346, "north": 344 }
+    },
+    {
+      "id": 346, "name": "Cavernous foyer",
+      "exits": { "west": 348, "east": 347, "north": 345 }
+    },
+    {
+      "id": 347, "name": "Icy room",
+      "exits": { "west": 346 }
+    },
+    {
+      "id": 348, "name": "Cold hallway",
+      "exits": { "east": 346, "south": 349 }
+    },
+    {
+      "id": 349, "name": "Snowy cave",
+      "exits": { "north": 348 }
+    },
+    {
+      "id": 350, "name": "With no gate guard present, you are able to enter the walled estate",
+      "exits": { "south": 342, "north": 351 }
+    },
+    {
+      "id": 351, "name": "Foyer",
+      "exits": { "east": 352, "south": 350 }
+    },
+    {
+      "id": 352, "name": "Wood-paneled Hallway",
+      "exits": { "west": 351, "north": 353 }
+    },
+    {
+      "id": 353, "name": "Busy Kitchen",
+      "exits": { "south": 352 }
+    },
+    {
+      "id": 354, "name": "Mom's General Store",
+      "exits": { "east": 312 }
+    },
+    {
+      "id": 355, "name": "Drawbridge",
+      "exits": { "east": 310, "west": 356 }
+    },
+    {
+      "id": 356, "name": "Library's entrance",
+      "exits": { "south": 357, "west": 361, "east": 355, "north": 362 }
+    },
+    {
+      "id": 357, "name": "Cobblestoned hallway",
+      "exits": { "south": 358, "east": 360, "north": 356 }
+    },
+    {
+      "id": 358, "name": "A bend in the hallway",
+      "exits": { "west": 359, "north": 357 }
+    },
+    {
+      "id": 359, "name": "A monk's cell",
+      "exits": { "east": 358 }
+    },
+    {
+      "id": 360, "name": "A monk's cell",
+      "exits": { "west": 357 }
+    },
+    {
+      "id": 361, "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
+      "exits": { "east": 356 }
+    },
+    {
+      "id": 362, "name": "Cobblestoned hallway",
+      "exits": { "south": 356, "east": 363, "north": 364 }
+    },
+    {
+      "id": 363, "name": "A monk's cell",
+      "exits": { "west": 362 }
+    },
+    {
+      "id": 364, "name": "A bend in the hallway",
+      "exits": { "west": 365, "south": 362 }
     },
-    {
-      "name": "A monk's cell",
-      "exits": {
-        "east": 358
-      },
-      "id": 359
+    {
+      "id": 365, "name": "A monk's cell",
+      "exits": { "east": 364 }
+    },
+    {
+      "id": 366, "name": "The Cadaver Emporium",
+      "exits": { "north": 289 }
+    },
+    {
+      "id": 367, "name": "Velvet Unicorn",
+      "exits": { "south": 288 }
+    },
+    {
+      "id": 368, "name": "Eidolon Warlords",
+      "exits": { "north": 288 }
+    },
+    {
+      "id": 369, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 290 }
+    },
+    {
+      "id": 370, "name": "Beginning of park path",
+      "exits": { "south": 291, "north": 371 }
+    },
+    {
+      "id": 371, "name": "Park path intersection",
+      "exits": { "south": 370, "west": 372, "east": 378, "north": 373 }
+    },
+    {
+      "id": 372, "name": "Exedoria Pet Cemetary",
+      "exits": { "east": 371 }
+    },
+    {
+      "id": 373, "name": "Park path on the hill",
+      "exits": { "south": 371, "north": 374 }
+    },
+    {
+      "id": 374, "name": "Elevated park path",
+      "exits": { "south": 373, "north": 375 }
+    },
+    {
+      "id": 375, "name": "End of park path",
+      "exits": { "east": 376, "south": 374 }
+    },
+    {
+      "id": 376, "name": "Temple ruins",
+      "exits": { "east": 377, "west": 375 }
+    },
+    {
+      "id": 377, "name": "Temple rotunda",
+      "exits": { "west": 376 }
+    },
+    {
+      "id": 378, "name": "Gravel path to the mansion",
+      "exits": { "east": 379, "west": 371 }
+    },
+    {
+      "id": 379, "name": "Gravel path on the hill",
+      "exits": { "east": 380, "west": 378 }
     },
     {
-      "name": "A monk's cell",
-      "exits": {
-        "west": 357
-      },
-      "id": 360
-    },
+      "id": 380, "name": "Intersection in the gravel path",
+      "exits": { "west": 379, "southeast": 382, "north": 381 }
+    },
+    {
+      "id": 381, "name": "Before a white mansion",
+      "exits": { "south": 380 }
+    },
     {
-      "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
-      "exits": {
-        "east": 356
-      },
-      "id": 361
-    },
-    {
-      "name": "Cobblestoned hallway",
-      "exits": {
-        "south": 356,
-        "east": 363,
-        "north": 364
-      },
-      "id": 362
-    },
+      "id": 382, "name": "Outside the cemetery gate",
+      "exits": { "northwest": 380 }
+    },
     {
-      "name": "A monk's cell",
-      "exits": {
-        "west": 362
-      },
-      "id": 363
-    },
-    {
-      "name": "A bend in the hallway",
-      "exits": {
-        "west": 365,
-        "south": 362
-      },
-      "id": 364
-    },
+      "id": 383, "name": "Guard Post",
+      "exits": { "south": 384, "north": 292 }
+    },
     {
-      "name": "A monk's cell",
-      "exits": {
-        "east": 364
-      },
-      "id": 365
-    },
-    {
-      "name": "The Cadaver Emporium",
-      "exits": {
-        "north": 289
-      },
-      "id": 366
-    },
-    {
-      "name": "Velvet Unicorn",
-      "exits": {
-        "south": 288
-      },
-      "id": 367
-    },
-    {
-      "name": "Eidolon Warlords",
-      "exits": {
-        "north": 288
-      },
-      "id": 368
-    },
-    {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
-      "exits": {
-        "south": 290
-      },
-      "id": 369
+      "id": 384, "name": "Beginning of Brapnor Road",
+      "exits": { "west": 385, "southeast": 386, "north": 383 }
     },
-    {
-      "name": "Beginning of park path",
-      "exits": {
-        "south": 291,
-        "north": 371
-      },
-      "id": 370
+    {
+      "id": 385, "name": "Brapnor Road",
+      "exits": { "east": 384, "west": 300 }
     },
-    {
-      "name": "Park path intersection",
-      "exits": {
-        "south": 370,
-        "west": 372,
-        "east": 378,
-        "north": 373
-      },
-      "id": 371
-    },
-    {
-      "name": "Exedoria Pet Cemetary",
-      "exits": {
-        "east": 371
-      },
-      "id": 372
-    },
-    {
-      "name": "Park path on the hill",
-      "exits": {
-        "south": 371,
-        "north": 374
-      },
-      "id": 373
-    },
-    {
-      "name": "Elevated park path",
-      "exits": {
-        "south": 373,
-        "north": 375
-      },
-      "id": 374
-    },
-    {
-      "name": "End of park path",
-      "exits": {
-        "east": 376,
-        "south": 374
-      },
-      "id": 375
-    },
-    {
-      "name": "Temple ruins",
-      "exits": {
-        "east": 377,
-        "west": 375
-      },
-      "id": 376
-    },
-    {
-      "name": "Temple rotunda",
-      "exits": {
-        "west": 376
-      },
-      "id": 377
+    {
+      "id": 386, "name": "Necrom's Gate",
+      "exits": { "northwest": 384, "southeast": 387 }
     },
-    {
-      "name": "Gravel path to the mansion",
-      "exits": {
-        "east": 379,
-        "west": 371
-      },
-      "id": 378
+    {
+      "id": 387, "name": "Paved intersection",
+      "exits": { "east": 388, "northwest": 386, "south": 527 }
     },
-    {
-      "name": "Gravel path on the hill",
-      "exits": {
-        "east": 380,
-        "west": 378
-      },
-      "id": 379
+    {
+      "id": 388, "name": "Eastern path through the University",
+      "exits": { "east": 389, "west": 387 }
     },
-    {
-      "name": "Intersection in the gravel path",
-      "exits": {
-        "west": 379,
-        "southeast": 382,
-        "north": 381
-      },
-      "id": 380
-    },
-    {
-      "name": "Before a white mansion",
-      "exits": {
-        "south": 380
-      },
-      "id": 381
+    {
+      "id": 389, "name": "Eastern path through the University",
+      "exits": { "east": 390, "west": 388 }
     },
-    {
-      "name": "Outside the cemetery gate",
-      "exits": {
-        "northwest": 380
-      },
-      "id": 382
+    {
+      "id": 390, "name": "In front of a temporary building",
+      "exits": { "west": 389, "east": 391, "south": 904 }
     },
     {
-      "name": "Guard Post",
-      "exits": {
-        "south": 384,
-        "north": 292
-      },
-      "id": 383
+      "id": 391, "name": "Construction site",
+      "exits": { "west": 390 }
     },
     {
-      "name": "Beginning of Brapnor Road",
-      "exits": {
-        "west": 385,
-        "southeast": 386,
-        "north": 383
-      },
-      "id": 384
+      "id": 392, "name": "Delilah's Deli",
+      "exits": { "north": 302 }
     },
-    {
-      "name": "Brapnor Road",
-      "exits": {
-        "east": 384,
-        "west": 300
-      },
-      "id": 385
+    {
+      "id": 393, "name": "Guard Tower Entrance",
+      "exits": { "south": 305 }
     },
-    {
-      "name": "Necrom's Gate",
-      "exits": {
-        "northwest": 384,
-        "southeast": 387
-      },
-      "id": 386
+    {
+      "id": 527, "name": "Southern path through the University",
+      "exits": { "south": 528, "north": 387 }
     },
-    {
-      "name": "Paved intersection",
-      "exits": {
-        "east": 388,
-        "northwest": 386,
-        "south": 527
-      },
-      "id": 387
-    },
-    {
-      "name": "Eastern path through the University",
-      "exits": {
-        "east": 389,
-        "west": 387
-      },
-      "id": 388
-    },
-    {
-      "name": "Eastern path through the University",
-      "exits": {
-        "east": 390,
-        "west": 388
-      },
-      "id": 389
-    },
-    {
-      "name": "In front of a temporary building",
-      "exits": {
-        "west": 389,
-        "east": 391,
-        "south": 904
-      },
-      "id": 390
-    },
-    {
-      "name": "Construction site",
-      "exits": {
-        "west": 390
-      },
-      "id": 391
-    },
-    {
-      "name": "Delilah's Deli",
-      "exits": {
-        "north": 302
-      },
-      "id": 392
+    {
+      "id": 528, "name": "Southern path through the University",
+      "exits": { "south": 896, "east": 894, "north": 527 }
     },
-    {
-      "name": "Guard Tower Entrance",
-      "exits": {
-        "south": 305
-      },
-      "id": 393
+    {
+      "id": 602, "name": "Railed entrance",
+      "exits": { "south": 336 }
     },
     {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 528,
-        "north": 387
-      },
-      "id": 527
+      "id": 603, "name": "Flagstoned entry",
+      "exits": { "south": 915, "north": 337 }
     },
     {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 896,
-        "east": 894,
-        "north": 527
-      },
-      "id": 528
+      "id": 604, "name": "You rudely trespass on the private property.",
+      "exits": { "northeast": 907, "northwest": 910, "south": 338 }
     },
-    {
-      "name": "Railed entrance",
-      "exits": {
-        "south": 336
-      },
-      "id": 602
+    {
+      "id": 894, "name": "Dormitory foyer",
+      "exits": { "west": 528, "south": 895, "north": 903 }
     },
     {
-      "name": "Flagstoned entry",
-      "exits": {
-        "south": 915,
-        "north": 337
-      },
-      "id": 603
+      "id": 895, "name": "Dining commons",
+      "exits": { "north": 894 }
     },
     {
-      "name": "You rudely trespass on the private property.",
-      "exits": {
-        "northeast": 907,
-        "northwest": 910,
-        "south": 338
-      },
-      "id": 604
+      "id": 896, "name": "Southern path through the University",
+      "exits": { "south": 897, "north": 528 }
     },
-    {
-      "name": "Dormitory foyer",
-      "exits": {
-        "west": 528,
-        "south": 895,
-        "north": 903
-      },
-      "id": 894
-    },
     {
-      "name": "Dining commons",
-      "exits": {
-        "north": 894
-      },
-      "id": 895
+      "id": 897, "name": "Southern path through the University",
+      "exits": { "south": 898, "north": 896 }
     },
-    {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 897,
-        "north": 528
-      },
-      "id": 896
+    {
+      "id": 898, "name": "Southern path through the University",
+      "exits": { "south": 899, "north": 897 }
     },
-    {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 898,
-        "north": 896
-      },
-      "id": 897
+    {
+      "id": 899, "name": "Southern path through the University",
+      "exits": { "south": 902, "east": 900, "north": 898 }
     },
-    {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 899,
-        "north": 897
-      },
-      "id": 898
+    {
+      "id": 900, "name": "School of Business",
+      "exits": { "west": 899, "north": 901 }
     },
-    {
-      "name": "Southern path through the University",
-      "exits": {
-        "south": 902,
-        "east": 900,
-        "north": 898
-      },
-      "id": 899
-    },
-    {
-      "name": "School of Business",
-      "exits": {
-        "west": 899,
-        "north": 901
-      },
-      "id": 900
-    },
-    {
-      "name": "Dean's office",
-      "exits": {
-        "south": 900
-      },
-      "id": 901
+    {
+      "id": 901, "name": "Dean's office",
+      "exits": { "south": 900 }
     },
-    {
-      "name": "Construction site",
-      "exits": {
-        "north": 899
-      },
-      "id": 902
+    {
+      "id": 902, "name": "Construction site",
+      "exits": { "north": 899 }
     },
     {
-      "name": "Resident Advisor's office",
-      "exits": {
-        "south": 894
-      },
-      "id": 903
+      "id": 903, "name": "Resident Advisor's office",
+      "exits": { "south": 894 }
     },
     {
-      "name": "Science building's entry",
-      "exits": {
-        "west": 905,
-        "east": 906,
-        "north": 390
-      },
-      "id": 904
+      "id": 904, "name": "Science building's entry",
+      "exits": { "west": 905, "east": 906, "north": 390 }
     },
     {
-      "name": "Science laboratory",
-      "exits": {
-        "east": 904
-      },
-      "id": 905
+      "id": 905, "name": "Science laboratory",
+      "exits": { "east": 904 }
     },
     {
-      "name": "Science lecture hall",
-      "exits": {
-        "west": 904
-      },
-      "id": 906
+      "id": 906, "name": "Science lecture hall",
+      "exits": { "west": 904 }
     },
     {
-      "name": "Gravel Path",
-      "exits": {
-        "northwest": 908,
-        "southwest": 604
-      },
-      "id": 907
+      "id": 907, "name": "Gravel Path",
+      "exits": { "northwest": 908, "southwest": 604 }
     },
     {
-      "name": "Vine-covered Entry",
-      "exits": {
-        "southwest": 910,
-        "southeast": 907,
-        "north": 909
-      },
-      "id": 908
+      "id": 908, "name": "Vine-covered Entry",
+      "exits": { "southwest": 910, "southeast": 907, "north": 909 }
     },
     {
-      "name": "Grand Foyer",
-      "exits": {
-        "up": 914,
-        "west": 911,
-        "east": 912,
-        "south": 908
-      },
-      "id": 909
+      "id": 909, "name": "Grand Foyer",
+      "exits": { "up": 914, "west": 911, "east": 912, "south": 908 }
     },
-    {
-      "name": "Gravel Path",
-      "exits": {
-        "southeast": 604,
-        "northeast": 908
-      },
-      "id": 910
+    {
+      "id": 910, "name": "Gravel Path",
+      "exits": { "southeast": 604, "northeast": 908 }
     },
-    {
-      "name": "Child's Den",
-      "exits": {
-        "east": 909
-      },
-      "id": 911
+    {
+      "id": 911, "name": "Child's Den",
+      "exits": { "east": 909 }
     },
     {
-      "name": "Wooded Hallway",
-      "exits": {
-        "east": 913,
-        "west": 909
-      },
-      "id": 912
+      "id": 912, "name": "Wooded Hallway",
+      "exits": { "east": 913, "west": 909 }
     },
     {
-      "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
-      "exits": {
-        "west": 912
-      },
-      "id": 913
+      "id": 913, "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
+      "exits": { "west": 912 }
     },
     {
-      "name": "Treetop Bedroom",
-      "exits": {
-        "down": 909
-      },
-      "id": 914
+      "id": 914, "name": "Treetop Bedroom",
+      "exits": { "down": 909 }
     },
     {
-      "name": "Flagstoned path",
-      "exits": {
-        "south": 916,
-        "west": 919,
-        "east": 918,
-        "north": 603
-      },
-      "id": 915
+      "id": 915, "name": "Flagstoned path",
+      "exits": { "south": 916, "west": 919, "east": 918, "north": 603 }
     },
     {
-      "name": "Gray foyer",
-      "exits": {
-        "south": 917,
-        "north": 915
-      },
-      "id": 916
+      "id": 916, "name": "Gray foyer",
+      "exits": { "south": 917, "north": 915 }
     },
     {
-      "name": "Trinian merchant's office",
-      "exits": {
-        "north": 916
-      },
-      "id": 917
+      "id": 917, "name": "Trinian merchant's office",
+      "exits": { "north": 916 }
     },
     {
-      "name": "Carriage house",
-      "exits": {
-        "west": 915
-      },
-      "id": 918
+      "id": 918, "name": "Carriage house",
+      "exits": { "west": 915 }
     },
     {
-      "name": "Slave quarters",
-      "exits": {
-        "east": 915
-      },
-      "id": 919
+      "id": 919, "name": "Slave quarters",
+      "exits": { "east": 915 }
     },
     {
-      "name": "Dwarven Embassy foyer",
-      "exits": {
-        "west": 923,
-        "up": 921,
-        "south": 333,
-        "east": 925,
-        "north": 924
-      },
-      "id": 920
+      "id": 920, "name": "Dwarven Embassy foyer",
+      "exits": { "west": 923, "up": 921, "south": 333, "east": 925, "north": 924 }
     },
     {
-      "name": "Dwarven watchtower",
-      "exits": {
-        "down": 920,
-        "north": 922
-      },
-      "id": 921
+      "id": 921, "name": "Dwarven watchtower",
+      "exits": { "down": 920, "north": 922 }
     },
     {
-      "name": "Ambassadors Suite",
-      "exits": {
-        "south": 921
-      },
-      "id": 922
+      "id": 922, "name": "Ambassadors Suite",
+      "exits": { "south": 921 }
     },
     {
-      "name": "Dwarven brewery",
-      "exits": {
-        "east": 920
-      },
-      "id": 923
+      "id": 923, "name": "Dwarven brewery",
+      "exits": { "east": 920 }
     },
     {
-      "name": "Dwarven Ambassador's office",
-      "exits": {
-        "south": 920
-      },
-      "id": 924
+      "id": 924, "name": "Dwarven Ambassador's office",
+      "exits": { "south": 920 }
     },
     {
-      "name": "Dwarven armoury",
-      "exits": {
-        "west": 920
-      },
-      "id": 925
+      "id": 925, "name": "Dwarven armoury",
+      "exits": { "west": 920 }
     },
     {
-      "name": "Ground Floor of the Windmill",
-      "exits": {
-        "up": 929,
-        "west": 927,
-        "east": 928,
-        "south": 319
-      },
-      "id": 926
+      "id": 926, "name": "Ground Floor of the Windmill",
+      "exits": { "up": 929, "west": 927, "east": 928, "south": 319 }
     },
     {
-      "name": "Garden of Machines",
-      "exits": {
-        "east": 926
-      },
-      "id": 927
+      "id": 927, "name": "Garden of Machines",
+      "exits": { "east": 926 }
     },
     {
-      "name": "Cemetery",
-      "exits": {
-        "west": 926
-      },
-      "id": 928
+      "id": 928, "name": "Cemetery",
+      "exits": { "west": 926 }
     },
     {
-      "name": "Gnome Laboratory",
-      "exits": {
-        "down": 926,
-        "up": 930
-      },
-      "id": 929
+      "id": 929, "name": "Gnome Laboratory",
+      "exits": { "down": 926, "up": 930 }
     },
     {
-      "name": "Machinery Room",
-      "exits": {
-        "down": 929
-      },
-      "id": 930
+      "id": 930, "name": "Machinery Room",
+      "exits": { "down": 929 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/great-bazaar-of-candera.json
+++ b/maps/great-bazaar-of-candera.json
@@ -4,155 +4,76 @@
   },
   "rooms": [
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 96,
-        "east": 428,
-        "north": 995
-      },
-      "id": 977
+      "id": 977, "name": "Great Bazaar of Candera",
+      "exits": { "south": 96, "east": 428, "north": 995 }
     },
     {
-      "name": "Nut Shop",
-      "exits": {
-        "south": 989
-      },
-      "id": 978
+      "id": 978, "name": "Nut Shop",
+      "exits": { "south": 989 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 980,
-        "west": 984,
-        "east": 991,
-        "north": 989
-      },
-      "id": 979
+      "id": 979, "name": "Great Bazaar of Candera",
+      "exits": { "south": 980, "west": 984, "east": 991, "north": 989 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 981,
-        "west": 983,
-        "east": 993,
-        "north": 979
-      },
-      "id": 980
+      "id": 980, "name": "Great Bazaar of Candera",
+      "exits": { "south": 981, "west": 983, "east": 993, "north": 979 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "west": 982,
-        "east": 995,
-        "north": 980
-      },
-      "id": 981
+      "id": 981, "name": "Great Bazaar of Candera",
+      "exits": { "west": 982, "east": 995, "north": 980 }
     },
     {
-      "name": "Shader's Scales",
-      "exits": {
-        "east": 981
-      },
-      "id": 982
+      "id": 982, "name": "Shader's Scales",
+      "exits": { "east": 981 }
     },
     {
-      "name": "Omars' Oil:",
-      "exits": {
-        "east": 980
-      },
-      "id": 983
+      "id": 983, "name": "Omars' Oil:",
+      "exits": { "east": 980 }
     },
     {
-      "name": "Smithy",
-      "exits": {
-        "east": 979
-      },
-      "id": 984
+      "id": 984, "name": "Smithy",
+      "exits": { "east": 979 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 991,
-        "west": 989,
-        "east": 987,
-        "north": 988
-      },
-      "id": 985
+      "id": 985, "name": "Great Bazaar of Candera",
+      "exits": { "south": 991, "west": 989, "east": 987, "north": 988 }
     },
     {
-      "name": "Lord Candera's Lottery",
-      "exits": {
-        "west": 985
-      },
-      "id": 987
+      "id": 987, "name": "Lord Candera's Lottery",
+      "exits": { "west": 985 }
     },
     {
-      "name": "Empty Tent",
-      "exits": {
-        "south": 985
-      },
-      "id": 988
+      "id": 988, "name": "Empty Tent",
+      "exits": { "south": 985 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 979,
-        "west": 966,
-        "east": 985,
-        "north": 978
-      },
-      "id": 989
+      "id": 989, "name": "Great Bazaar of Candera",
+      "exits": { "south": 979, "west": 966, "east": 985, "north": 978 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 993,
-        "west": 979,
-        "east": 992,
-        "north": 985
-      },
-      "id": 991
+      "id": 991, "name": "Great Bazaar of Candera",
+      "exits": { "south": 993, "west": 979, "east": 992, "north": 985 }
     },
     {
-      "name": "Kamal's Camel Lot:",
-      "exits": {
-        "west": 991
-      },
-      "id": 992
+      "id": 992, "name": "Kamal's Camel Lot:",
+      "exits": { "west": 991 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 995,
-        "west": 980,
-        "east": 994,
-        "north": 991
-      },
-      "id": 993
+      "id": 993, "name": "Great Bazaar of Candera",
+      "exits": { "south": 995, "west": 980, "east": 994, "north": 991 }
     },
     {
-      "name": "Perfume Tent:",
-      "exits": {
-        "west": 993
-      },
-      "id": 994
+      "id": 994, "name": "Perfume Tent:",
+      "exits": { "west": 993 }
     },
     {
-      "name": "Great Bazaar of Candera",
-      "exits": {
-        "south": 977,
-        "west": 981,
-        "east": 1739,
-        "north": 993
-      },
-      "id": 995
+      "id": 995, "name": "Great Bazaar of Candera",
+      "exits": { "south": 977, "west": 981, "east": 1739, "north": 993 }
     },
     {
-      "name": "Landak's Hut:",
-      "exits": {
-        "west": 995
-      },
-      "id": 1739
+      "id": 1739, "name": "Landak's Hut:",
+      "exits": { "west": 995 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/ice-dragons-den.json
+++ b/maps/ice-dragons-den.json
@@ -4,198 +4,100 @@
   },
   "rooms": [
     {
-      "name": "Ice Dragon's Den",
-      "exits": {
-        "down": 1339
-      },
-      "id": 1338
+      "id": 1338, "name": "Ice Dragon's Den",
+      "exits": { "down": 1339 }
     },
     {
-      "name": "Near a Frozen Waterfall",
-      "exits": {
-        "northwest": 1340,
-        "east": 1342
-      },
-      "id": 1339
+      "id": 1339, "name": "Near a Frozen Waterfall",
+      "exits": { "northwest": 1340, "east": 1342 }
     },
     {
-      "name": "By an Icy Gate",
-      "exits": {
-        "southeast": 1339,
-        "east": 1341
-      },
-      "id": 1340
+      "id": 1340, "name": "By an Icy Gate",
+      "exits": { "southeast": 1339, "east": 1341 }
     },
     {
-      "name": "Edge of an Icy Cliff",
-      "exits": {
-        "west": 1340
-      },
-      "id": 1341
+      "id": 1341, "name": "Edge of an Icy Cliff",
+      "exits": { "west": 1340 }
     },
     {
-      "name": "On Top of a Frozen River",
-      "exits": {
-        "west": 1339,
-        "north": 1343
-      },
-      "id": 1342
+      "id": 1342, "name": "On Top of a Frozen River",
+      "exits": { "west": 1339, "north": 1343 }
     },
     {
-      "name": "On Top of a Frozen River",
-      "exits": {
-        "south": 1342,
-        "north": 1344
-      },
-      "id": 1343
+      "id": 1343, "name": "On Top of a Frozen River",
+      "exits": { "south": 1342, "north": 1344 }
     },
     {
-      "name": "Under a Snowy Overhang",
-      "exits": {
-        "northwest": 1345,
-        "south": 1343
-      },
-      "id": 1344
+      "id": 1344, "name": "Under a Snowy Overhang",
+      "exits": { "northwest": 1345, "south": 1343 }
     },
     {
-      "name": "On Top of an Icy Stream",
-      "exits": {
-        "southeast": 1344,
-        "west": 1346
-      },
-      "id": 1345
+      "id": 1345, "name": "On Top of an Icy Stream",
+      "exits": { "southeast": 1344, "west": 1346 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "east": 1345,
-        "northwest": 1347,
-        "southeast": 1360,
-        "west": 1358
-      },
-      "id": 1346
+      "id": 1346, "name": "On Top of an Icy Lake",
+      "exits": { "east": 1345, "northwest": 1347, "southeast": 1360, "west": 1358 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "west": 1351,
-        "northeast": 1348,
-        "southeast": 1346,
-        "south": 1358
-      },
-      "id": 1347
+      "id": 1347, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1351, "northeast": 1348, "southeast": 1346, "south": 1358 }
     },
     {
-      "name": "Entrance to a Frozen Cavern",
-      "exits": {
-        "southwest": 1347,
-        "southeast": 1349
-      },
-      "id": 1348
+      "id": 1348, "name": "Entrance to a Frozen Cavern",
+      "exits": { "southwest": 1347, "southeast": 1349 }
     },
     {
-      "name": "Frozen Cavern",
-      "exits": {
-        "northwest": 1348,
-        "east": 1350
-      },
-      "id": 1349
+      "id": 1349, "name": "Frozen Cavern",
+      "exits": { "northwest": 1348, "east": 1350 }
     },
     {
-      "name": "End of a Frozen Cavern",
-      "exits": {
-        "west": 1349
-      },
-      "id": 1350
+      "id": 1350, "name": "End of a Frozen Cavern",
+      "exits": { "west": 1349 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "west": 1352,
-        "east": 1347,
-        "south": 1356
-      },
-      "id": 1351
+      "id": 1351, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1352, "east": 1347, "south": 1356 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "east": 1351,
-        "northwest": 1359,
-        "south": 1353
-      },
-      "id": 1352
+      "id": 1352, "name": "On Top of an Icy Lake",
+      "exits": { "east": 1351, "northwest": 1359, "south": 1353 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "southwest": 1354,
-        "east": 1356,
-        "north": 1352
-      },
-      "id": 1353
+      "id": 1353, "name": "On Top of an Icy Lake",
+      "exits": { "southwest": 1354, "east": 1356, "north": 1352 }
     },
     {
-      "name": "Ice Cave Entrance",
-      "exits": {
-        "east": 1355,
-        "northeast": 1353
-      },
-      "id": 1354
+      "id": 1354, "name": "Ice Cave Entrance",
+      "exits": { "east": 1355, "northeast": 1353 }
     },
     {
-      "name": "Inside an Ice Cave",
-      "exits": {
-        "west": 1354
-      },
-      "id": 1355
+      "id": 1355, "name": "Inside an Ice Cave",
+      "exits": { "west": 1354 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "south": 1357,
-        "west": 1353,
-        "east": 1358,
-        "north": 1351
-      },
-      "id": 1356
+      "id": 1356, "name": "On Top of an Icy Lake",
+      "exits": { "south": 1357, "west": 1353, "east": 1358, "north": 1351 }
     },
     {
-      "name": "Isolated Icy Area",
-      "exits": {
-        "north": 1356
-      },
-      "id": 1357
+      "id": 1357, "name": "Isolated Icy Area",
+      "exits": { "north": 1356 }
     },
     {
-      "name": "On Top of an Icy Lake",
-      "exits": {
-        "west": 1356,
-        "east": 1346,
-        "north": 1347
-      },
-      "id": 1358
+      "id": 1358, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1356, "east": 1346, "north": 1347 }
     },
     {
-      "name": "Northern Shore of an Icy Lake",
-      "exits": {
-        "southeast": 1352
-      },
-      "id": 1359
+      "id": 1359, "name": "Northern Shore of an Icy Lake",
+      "exits": { "southeast": 1352 }
     },
     {
-      "name": "Snowy Overhang",
-      "exits": {
-        "northwest": 1346
-      },
-      "id": 1360
+      "id": 1360, "name": "Snowy Overhang",
+      "exits": { "northwest": 1346 }
     },
     {
-      "name": "down the waterfall.",
-      "exits": {
-        "down": 1339
-      },
-      "id": 1869
+      "id": 1869, "name": "down the waterfall.",
+      "exits": { "down": 1339 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/indel-city-park.json
+++ b/maps/indel-city-park.json
@@ -4,139 +4,64 @@
   },
   "rooms": [
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1525,
-        "east": 1607,
-        "north": 1608
-      },
-      "id": 1606
+      "id": 1606, "name": "Indel City Park",
+      "exits": { "west": 1525, "east": 1607, "north": 1608 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1606,
-        "east": 1613,
-        "north": 1609
-      },
-      "id": 1607
+      "id": 1607, "name": "Indel City Park",
+      "exits": { "west": 1606, "east": 1613, "north": 1609 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1606,
-        "east": 1609,
-        "north": 1611
-      },
-      "id": 1608
+      "id": 1608, "name": "Indel City Park",
+      "exits": { "south": 1606, "east": 1609, "north": 1611 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1607,
-        "west": 1608,
-        "east": 1610,
-        "north": 1612
-      },
-      "id": 1609
+      "id": 1609, "name": "Indel City Park",
+      "exits": { "south": 1607, "west": 1608, "east": 1610, "north": 1612 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1609,
-        "south": 1613,
-        "north": 1614
-      },
-      "id": 1610
+      "id": 1610, "name": "Indel City Park",
+      "exits": { "west": 1609, "south": 1613, "north": 1614 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1608,
-        "east": 1612,
-        "north": 1615
-      },
-      "id": 1611
+      "id": 1611, "name": "Indel City Park",
+      "exits": { "south": 1608, "east": 1612, "north": 1615 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1609,
-        "west": 1611,
-        "east": 1614,
-        "north": 1616
-      },
-      "id": 1612
+      "id": 1612, "name": "Indel City Park",
+      "exits": { "south": 1609, "west": 1611, "east": 1614, "north": 1616 }
     },
     {
-      "name": "Gazebo in the Park",
-      "exits": {
-        "west": 1607,
-        "north": 1610
-      },
-      "id": 1613
+      "id": 1613, "name": "Gazebo in the Park",
+      "exits": { "west": 1607, "north": 1610 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1612,
-        "south": 1610,
-        "north": 1617
-      },
-      "id": 1614
+      "id": 1614, "name": "Indel City Park",
+      "exits": { "west": 1612, "south": 1610, "north": 1617 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1611,
-        "east": 1616,
-        "north": 1619
-      },
-      "id": 1615
+      "id": 1615, "name": "Indel City Park",
+      "exits": { "south": 1611, "east": 1616, "north": 1619 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "south": 1612,
-        "west": 1615,
-        "east": 1617,
-        "north": 1618
-      },
-      "id": 1616
+      "id": 1616, "name": "Indel City Park",
+      "exits": { "south": 1612, "west": 1615, "east": 1617, "north": 1618 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1616,
-        "south": 1614,
-        "north": 1620
-      },
-      "id": 1617
+      "id": 1617, "name": "Indel City Park",
+      "exits": { "west": 1616, "south": 1614, "north": 1620 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1619,
-        "east": 1620,
-        "south": 1616
-      },
-      "id": 1618
+      "id": 1618, "name": "Indel City Park",
+      "exits": { "west": 1619, "east": 1620, "south": 1616 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "east": 1618,
-        "south": 1615
-      },
-      "id": 1619
+      "id": 1619, "name": "Indel City Park",
+      "exits": { "east": 1618, "south": 1615 }
     },
     {
-      "name": "Indel City Park",
-      "exits": {
-        "west": 1618,
-        "south": 1617
-      },
-      "id": 1620
+      "id": 1620, "name": "Indel City Park",
+      "exits": { "west": 1618, "south": 1617 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/indel.json
+++ b/maps/indel.json
@@ -4,1270 +4,632 @@
   },
   "rooms": [
     {
-      "name": "City of Indel, Wilderness Gate",
-      "exits": {
-        "west": 1635,
-        "east": 1636,
-        "south": 1402
-      },
-      "id": 1401
-    },
-    {
-      "name": "Castle Road",
-      "exits": {
-        "south": 1403,
-        "west": 1631,
-        "east": 1633,
-        "north": 1401
-      },
-      "id": 1402
-    },
-    {
-      "name": "Castle Road",
-      "exits": {
-        "south": 1404,
-        "west": 1628,
-        "east": 1630,
-        "north": 1402
-      },
-      "id": 1403
-    },
-    {
-      "name": "Castle Road Courtyard",
-      "exits": {
-        "south": 1405,
-        "west": 1626,
-        "east": 1627,
-        "north": 1403
-      },
-      "id": 1404
-    },
-    {
-      "name": "Castle Road",
-      "exits": {
-        "west": 1625,
-        "south": 1406,
-        "north": 1404
-      },
-      "id": 1405
-    },
-    {
-      "name": "Intersection of Castle Road and Merchant's Row",
-      "exits": {
-        "south": 1584,
-        "west": 1407,
-        "east": 1508,
-        "north": 1405
-      },
-      "id": 1406
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1406,
-        "west": 1408
-      },
-      "id": 1407
-    },
-    {
-      "name": "West Merchant's Row, north of the Silver Griffin",
-      "exits": {
-        "west": 1409,
-        "east": 1407,
-        "south": 1589
-      },
-      "id": 1408
-    },
-    {
-      "name": "West Merchant's Row, south of Big Bob's Sign Shop",
-      "exits": {
-        "west": 1410,
-        "east": 1408,
-        "south": 1590
-      },
-      "id": 1409
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1409,
-        "west": 1411
-      },
-      "id": 1410
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1410,
-        "west": 1412
-      },
-      "id": 1411
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1411,
-        "west": 1413
-      },
-      "id": 1412
-    },
-    {
-      "name": "West Merchant's Row, south of Knights of Solamnia",
-      "exits": {
-        "east": 1412,
-        "west": 1414
-      },
-      "id": 1413
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1413,
-        "west": 1415
-      },
-      "id": 1414
-    },
-    {
-      "name": "West Merchant's Row, south of the Cobbler's Shop",
-      "exits": {
-        "east": 1414,
-        "west": 1416
-      },
-      "id": 1415
-    },
-    {
-      "name": "West Merchant's Row, south of Laird's Forge",
-      "exits": {
-        "east": 1415,
-        "west": 1417
-      },
-      "id": 1416
-    },
-    {
-      "name": "West Merchant's Row",
-      "exits": {
-        "east": 1416,
-        "west": 1418
-      },
-      "id": 1417
-    },
-    {
-      "name": "Pier Street and Merchant's Row",
-      "exits": {
-        "south": 1419,
-        "east": 1417,
-        "north": 1448
-      },
-      "id": 1418
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1420,
-        "north": 1418
-      },
-      "id": 1419
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1421,
-        "north": 1419
-      },
-      "id": 1420
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1422,
-        "north": 1420
-      },
-      "id": 1421
-    },
-    {
-      "name": "Pier Street west of the Waterfront Gate",
-      "exits": {
-        "south": 1423,
-        "north": 1421
-      },
-      "id": 1422
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1424,
-        "north": 1422
-      },
-      "id": 1423
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1425,
-        "north": 1423
-      },
-      "id": 1424
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1426,
-        "north": 1424
-      },
-      "id": 1425
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1427,
-        "north": 1425
-      },
-      "id": 1426
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1428,
-        "north": 1426
-      },
-      "id": 1427
-    },
-    {
-      "name": "Pier Street",
-      "exits": {
-        "south": 1429,
-        "north": 1427
-      },
-      "id": 1428
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1430,
-        "north": 1428
-      },
-      "id": 1429
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1431,
-        "north": 1429
-      },
-      "id": 1430
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1432,
-        "north": 1430
-      },
-      "id": 1431
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1433,
-        "north": 1431
-      },
-      "id": 1432
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1434,
-        "north": 1432
-      },
-      "id": 1433
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1435,
-        "east": 1545,
-        "north": 1433
-      },
-      "id": 1434
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1436,
-        "north": 1434
-      },
-      "id": 1435
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1437,
-        "north": 1435
-      },
-      "id": 1436
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1438,
-        "north": 1436
-      },
-      "id": 1437
-    },
-    {
-      "name": "South Pier Street",
-      "exits": {
-        "south": 1439,
-        "north": 1437
-      },
-      "id": 1438
-    },
-    {
-      "name": "Forester's Gate",
-      "exits": {
-        "north": 1438
-      },
-      "id": 1439
-    },
-    {
-      "name": "North Pier Street",
-      "exits": {
-        "south": 1418,
-        "north": 1507
-      },
-      "id": 1448
-    },
-    {
-      "name": "Cobblestone courtyard",
-      "exits": {
-        "south": 1448
-      },
-      "id": 1507
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1509,
-        "west": 1406
-      },
-      "id": 1508
-    },
-    {
-      "name": "East Merchant's Row, south of Saul's Formal Wear",
-      "exits": {
-        "west": 1508,
-        "east": 1510,
-        "north": 1624
-      },
-      "id": 1509
-    },
-    {
-      "name": "East Merchant's Row, south of a livestock lot",
-      "exits": {
-        "west": 1509,
-        "east": 1511,
-        "north": 1623
-      },
-      "id": 1510
-    },
-    {
-      "name": "East Merchant's Row, south of Mother Whitman's",
-      "exits": {
-        "west": 1510,
-        "east": 1512,
-        "north": 1622
-      },
-      "id": 1511
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1513,
-        "west": 1511
-      },
-      "id": 1512
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1514,
-        "west": 1512
-      },
-      "id": 1513
-    },
-    {
-      "name": "East Merchant's Row, south of Sithicus",
-      "exits": {
-        "west": 1513,
-        "east": 1515,
-        "north": 1621
-      },
-      "id": 1514
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1516,
-        "west": 1514
-      },
-      "id": 1515
-    },
-    {
-      "name": "Merchant's Row and Pensji Lane",
-      "exits": {
-        "west": 1515,
-        "east": 1517,
-        "south": 1520
-      },
-      "id": 1516
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1518,
-        "west": 1516
-      },
-      "id": 1517
-    },
-    {
-      "name": "East Merchant's Row",
-      "exits": {
-        "east": 1519,
-        "west": 1517
-      },
-      "id": 1518
-    },
-    {
-      "name": "End of Merchant's Row",
-      "exits": {
-        "west": 1518
-      },
-      "id": 1519
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1521,
-        "north": 1516
-      },
-      "id": 1520
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1522,
-        "north": 1520
-      },
-      "id": 1521
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1523,
-        "north": 1521
-      },
-      "id": 1522
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1524,
-        "north": 1522
-      },
-      "id": 1523
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1525,
-        "north": 1523
-      },
-      "id": 1524
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1526,
-        "east": 1606,
-        "north": 1524
-      },
-      "id": 1525
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1527,
-        "north": 1525
-      },
-      "id": 1526
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1528,
-        "north": 1526
-      },
-      "id": 1527
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1529,
-        "north": 1527
-      },
-      "id": 1528
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1530,
-        "north": 1528
-      },
-      "id": 1529
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1531,
-        "north": 1529
-      },
-      "id": 1530
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1532,
-        "north": 1530
-      },
-      "id": 1531
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1533,
-        "north": 1531
-      },
-      "id": 1532
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1534,
-        "east": 1597,
-        "north": 1532
-      },
-      "id": 1533
-    },
-    {
-      "name": "Pensji Lane",
-      "exits": {
-        "south": 1542,
-        "north": 1533
-      },
-      "id": 1534
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1536,
-        "west": 1557
-      },
-      "id": 1535
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1537,
-        "west": 1535
-      },
-      "id": 1536
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1538,
-        "west": 1536
-      },
-      "id": 1537
-    },
-    {
-      "name": "City Barracks Gate",
-      "exits": {
-        "east": 1539,
-        "west": 1537
-      },
-      "id": 1538
-    },
-    {
-      "name": "West Martial Row",
-      "exits": {
-        "east": 1540,
-        "west": 1538
-      },
-      "id": 1539
-    },
-    {
-      "name": "West Martial Row",
-      "exits": {
-        "east": 1541,
-        "west": 1539
-      },
-      "id": 1540
-    },
-    {
-      "name": "West Martial Row",
-      "exits": {
-        "east": 1542,
-        "west": 1540
-      },
-      "id": 1541
-    },
-    {
-      "name": "Intersection of Martial Row and Pensji Lane",
-      "exits": {
-        "west": 1541,
-        "east": 1591,
-        "north": 1534
-      },
-      "id": 1542
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1546,
-        "north": 1544
-      },
-      "id": 1543
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1543,
-        "north": 1558
-      },
-      "id": 1544
-    },
-    {
-      "name": "Ambassador Gate",
-      "exits": {
-        "east": 1546,
-        "west": 1434
-      },
-      "id": 1545
-    },
-    {
-      "name": "Intersection of Church Road and Embassy Row",
-      "exits": {
-        "west": 1545,
-        "east": 1547,
-        "north": 1543
-      },
-      "id": 1546
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1548,
-        "west": 1546
-      },
-      "id": 1547
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1549,
-        "west": 1547
-      },
-      "id": 1548
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1550,
-        "west": 1548
-      },
-      "id": 1549
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1551,
-        "west": 1549
-      },
-      "id": 1550
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1552,
-        "west": 1550
-      },
-      "id": 1551
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1553,
-        "west": 1551
-      },
-      "id": 1552
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1554,
-        "west": 1552
-      },
-      "id": 1553
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1555,
-        "west": 1553
-      },
-      "id": 1554
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1556,
-        "west": 1554
-      },
-      "id": 1555
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1557,
-        "west": 1555
-      },
-      "id": 1556
-    },
-    {
-      "name": "Embassy Row",
-      "exits": {
-        "east": 1535,
-        "west": 1556
-      },
-      "id": 1557
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1544,
-        "north": 1559
-      },
-      "id": 1558
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1558,
-        "north": 1560
-      },
-      "id": 1559
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1559,
-        "north": 1561
-      },
-      "id": 1560
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1560,
-        "north": 1562
-      },
-      "id": 1561
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1561,
-        "north": 1563
-      },
-      "id": 1562
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1562,
-        "north": 1564
-      },
-      "id": 1563
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1563,
-        "north": 1565
-      },
-      "id": 1564
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1564,
-        "north": 1566
-      },
-      "id": 1565
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1565,
-        "north": 1567
-      },
-      "id": 1566
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1566,
-        "north": 1568
-      },
-      "id": 1567
-    },
-    {
-      "name": "West Church Road",
-      "exits": {
-        "south": 1567,
-        "north": 1569
-      },
-      "id": 1568
-    },
-    {
-      "name": "Church Road Bend",
-      "exits": {
-        "east": 1570,
-        "south": 1568
-      },
-      "id": 1569
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1571,
-        "west": 1569
-      },
-      "id": 1570
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1572,
-        "west": 1570
-      },
-      "id": 1571
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1573,
-        "west": 1571
-      },
-      "id": 1572
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1574,
-        "west": 1572
-      },
-      "id": 1573
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1575,
-        "west": 1573
-      },
-      "id": 1574
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1576,
-        "west": 1574
-      },
-      "id": 1575
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1577,
-        "west": 1575
-      },
-      "id": 1576
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1578,
-        "west": 1576
-      },
-      "id": 1577
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1579,
-        "west": 1577
-      },
-      "id": 1578
-    },
-    {
-      "name": "Intersection of Castle Road and Church Road",
-      "exits": {
-        "south": 1585,
-        "west": 1578,
-        "east": 1580,
-        "north": 1584
-      },
-      "id": 1579
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1581,
-        "west": 1579
-      },
-      "id": 1580
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1582,
-        "west": 1580
-      },
-      "id": 1581
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "east": 1583,
-        "west": 1581
-      },
-      "id": 1582
-    },
-    {
-      "name": "North Church Road",
-      "exits": {
-        "down": 1653,
-        "west": 1582
-      },
-      "id": 1583
-    },
-    {
-      "name": "Olde City Gate",
-      "exits": {
-        "south": 1579,
-        "west": 1588,
-        "east": 1587,
-        "north": 1406
-      },
-      "id": 1584
-    },
-    {
-      "name": "Castle Drawbridge",
-      "exits": {
-        "south": 1586,
-        "north": 1579
-      },
-      "id": 1585
-    },
-    {
-      "name": "Castle Gatehouse",
-      "exits": {
-        "north": 1585
-      },
-      "id": 1586
-    },
-    {
-      "name": "Krakenwater",
-      "exits": {
-        "west": 1584
-      },
-      "id": 1587
-    },
-    {
-      "name": "Deep Sea Thunder",
-      "exits": {
-        "east": 1584,
-        "west": 1589
-      },
-      "id": 1588
-    },
-    {
-      "name": "The Silver Griffin",
-      "exits": {
-        "west": 1590,
-        "east": 1588,
-        "north": 1408
-      },
-      "id": 1589
-    },
-    {
-      "name": "Horrors of the Deep",
-      "exits": {
-        "east": 1589,
-        "north": 1409
-      },
-      "id": 1590
-    },
-    {
-      "name": "East Martial Row",
-      "exits": {
-        "east": 1592,
-        "west": 1542
-      },
-      "id": 1591
-    },
-    {
-      "name": "East Martial Row",
-      "exits": {
-        "east": 1593,
-        "west": 1591
-      },
-      "id": 1592
-    },
-    {
-      "name": "East Martial Row",
-      "exits": {
-        "west": 1592,
-        "north": 1594
-      },
-      "id": 1593
-    },
-    {
-      "name": "Army Encampment Gate",
-      "exits": {
-        "west": 1595,
-        "south": 1593
-      },
-      "id": 1594
-    },
-    {
-      "name": "Punishment Grounds",
-      "exits": {
-        "east": 1594,
-        "west": 1596
-      },
-      "id": 1595
-    },
-    {
-      "name": "Parade Grounds",
-      "exits": {
-        "east": 1595,
-        "north": 1597
-      },
-      "id": 1596
-    },
-    {
-      "name": "Cavalry Gate",
-      "exits": {
-        "west": 1533,
-        "south": 1596,
-        "north": 1598
-      },
-      "id": 1597
-    },
-    {
-      "name": "Training Grounds",
-      "exits": {
-        "south": 1597,
-        "east": 1600,
-        "north": 1599
-      },
-      "id": 1598
-    },
-    {
-      "name": "Combat Training",
-      "exits": {
-        "south": 1598
-      },
-      "id": 1599
-    },
-    {
-      "name": "Post Exchange",
-      "exits": {
-        "south": 1602,
-        "west": 1598,
-        "east": 1601,
-        "north": 1603
-      },
-      "id": 1600
-    },
-    {
-      "name": "Stockade",
-      "exits": {
-        "west": 1600
-      },
-      "id": 1601
-    },
-    {
-      "name": "Infirmary",
-      "exits": {
-        "east": 1605,
-        "north": 1600
-      },
-      "id": 1602
-    },
-    {
-      "name": "Soldiers' Tent",
-      "exits": {
-        "east": 1604,
-        "south": 1600
-      },
-      "id": 1603
-    },
-    {
-      "name": "Soldiers' Tent",
-      "exits": {
-        "west": 1603
-      },
-      "id": 1604
-    },
-    {
-      "name": "You move the partition to the side and walk into the back of the tent.",
-      "exits": {
-        "west": 1602
-      },
-      "id": 1605
-    },
-    {
-      "name": "Sithicus",
-      "exits": {
-        "south": 1514
-      },
-      "id": 1621
-    },
-    {
-      "name": "Mother Whitman's Confections Shop",
-      "exits": {
-        "south": 1511
-      },
-      "id": 1622
-    },
-    {
-      "name": "Livestock Lot",
-      "exits": {
-        "south": 1510,
-        "north": 1643
-      },
-      "id": 1623
-    },
-    {
-      "name": "Saul's formal wear",
-      "exits": {
-        "south": 1509
-      },
-      "id": 1624
-    },
-    {
-      "name": "Quicksilver Delivery Service",
-      "exits": {
-        "east": 1405
-      },
-      "id": 1625
-    },
-    {
-      "name": "Jusonah's Pawn and Polearms",
-      "exits": {
-        "east": 1404
-      },
-      "id": 1626
-    },
-    {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
-      "exits": {
-        "west": 1404,
-        "south": 1637
-      },
-      "id": 1627
-    },
-    {
-      "name": "Zomar's Dry Goods",
-      "exits": {
-        "east": 1403,
-        "down": 1629
-      },
-      "id": 1628
-    },
-    {
-      "name": "The Art of Darkness",
-      "exits": {
-        "up": 1628
-      },
-      "id": 1629
-    },
-    {
-      "name": "Burrow's Map Shop",
-      "exits": {
-        "west": 1403
-      },
-      "id": 1630
-    },
-    {
-      "name": "Muddy Lane",
-      "exits": {
-        "east": 1402,
-        "west": 1632
-      },
-      "id": 1631
-    },
-    {
-      "name": "Muddy Lane",
-      "exits": {
-        "east": 1631
-      },
-      "id": 1632
-    },
-    {
-      "name": "Muddy Lane",
-      "exits": {
-        "east": 1634,
-        "west": 1402
-      },
-      "id": 1633
-    },
-    {
-      "name": "Farm Road",
-      "exits": {
-        "west": 1633
-      },
-      "id": 1634
-    },
-    {
-      "name": "West Ready Room",
-      "exits": {
-        "east": 1401
-      },
-      "id": 1635
-    },
-    {
-      "name": "East Ready Room",
-      "exits": {
-        "west": 1401
-      },
-      "id": 1636
-    },
-    {
-      "name": "Player Appreciation Week Discussions",
-      "exits": {
-        "north": 1627
-      },
-      "id": 1637
-    },
-    {
-      "name": "Mudball Arena Entrance",
-      "exits": {
-        "up": 1583
-      },
-      "id": 1653
+      "id": 1401, "name": "City of Indel, Wilderness Gate",
+      "exits": { "west": 1635, "east": 1636, "south": 1402 }
+    },
+    {
+      "id": 1402, "name": "Castle Road",
+      "exits": { "south": 1403, "west": 1631, "east": 1633, "north": 1401 }
+    },
+    {
+      "id": 1403, "name": "Castle Road",
+      "exits": { "south": 1404, "west": 1628, "east": 1630, "north": 1402 }
+    },
+    {
+      "id": 1404, "name": "Castle Road Courtyard",
+      "exits": { "south": 1405, "west": 1626, "east": 1627, "north": 1403 }
+    },
+    {
+      "id": 1405, "name": "Castle Road",
+      "exits": { "west": 1625, "south": 1406, "north": 1404 }
+    },
+    {
+      "id": 1406, "name": "Intersection of Castle Road and Merchant's Row",
+      "exits": { "south": 1584, "west": 1407, "east": 1508, "north": 1405 }
+    },
+    {
+      "id": 1407, "name": "West Merchant's Row",
+      "exits": { "east": 1406, "west": 1408 }
+    },
+    {
+      "id": 1408, "name": "West Merchant's Row, north of the Silver Griffin",
+      "exits": { "west": 1409, "east": 1407, "south": 1589 }
+    },
+    {
+      "id": 1409, "name": "West Merchant's Row, south of Big Bob's Sign Shop",
+      "exits": { "west": 1410, "east": 1408, "south": 1590 }
+    },
+    {
+      "id": 1410, "name": "West Merchant's Row",
+      "exits": { "east": 1409, "west": 1411 }
+    },
+    {
+      "id": 1411, "name": "West Merchant's Row",
+      "exits": { "east": 1410, "west": 1412 }
+    },
+    {
+      "id": 1412, "name": "West Merchant's Row",
+      "exits": { "east": 1411, "west": 1413 }
+    },
+    {
+      "id": 1413, "name": "West Merchant's Row, south of Knights of Solamnia",
+      "exits": { "east": 1412, "west": 1414 }
+    },
+    {
+      "id": 1414, "name": "West Merchant's Row",
+      "exits": { "east": 1413, "west": 1415 }
+    },
+    {
+      "id": 1415, "name": "West Merchant's Row, south of the Cobbler's Shop",
+      "exits": { "east": 1414, "west": 1416 }
+    },
+    {
+      "id": 1416, "name": "West Merchant's Row, south of Laird's Forge",
+      "exits": { "east": 1415, "west": 1417 }
+    },
+    {
+      "id": 1417, "name": "West Merchant's Row",
+      "exits": { "east": 1416, "west": 1418 }
+    },
+    {
+      "id": 1418, "name": "Pier Street and Merchant's Row",
+      "exits": { "south": 1419, "east": 1417, "north": 1448 }
+    },
+    {
+      "id": 1419, "name": "Pier Street",
+      "exits": { "south": 1420, "north": 1418 }
+    },
+    {
+      "id": 1420, "name": "Pier Street",
+      "exits": { "south": 1421, "north": 1419 }
+    },
+    {
+      "id": 1421, "name": "Pier Street",
+      "exits": { "south": 1422, "north": 1420 }
+    },
+    {
+      "id": 1422, "name": "Pier Street west of the Waterfront Gate",
+      "exits": { "south": 1423, "north": 1421 }
+    },
+    {
+      "id": 1423, "name": "Pier Street",
+      "exits": { "south": 1424, "north": 1422 }
+    },
+    {
+      "id": 1424, "name": "Pier Street",
+      "exits": { "south": 1425, "north": 1423 }
+    },
+    {
+      "id": 1425, "name": "Pier Street",
+      "exits": { "south": 1426, "north": 1424 }
+    },
+    {
+      "id": 1426, "name": "Pier Street",
+      "exits": { "south": 1427, "north": 1425 }
+    },
+    {
+      "id": 1427, "name": "Pier Street",
+      "exits": { "south": 1428, "north": 1426 }
+    },
+    {
+      "id": 1428, "name": "Pier Street",
+      "exits": { "south": 1429, "north": 1427 }
+    },
+    {
+      "id": 1429, "name": "South Pier Street",
+      "exits": { "south": 1430, "north": 1428 }
+    },
+    {
+      "id": 1430, "name": "South Pier Street",
+      "exits": { "south": 1431, "north": 1429 }
+    },
+    {
+      "id": 1431, "name": "South Pier Street",
+      "exits": { "south": 1432, "north": 1430 }
+    },
+    {
+      "id": 1432, "name": "South Pier Street",
+      "exits": { "south": 1433, "north": 1431 }
+    },
+    {
+      "id": 1433, "name": "South Pier Street",
+      "exits": { "south": 1434, "north": 1432 }
+    },
+    {
+      "id": 1434, "name": "South Pier Street",
+      "exits": { "south": 1435, "east": 1545, "north": 1433 }
+    },
+    {
+      "id": 1435, "name": "South Pier Street",
+      "exits": { "south": 1436, "north": 1434 }
+    },
+    {
+      "id": 1436, "name": "South Pier Street",
+      "exits": { "south": 1437, "north": 1435 }
+    },
+    {
+      "id": 1437, "name": "South Pier Street",
+      "exits": { "south": 1438, "north": 1436 }
+    },
+    {
+      "id": 1438, "name": "South Pier Street",
+      "exits": { "south": 1439, "north": 1437 }
+    },
+    {
+      "id": 1439, "name": "Forester's Gate",
+      "exits": { "north": 1438 }
+    },
+    {
+      "id": 1448, "name": "North Pier Street",
+      "exits": { "south": 1418, "north": 1507 }
+    },
+    {
+      "id": 1507, "name": "Cobblestone courtyard",
+      "exits": { "south": 1448 }
+    },
+    {
+      "id": 1508, "name": "East Merchant's Row",
+      "exits": { "east": 1509, "west": 1406 }
+    },
+    {
+      "id": 1509, "name": "East Merchant's Row, south of Saul's Formal Wear",
+      "exits": { "west": 1508, "east": 1510, "north": 1624 }
+    },
+    {
+      "id": 1510, "name": "East Merchant's Row, south of a livestock lot",
+      "exits": { "west": 1509, "east": 1511, "north": 1623 }
+    },
+    {
+      "id": 1511, "name": "East Merchant's Row, south of Mother Whitman's",
+      "exits": { "west": 1510, "east": 1512, "north": 1622 }
+    },
+    {
+      "id": 1512, "name": "East Merchant's Row",
+      "exits": { "east": 1513, "west": 1511 }
+    },
+    {
+      "id": 1513, "name": "East Merchant's Row",
+      "exits": { "east": 1514, "west": 1512 }
+    },
+    {
+      "id": 1514, "name": "East Merchant's Row, south of Sithicus",
+      "exits": { "west": 1513, "east": 1515, "north": 1621 }
+    },
+    {
+      "id": 1515, "name": "East Merchant's Row",
+      "exits": { "east": 1516, "west": 1514 }
+    },
+    {
+      "id": 1516, "name": "Merchant's Row and Pensji Lane",
+      "exits": { "west": 1515, "east": 1517, "south": 1520 }
+    },
+    {
+      "id": 1517, "name": "East Merchant's Row",
+      "exits": { "east": 1518, "west": 1516 }
+    },
+    {
+      "id": 1518, "name": "East Merchant's Row",
+      "exits": { "east": 1519, "west": 1517 }
+    },
+    {
+      "id": 1519, "name": "End of Merchant's Row",
+      "exits": { "west": 1518 }
+    },
+    {
+      "id": 1520, "name": "Pensji Lane",
+      "exits": { "south": 1521, "north": 1516 }
+    },
+    {
+      "id": 1521, "name": "Pensji Lane",
+      "exits": { "south": 1522, "north": 1520 }
+    },
+    {
+      "id": 1522, "name": "Pensji Lane",
+      "exits": { "south": 1523, "north": 1521 }
+    },
+    {
+      "id": 1523, "name": "Pensji Lane",
+      "exits": { "south": 1524, "north": 1522 }
+    },
+    {
+      "id": 1524, "name": "Pensji Lane",
+      "exits": { "south": 1525, "north": 1523 }
+    },
+    {
+      "id": 1525, "name": "Pensji Lane",
+      "exits": { "south": 1526, "east": 1606, "north": 1524 }
+    },
+    {
+      "id": 1526, "name": "Pensji Lane",
+      "exits": { "south": 1527, "north": 1525 }
+    },
+    {
+      "id": 1527, "name": "Pensji Lane",
+      "exits": { "south": 1528, "north": 1526 }
+    },
+    {
+      "id": 1528, "name": "Pensji Lane",
+      "exits": { "south": 1529, "north": 1527 }
+    },
+    {
+      "id": 1529, "name": "Pensji Lane",
+      "exits": { "south": 1530, "north": 1528 }
+    },
+    {
+      "id": 1530, "name": "Pensji Lane",
+      "exits": { "south": 1531, "north": 1529 }
+    },
+    {
+      "id": 1531, "name": "Pensji Lane",
+      "exits": { "south": 1532, "north": 1530 }
+    },
+    {
+      "id": 1532, "name": "Pensji Lane",
+      "exits": { "south": 1533, "north": 1531 }
+    },
+    {
+      "id": 1533, "name": "Pensji Lane",
+      "exits": { "south": 1534, "east": 1597, "north": 1532 }
+    },
+    {
+      "id": 1534, "name": "Pensji Lane",
+      "exits": { "south": 1542, "north": 1533 }
+    },
+    {
+      "id": 1535, "name": "Embassy Row",
+      "exits": { "east": 1536, "west": 1557 }
+    },
+    {
+      "id": 1536, "name": "Embassy Row",
+      "exits": { "east": 1537, "west": 1535 }
+    },
+    {
+      "id": 1537, "name": "Embassy Row",
+      "exits": { "east": 1538, "west": 1536 }
+    },
+    {
+      "id": 1538, "name": "City Barracks Gate",
+      "exits": { "east": 1539, "west": 1537 }
+    },
+    {
+      "id": 1539, "name": "West Martial Row",
+      "exits": { "east": 1540, "west": 1538 }
+    },
+    {
+      "id": 1540, "name": "West Martial Row",
+      "exits": { "east": 1541, "west": 1539 }
+    },
+    {
+      "id": 1541, "name": "West Martial Row",
+      "exits": { "east": 1542, "west": 1540 }
+    },
+    {
+      "id": 1542, "name": "Intersection of Martial Row and Pensji Lane",
+      "exits": { "west": 1541, "east": 1591, "north": 1534 }
+    },
+    {
+      "id": 1543, "name": "West Church Road",
+      "exits": { "south": 1546, "north": 1544 }
+    },
+    {
+      "id": 1544, "name": "West Church Road",
+      "exits": { "south": 1543, "north": 1558 }
+    },
+    {
+      "id": 1545, "name": "Ambassador Gate",
+      "exits": { "east": 1546, "west": 1434 }
+    },
+    {
+      "id": 1546, "name": "Intersection of Church Road and Embassy Row",
+      "exits": { "west": 1545, "east": 1547, "north": 1543 }
+    },
+    {
+      "id": 1547, "name": "Embassy Row",
+      "exits": { "east": 1548, "west": 1546 }
+    },
+    {
+      "id": 1548, "name": "Embassy Row",
+      "exits": { "east": 1549, "west": 1547 }
+    },
+    {
+      "id": 1549, "name": "Embassy Row",
+      "exits": { "east": 1550, "west": 1548 }
+    },
+    {
+      "id": 1550, "name": "Embassy Row",
+      "exits": { "east": 1551, "west": 1549 }
+    },
+    {
+      "id": 1551, "name": "Embassy Row",
+      "exits": { "east": 1552, "west": 1550 }
+    },
+    {
+      "id": 1552, "name": "Embassy Row",
+      "exits": { "east": 1553, "west": 1551 }
+    },
+    {
+      "id": 1553, "name": "Embassy Row",
+      "exits": { "east": 1554, "west": 1552 }
+    },
+    {
+      "id": 1554, "name": "Embassy Row",
+      "exits": { "east": 1555, "west": 1553 }
+    },
+    {
+      "id": 1555, "name": "Embassy Row",
+      "exits": { "east": 1556, "west": 1554 }
+    },
+    {
+      "id": 1556, "name": "Embassy Row",
+      "exits": { "east": 1557, "west": 1555 }
+    },
+    {
+      "id": 1557, "name": "Embassy Row",
+      "exits": { "east": 1535, "west": 1556 }
+    },
+    {
+      "id": 1558, "name": "West Church Road",
+      "exits": { "south": 1544, "north": 1559 }
+    },
+    {
+      "id": 1559, "name": "West Church Road",
+      "exits": { "south": 1558, "north": 1560 }
+    },
+    {
+      "id": 1560, "name": "West Church Road",
+      "exits": { "south": 1559, "north": 1561 }
+    },
+    {
+      "id": 1561, "name": "West Church Road",
+      "exits": { "south": 1560, "north": 1562 }
+    },
+    {
+      "id": 1562, "name": "West Church Road",
+      "exits": { "south": 1561, "north": 1563 }
+    },
+    {
+      "id": 1563, "name": "West Church Road",
+      "exits": { "south": 1562, "north": 1564 }
+    },
+    {
+      "id": 1564, "name": "West Church Road",
+      "exits": { "south": 1563, "north": 1565 }
+    },
+    {
+      "id": 1565, "name": "West Church Road",
+      "exits": { "south": 1564, "north": 1566 }
+    },
+    {
+      "id": 1566, "name": "West Church Road",
+      "exits": { "south": 1565, "north": 1567 }
+    },
+    {
+      "id": 1567, "name": "West Church Road",
+      "exits": { "south": 1566, "north": 1568 }
+    },
+    {
+      "id": 1568, "name": "West Church Road",
+      "exits": { "south": 1567, "north": 1569 }
+    },
+    {
+      "id": 1569, "name": "Church Road Bend",
+      "exits": { "east": 1570, "south": 1568 }
+    },
+    {
+      "id": 1570, "name": "North Church Road",
+      "exits": { "east": 1571, "west": 1569 }
+    },
+    {
+      "id": 1571, "name": "North Church Road",
+      "exits": { "east": 1572, "west": 1570 }
+    },
+    {
+      "id": 1572, "name": "North Church Road",
+      "exits": { "east": 1573, "west": 1571 }
+    },
+    {
+      "id": 1573, "name": "North Church Road",
+      "exits": { "east": 1574, "west": 1572 }
+    },
+    {
+      "id": 1574, "name": "North Church Road",
+      "exits": { "east": 1575, "west": 1573 }
+    },
+    {
+      "id": 1575, "name": "North Church Road",
+      "exits": { "east": 1576, "west": 1574 }
+    },
+    {
+      "id": 1576, "name": "North Church Road",
+      "exits": { "east": 1577, "west": 1575 }
+    },
+    {
+      "id": 1577, "name": "North Church Road",
+      "exits": { "east": 1578, "west": 1576 }
+    },
+    {
+      "id": 1578, "name": "North Church Road",
+      "exits": { "east": 1579, "west": 1577 }
+    },
+    {
+      "id": 1579, "name": "Intersection of Castle Road and Church Road",
+      "exits": { "south": 1585, "west": 1578, "east": 1580, "north": 1584 }
+    },
+    {
+      "id": 1580, "name": "North Church Road",
+      "exits": { "east": 1581, "west": 1579 }
+    },
+    {
+      "id": 1581, "name": "North Church Road",
+      "exits": { "east": 1582, "west": 1580 }
+    },
+    {
+      "id": 1582, "name": "North Church Road",
+      "exits": { "east": 1583, "west": 1581 }
+    },
+    {
+      "id": 1583, "name": "North Church Road",
+      "exits": { "down": 1653, "west": 1582 }
+    },
+    {
+      "id": 1584, "name": "Olde City Gate",
+      "exits": { "south": 1579, "west": 1588, "east": 1587, "north": 1406 }
+    },
+    {
+      "id": 1585, "name": "Castle Drawbridge",
+      "exits": { "south": 1586, "north": 1579 }
+    },
+    {
+      "id": 1586, "name": "Castle Gatehouse",
+      "exits": { "north": 1585 }
+    },
+    {
+      "id": 1587, "name": "Krakenwater",
+      "exits": { "west": 1584 }
+    },
+    {
+      "id": 1588, "name": "Deep Sea Thunder",
+      "exits": { "east": 1584, "west": 1589 }
+    },
+    {
+      "id": 1589, "name": "The Silver Griffin",
+      "exits": { "west": 1590, "east": 1588, "north": 1408 }
+    },
+    {
+      "id": 1590, "name": "Horrors of the Deep",
+      "exits": { "east": 1589, "north": 1409 }
+    },
+    {
+      "id": 1591, "name": "East Martial Row",
+      "exits": { "east": 1592, "west": 1542 }
+    },
+    {
+      "id": 1592, "name": "East Martial Row",
+      "exits": { "east": 1593, "west": 1591 }
+    },
+    {
+      "id": 1593, "name": "East Martial Row",
+      "exits": { "west": 1592, "north": 1594 }
+    },
+    {
+      "id": 1594, "name": "Army Encampment Gate",
+      "exits": { "west": 1595, "south": 1593 }
+    },
+    {
+      "id": 1595, "name": "Punishment Grounds",
+      "exits": { "east": 1594, "west": 1596 }
+    },
+    {
+      "id": 1596, "name": "Parade Grounds",
+      "exits": { "east": 1595, "north": 1597 }
+    },
+    {
+      "id": 1597, "name": "Cavalry Gate",
+      "exits": { "west": 1533, "south": 1596, "north": 1598 }
+    },
+    {
+      "id": 1598, "name": "Training Grounds",
+      "exits": { "south": 1597, "east": 1600, "north": 1599 }
+    },
+    {
+      "id": 1599, "name": "Combat Training",
+      "exits": { "south": 1598 }
+    },
+    {
+      "id": 1600, "name": "Post Exchange",
+      "exits": { "south": 1602, "west": 1598, "east": 1601, "north": 1603 }
+    },
+    {
+      "id": 1601, "name": "Stockade",
+      "exits": { "west": 1600 }
+    },
+    {
+      "id": 1602, "name": "Infirmary",
+      "exits": { "east": 1605, "north": 1600 }
+    },
+    {
+      "id": 1603, "name": "Soldiers' Tent",
+      "exits": { "east": 1604, "south": 1600 }
+    },
+    {
+      "id": 1604, "name": "Soldiers' Tent",
+      "exits": { "west": 1603 }
+    },
+    {
+      "id": 1605, "name": "You move the partition to the side and walk into the back of the tent.",
+      "exits": { "west": 1602 }
+    },
+    {
+      "id": 1621, "name": "Sithicus",
+      "exits": { "south": 1514 }
+    },
+    {
+      "id": 1622, "name": "Mother Whitman's Confections Shop",
+      "exits": { "south": 1511 }
+    },
+    {
+      "id": 1623, "name": "Livestock Lot",
+      "exits": { "south": 1510, "north": 1643 }
+    },
+    {
+      "id": 1624, "name": "Saul's formal wear",
+      "exits": { "south": 1509 }
+    },
+    {
+      "id": 1625, "name": "Quicksilver Delivery Service",
+      "exits": { "east": 1405 }
+    },
+    {
+      "id": 1626, "name": "Jusonah's Pawn and Polearms",
+      "exits": { "east": 1404 }
+    },
+    {
+      "id": 1627, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
+      "exits": { "west": 1404, "south": 1637 }
+    },
+    {
+      "id": 1628, "name": "Zomar's Dry Goods",
+      "exits": { "east": 1403, "down": 1629 }
+    },
+    {
+      "id": 1629, "name": "The Art of Darkness",
+      "exits": { "up": 1628 }
+    },
+    {
+      "id": 1630, "name": "Burrow's Map Shop",
+      "exits": { "west": 1403 }
+    },
+    {
+      "id": 1631, "name": "Muddy Lane",
+      "exits": { "east": 1402, "west": 1632 }
+    },
+    {
+      "id": 1632, "name": "Muddy Lane",
+      "exits": { "east": 1631 }
+    },
+    {
+      "id": 1633, "name": "Muddy Lane",
+      "exits": { "east": 1634, "west": 1402 }
+    },
+    {
+      "id": 1634, "name": "Farm Road",
+      "exits": { "west": 1633 }
+    },
+    {
+      "id": 1635, "name": "West Ready Room",
+      "exits": { "east": 1401 }
+    },
+    {
+      "id": 1636, "name": "East Ready Room",
+      "exits": { "west": 1401 }
+    },
+    {
+      "id": 1637, "name": "Player Appreciation Week Discussions",
+      "exits": { "north": 1627 }
+    },
+    {
+      "id": 1653, "name": "Mudball Arena Entrance",
+      "exits": { "up": 1583 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/moraldecay.json
+++ b/maps/moraldecay.json
@@ -4,24819 +4,13094 @@
   },
   "rooms": [
     {
-      "name": "North Gate",
+      "id": 1, "name": "North Gate",
+      "exits": { "west": 56, "east": 2, "south": 57 },
       "environment": -1,
-      "exits": {
-        "west": 56,
-        "east": 2,
-        "south": 57
-      },
       "weight": 1,
-      "id": 1,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 2, "name": "New Outer Wall",
+      "exits": { "east": 3, "west": 1 },
       "environment": -1,
-      "exits": {
-        "east": 3,
-        "west": 1
-      },
       "weight": 1,
-      "id": 2,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 3, "name": "New Outer Wall",
+      "exits": { "east": 4, "west": 2 },
       "environment": -1,
-      "exits": {
-        "east": 4,
-        "west": 2
-      },
       "weight": 1,
-      "id": 3,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 4, "name": "New Outer Wall",
+      "exits": { "east": 5, "west": 3 },
       "environment": -1,
-      "exits": {
-        "east": 5,
-        "west": 3
-      },
       "weight": 1,
-      "id": 4,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 5, "name": "New Outer Wall",
+      "exits": { "east": 6, "west": 4 },
       "environment": -1,
-      "exits": {
-        "east": 6,
-        "west": 4
-      },
       "weight": 1,
-      "id": 5,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 6, "name": "New Outer Wall",
+      "exits": { "east": 7, "west": 5 },
       "environment": -1,
-      "exits": {
-        "east": 7,
-        "west": 5
-      },
       "weight": 1,
-      "id": 6,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Entrance to the Northeast Tower",
+      "id": 7, "name": "Entrance to the Northeast Tower",
+      "exits": { "east": 8, "west": 6 },
       "environment": -1,
-      "exits": {
-        "east": 8,
-        "west": 6
-      },
       "weight": 1,
-      "id": 7,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Northeast Corner",
+      "id": 8, "name": "Northeast Corner",
+      "exits": { "west": 7, "south": 9 },
       "environment": -1,
-      "exits": {
-        "west": 7,
-        "south": 9
-      },
       "weight": 1,
-      "id": 8,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Entrance to the Northeast Tower",
+      "id": 9, "name": "Entrance to the Northeast Tower",
+      "exits": { "south": 10, "north": 8 },
       "environment": -1,
-      "exits": {
-        "south": 10,
-        "north": 8
-      },
       "weight": 1,
-      "id": 9,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 10, "name": "New Outer Wall",
+      "exits": { "south": 11, "north": 9 },
       "environment": -1,
-      "exits": {
-        "south": 11,
-        "north": 9
-      },
       "weight": 1,
-      "id": 10,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 11, "name": "New Outer Wall",
+      "exits": { "south": 12, "north": 10 },
       "environment": -1,
-      "exits": {
-        "south": 12,
-        "north": 10
-      },
       "weight": 1,
-      "id": 11,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 12, "name": "New Outer Wall",
+      "exits": { "south": 13, "north": 11 },
       "environment": -1,
-      "exits": {
-        "south": 13,
-        "north": 11
-      },
       "weight": 1,
-      "id": 12,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 13, "name": "New Outer Wall",
+      "exits": { "south": 14, "north": 12 },
       "environment": -1,
-      "exits": {
-        "south": 14,
-        "north": 12
-      },
       "weight": 1,
-      "id": 13,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 14, "name": "New Outer Wall",
+      "exits": { "south": 15, "north": 13 },
       "environment": -1,
-      "exits": {
-        "south": 15,
-        "north": 13
-      },
       "weight": 1,
-      "id": 14,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "East Wall Guard Station",
+      "id": 15, "name": "East Wall Guard Station",
+      "exits": { "south": 16, "east": 973, "north": 14 },
       "environment": -1,
-      "exits": {
-        "south": 16,
-        "east": 973,
-        "north": 14
-      },
       "weight": 1,
-      "id": 15,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 16, "name": "New Outer Wall",
+      "exits": { "south": 17, "north": 15 },
       "environment": -1,
-      "exits": {
-        "south": 17,
-        "north": 15
-      },
       "weight": 1,
-      "id": 16,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 17, "name": "New Outer Wall",
+      "exits": { "south": 18, "north": 16 },
       "environment": -1,
-      "exits": {
-        "south": 18,
-        "north": 16
-      },
       "weight": 1,
-      "id": 17,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 18, "name": "New Outer Wall",
+      "exits": { "south": 19, "north": 17 },
       "environment": -1,
-      "exits": {
-        "south": 19,
-        "north": 17
-      },
       "weight": 1,
-      "id": 18,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 19, "name": "New Outer Wall",
+      "exits": { "south": 20, "north": 18 },
       "environment": -1,
-      "exits": {
-        "south": 20,
-        "north": 18
-      },
       "weight": 1,
-      "id": 19,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 20, "name": "New Outer Wall",
+      "exits": { "south": 21, "north": 19 },
       "environment": -1,
-      "exits": {
-        "south": 21,
-        "north": 19
-      },
       "weight": 1,
-      "id": 20,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 21, "name": "New Outer Wall",
+      "exits": { "south": 22, "north": 20 },
       "environment": -1,
-      "exits": {
-        "south": 22,
-        "north": 20
-      },
       "weight": 1,
-      "id": 21,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 22, "name": "New Outer Wall",
+      "exits": { "west": 23, "north": 21 },
       "environment": -1,
-      "exits": {
-        "west": 23,
-        "north": 21
-      },
       "weight": 1,
-      "id": 22,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 23, "name": "New Outer Wall",
+      "exits": { "east": 22, "west": 24 },
       "environment": -1,
-      "exits": {
-        "east": 22,
-        "west": 24
-      },
       "weight": 1,
-      "id": 23,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 24, "name": "New Outer Wall",
+      "exits": { "east": 23, "west": 25 },
       "environment": -1,
-      "exits": {
-        "east": 23,
-        "west": 25
-      },
       "weight": 1,
-      "id": 24,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 25, "name": "New Outer Wall",
+      "exits": { "east": 24, "west": 26 },
       "environment": -1,
-      "exits": {
-        "east": 24,
-        "west": 26
-      },
       "weight": 1,
-      "id": 25,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 26, "name": "New Outer Wall",
+      "exits": { "east": 25, "west": 27 },
       "environment": -1,
-      "exits": {
-        "east": 25,
-        "west": 27
-      },
       "weight": 1,
-      "id": 26,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 27, "name": "New Outer Wall",
+      "exits": { "east": 26, "west": 28 },
       "environment": -1,
-      "exits": {
-        "east": 26,
-        "west": 28
-      },
       "weight": 1,
-      "id": 27,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 28, "name": "New Outer Wall",
+      "exits": { "east": 27, "west": 29 },
       "environment": -1,
-      "exits": {
-        "east": 27,
-        "west": 29
-      },
       "weight": 1,
-      "id": 28,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "South Wall Guard Station",
+      "id": 29, "name": "South Wall Guard Station",
+      "exits": { "west": 30, "east": 28, "south": 1030 },
       "environment": -1,
-      "exits": {
-        "west": 30,
-        "east": 28,
-        "south": 1030
-      },
       "weight": 1,
-      "id": 29,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 30, "name": "New Outer Wall",
+      "exits": { "east": 29, "west": 31 },
       "environment": -1,
-      "exits": {
-        "east": 29,
-        "west": 31
-      },
       "weight": 1,
-      "id": 30,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 31, "name": "New Outer Wall",
+      "exits": { "east": 30, "west": 32 },
       "environment": -1,
-      "exits": {
-        "east": 30,
-        "west": 32
-      },
       "weight": 1,
-      "id": 31,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 32, "name": "New Outer Wall",
+      "exits": { "east": 31, "west": 33 },
       "environment": -1,
-      "exits": {
-        "east": 31,
-        "west": 33
-      },
       "weight": 1,
-      "id": 32,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 33, "name": "New Outer Wall",
+      "exits": { "east": 32, "west": 34 },
       "environment": -1,
-      "exits": {
-        "east": 32,
-        "west": 34
-      },
       "weight": 1,
-      "id": 33,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 34, "name": "New Outer Wall",
+      "exits": { "east": 33, "west": 35 },
       "environment": -1,
-      "exits": {
-        "east": 33,
-        "west": 35
-      },
       "weight": 1,
-      "id": 34,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 35, "name": "New Outer Wall",
+      "exits": { "east": 34, "west": 36 },
       "environment": -1,
-      "exits": {
-        "east": 34,
-        "west": 36
-      },
       "weight": 1,
-      "id": 35,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Southwest Corner",
+      "id": 36, "name": "Southwest Corner",
+      "exits": { "east": 35, "north": 37 },
       "environment": -1,
-      "exits": {
-        "east": 35,
-        "north": 37
-      },
       "weight": 1,
-      "id": 36,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 37, "name": "New Outer Wall",
+      "exits": { "south": 36, "north": 38 },
       "environment": -1,
-      "exits": {
-        "south": 36,
-        "north": 38
-      },
       "weight": 1,
-      "id": 37,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 38, "name": "New Outer Wall",
+      "exits": { "south": 37, "north": 39 },
       "environment": -1,
-      "exits": {
-        "south": 37,
-        "north": 39
-      },
       "weight": 1,
-      "id": 38,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 39, "name": "New Outer Wall",
+      "exits": { "south": 38, "north": 40 },
       "environment": -1,
-      "exits": {
-        "south": 38,
-        "north": 40
-      },
       "weight": 1,
-      "id": 39,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 40, "name": "New Outer Wall",
+      "exits": { "south": 39, "north": 41 },
       "environment": -1,
-      "exits": {
-        "south": 39,
-        "north": 41
-      },
       "weight": 1,
-      "id": 40,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 41, "name": "New Outer Wall",
+      "exits": { "south": 40, "north": 42 },
       "environment": -1,
-      "exits": {
-        "south": 40,
-        "north": 42
-      },
       "weight": 1,
-      "id": 41,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 42, "name": "New Outer Wall",
+      "exits": { "south": 41, "north": 43 },
       "environment": -1,
-      "exits": {
-        "south": 41,
-        "north": 43
-      },
       "weight": 1,
-      "id": 42,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "West Wall Guard Station",
+      "id": 43, "name": "West Wall Guard Station",
+      "exits": { "west": 1033, "south": 42, "north": 44 },
       "environment": -1,
-      "exits": {
-        "west": 1033,
-        "south": 42,
-        "north": 44
-      },
       "weight": 1,
-      "id": 43,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 44, "name": "New Outer Wall",
+      "exits": { "south": 43, "north": 45 },
       "environment": -1,
-      "exits": {
-        "south": 43,
-        "north": 45
-      },
       "weight": 1,
-      "id": 44,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 45, "name": "New Outer Wall",
+      "exits": { "south": 44, "north": 46 },
       "environment": -1,
-      "exits": {
-        "south": 44,
-        "north": 46
-      },
       "weight": 1,
-      "id": 45,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 46, "name": "New Outer Wall",
+      "exits": { "south": 45, "north": 47 },
       "environment": -1,
-      "exits": {
-        "south": 45,
-        "north": 47
-      },
       "weight": 1,
-      "id": 46,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 47, "name": "New Outer Wall",
+      "exits": { "south": 46, "north": 48 },
       "environment": -1,
-      "exits": {
-        "south": 46,
-        "north": 48
-      },
       "weight": 1,
-      "id": 47,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 48, "name": "New Outer Wall",
+      "exits": { "south": 47, "north": 49 },
       "environment": -1,
-      "exits": {
-        "south": 47,
-        "north": 49
-      },
       "weight": 1,
-      "id": 48,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Entrance to the Northwest Tower",
+      "id": 49, "name": "Entrance to the Northwest Tower",
+      "exits": { "south": 48, "north": 50 },
       "environment": -1,
-      "exits": {
-        "south": 48,
-        "north": 50
-      },
       "weight": 1,
-      "id": 49,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Northwest Corner",
+      "id": 50, "name": "Northwest Corner",
+      "exits": { "east": 51, "south": 49 },
       "environment": -1,
-      "exits": {
-        "east": 51,
-        "south": 49
-      },
       "weight": 1,
-      "id": 50,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Entrance to the Northwest Tower",
+      "id": 51, "name": "Entrance to the Northwest Tower",
+      "exits": { "east": 52, "west": 50 },
       "environment": -1,
-      "exits": {
-        "east": 52,
-        "west": 50
-      },
       "weight": 1,
-      "id": 51,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 52, "name": "New Outer Wall",
+      "exits": { "east": 53, "west": 51 },
       "environment": -1,
-      "exits": {
-        "east": 53,
-        "west": 51
-      },
       "weight": 1,
-      "id": 52,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 53, "name": "New Outer Wall",
+      "exits": { "east": 54, "west": 52 },
       "environment": -1,
-      "exits": {
-        "east": 54,
-        "west": 52
-      },
       "weight": 1,
-      "id": 53,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 54, "name": "New Outer Wall",
+      "exits": { "east": 55, "west": 53 },
       "environment": -1,
-      "exits": {
-        "east": 55,
-        "west": 53
-      },
       "weight": 1,
-      "id": 54,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 55, "name": "New Outer Wall",
+      "exits": { "east": 56, "west": 54 },
       "environment": -1,
-      "exits": {
-        "east": 56,
-        "west": 54
-      },
       "weight": 1,
-      "id": 55,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "New Outer Wall",
+      "id": 56, "name": "New Outer Wall",
+      "exits": { "east": 1, "west": 55 },
       "environment": -1,
-      "exits": {
-        "east": 1,
-        "west": 55
-      },
       "weight": 1,
-      "id": 56,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 57, "name": "Warrior's Walk",
+      "exits": { "south": 58, "west": 963, "east": 964, "north": 1 },
       "environment": -1,
-      "exits": {
-        "south": 58,
-        "west": 963,
-        "east": 964,
-        "north": 1
-      },
       "weight": 1,
-      "id": 57,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 58, "name": "Warrior's Walk",
+      "exits": { "south": 59, "west": 965, "east": 966, "north": 57 },
       "environment": -1,
-      "exits": {
-        "south": 59,
-        "west": 965,
-        "east": 966,
-        "north": 57
-      },
       "weight": 1,
-      "id": 58,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 59, "name": "Warrior's Walk",
+      "exits": { "west": 967, "south": 60, "north": 58 },
       "environment": -1,
-      "exits": {
-        "west": 967,
-        "south": 60,
-        "north": 58
-      },
       "weight": 1,
-      "id": 59,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 60, "name": "Warrior's Walk",
+      "exits": { "south": 61, "west": 968, "east": 969, "north": 59 },
       "environment": -1,
-      "exits": {
-        "south": 61,
-        "west": 968,
-        "east": 969,
-        "north": 59
-      },
       "weight": 1,
-      "id": 60,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 61, "name": "Warrior's Walk",
+      "exits": { "west": 970, "south": 62, "north": 60 },
       "environment": -1,
-      "exits": {
-        "west": 970,
-        "south": 62,
-        "north": 60
-      },
       "weight": 1,
-      "id": 61,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 62, "name": "Warrior's Walk",
+      "exits": { "south": 63, "west": 971, "east": 972, "north": 61 },
       "environment": -1,
-      "exits": {
-        "south": 63,
-        "west": 971,
-        "east": 972,
-        "north": 61
-      },
       "weight": 1,
-      "id": 62,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Canderan Well",
+      "id": 63, "name": "Canderan Well",
+      "exits": { "south": 64, "west": 72, "east": 94, "north": 62 },
       "environment": -1,
-      "exits": {
-        "south": 64,
-        "west": 72,
-        "east": 94,
-        "north": 62
-      },
       "weight": 1,
-      "id": 63,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 64, "name": "Warrior's Walk",
+      "exits": { "south": 65, "west": 429, "east": 427, "north": 63 },
       "environment": -1,
-      "exits": {
-        "south": 65,
-        "west": 429,
-        "east": 427,
-        "north": 63
-      },
       "weight": 1,
-      "id": 64,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 65, "name": "Warrior's Walk",
+      "exits": { "south": 66, "west": 430, "east": 1015, "north": 64 },
       "environment": -1,
-      "exits": {
-        "south": 66,
-        "west": 430,
-        "east": 1015,
-        "north": 64
-      },
       "weight": 1,
-      "id": 65,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 66, "name": "Warrior's Walk",
+      "exits": { "south": 67, "north": 65 },
       "environment": -1,
-      "exits": {
-        "south": 67,
-        "north": 65
-      },
       "weight": 1,
-      "id": 66,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 67, "name": "Warrior's Walk",
+      "exits": { "south": 68, "north": 66 },
       "environment": -1,
-      "exits": {
-        "south": 68,
-        "north": 66
-      },
       "weight": 1,
-      "id": 67,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Warrior's Walk",
+      "id": 68, "name": "Warrior's Walk",
+      "exits": { "south": 69, "east": 431, "north": 67 },
       "environment": -1,
-      "exits": {
-        "south": 69,
-        "east": 431,
-        "north": 67
-      },
       "weight": 1,
-      "id": 68,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "House of Lord Candera",
+      "id": 69, "name": "House of Lord Candera",
+      "exits": { "up": 1134, "west": 70, "east": 71, "north": 68 },
       "environment": -1,
-      "exits": {
-        "up": 1134,
-        "west": 70,
-        "east": 71,
-        "north": 68
-      },
       "weight": 1,
-      "id": 69,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "House of Lord Candera",
+      "id": 70, "name": "House of Lord Candera",
+      "exits": { "east": 69 },
       "environment": -1,
-      "exits": {
-        "east": 69
-      },
       "weight": 1,
-      "id": 70,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "House of Lord Candera",
+      "id": 71, "name": "House of Lord Candera",
+      "exits": { "west": 69 },
       "environment": -1,
-      "exits": {
-        "west": 69
-      },
       "weight": 1,
-      "id": 71,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 72, "name": "Clansmen Way",
+      "exits": { "west": 73, "east": 63, "south": 429 },
       "environment": -1,
-      "exits": {
-        "west": 73,
-        "east": 63,
-        "south": 429
-      },
       "weight": 1,
-      "id": 72,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 73, "name": "Clansmen Way",
+      "exits": { "south": 1016, "west": 74, "east": 72, "north": 1017 },
       "environment": -1,
-      "exits": {
-        "south": 1016,
-        "west": 74,
-        "east": 72,
-        "north": 1017
-      },
       "weight": 1,
-      "id": 73,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 74, "name": "Clansmen Way",
+      "exits": { "south": 1019, "west": 75, "east": 73, "north": 1018 },
       "environment": -1,
-      "exits": {
-        "south": 1019,
-        "west": 75,
-        "east": 73,
-        "north": 1018
-      },
       "weight": 1,
-      "id": 74,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 75, "name": "Clansmen Way",
+      "exits": { "west": 76, "east": 74, "south": 1095 },
       "environment": -1,
-      "exits": {
-        "west": 76,
-        "east": 74,
-        "south": 1095
-      },
       "weight": 1,
-      "id": 75,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 76, "name": "Clansmen Way",
+      "exits": { "south": 78, "west": 77, "east": 75, "north": 86 },
       "environment": -1,
-      "exits": {
-        "south": 78,
-        "west": 77,
-        "east": 75,
-        "north": 86
-      },
       "weight": 1,
-      "id": 76,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "House of Clan Lord Bracknar",
+      "id": 77, "name": "House of Clan Lord Bracknar",
+      "exits": { "west": 1080, "up": 1081, "south": 1079, "east": 76, "north": 1078 },
       "environment": -1,
-      "exits": {
-        "west": 1080,
-        "up": 1081,
-        "south": 1079,
-        "east": 76,
-        "north": 1078
-      },
       "weight": 1,
-      "id": 77,
-      "area": {
-        "id": 18
-      }
+      "area": {"id": 18}
     },
     {
-      "name": "Zoman's Flat",
+      "id": 78, "name": "Zoman's Flat",
+      "exits": { "south": 79, "north": 76 },
       "environment": -1,
-      "exits": {
-        "south": 79,
-        "north": 76
-      },
       "weight": 1,
-      "id": 78,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Zoman's Flat",
+      "id": 79, "name": "Zoman's Flat",
+      "exits": { "south": 80, "east": 1096, "north": 78 },
       "environment": -1,
-      "exits": {
-        "south": 80,
-        "east": 1096,
-        "north": 78
-      },
       "weight": 1,
-      "id": 79,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Zoman's Flat",
+      "id": 80, "name": "Zoman's Flat",
+      "exits": { "south": 81, "north": 79 },
       "environment": -1,
-      "exits": {
-        "south": 81,
-        "north": 79
-      },
       "weight": 1,
-      "id": 80,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Zoman's Flat",
+      "id": 81, "name": "Zoman's Flat",
+      "exits": { "south": 82, "north": 80 },
       "environment": -1,
-      "exits": {
-        "south": 82,
-        "north": 80
-      },
       "weight": 1,
-      "id": 81,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Zoman's Flat",
+      "id": 82, "name": "Zoman's Flat",
+      "exits": { "south": 83, "west": 1097, "east": 1098, "north": 81 },
       "environment": -1,
-      "exits": {
-        "south": 83,
-        "west": 1097,
-        "east": 1098,
-        "north": 81
-      },
       "weight": 1,
-      "id": 82,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Air",
+      "id": 83, "name": "Temple of Air",
+      "exits": { "west": 84, "east": 85, "north": 82 },
       "environment": -1,
-      "exits": {
-        "west": 84,
-        "east": 85,
-        "north": 82
-      },
       "weight": 1,
-      "id": 83,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Air",
+      "id": 84, "name": "Temple of Air",
+      "exits": { "east": 83, "up": 1130 },
       "environment": -1,
-      "exits": {
-        "east": 83,
-        "up": 1130
-      },
       "weight": 1,
-      "id": 84,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Air",
+      "id": 85, "name": "Temple of Air",
+      "exits": { "up": 1131, "west": 83 },
       "environment": -1,
-      "exits": {
-        "up": 1131,
-        "west": 83
-      },
       "weight": 1,
-      "id": 85,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Suran's Flat",
+      "id": 86, "name": "Suran's Flat",
+      "exits": { "south": 76, "north": 87 },
       "environment": -1,
-      "exits": {
-        "south": 76,
-        "north": 87
-      },
       "weight": 1,
-      "id": 86,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Suran's Flat",
+      "id": 87, "name": "Suran's Flat",
+      "exits": { "west": 1082, "south": 86, "north": 88 },
       "environment": -1,
-      "exits": {
-        "west": 1082,
-        "south": 86,
-        "north": 88
-      },
       "weight": 1,
-      "id": 87,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Suran's Flat",
+      "id": 88, "name": "Suran's Flat",
+      "exits": { "south": 87, "north": 89 },
       "environment": -1,
-      "exits": {
-        "south": 87,
-        "north": 89
-      },
       "weight": 1,
-      "id": 88,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Suran's Flat",
+      "id": 89, "name": "Suran's Flat",
+      "exits": { "south": 88, "north": 90 },
       "environment": -1,
-      "exits": {
-        "south": 88,
-        "north": 90
-      },
       "weight": 1,
-      "id": 89,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Suran's Flat",
+      "id": 90, "name": "Suran's Flat",
+      "exits": { "south": 89, "west": 1093, "east": 1094, "north": 91 },
       "environment": -1,
-      "exits": {
-        "south": 89,
-        "west": 1093,
-        "east": 1094,
-        "north": 91
-      },
       "weight": 1,
-      "id": 90,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Water",
+      "id": 91, "name": "Temple of Water",
+      "exits": { "west": 92, "east": 93, "south": 90 },
       "environment": -1,
-      "exits": {
-        "west": 92,
-        "east": 93,
-        "south": 90
-      },
       "weight": 1,
-      "id": 91,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Water",
+      "id": 92, "name": "Temple of Water",
+      "exits": { "east": 91, "up": 1132 },
       "environment": -1,
-      "exits": {
-        "east": 91,
-        "up": 1132
-      },
       "weight": 1,
-      "id": 92,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Water",
+      "id": 93, "name": "Temple of Water",
+      "exits": { "up": 1133, "west": 91 },
       "environment": -1,
-      "exits": {
-        "up": 1133,
-        "west": 91
-      },
       "weight": 1,
-      "id": 93,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 94, "name": "Clansmen Way",
+      "exits": { "south": 427, "west": 63, "east": 95, "north": 972 },
       "environment": -1,
-      "exits": {
-        "south": 427,
-        "west": 63,
-        "east": 95,
-        "north": 972
-      },
       "weight": 1,
-      "id": 94,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 95, "name": "Clansmen Way",
+      "exits": { "west": 94, "east": 96, "south": 975 },
       "environment": -1,
-      "exits": {
-        "west": 94,
-        "east": 96,
-        "south": 975
-      },
       "weight": 1,
-      "id": 95,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 96, "name": "Clansmen Way",
+      "exits": { "south": 976, "west": 95, "east": 97, "north": 977 },
       "environment": -1,
-      "exits": {
-        "south": 976,
-        "west": 95,
-        "east": 97,
-        "north": 977
-      },
       "weight": 1,
-      "id": 96,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 97, "name": "Clansmen Way",
+      "exits": { "west": 96, "east": 98, "north": 428 },
       "environment": -1,
-      "exits": {
-        "west": 96,
-        "east": 98,
-        "north": 428
-      },
       "weight": 1,
-      "id": 97,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Clansmen Way",
+      "id": 98, "name": "Clansmen Way",
+      "exits": { "south": 99, "west": 97, "east": 1000, "north": 107 },
       "environment": -1,
-      "exits": {
-        "south": 99,
-        "west": 97,
-        "east": 1000,
-        "north": 107
-      },
       "weight": 1,
-      "id": 98,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Fallah's Flat:",
+      "id": 99, "name": "Fallah's Flat:",
+      "exits": { "south": 100, "north": 98 },
       "environment": -1,
-      "exits": {
-        "south": 100,
-        "north": 98
-      },
       "weight": 1,
-      "id": 99,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Fallah's Flat:",
+      "id": 100, "name": "Fallah's Flat:",
+      "exits": { "south": 101, "west": 505, "east": 997, "north": 99 },
       "environment": -1,
-      "exits": {
-        "south": 101,
-        "west": 505,
-        "east": 997,
-        "north": 99
-      },
       "weight": 1,
-      "id": 100,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Fallah's Flat",
+      "id": 101, "name": "Fallah's Flat",
+      "exits": { "south": 102, "north": 100 },
       "environment": -1,
-      "exits": {
-        "south": 102,
-        "north": 100
-      },
       "weight": 1,
-      "id": 101,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Fallah's Flat",
+      "id": 102, "name": "Fallah's Flat",
+      "exits": { "south": 103, "north": 101 },
       "environment": -1,
-      "exits": {
-        "south": 103,
-        "north": 101
-      },
       "weight": 1,
-      "id": 102,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Fallah's Flat:",
+      "id": 103, "name": "Fallah's Flat:",
+      "exits": { "south": 104, "west": 998, "east": 999, "north": 102 },
       "environment": -1,
-      "exits": {
-        "south": 104,
-        "west": 998,
-        "east": 999,
-        "north": 102
-      },
       "weight": 1,
-      "id": 103,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Earth",
+      "id": 104, "name": "Temple of Earth",
+      "exits": { "west": 105, "east": 106, "north": 103 },
       "environment": -1,
-      "exits": {
-        "west": 105,
-        "east": 106,
-        "north": 103
-      },
       "weight": 1,
-      "id": 104,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Earth",
+      "id": 105, "name": "Temple of Earth",
+      "exits": { "east": 104, "up": 1127 },
       "environment": -1,
-      "exits": {
-        "east": 104,
-        "up": 1127
-      },
       "weight": 1,
-      "id": 105,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Earth",
+      "id": 106, "name": "Temple of Earth",
+      "exits": { "up": 1126, "west": 104 },
       "environment": -1,
-      "exits": {
-        "up": 1126,
-        "west": 104
-      },
       "weight": 1,
-      "id": 106,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Phaekads Flat:",
+      "id": 107, "name": "Phaekads Flat:",
+      "exits": { "south": 98, "north": 108 },
       "environment": -1,
-      "exits": {
-        "south": 98,
-        "north": 108
-      },
       "weight": 1,
-      "id": 107,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Phaekads Flat:",
+      "id": 108, "name": "Phaekads Flat:",
+      "exits": { "south": 107, "north": 109 },
       "environment": -1,
-      "exits": {
-        "south": 107,
-        "north": 109
-      },
       "weight": 1,
-      "id": 108,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Phaekads Flat",
+      "id": 109, "name": "Phaekads Flat",
+      "exits": { "south": 108, "north": 110 },
       "environment": -1,
-      "exits": {
-        "south": 108,
-        "north": 110
-      },
       "weight": 1,
-      "id": 109,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Phaekads Flat",
+      "id": 110, "name": "Phaekads Flat",
+      "exits": { "south": 109, "north": 111 },
       "environment": -1,
-      "exits": {
-        "south": 109,
-        "north": 111
-      },
       "weight": 1,
-      "id": 110,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Phaekads Flat:",
+      "id": 111, "name": "Phaekads Flat:",
+      "exits": { "south": 110, "east": 996, "north": 112 },
       "environment": -1,
-      "exits": {
-        "south": 110,
-        "east": 996,
-        "north": 112
-      },
       "weight": 1,
-      "id": 111,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Fire",
+      "id": 112, "name": "Temple of Fire",
+      "exits": { "west": 113, "east": 114, "south": 111 },
       "environment": -1,
-      "exits": {
-        "west": 113,
-        "east": 114,
-        "south": 111
-      },
       "weight": 1,
-      "id": 112,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Fire",
+      "id": 113, "name": "Temple of Fire",
+      "exits": { "east": 112, "up": 1129 },
       "environment": -1,
-      "exits": {
-        "east": 112,
-        "up": 1129
-      },
       "weight": 1,
-      "id": 113,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Fire",
+      "id": 114, "name": "Temple of Fire",
+      "exits": { "up": 1128, "west": 112 },
       "environment": -1,
-      "exits": {
-        "up": 1128,
-        "west": 112
-      },
       "weight": 1,
-      "id": 114,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "The Gate to the Wilderness",
+      "id": 115, "name": "The Gate to the Wilderness",
+      "exits": { "west": 116 },
       "environment": -1,
-      "exits": {
-        "west": 116
-      },
       "weight": 1,
-      "id": 115,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Park Street and Caravan Road",
+      "id": 116, "name": "Intersection of Park Street and Caravan Road",
+      "exits": { "south": 233, "west": 117, "east": 115, "north": 172 },
       "environment": -1,
-      "exits": {
-        "south": 233,
-        "west": 117,
-        "east": 115,
-        "north": 172
-      },
       "weight": 1,
-      "id": 116,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Park Street and Via Sacra",
+      "id": 117, "name": "Intersection of Park Street and Via Sacra",
+      "exits": { "south": 220, "west": 118, "east": 116, "north": 226 },
       "environment": -1,
-      "exits": {
-        "south": 220,
-        "west": 118,
-        "east": 116,
-        "north": 226
-      },
       "weight": 1,
-      "id": 117,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 118, "name": "A shaded walk",
+      "exits": { "south": 221, "west": 119, "east": 117, "north": 227 },
       "environment": -1,
-      "exits": {
-        "south": 221,
-        "west": 119,
-        "east": 117,
-        "north": 227
-      },
       "weight": 1,
-      "id": 118,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 119, "name": "A shaded walk",
+      "exits": { "south": 222, "west": 120, "east": 118, "north": 230 },
       "environment": -1,
-      "exits": {
-        "south": 222,
-        "west": 120,
-        "east": 118,
-        "north": 230
-      },
       "weight": 1,
-      "id": 119,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 120, "name": "A shaded walk",
+      "exits": { "west": 121, "east": 119, "south": 223 },
       "environment": -1,
-      "exits": {
-        "west": 121,
-        "east": 119,
-        "south": 223
-      },
       "weight": 1,
-      "id": 120,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 121, "name": "A shaded walk",
+      "exits": { "south": 224, "west": 122, "east": 120, "north": 425 },
       "environment": -1,
-      "exits": {
-        "south": 224,
-        "west": 122,
-        "east": 120,
-        "north": 425
-      },
       "weight": 1,
-      "id": 121,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 122, "name": "A shaded walk",
+      "exits": { "south": 225, "west": 123, "east": 121, "north": 410 },
       "environment": -1,
-      "exits": {
-        "south": 225,
-        "west": 123,
-        "east": 121,
-        "north": 410
-      },
       "weight": 1,
-      "id": 122,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A shaded walk",
+      "id": 123, "name": "A shaded walk",
+      "exits": { "west": 124, "east": 122, "north": 411 },
       "environment": -1,
-      "exits": {
-        "west": 124,
-        "east": 122,
-        "north": 411
-      },
       "weight": 1,
-      "id": 123,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A break in the coverage",
+      "id": 124, "name": "A break in the coverage",
+      "exits": { "west": 125, "east": 123, "north": 412 },
       "environment": -1,
-      "exits": {
-        "west": 125,
-        "east": 123,
-        "north": 412
-      },
       "weight": 1,
-      "id": 124,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A busy intersection",
+      "id": 125, "name": "A busy intersection",
+      "exits": { "south": 159, "west": 126, "east": 124, "north": 160 },
       "environment": -1,
-      "exits": {
-        "south": 159,
-        "west": 126,
-        "east": 124,
-        "north": 160
-      },
       "weight": 1,
-      "id": 125,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The end of the park street",
+      "id": 126, "name": "The end of the park street",
+      "exits": { "south": 880, "west": 127, "east": 125, "north": 879 },
       "environment": -1,
-      "exits": {
-        "south": 880,
-        "west": 127,
-        "east": 125,
-        "north": 879
-      },
       "weight": 1,
-      "id": 126,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Entrance to the Old City.",
+      "id": 127, "name": "Entrance to the Old City.",
+      "exits": { "west": 128, "east": 126, "north": 878 },
       "environment": -1,
-      "exits": {
-        "west": 128,
-        "east": 126,
-        "north": 878
-      },
       "weight": 1,
-      "id": 127,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Westroad, The Entrance to the Old City.",
+      "id": 128, "name": "Westroad, The Entrance to the Old City.",
+      "exits": { "west": 129, "east": 127, "north": 881 },
       "environment": -1,
-      "exits": {
-        "west": 129,
-        "east": 127,
-        "north": 881
-      },
       "weight": 1,
-      "id": 128,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Westroad",
+      "id": 129, "name": "Westroad",
+      "exits": { "west": 130, "east": 128, "south": 419 },
       "environment": -1,
-      "exits": {
-        "west": 130,
-        "east": 128,
-        "south": 419
-      },
       "weight": 1,
-      "id": 129,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Westroad",
+      "id": 130, "name": "Westroad",
+      "exits": { "west": 131, "east": 129, "south": 420 },
       "environment": -1,
-      "exits": {
-        "west": 131,
-        "east": 129,
-        "south": 420
-      },
       "weight": 1,
-      "id": 130,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Westroad",
+      "id": 131, "name": "Westroad",
+      "exits": { "west": 132, "east": 130, "north": 858 },
       "environment": -1,
-      "exits": {
-        "west": 132,
-        "east": 130,
-        "north": 858
-      },
       "weight": 1,
-      "id": 131,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Westroad",
+      "id": 132, "name": "Westroad",
+      "exits": { "west": 133, "east": 131, "south": 421 },
       "environment": -1,
-      "exits": {
-        "west": 133,
-        "east": 131,
-        "south": 421
-      },
       "weight": 1,
-      "id": 132,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The corner of Westroad and Basalt Avenue",
+      "id": 133, "name": "The corner of Westroad and Basalt Avenue",
+      "exits": { "west": 134, "east": 132, "south": 135 },
       "environment": -1,
-      "exits": {
-        "west": 134,
-        "east": 132,
-        "south": 135
-      },
       "weight": 1,
-      "id": 133,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Western Gate of Vesla",
+      "id": 134, "name": "Western Gate of Vesla",
+      "exits": { "east": 133 },
       "environment": -1,
-      "exits": {
-        "east": 133
-      },
       "weight": 1,
-      "id": 134,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 135, "name": "Basalt Avenue",
+      "exits": { "south": 136, "north": 133 },
       "environment": -1,
-      "exits": {
-        "south": 136,
-        "north": 133
-      },
       "weight": 1,
-      "id": 135,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 136, "name": "Basalt Avenue",
+      "exits": { "south": 137, "north": 135 },
       "environment": -1,
-      "exits": {
-        "south": 137,
-        "north": 135
-      },
       "weight": 1,
-      "id": 136,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Basalt Avenue and Rapier Way",
+      "id": 137, "name": "Intersection of Basalt Avenue and Rapier Way",
+      "exits": { "south": 138, "east": 193, "north": 136 },
       "environment": -1,
-      "exits": {
-        "south": 138,
-        "east": 193,
-        "north": 136
-      },
       "weight": 1,
-      "id": 137,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 138, "name": "Basalt Avenue",
+      "exits": { "south": 139, "west": 856, "east": 855, "north": 137 },
       "environment": -1,
-      "exits": {
-        "south": 139,
-        "west": 856,
-        "east": 855,
-        "north": 137
-      },
       "weight": 1,
-      "id": 138,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 139, "name": "Basalt Avenue",
+      "exits": { "south": 140, "west": 853, "east": 854, "north": 138 },
       "environment": -1,
-      "exits": {
-        "south": 140,
-        "west": 853,
-        "east": 854,
-        "north": 138
-      },
       "weight": 1,
-      "id": 139,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Basalt Avenue and Street of the Bells",
+      "id": 140, "name": "Intersection of Basalt Avenue and Street of the Bells",
+      "exits": { "south": 141, "east": 204, "north": 139 },
       "environment": -1,
-      "exits": {
-        "south": 141,
-        "east": 204,
-        "north": 139
-      },
       "weight": 1,
-      "id": 140,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 141, "name": "Basalt Avenue",
+      "exits": { "south": 142, "north": 140 },
       "environment": -1,
-      "exits": {
-        "south": 142,
-        "north": 140
-      },
       "weight": 1,
-      "id": 141,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Basalt Avenue",
+      "id": 142, "name": "Basalt Avenue",
+      "exits": { "south": 143, "east": 850, "north": 141 },
       "environment": -1,
-      "exits": {
-        "south": 143,
-        "east": 850,
-        "north": 141
-      },
       "weight": 1,
-      "id": 142,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Corner of Basalt Avenue and West River Street",
+      "id": 143, "name": "Corner of Basalt Avenue and West River Street",
+      "exits": { "east": 144, "north": 142 },
       "environment": -1,
-      "exits": {
-        "east": 144,
-        "north": 142
-      },
       "weight": 1,
-      "id": 143,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River Street",
+      "id": 144, "name": "West River Street",
+      "exits": { "west": 143, "east": 145, "south": 847 },
       "environment": -1,
-      "exits": {
-        "west": 143,
-        "east": 145,
-        "south": 847
-      },
       "weight": 1,
-      "id": 144,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River Street",
+      "id": 145, "name": "West River Street",
+      "exits": { "east": 146, "west": 144 },
       "environment": -1,
-      "exits": {
-        "east": 146,
-        "west": 144
-      },
       "weight": 1,
-      "id": 145,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River Street",
+      "id": 146, "name": "West River Street",
+      "exits": { "south": 845, "west": 145, "east": 147, "north": 842 },
       "environment": -1,
-      "exits": {
-        "south": 845,
-        "west": 145,
-        "east": 147,
-        "north": 842
-      },
       "weight": 1,
-      "id": 146,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River Street",
+      "id": 147, "name": "West River Street",
+      "exits": { "south": 846, "west": 146, "east": 148, "north": 841 },
       "environment": -1,
-      "exits": {
-        "south": 846,
-        "west": 146,
-        "east": 148,
-        "north": 841
-      },
       "weight": 1,
-      "id": 147,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River Street",
+      "id": 148, "name": "West River Street",
+      "exits": { "west": 147, "east": 149, "north": 840 },
       "environment": -1,
-      "exits": {
-        "west": 147,
-        "east": 149,
-        "north": 840
-      },
       "weight": 1,
-      "id": 148,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River street",
+      "id": 149, "name": "West River street",
+      "exits": { "east": 150, "west": 148 },
       "environment": -1,
-      "exits": {
-        "east": 150,
-        "west": 148
-      },
       "weight": 1,
-      "id": 149,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "West River street",
+      "id": 150, "name": "West River street",
+      "exits": { "east": 151, "west": 149 },
       "environment": -1,
-      "exits": {
-        "east": 151,
-        "west": 149
-      },
       "weight": 1,
-      "id": 150,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "River Street and South Main",
+      "id": 151, "name": "River Street and South Main",
+      "exits": { "south": 816, "west": 150, "east": 205, "north": 152 },
       "environment": -1,
-      "exits": {
-        "south": 816,
-        "west": 150,
-        "east": 205,
-        "north": 152
-      },
       "weight": 1,
-      "id": 151,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main street",
+      "id": 152, "name": "South Main street",
+      "exits": { "south": 151, "west": 819, "east": 817, "north": 153 },
       "environment": -1,
-      "exits": {
-        "south": 151,
-        "west": 819,
-        "east": 817,
-        "north": 153
-      },
       "weight": 1,
-      "id": 152,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main Street",
+      "id": 153, "name": "South Main Street",
+      "exits": { "west": 820, "south": 152, "north": 154 },
       "environment": -1,
-      "exits": {
-        "west": 820,
-        "south": 152,
-        "north": 154
-      },
       "weight": 1,
-      "id": 153,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main Street",
+      "id": 154, "name": "South Main Street",
+      "exits": { "south": 153, "east": 821, "north": 155 },
       "environment": -1,
-      "exits": {
-        "south": 153,
-        "east": 821,
-        "north": 155
-      },
       "weight": 1,
-      "id": 154,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main Street",
+      "id": 155, "name": "South Main Street",
+      "exits": { "south": 154, "west": 423, "east": 422, "north": 156 },
       "environment": -1,
-      "exits": {
-        "south": 154,
-        "west": 423,
-        "east": 422,
-        "north": 156
-      },
       "weight": 1,
-      "id": 155,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main Street",
+      "id": 156, "name": "South Main Street",
+      "exits": { "south": 155, "west": 822, "east": 424, "north": 157 },
       "environment": -1,
-      "exits": {
-        "south": 155,
-        "west": 822,
-        "east": 424,
-        "north": 157
-      },
       "weight": 1,
-      "id": 156,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main Street",
+      "id": 157, "name": "South Main Street",
+      "exits": { "south": 156, "west": 823, "east": 830, "north": 158 },
       "environment": -1,
-      "exits": {
-        "south": 156,
-        "west": 823,
-        "east": 830,
-        "north": 158
-      },
       "weight": 1,
-      "id": 157,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main street",
+      "id": 158, "name": "South Main street",
+      "exits": { "west": 824, "south": 157, "north": 159 },
       "environment": -1,
-      "exits": {
-        "west": 824,
-        "south": 157,
-        "north": 159
-      },
       "weight": 1,
-      "id": 158,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South Main street",
+      "id": 159, "name": "South Main street",
+      "exits": { "south": 158, "north": 125 },
       "environment": -1,
-      "exits": {
-        "south": 158,
-        "north": 125
-      },
       "weight": 1,
-      "id": 159,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main",
+      "id": 160, "name": "Northern Main",
+      "exits": { "south": 125, "east": 412, "north": 161 },
       "environment": -1,
-      "exits": {
-        "south": 125,
-        "east": 412,
-        "north": 161
-      },
       "weight": 1,
-      "id": 160,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main Street",
+      "id": 161, "name": "Northern Main Street",
+      "exits": { "south": 160, "east": 808, "north": 162 },
       "environment": -1,
-      "exits": {
-        "south": 160,
-        "east": 808,
-        "north": 162
-      },
       "weight": 1,
-      "id": 161,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main street",
+      "id": 162, "name": "Northern Main street",
+      "exits": { "south": 161, "east": 810, "north": 163 },
       "environment": -1,
-      "exits": {
-        "south": 161,
-        "east": 810,
-        "north": 163
-      },
       "weight": 1,
-      "id": 162,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main Street",
+      "id": 163, "name": "Northern Main Street",
+      "exits": { "south": 162, "east": 811, "north": 164 },
       "environment": -1,
-      "exits": {
-        "south": 162,
-        "east": 811,
-        "north": 164
-      },
       "weight": 1,
-      "id": 163,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main street",
+      "id": 164, "name": "Northern Main street",
+      "exits": { "south": 163, "east": 812, "north": 165 },
       "environment": -1,
-      "exits": {
-        "south": 163,
-        "east": 812,
-        "north": 165
-      },
       "weight": 1,
-      "id": 164,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main street",
+      "id": 165, "name": "Northern Main street",
+      "exits": { "south": 164, "north": 166 },
       "environment": -1,
-      "exits": {
-        "south": 164,
-        "north": 166
-      },
       "weight": 1,
-      "id": 165,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of North Main and Scholar's Way",
+      "id": 166, "name": "Intersection of North Main and Scholar's Way",
+      "exits": { "south": 165, "east": 192, "north": 167 },
       "environment": -1,
-      "exits": {
-        "south": 165,
-        "east": 192,
-        "north": 167
-      },
       "weight": 1,
-      "id": 166,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Main street",
+      "id": 167, "name": "Northern Main street",
+      "exits": { "south": 166, "north": 168 },
       "environment": -1,
-      "exits": {
-        "south": 166,
-        "north": 168
-      },
       "weight": 1,
-      "id": 167,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of North Main and Wall Street",
+      "id": 168, "name": "Intersection of North Main and Wall Street",
+      "exits": { "south": 167, "west": 793, "east": 170, "north": 169 },
       "environment": -1,
-      "exits": {
-        "south": 167,
-        "west": 793,
-        "east": 170,
-        "north": 169
-      },
       "weight": 1,
-      "id": 168,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern Gate",
+      "id": 169, "name": "Northern Gate",
+      "exits": { "south": 168, "northeast": 753 },
       "environment": -1,
-      "exits": {
-        "south": 168,
-        "northeast": 753
-      },
       "weight": 1,
-      "id": 169,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Western End of Wall Street",
+      "id": 170, "name": "Western End of Wall Street",
+      "exits": { "east": 171, "west": 168 },
       "environment": -1,
-      "exits": {
-        "east": 171,
-        "west": 168
-      },
       "weight": 1,
-      "id": 170,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Wall Street",
+      "id": 171, "name": "Wall Street",
+      "exits": { "west": 170 },
       "environment": -1,
-      "exits": {
-        "west": 170
-      },
       "weight": 1,
-      "id": 171,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 172, "name": "Caravan Road",
+      "exits": { "south": 116, "west": 226, "east": 735, "north": 173 },
       "environment": -1,
-      "exits": {
-        "south": 116,
-        "west": 226,
-        "east": 735,
-        "north": 173
-      },
       "weight": 1,
-      "id": 172,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 173, "name": "Caravan Road",
+      "exits": { "south": 172, "west": 232, "east": 736, "north": 174 },
       "environment": -1,
-      "exits": {
-        "south": 172,
-        "west": 232,
-        "east": 736,
-        "north": 174
-      },
       "weight": 1,
-      "id": 173,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 174, "name": "Caravan Road",
+      "exits": { "south": 173, "north": 175 },
       "environment": -1,
-      "exits": {
-        "south": 173,
-        "north": 175
-      },
       "weight": 1,
-      "id": 174,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 175, "name": "Caravan Road",
+      "exits": { "south": 174, "north": 176 },
       "environment": -1,
-      "exits": {
-        "south": 174,
-        "north": 176
-      },
       "weight": 1,
-      "id": 175,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 176, "name": "Caravan Road",
+      "exits": { "south": 175, "north": 177 },
       "environment": -1,
-      "exits": {
-        "south": 175,
-        "north": 177
-      },
       "weight": 1,
-      "id": 176,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 177, "name": "Caravan Road",
+      "exits": { "south": 176, "north": 178 },
       "environment": -1,
-      "exits": {
-        "south": 176,
-        "north": 178
-      },
       "weight": 1,
-      "id": 177,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Scholar's Way and Caravan Road",
+      "id": 178, "name": "Intersection of Scholar's Way and Caravan Road",
+      "exits": { "west": 185, "south": 177, "north": 179 },
       "environment": -1,
-      "exits": {
-        "west": 185,
-        "south": 177,
-        "north": 179
-      },
       "weight": 1,
-      "id": 178,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Caravan Road",
+      "id": 179, "name": "Caravan Road",
+      "exits": { "south": 178, "north": 180 },
       "environment": -1,
-      "exits": {
-        "south": 178,
-        "north": 180
-      },
       "weight": 1,
-      "id": 179,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Caravan Road and Wall Street",
+      "id": 180, "name": "Intersection of Caravan Road and Wall Street",
+      "exits": { "west": 181, "south": 179 },
       "environment": -1,
-      "exits": {
-        "west": 181,
-        "south": 179
-      },
       "weight": 1,
-      "id": 180,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Eastern End of Wall Street",
+      "id": 181, "name": "Eastern End of Wall Street",
+      "exits": { "east": 180, "west": 182 },
       "environment": -1,
-      "exits": {
-        "east": 180,
-        "west": 182
-      },
       "weight": 1,
-      "id": 181,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Wall Street",
+      "id": 182, "name": "Wall Street",
+      "exits": { "east": 181, "west": 183 },
       "environment": -1,
-      "exits": {
-        "east": 181,
-        "west": 183
-      },
       "weight": 1,
-      "id": 182,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Wall Street",
+      "id": 183, "name": "Wall Street",
+      "exits": { "east": 182, "west": 184 },
       "environment": -1,
-      "exits": {
-        "east": 182,
-        "west": 184
-      },
       "weight": 1,
-      "id": 183,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Wall Street",
+      "id": 184, "name": "Wall Street",
+      "exits": { "east": 183 },
       "environment": -1,
-      "exits": {
-        "east": 183
-      },
       "weight": 1,
-      "id": 184,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 185, "name": "Scholar's Way",
+      "exits": { "east": 178, "west": 186 },
       "environment": -1,
-      "exits": {
-        "east": 178,
-        "west": 186
-      },
       "weight": 1,
-      "id": 185,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 186, "name": "Scholar's Way",
+      "exits": { "east": 185, "west": 187 },
       "environment": -1,
-      "exits": {
-        "east": 185,
-        "west": 187
-      },
       "weight": 1,
-      "id": 186,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 187, "name": "Scholar's Way",
+      "exits": { "west": 188, "east": 186, "north": 737 },
       "environment": -1,
-      "exits": {
-        "west": 188,
-        "east": 186,
-        "north": 737
-      },
       "weight": 1,
-      "id": 187,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 188, "name": "Scholar's Way",
+      "exits": { "west": 189, "east": 187, "north": 738 },
       "environment": -1,
-      "exits": {
-        "west": 189,
-        "east": 187,
-        "north": 738
-      },
       "weight": 1,
-      "id": 188,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 189, "name": "Scholar's Way",
+      "exits": { "west": 190, "east": 188, "south": 739 },
       "environment": -1,
-      "exits": {
-        "west": 190,
-        "east": 188,
-        "south": 739
-      },
       "weight": 1,
-      "id": 189,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 190, "name": "Scholar's Way",
+      "exits": { "south": 740, "west": 191, "east": 189, "north": 741 },
       "environment": -1,
-      "exits": {
-        "south": 740,
-        "west": 191,
-        "east": 189,
-        "north": 741
-      },
       "weight": 1,
-      "id": 190,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 191, "name": "Scholar's Way",
+      "exits": { "south": 742, "west": 192, "east": 190, "north": 743 },
       "environment": -1,
-      "exits": {
-        "south": 742,
-        "west": 192,
-        "east": 190,
-        "north": 743
-      },
       "weight": 1,
-      "id": 191,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Scholar's Way",
+      "id": 192, "name": "Scholar's Way",
+      "exits": { "west": 166, "east": 191, "south": 744 },
       "environment": -1,
-      "exits": {
-        "west": 166,
-        "east": 191,
-        "south": 744
-      },
       "weight": 1,
-      "id": 192,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Rapier Way",
+      "id": 193, "name": "Rapier Way",
+      "exits": { "east": 194, "west": 137 },
       "environment": -1,
-      "exits": {
-        "east": 194,
-        "west": 137
-      },
       "weight": 1,
-      "id": 193,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Rapier Way",
+      "id": 194, "name": "Rapier Way",
+      "exits": { "east": 195, "west": 193 },
       "environment": -1,
-      "exits": {
-        "east": 195,
-        "west": 193
-      },
       "weight": 1,
-      "id": 194,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Rapier Way",
+      "id": 195, "name": "Rapier Way",
+      "exits": { "east": 196, "west": 194 },
       "environment": -1,
-      "exits": {
-        "east": 196,
-        "west": 194
-      },
       "weight": 1,
-      "id": 195,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Rapier Way",
+      "id": 196, "name": "Rapier Way",
+      "exits": { "east": 197, "west": 195 },
       "environment": -1,
-      "exits": {
-        "east": 197,
-        "west": 195
-      },
       "weight": 1,
-      "id": 196,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Rapier Way and Zand Boulevard",
+      "id": 197, "name": "Intersection of Rapier Way and Zand Boulevard",
+      "exits": { "west": 196, "south": 198 },
       "environment": -1,
-      "exits": {
-        "west": 196,
-        "south": 198
-      },
       "weight": 1,
-      "id": 197,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Zand Boulevard",
+      "id": 198, "name": "Zand Boulevard",
+      "exits": { "south": 199, "east": 857, "north": 197 },
       "environment": -1,
-      "exits": {
-        "south": 199,
-        "east": 857,
-        "north": 197
-      },
       "weight": 1,
-      "id": 198,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Zand Boulevard",
+      "id": 199, "name": "Zand Boulevard",
+      "exits": { "south": 200, "east": 962, "north": 198 },
       "environment": -1,
-      "exits": {
-        "south": 200,
-        "east": 962,
-        "north": 198
-      },
       "weight": 1,
-      "id": 199,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Street of the Bells and Zand Boulevard",
+      "id": 200, "name": "Intersection of Street of the Bells and Zand Boulevard",
+      "exits": { "west": 201, "north": 199 },
       "environment": -1,
-      "exits": {
-        "west": 201,
-        "north": 199
-      },
       "weight": 1,
-      "id": 200,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Street of the Bells",
+      "id": 201, "name": "Street of the Bells",
+      "exits": { "south": 843, "west": 202, "east": 200, "north": 931 },
       "environment": -1,
-      "exits": {
-        "south": 843,
-        "west": 202,
-        "east": 200,
-        "north": 931
-      },
       "weight": 1,
-      "id": 201,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Street of the Bells",
+      "id": 202, "name": "Street of the Bells",
+      "exits": { "west": 203, "east": 201, "south": 844 },
       "environment": -1,
-      "exits": {
-        "west": 203,
-        "east": 201,
-        "south": 844
-      },
       "weight": 1,
-      "id": 202,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Street of the Bells",
+      "id": 203, "name": "Street of the Bells",
+      "exits": { "east": 202, "west": 204 },
       "environment": -1,
-      "exits": {
-        "east": 202,
-        "west": 204
-      },
       "weight": 1,
-      "id": 203,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Street of the Bells",
+      "id": 204, "name": "Street of the Bells",
+      "exits": { "east": 203, "west": 140 },
       "environment": -1,
-      "exits": {
-        "east": 203,
-        "west": 140
-      },
       "weight": 1,
-      "id": 204,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 205, "name": "East River Street",
+      "exits": { "east": 206, "west": 151 },
       "environment": -1,
-      "exits": {
-        "east": 206,
-        "west": 151
-      },
       "weight": 1,
-      "id": 205,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 206, "name": "East River Street",
+      "exits": { "west": 205, "east": 207, "north": 397 },
       "environment": -1,
-      "exits": {
-        "west": 205,
-        "east": 207,
-        "north": 397
-      },
       "weight": 1,
-      "id": 206,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 207, "name": "East River Street",
+      "exits": { "east": 208, "west": 206 },
       "environment": -1,
-      "exits": {
-        "east": 208,
-        "west": 206
-      },
       "weight": 1,
-      "id": 207,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 208, "name": "East River Street",
+      "exits": { "west": 207, "east": 209, "north": 396 },
       "environment": -1,
-      "exits": {
-        "west": 207,
-        "east": 209,
-        "north": 396
-      },
       "weight": 1,
-      "id": 208,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 209, "name": "East River Street",
+      "exits": { "west": 208, "east": 210, "north": 395 },
       "environment": -1,
-      "exits": {
-        "west": 208,
-        "east": 210,
-        "north": 395
-      },
       "weight": 1,
-      "id": 209,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "East River Street",
+      "id": 210, "name": "East River Street",
+      "exits": { "west": 209, "east": 211, "north": 394 },
       "environment": -1,
-      "exits": {
-        "west": 209,
-        "east": 211,
-        "north": 394
-      },
       "weight": 1,
-      "id": 210,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "End of East River Street",
+      "id": 211, "name": "End of East River Street",
+      "exits": { "east": 212, "west": 210 },
       "environment": -1,
-      "exits": {
-        "east": 212,
-        "west": 210
-      },
       "weight": 1,
-      "id": 211,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Intersection of Via Sacra and River Street",
+      "id": 212, "name": "Intersection of Via Sacra and River Street",
+      "exits": { "west": 211, "north": 213 },
       "environment": -1,
-      "exits": {
-        "west": 211,
-        "north": 213
-      },
       "weight": 1,
-      "id": 212,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "South End of Via Sacra",
+      "id": 213, "name": "South End of Via Sacra",
+      "exits": { "south": 212, "east": 399, "north": 214 },
       "environment": -1,
-      "exits": {
-        "south": 212,
-        "east": 399,
-        "north": 214
-      },
       "weight": 1,
-      "id": 213,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Southern Via Sacra",
+      "id": 214, "name": "Southern Via Sacra",
+      "exits": { "south": 213, "west": 400, "east": 401, "north": 215 },
       "environment": -1,
-      "exits": {
-        "south": 213,
-        "west": 400,
-        "east": 401,
-        "north": 215
-      },
       "weight": 1,
-      "id": 214,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Via Sacra",
+      "id": 215, "name": "Via Sacra",
+      "exits": { "south": 214, "north": 216 },
       "environment": -1,
-      "exits": {
-        "south": 214,
-        "north": 216
-      },
       "weight": 1,
-      "id": 215,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Via Sacra",
+      "id": 216, "name": "Via Sacra",
+      "exits": { "south": 215, "west": 402, "east": 403, "north": 217 },
       "environment": -1,
-      "exits": {
-        "south": 215,
-        "west": 402,
-        "east": 403,
-        "north": 217
-      },
       "weight": 1,
-      "id": 216,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Via Sacra",
+      "id": 217, "name": "Via Sacra",
+      "exits": { "west": 408, "south": 216, "north": 218 },
       "environment": -1,
-      "exits": {
-        "west": 408,
-        "south": 216,
-        "north": 218
-      },
       "weight": 1,
-      "id": 217,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Via Sacra",
+      "id": 218, "name": "Via Sacra",
+      "exits": { "south": 217, "north": 219 },
       "environment": -1,
-      "exits": {
-        "south": 217,
-        "north": 219
-      },
       "weight": 1,
-      "id": 218,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Via Sacra",
+      "id": 219, "name": "Via Sacra",
+      "exits": { "west": 409, "south": 218, "north": 220 },
       "environment": -1,
-      "exits": {
-        "west": 409,
-        "south": 218,
-        "north": 220
-      },
       "weight": 1,
-      "id": 219,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Northern End of Via Sacra",
+      "id": 220, "name": "Northern End of Via Sacra",
+      "exits": { "south": 219, "west": 221, "east": 233, "north": 117 },
       "environment": -1,
-      "exits": {
-        "south": 219,
-        "west": 221,
-        "east": 233,
-        "north": 117
-      },
       "weight": 1,
-      "id": 220,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "General Store",
+      "id": 221, "name": "General Store",
+      "exits": { "west": 222, "east": 220, "north": 118 },
       "environment": -1,
-      "exits": {
-        "west": 222,
-        "east": 220,
-        "north": 118
-      },
       "weight": 1,
-      "id": 221,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Comfortably Numb",
+      "id": 222, "name": "Comfortably Numb",
+      "exits": { "west": 223, "east": 221, "north": 119 },
       "environment": -1,
-      "exits": {
-        "west": 223,
-        "east": 221,
-        "north": 119
-      },
       "weight": 1,
-      "id": 222,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Medieval Mounts",
+      "id": 223, "name": "Medieval Mounts",
+      "exits": { "west": 224, "east": 222, "north": 120 },
       "environment": -1,
-      "exits": {
-        "west": 224,
-        "east": 222,
-        "north": 120
-      },
       "weight": 1,
-      "id": 223,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Big Hole Banking",
+      "id": 224, "name": "Big Hole Banking",
+      "exits": { "west": 225, "east": 223, "north": 121 },
       "environment": -1,
-      "exits": {
-        "west": 225,
-        "east": 223,
-        "north": 121
-      },
       "weight": 1,
-      "id": 224,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Brimstone",
+      "id": 225, "name": "Brimstone",
+      "exits": { "east": 224, "north": 122 },
       "environment": -1,
-      "exits": {
-        "east": 224,
-        "north": 122
-      },
       "weight": 1,
-      "id": 225,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 226, "name": "A peaceful park",
+      "exits": { "south": 117, "west": 227, "east": 172, "north": 232 },
       "environment": -1,
-      "exits": {
-        "south": 117,
-        "west": 227,
-        "east": 172,
-        "north": 232
-      },
       "weight": 1,
-      "id": 226,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 227, "name": "A peaceful park",
+      "exits": { "south": 118, "west": 230, "east": 226, "north": 228 },
       "environment": -1,
-      "exits": {
-        "south": 118,
-        "west": 230,
-        "east": 226,
-        "north": 228
-      },
       "weight": 1,
-      "id": 227,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 228, "name": "A peaceful park",
+      "exits": { "south": 227, "west": 231, "east": 232, "north": 229 },
       "environment": -1,
-      "exits": {
-        "south": 227,
-        "west": 231,
-        "east": 232,
-        "north": 229
-      },
       "weight": 1,
-      "id": 228,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Sanctuary",
+      "id": 229, "name": "Sanctuary",
+      "exits": { "up": 893, "south": 228 },
       "environment": -1,
-      "exits": {
-        "up": 893,
-        "south": 228
-      },
       "weight": 1,
-      "id": 229,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 230, "name": "A peaceful park",
+      "exits": { "south": 119, "west": 815, "east": 227, "north": 231 },
       "environment": -1,
-      "exits": {
-        "south": 119,
-        "west": 815,
-        "east": 227,
-        "north": 231
-      },
       "weight": 1,
-      "id": 230,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 231, "name": "A peaceful park",
+      "exits": { "south": 230, "west": 796, "east": 228, "north": 426 },
       "environment": -1,
-      "exits": {
-        "south": 230,
-        "west": 796,
-        "east": 228,
-        "north": 426
-      },
       "weight": 1,
-      "id": 231,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A peaceful park",
+      "id": 232, "name": "A peaceful park",
+      "exits": { "south": 226, "west": 228, "east": 173, "north": 234 },
       "environment": -1,
-      "exits": {
-        "south": 226,
-        "west": 228,
-        "east": 173,
-        "north": 234
-      },
       "weight": 1,
-      "id": 232,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The Shadowed Anvil",
+      "id": 233, "name": "The Shadowed Anvil",
+      "exits": { "west": 220, "north": 116 },
       "environment": -1,
-      "exits": {
-        "west": 220,
-        "north": 116
-      },
       "weight": 1,
-      "id": 233,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Andre's Clothing",
+      "id": 234, "name": "Andre's Clothing",
+      "exits": { "south": 232 },
       "environment": -1,
-      "exits": {
-        "south": 232
-      },
       "weight": 1,
-      "id": 234,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Before the Anshelm Gatehouse",
+      "id": 235, "name": "Before the Anshelm Gatehouse",
+      "exits": { "north": 236 },
       "environment": -1,
-      "exits": {
-        "north": 236
-      },
       "weight": 1,
-      "id": 235,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Under the Anshelmish Gatehouse",
+      "id": 236, "name": "Under the Anshelmish Gatehouse",
+      "exits": { "west": 1143, "south": 235, "north": 237 },
       "environment": -1,
-      "exits": {
-        "west": 1143,
-        "south": 235,
-        "north": 237
-      },
       "weight": 1,
-      "id": 236,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Southern end of Rue du Nord",
+      "id": 237, "name": "Southern end of Rue du Nord",
+      "exits": { "southwest": 1135, "south": 236, "southeast": 1154, "north": 238 },
       "environment": -1,
-      "exits": {
-        "southwest": 1135,
-        "south": 236,
-        "southeast": 1154,
-        "north": 238
-      },
       "weight": 1,
-      "id": 237,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 238, "name": "Rue du Nord",
+      "exits": { "west": 413, "south": 237, "north": 239 },
       "environment": -1,
-      "exits": {
-        "west": 413,
-        "south": 237,
-        "north": 239
-      },
       "weight": 1,
-      "id": 238,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Intersection of Rue du Nord and Beitel Straat",
+      "id": 239, "name": "Intersection of Rue du Nord and Beitel Straat",
+      "exits": { "south": 238, "west": 414, "east": 1185, "north": 240 },
       "environment": -1,
-      "exits": {
-        "south": 238,
-        "west": 414,
-        "east": 1185,
-        "north": 240
-      },
       "weight": 1,
-      "id": 239,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 240, "name": "Rue du Nord",
+      "exits": { "south": 239, "west": 415, "east": 1192, "north": 241 },
       "environment": -1,
-      "exits": {
-        "south": 239,
-        "west": 415,
-        "east": 1192,
-        "north": 241
-      },
       "weight": 1,
-      "id": 240,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 241, "name": "Rue du Nord",
+      "exits": { "west": 416, "south": 240, "north": 242 },
       "environment": -1,
-      "exits": {
-        "west": 416,
-        "south": 240,
-        "north": 242
-      },
       "weight": 1,
-      "id": 241,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Gateway to Middle Bailey",
+      "id": 242, "name": "Gateway to Middle Bailey",
+      "exits": { "south": 241, "north": 243 },
       "environment": -1,
-      "exits": {
-        "south": 241,
-        "north": 243
-      },
       "weight": 1,
-      "id": 242,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 243, "name": "Rue du Nord",
+      "exits": { "south": 242, "north": 244 },
       "environment": -1,
-      "exits": {
-        "south": 242,
-        "north": 244
-      },
       "weight": 1,
-      "id": 243,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western intersection of Rue du Nord and Kirsch Lane",
+      "id": 244, "name": "Western intersection of Rue du Nord and Kirsch Lane",
+      "exits": { "west": 245, "east": 250, "south": 243 },
       "environment": -1,
-      "exits": {
-        "west": 245,
-        "east": 250,
-        "south": 243
-      },
       "weight": 1,
-      "id": 244,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kirsch Lane",
+      "id": 245, "name": "Kirsch Lane",
+      "exits": { "east": 244, "west": 246 },
       "environment": -1,
-      "exits": {
-        "east": 244,
-        "west": 246
-      },
       "weight": 1,
-      "id": 245,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kirsch Lane",
+      "id": 246, "name": "Kirsch Lane",
+      "exits": { "west": 247, "east": 245, "south": 249 },
       "environment": -1,
-      "exits": {
-        "west": 247,
-        "east": 245,
-        "south": 249
-      },
       "weight": 1,
-      "id": 246,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western end of Kirsch Lane",
+      "id": 247, "name": "Western end of Kirsch Lane",
+      "exits": { "east": 246, "south": 248 },
       "environment": -1,
-      "exits": {
-        "east": 246,
-        "south": 248
-      },
       "weight": 1,
-      "id": 247,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 248, "name": "Construction site",
+      "exits": { "north": 247 },
       "environment": -1,
-      "exits": {
-        "north": 247
-      },
       "weight": 1,
-      "id": 248,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kaneohe Armory",
+      "id": 249, "name": "Kaneohe Armory",
+      "exits": { "north": 246 },
       "environment": -1,
-      "exits": {
-        "north": 246
-      },
       "weight": 1,
-      "id": 249,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
+      "id": 250, "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
+      "exits": { "west": 244, "east": 283, "north": 251 },
       "environment": -1,
-      "exits": {
-        "west": 244,
-        "east": 283,
-        "north": 251
-      },
       "weight": 1,
-      "id": 250,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 251, "name": "Rue du Nord",
+      "exits": { "south": 250, "east": 1193, "north": 252 },
       "environment": -1,
-      "exits": {
-        "south": 250,
-        "east": 1193,
-        "north": 252
-      },
       "weight": 1,
-      "id": 251,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 252, "name": "Rue du Nord",
+      "exits": { "south": 251, "north": 253 },
       "environment": -1,
-      "exits": {
-        "south": 251,
-        "north": 253
-      },
       "weight": 1,
-      "id": 252,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 253, "name": "Rue du Nord",
+      "exits": { "south": 252, "north": 254 },
       "environment": -1,
-      "exits": {
-        "south": 252,
-        "north": 254
-      },
       "weight": 1,
-      "id": 253,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 254, "name": "Rue du Nord",
+      "exits": { "south": 253, "north": 255 },
       "environment": -1,
-      "exits": {
-        "south": 253,
-        "north": 255
-      },
       "weight": 1,
-      "id": 254,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Central Square on the Rue du Nord",
+      "id": 255, "name": "Central Square on the Rue du Nord",
+      "exits": { "south": 254, "west": 1195, "east": 1194, "north": 256 },
       "environment": -1,
-      "exits": {
-        "south": 254,
-        "west": 1195,
-        "east": 1194,
-        "north": 256
-      },
       "weight": 1,
-      "id": 255,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 256, "name": "Rue du Nord",
+      "exits": { "south": 255, "north": 257 },
       "environment": -1,
-      "exits": {
-        "south": 255,
-        "north": 257
-      },
       "weight": 1,
-      "id": 256,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 257, "name": "Rue du Nord",
+      "exits": { "south": 256, "north": 258 },
       "environment": -1,
-      "exits": {
-        "south": 256,
-        "north": 258
-      },
       "weight": 1,
-      "id": 257,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Intersection of Rue du Nord and East Geld Strasse",
+      "id": 258, "name": "Intersection of Rue du Nord and East Geld Strasse",
+      "exits": { "west": 259, "east": 281, "south": 257 },
       "environment": -1,
-      "exits": {
-        "west": 259,
-        "east": 281,
-        "south": 257
-      },
       "weight": 1,
-      "id": 258,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 259, "name": "Rue du Nord",
+      "exits": { "east": 258, "west": 260 },
       "environment": -1,
-      "exits": {
-        "east": 258,
-        "west": 260
-      },
       "weight": 1,
-      "id": 259,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Intersection of Rue du Nord and West Geld Strasse",
+      "id": 260, "name": "Intersection of Rue du Nord and West Geld Strasse",
+      "exits": { "west": 261, "east": 259, "north": 264 },
       "environment": -1,
-      "exits": {
-        "west": 261,
-        "east": 259,
-        "north": 264
-      },
       "weight": 1,
-      "id": 260,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Geld Strasse",
+      "id": 261, "name": "Geld Strasse",
+      "exits": { "east": 260, "west": 262 },
       "environment": -1,
-      "exits": {
-        "east": 260,
-        "west": 262
-      },
       "weight": 1,
-      "id": 261,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Geld Strasse",
+      "id": 262, "name": "Geld Strasse",
+      "exits": { "east": 261, "west": 263 },
       "environment": -1,
-      "exits": {
-        "east": 261,
-        "west": 263
-      },
       "weight": 1,
-      "id": 262,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western end of Geld Strasse",
+      "id": 263, "name": "Western end of Geld Strasse",
+      "exits": { "east": 262 },
       "environment": -1,
-      "exits": {
-        "east": 262
-      },
       "weight": 1,
-      "id": 263,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 264, "name": "Rue du Nord",
+      "exits": { "south": 260, "north": 265 },
       "environment": -1,
-      "exits": {
-        "south": 260,
-        "north": 265
-      },
       "weight": 1,
-      "id": 264,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Gateway to Upper Bailey",
+      "id": 265, "name": "Gateway to Upper Bailey",
+      "exits": { "south": 264, "west": 282, "east": 1198, "north": 266 },
       "environment": -1,
-      "exits": {
-        "south": 264,
-        "west": 282,
-        "east": 1198,
-        "north": 266
-      },
       "weight": 1,
-      "id": 265,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 266, "name": "Rue du Nord",
+      "exits": { "south": 265, "north": 267 },
       "environment": -1,
-      "exits": {
-        "south": 265,
-        "north": 267
-      },
       "weight": 1,
-      "id": 266,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Intersection of Rue du Nord and Kasernegade",
+      "id": 267, "name": "Intersection of Rue du Nord and Kasernegade",
+      "exits": { "south": 266, "west": 268, "east": 276, "north": 273 },
       "environment": -1,
-      "exits": {
-        "south": 266,
-        "west": 268,
-        "east": 276,
-        "north": 273
-      },
       "weight": 1,
-      "id": 267,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 268, "name": "Kasernegade",
+      "exits": { "east": 267, "west": 269 },
       "environment": -1,
-      "exits": {
-        "east": 267,
-        "west": 269
-      },
       "weight": 1,
-      "id": 268,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 269, "name": "Kasernegade",
+      "exits": { "east": 268, "west": 270 },
       "environment": -1,
-      "exits": {
-        "east": 268,
-        "west": 270
-      },
       "weight": 1,
-      "id": 269,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 270, "name": "Kasernegade",
+      "exits": { "west": 271, "east": 269, "south": 1199 },
       "environment": -1,
-      "exits": {
-        "west": 271,
-        "east": 269,
-        "south": 1199
-      },
       "weight": 1,
-      "id": 270,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western end of Kasernegade",
+      "id": 271, "name": "Western end of Kasernegade",
+      "exits": { "east": 270, "north": 272 },
       "environment": -1,
-      "exits": {
-        "east": 270,
-        "north": 272
-      },
       "weight": 1,
-      "id": 271,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 272, "name": "Construction site",
+      "exits": { "south": 271 },
       "environment": -1,
-      "exits": {
-        "south": 271
-      },
       "weight": 1,
-      "id": 272,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Rue du Nord",
+      "id": 273, "name": "Rue du Nord",
+      "exits": { "south": 267, "northwest": 1202, "north": 274 },
       "environment": -1,
-      "exits": {
-        "south": 267,
-        "northwest": 1202,
-        "north": 274
-      },
       "weight": 1,
-      "id": 273,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Under the Town Gate",
+      "id": 274, "name": "Under the Town Gate",
+      "exits": { "south": 273, "north": 275 },
       "environment": -1,
-      "exits": {
-        "south": 273,
-        "north": 275
-      },
       "weight": 1,
-      "id": 274,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Before the Anshelm Town Gate",
+      "id": 275, "name": "Before the Anshelm Town Gate",
+      "exits": { "south": 274 },
       "environment": -1,
-      "exits": {
-        "south": 274
-      },
       "weight": 1,
-      "id": 275,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 276, "name": "Kasernegade",
+      "exits": { "west": 267, "east": 277, "north": 1200 },
       "environment": -1,
-      "exits": {
-        "west": 267,
-        "east": 277,
-        "north": 1200
-      },
       "weight": 1,
-      "id": 276,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 277, "name": "Kasernegade",
+      "exits": { "east": 278, "west": 276 },
       "environment": -1,
-      "exits": {
-        "east": 278,
-        "west": 276
-      },
       "weight": 1,
-      "id": 277,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 278, "name": "Kasernegade",
+      "exits": { "east": 279, "west": 277 },
       "environment": -1,
-      "exits": {
-        "east": 279,
-        "west": 277
-      },
       "weight": 1,
-      "id": 278,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kasernegade",
+      "id": 279, "name": "Kasernegade",
+      "exits": { "east": 280, "west": 278 },
       "environment": -1,
-      "exits": {
-        "east": 280,
-        "west": 278
-      },
       "weight": 1,
-      "id": 279,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern end of Kasernegade",
+      "id": 280, "name": "Eastern end of Kasernegade",
+      "exits": { "west": 279, "south": 1201 },
       "environment": -1,
-      "exits": {
-        "west": 279,
-        "south": 1201
-      },
       "weight": 1,
-      "id": 280,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Geld Strasse",
+      "id": 281, "name": "Geld Strasse",
+      "exits": { "west": 258, "east": 1328, "north": 1197 },
       "environment": -1,
-      "exits": {
-        "west": 258,
-        "east": 1328,
-        "north": 1197
-      },
       "weight": 1,
-      "id": 281,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "id": 282, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "exits": { "east": 265 },
       "environment": -1,
-      "exits": {
-        "east": 265
-      },
       "weight": 1,
-      "id": 282,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kirsch Lane",
+      "id": 283, "name": "Kirsch Lane",
+      "exits": { "west": 250, "east": 284, "north": 1326 },
       "environment": -1,
-      "exits": {
-        "west": 250,
-        "east": 284,
-        "north": 1326
-      },
       "weight": 1,
-      "id": 283,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Kirsch Lane",
+      "id": 284, "name": "Kirsch Lane",
+      "exits": { "west": 283, "east": 285, "north": 1327 },
       "environment": -1,
-      "exits": {
-        "west": 283,
-        "east": 285,
-        "north": 1327
-      },
       "weight": 1,
-      "id": 284,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern end of Kirsch Lane",
+      "id": 285, "name": "Eastern end of Kirsch Lane",
+      "exits": { "west": 284 },
       "environment": -1,
-      "exits": {
-        "west": 284
-      },
       "weight": 1,
-      "id": 285,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Entrance to Exedoria",
+      "id": 286, "name": "Entrance to Exedoria",
+      "exits": { "east": 287 },
       "environment": -1,
-      "exits": {
-        "east": 287
-      },
       "weight": 1,
-      "id": 286,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 287, "name": "Main Street",
+      "exits": { "west": 286, "east": 288, "south": 330 },
       "environment": -1,
-      "exits": {
-        "west": 286,
-        "east": 288,
-        "south": 330
-      },
       "weight": 1,
-      "id": 287,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 288, "name": "Main Street",
+      "exits": { "south": 368, "west": 287, "east": 289, "north": 367 },
       "environment": -1,
-      "exits": {
-        "south": 368,
-        "west": 287,
-        "east": 289,
-        "north": 367
-      },
       "weight": 1,
-      "id": 288,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 289, "name": "Main Street",
+      "exits": { "west": 288, "east": 290, "south": 366 },
       "environment": -1,
-      "exits": {
-        "west": 288,
-        "east": 290,
-        "south": 366
-      },
       "weight": 1,
-      "id": 289,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Monument Circle, Main Street",
+      "id": 290, "name": "Monument Circle, Main Street",
+      "exits": { "south": 299, "west": 289, "east": 291, "north": 369 },
       "environment": -1,
-      "exits": {
-        "south": 299,
-        "west": 289,
-        "east": 291,
-        "north": 369
-      },
       "weight": 1,
-      "id": 290,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 291, "name": "Main Street",
+      "exits": { "south": 298, "west": 290, "east": 292, "north": 370 },
       "environment": -1,
-      "exits": {
-        "south": 298,
-        "west": 290,
-        "east": 292,
-        "north": 370
-      },
       "weight": 1,
-      "id": 291,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 292, "name": "Main Street",
+      "exits": { "west": 291, "east": 293, "south": 383 },
       "environment": -1,
-      "exits": {
-        "west": 291,
-        "east": 293,
-        "south": 383
-      },
       "weight": 1,
-      "id": 292,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 293, "name": "Main Street",
+      "exits": { "east": 294, "west": 292 },
       "environment": -1,
-      "exits": {
-        "east": 294,
-        "west": 292
-      },
       "weight": 1,
-      "id": 293,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 294, "name": "Main Street",
+      "exits": { "east": 295, "west": 293 },
       "environment": -1,
-      "exits": {
-        "east": 295,
-        "west": 293
-      },
       "weight": 1,
-      "id": 294,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 295, "name": "Main Street",
+      "exits": { "east": 296, "west": 294 },
       "environment": -1,
-      "exits": {
-        "east": 296,
-        "west": 294
-      },
       "weight": 1,
-      "id": 295,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Main Street",
+      "id": 296, "name": "Main Street",
+      "exits": { "east": 297, "west": 295 },
       "environment": -1,
-      "exits": {
-        "east": 297,
-        "west": 295
-      },
       "weight": 1,
-      "id": 296,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Corigan Court Intersection",
+      "id": 297, "name": "Corigan Court Intersection",
+      "exits": { "west": 296 },
       "environment": -1,
-      "exits": {
-        "west": 296
-      },
       "weight": 1,
-      "id": 297,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "City Hall",
+      "id": 298, "name": "City Hall",
+      "exits": { "north": 291 },
       "environment": -1,
-      "exits": {
-        "north": 291
-      },
       "weight": 1,
-      "id": 298,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Eithel Sirion",
+      "id": 299, "name": "Eithel Sirion",
+      "exits": { "south": 300, "north": 290 },
       "environment": -1,
-      "exits": {
-        "south": 300,
-        "north": 290
-      },
       "weight": 1,
-      "id": 299,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 300, "name": "Brapnor Road",
+      "exits": { "south": 301, "west": 302, "east": 385, "north": 299 },
       "environment": -1,
-      "exits": {
-        "south": 301,
-        "west": 302,
-        "east": 385,
-        "north": 299
-      },
       "weight": 1,
-      "id": 300,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Frenchie's II",
+      "id": 301, "name": "Frenchie's II",
+      "exits": { "north": 300 },
       "environment": -1,
-      "exits": {
-        "north": 300
-      },
       "weight": 1,
-      "id": 301,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 302, "name": "Brapnor Road",
+      "exits": { "west": 303, "east": 300, "south": 392 },
       "environment": -1,
-      "exits": {
-        "west": 303,
-        "east": 300,
-        "south": 392
-      },
       "weight": 1,
-      "id": 302,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Middle of Brapnor Road",
+      "id": 303, "name": "Middle of Brapnor Road",
+      "exits": { "west": 304, "east": 302, "south": 329 },
       "environment": -1,
-      "exits": {
-        "west": 304,
-        "east": 302,
-        "south": 329
-      },
       "weight": 1,
-      "id": 303,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 304, "name": "Brapnor Road",
+      "exits": { "west": 305, "east": 303, "north": 330 },
       "environment": -1,
-      "exits": {
-        "west": 305,
-        "east": 303,
-        "north": 330
-      },
       "weight": 1,
-      "id": 304,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 305, "name": "Brapnor Road",
+      "exits": { "west": 306, "east": 304, "north": 393 },
       "environment": -1,
-      "exits": {
-        "west": 306,
-        "east": 304,
-        "north": 393
-      },
       "weight": 1,
-      "id": 305,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 306, "name": "Brapnor Road",
+      "exits": { "east": 305, "west": 307 },
       "environment": -1,
-      "exits": {
-        "east": 305,
-        "west": 307
-      },
       "weight": 1,
-      "id": 306,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "End of Brapnor Road",
+      "id": 307, "name": "End of Brapnor Road",
+      "exits": { "east": 306, "northwest": 331, "south": 308 },
       "environment": -1,
-      "exits": {
-        "east": 306,
-        "northwest": 331,
-        "south": 308
-      },
       "weight": 1,
-      "id": 307,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Beginning of Lilu Lane",
+      "id": 308, "name": "Beginning of Lilu Lane",
+      "exits": { "south": 309, "north": 307 },
       "environment": -1,
-      "exits": {
-        "south": 309,
-        "north": 307
-      },
       "weight": 1,
-      "id": 308,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Lilu Lane",
+      "id": 309, "name": "Lilu Lane",
+      "exits": { "south": 310, "north": 308 },
       "environment": -1,
-      "exits": {
-        "south": 310,
-        "north": 308
-      },
       "weight": 1,
-      "id": 309,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Middle of Lilu Lane",
+      "id": 310, "name": "Middle of Lilu Lane",
+      "exits": { "west": 355, "south": 311, "north": 309 },
       "environment": -1,
-      "exits": {
-        "west": 355,
-        "south": 311,
-        "north": 309
-      },
       "weight": 1,
-      "id": 310,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Lilu Lane",
+      "id": 311, "name": "Lilu Lane",
+      "exits": { "south": 312, "north": 310 },
       "environment": -1,
-      "exits": {
-        "south": 312,
-        "north": 310
-      },
       "weight": 1,
-      "id": 311,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "End of Lilu Lane",
+      "id": 312, "name": "End of Lilu Lane",
+      "exits": { "west": 354, "south": 313, "north": 311 },
       "environment": -1,
-      "exits": {
-        "west": 354,
-        "south": 313,
-        "north": 311
-      },
       "weight": 1,
-      "id": 312,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Beginning of Embassy Row",
+      "id": 313, "name": "Beginning of Embassy Row",
+      "exits": { "east": 314, "north": 312 },
       "environment": -1,
-      "exits": {
-        "east": 314,
-        "north": 312
-      },
       "weight": 1,
-      "id": 313,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Embassy Row",
+      "id": 314, "name": "Embassy Row",
+      "exits": { "west": 313, "east": 315, "south": 322 },
       "environment": -1,
-      "exits": {
-        "west": 313,
-        "east": 315,
-        "south": 322
-      },
       "weight": 1,
-      "id": 314,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Embassy Row",
+      "id": 315, "name": "Embassy Row",
+      "exits": { "south": 320, "west": 314, "east": 316, "north": 321 },
       "environment": -1,
-      "exits": {
-        "south": 320,
-        "west": 314,
-        "east": 316,
-        "north": 321
-      },
       "weight": 1,
-      "id": 315,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Embassy Row",
+      "id": 316, "name": "Embassy Row",
+      "exits": { "south": 318, "west": 315, "east": 317, "north": 319 },
       "environment": -1,
-      "exits": {
-        "south": 318,
-        "west": 315,
-        "east": 317,
-        "north": 319
-      },
       "weight": 1,
-      "id": 316,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Embassy Row",
+      "id": 317, "name": "Embassy Row",
+      "exits": { "west": 316, "east": 323, "north": 333 },
       "environment": -1,
-      "exits": {
-        "west": 316,
-        "east": 323,
-        "north": 333
-      },
       "weight": 1,
-      "id": 317,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A Dark Hole in the Ground",
+      "id": 318, "name": "A Dark Hole in the Ground",
+      "exits": { "north": 316 },
       "environment": -1,
-      "exits": {
-        "north": 316
-      },
       "weight": 1,
-      "id": 318,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Guard Post for Gnome Embassy",
+      "id": 319, "name": "Guard Post for Gnome Embassy",
+      "exits": { "south": 316, "north": 926 },
       "environment": -1,
-      "exits": {
-        "south": 316,
-        "north": 926
-      },
       "weight": 1,
-      "id": 319,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Before a round door",
+      "id": 320, "name": "Before a round door",
+      "exits": { "north": 315 },
       "environment": -1,
-      "exits": {
-        "north": 315
-      },
       "weight": 1,
-      "id": 320,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Junk yard",
+      "id": 321, "name": "Junk yard",
+      "exits": { "south": 315 },
       "environment": -1,
-      "exits": {
-        "south": 315
-      },
       "weight": 1,
-      "id": 321,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Elven Embassy checkpoint",
+      "id": 322, "name": "Elven Embassy checkpoint",
+      "exits": { "north": 314 },
       "environment": -1,
-      "exits": {
-        "north": 314
-      },
       "weight": 1,
-      "id": 322,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "End of Embassy Row",
+      "id": 323, "name": "End of Embassy Row",
+      "exits": { "west": 317, "north": 324 },
       "environment": -1,
-      "exits": {
-        "west": 317,
-        "north": 324
-      },
       "weight": 1,
-      "id": 323,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern end of alley",
+      "id": 324, "name": "Southern end of alley",
+      "exits": { "south": 323, "north": 325 },
       "environment": -1,
-      "exits": {
-        "south": 323,
-        "north": 325
-      },
       "weight": 1,
-      "id": 324,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Bend in an alley",
+      "id": 325, "name": "Bend in an alley",
+      "exits": { "west": 326, "south": 324 },
       "environment": -1,
-      "exits": {
-        "west": 326,
-        "south": 324
-      },
       "weight": 1,
-      "id": 325,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A bend in the alley",
+      "id": 326, "name": "A bend in the alley",
+      "exits": { "east": 325, "north": 327 },
       "environment": -1,
-      "exits": {
-        "east": 325,
-        "north": 327
-      },
       "weight": 1,
-      "id": 326,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dark and narrow alley",
+      "id": 327, "name": "Dark and narrow alley",
+      "exits": { "south": 326, "north": 328 },
       "environment": -1,
-      "exits": {
-        "south": 326,
-        "north": 328
-      },
       "weight": 1,
-      "id": 327,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dark alley",
+      "id": 328, "name": "Dark alley",
+      "exits": { "south": 327, "north": 329 },
       "environment": -1,
-      "exits": {
-        "south": 327,
-        "north": 329
-      },
       "weight": 1,
-      "id": 328,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Alley entrance",
+      "id": 329, "name": "Alley entrance",
+      "exits": { "south": 328, "north": 303 },
       "environment": -1,
-      "exits": {
-        "south": 328,
-        "north": 303
-      },
       "weight": 1,
-      "id": 329,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "The Excalibur, a closed guild",
+      "id": 330, "name": "The Excalibur, a closed guild",
+      "exits": { "south": 304, "north": 287 },
       "environment": -1,
-      "exits": {
-        "south": 304,
-        "north": 287
-      },
       "weight": 1,
-      "id": 330,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Foyer of the Exedorian Inn",
+      "id": 331, "name": "Foyer of the Exedorian Inn",
+      "exits": { "southeast": 307, "west": 332 },
       "environment": -1,
-      "exits": {
-        "southeast": 307,
-        "west": 332
-      },
       "weight": 1,
-      "id": 331,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Exedorian saloon",
+      "id": 332, "name": "Exedorian saloon",
+      "exits": { "east": 331 },
       "environment": -1,
-      "exits": {
-        "east": 331
-      },
       "weight": 1,
-      "id": 332,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Before the Dwarven Embassy",
+      "id": 333, "name": "Before the Dwarven Embassy",
+      "exits": { "south": 317, "north": 920 },
       "environment": -1,
-      "exits": {
-        "south": 317,
-        "north": 920
-      },
       "weight": 1,
-      "id": 333,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street West",
+      "id": 334, "name": "Keen Street West",
+      "exits": { "east": 335 },
       "environment": -1,
-      "exits": {
-        "east": 335
-      },
       "weight": 1,
-      "id": 334,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street",
+      "id": 335, "name": "Keen Street",
+      "exits": { "east": 336, "west": 334 },
       "environment": -1,
-      "exits": {
-        "east": 336,
-        "west": 334
-      },
       "weight": 1,
-      "id": 335,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street",
+      "id": 336, "name": "Keen Street",
+      "exits": { "west": 335, "east": 337, "north": 602 },
       "environment": -1,
-      "exits": {
-        "west": 335,
-        "east": 337,
-        "north": 602
-      },
       "weight": 1,
-      "id": 336,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street",
+      "id": 337, "name": "Keen Street",
+      "exits": { "west": 336, "east": 338, "south": 603 },
       "environment": -1,
-      "exits": {
-        "west": 336,
-        "east": 338,
-        "south": 603
-      },
       "weight": 1,
-      "id": 337,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "East Keen Street Bridge",
+      "id": 338, "name": "East Keen Street Bridge",
+      "exits": { "west": 337, "east": 339, "north": 604 },
       "environment": -1,
-      "exits": {
-        "west": 337,
-        "east": 339,
-        "north": 604
-      },
       "weight": 1,
-      "id": 338,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street Bridge",
+      "id": 339, "name": "Keen Street Bridge",
+      "exits": { "east": 340, "west": 338 },
       "environment": -1,
-      "exits": {
-        "east": 340,
-        "west": 338
-      },
       "weight": 1,
-      "id": 339,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street",
+      "id": 340, "name": "Keen Street",
+      "exits": { "west": 339, "east": 341, "south": 343 },
       "environment": -1,
-      "exits": {
-        "west": 339,
-        "east": 341,
-        "south": 343
-      },
       "weight": 1,
-      "id": 340,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Keen Street East",
+      "id": 341, "name": "Keen Street East",
+      "exits": { "west": 340, "north": 342 },
       "environment": -1,
-      "exits": {
-        "west": 340,
-        "north": 342
-      },
       "weight": 1,
-      "id": 341,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Guard Post",
+      "id": 342, "name": "Guard Post",
+      "exits": { "south": 341, "north": 350 },
       "environment": -1,
-      "exits": {
-        "south": 341,
-        "north": 350
-      },
       "weight": 1,
-      "id": 342,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Statued lawn",
+      "id": 343, "name": "Statued lawn",
+      "exits": { "south": 344, "north": 340 },
       "environment": -1,
-      "exits": {
-        "south": 344,
-        "north": 340
-      },
       "weight": 1,
-      "id": 343,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Statued lawn",
+      "id": 344, "name": "Statued lawn",
+      "exits": { "south": 345, "north": 343 },
       "environment": -1,
-      "exits": {
-        "south": 345,
-        "north": 343
-      },
       "weight": 1,
-      "id": 344,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Manicured lawn",
+      "id": 345, "name": "Manicured lawn",
+      "exits": { "south": 346, "north": 344 },
       "environment": -1,
-      "exits": {
-        "south": 346,
-        "north": 344
-      },
       "weight": 1,
-      "id": 345,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Cavernous foyer",
+      "id": 346, "name": "Cavernous foyer",
+      "exits": { "west": 348, "east": 347, "north": 345 },
       "environment": -1,
-      "exits": {
-        "west": 348,
-        "east": 347,
-        "north": 345
-      },
       "weight": 1,
-      "id": 346,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Icy room",
+      "id": 347, "name": "Icy room",
+      "exits": { "west": 346 },
       "environment": -1,
-      "exits": {
-        "west": 346
-      },
       "weight": 1,
-      "id": 347,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Cold hallway",
+      "id": 348, "name": "Cold hallway",
+      "exits": { "east": 346, "south": 349 },
       "environment": -1,
-      "exits": {
-        "east": 346,
-        "south": 349
-      },
       "weight": 1,
-      "id": 348,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Snowy cave",
+      "id": 349, "name": "Snowy cave",
+      "exits": { "north": 348 },
       "environment": -1,
-      "exits": {
-        "north": 348
-      },
       "weight": 1,
-      "id": 349,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "With no gate guard present, you are able to enter the walled estate",
+      "id": 350, "name": "With no gate guard present, you are able to enter the walled estate",
+      "exits": { "south": 342, "north": 351 },
       "environment": -1,
-      "exits": {
-        "south": 342,
-        "north": 351
-      },
       "weight": 1,
-      "id": 350,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Foyer",
+      "id": 351, "name": "Foyer",
+      "exits": { "east": 352, "south": 350 },
       "environment": -1,
-      "exits": {
-        "east": 352,
-        "south": 350
-      },
       "weight": 1,
-      "id": 351,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Wood-paneled Hallway",
+      "id": 352, "name": "Wood-paneled Hallway",
+      "exits": { "west": 351, "north": 353 },
       "environment": -1,
-      "exits": {
-        "west": 351,
-        "north": 353
-      },
       "weight": 1,
-      "id": 352,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Busy Kitchen",
+      "id": 353, "name": "Busy Kitchen",
+      "exits": { "south": 352 },
       "environment": -1,
-      "exits": {
-        "south": 352
-      },
       "weight": 1,
-      "id": 353,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Mom's General Store",
+      "id": 354, "name": "Mom's General Store",
+      "exits": { "east": 312 },
       "environment": -1,
-      "exits": {
-        "east": 312
-      },
       "weight": 1,
-      "id": 354,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Drawbridge",
+      "id": 355, "name": "Drawbridge",
+      "exits": { "east": 310, "west": 356 },
       "environment": -1,
-      "exits": {
-        "east": 310,
-        "west": 356
-      },
       "weight": 1,
-      "id": 355,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Library's entrance",
+      "id": 356, "name": "Library's entrance",
+      "exits": { "south": 357, "west": 361, "east": 355, "north": 362 },
       "environment": -1,
-      "exits": {
-        "south": 357,
-        "west": 361,
-        "east": 355,
-        "north": 362
-      },
       "weight": 1,
-      "id": 356,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Cobblestoned hallway",
+      "id": 357, "name": "Cobblestoned hallway",
+      "exits": { "south": 358, "east": 360, "north": 356 },
       "environment": -1,
-      "exits": {
-        "south": 358,
-        "east": 360,
-        "north": 356
-      },
       "weight": 1,
-      "id": 357,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A bend in the hallway",
+      "id": 358, "name": "A bend in the hallway",
+      "exits": { "west": 359, "north": 357 },
       "environment": -1,
-      "exits": {
-        "west": 359,
-        "north": 357
-      },
       "weight": 1,
-      "id": 358,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A monk's cell",
+      "id": 359, "name": "A monk's cell",
+      "exits": { "east": 358 },
       "environment": -1,
-      "exits": {
-        "east": 358
-      },
       "weight": 1,
-      "id": 359,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A monk's cell",
+      "id": 360, "name": "A monk's cell",
+      "exits": { "west": 357 },
       "environment": -1,
-      "exits": {
-        "west": 357
-      },
       "weight": 1,
-      "id": 360,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
+      "id": 361, "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
+      "exits": { "east": 356 },
       "environment": -1,
-      "exits": {
-        "east": 356
-      },
       "weight": 1,
-      "id": 361,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Cobblestoned hallway",
+      "id": 362, "name": "Cobblestoned hallway",
+      "exits": { "south": 356, "east": 363, "north": 364 },
       "environment": -1,
-      "exits": {
-        "south": 356,
-        "east": 363,
-        "north": 364
-      },
       "weight": 1,
-      "id": 362,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A monk's cell",
+      "id": 363, "name": "A monk's cell",
+      "exits": { "west": 362 },
       "environment": -1,
-      "exits": {
-        "west": 362
-      },
       "weight": 1,
-      "id": 363,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A bend in the hallway",
+      "id": 364, "name": "A bend in the hallway",
+      "exits": { "west": 365, "south": 362 },
       "environment": -1,
-      "exits": {
-        "west": 365,
-        "south": 362
-      },
       "weight": 1,
-      "id": 364,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "A monk's cell",
+      "id": 365, "name": "A monk's cell",
+      "exits": { "east": 364 },
       "environment": -1,
-      "exits": {
-        "east": 364
-      },
       "weight": 1,
-      "id": 365,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "The Cadaver Emporium",
+      "id": 366, "name": "The Cadaver Emporium",
+      "exits": { "north": 289 },
       "environment": -1,
-      "exits": {
-        "north": 289
-      },
       "weight": 1,
-      "id": 366,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Velvet Unicorn",
+      "id": 367, "name": "Velvet Unicorn",
+      "exits": { "south": 288 },
       "environment": -1,
-      "exits": {
-        "south": 288
-      },
       "weight": 1,
-      "id": 367,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Eidolon Warlords",
+      "id": 368, "name": "Eidolon Warlords",
+      "exits": { "north": 288 },
       "environment": -1,
-      "exits": {
-        "north": 288
-      },
       "weight": 1,
-      "id": 368,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "id": 369, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 290 },
       "environment": -1,
-      "exits": {
-        "south": 290
-      },
       "weight": 1,
-      "id": 369,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Beginning of park path",
+      "id": 370, "name": "Beginning of park path",
+      "exits": { "south": 291, "north": 371 },
       "environment": -1,
-      "exits": {
-        "south": 291,
-        "north": 371
-      },
       "weight": 1,
-      "id": 370,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Park path intersection",
+      "id": 371, "name": "Park path intersection",
+      "exits": { "south": 370, "west": 372, "east": 378, "north": 373 },
       "environment": -1,
-      "exits": {
-        "south": 370,
-        "west": 372,
-        "east": 378,
-        "north": 373
-      },
       "weight": 1,
-      "id": 371,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Exedoria Pet Cemetary",
+      "id": 372, "name": "Exedoria Pet Cemetary",
+      "exits": { "east": 371 },
       "environment": -1,
-      "exits": {
-        "east": 371
-      },
       "weight": 1,
-      "id": 372,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Park path on the hill",
+      "id": 373, "name": "Park path on the hill",
+      "exits": { "south": 371, "north": 374 },
       "environment": -1,
-      "exits": {
-        "south": 371,
-        "north": 374
-      },
       "weight": 1,
-      "id": 373,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Elevated park path",
+      "id": 374, "name": "Elevated park path",
+      "exits": { "south": 373, "north": 375 },
       "environment": -1,
-      "exits": {
-        "south": 373,
-        "north": 375
-      },
       "weight": 1,
-      "id": 374,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "End of park path",
+      "id": 375, "name": "End of park path",
+      "exits": { "east": 376, "south": 374 },
       "environment": -1,
-      "exits": {
-        "east": 376,
-        "south": 374
-      },
       "weight": 1,
-      "id": 375,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Temple ruins",
+      "id": 376, "name": "Temple ruins",
+      "exits": { "east": 377, "west": 375 },
       "environment": -1,
-      "exits": {
-        "east": 377,
-        "west": 375
-      },
       "weight": 1,
-      "id": 376,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Temple rotunda",
+      "id": 377, "name": "Temple rotunda",
+      "exits": { "west": 376 },
       "environment": -1,
-      "exits": {
-        "west": 376
-      },
       "weight": 1,
-      "id": 377,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gravel path to the mansion",
+      "id": 378, "name": "Gravel path to the mansion",
+      "exits": { "east": 379, "west": 371 },
       "environment": -1,
-      "exits": {
-        "east": 379,
-        "west": 371
-      },
       "weight": 1,
-      "id": 378,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gravel path on the hill",
+      "id": 379, "name": "Gravel path on the hill",
+      "exits": { "east": 380, "west": 378 },
       "environment": -1,
-      "exits": {
-        "east": 380,
-        "west": 378
-      },
       "weight": 1,
-      "id": 379,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Intersection in the gravel path",
+      "id": 380, "name": "Intersection in the gravel path",
+      "exits": { "west": 379, "southeast": 382, "north": 381 },
       "environment": -1,
-      "exits": {
-        "west": 379,
-        "southeast": 382,
-        "north": 381
-      },
       "weight": 1,
-      "id": 380,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Before a white mansion",
+      "id": 381, "name": "Before a white mansion",
+      "exits": { "south": 380 },
       "environment": -1,
-      "exits": {
-        "south": 380
-      },
       "weight": 1,
-      "id": 381,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Outside the cemetery gate",
+      "id": 382, "name": "Outside the cemetery gate",
+      "exits": { "northwest": 380 },
       "environment": -1,
-      "exits": {
-        "northwest": 380
-      },
       "weight": 1,
-      "id": 382,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Guard Post",
+      "id": 383, "name": "Guard Post",
+      "exits": { "south": 384, "north": 292 },
       "environment": -1,
-      "exits": {
-        "south": 384,
-        "north": 292
-      },
       "weight": 1,
-      "id": 383,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Beginning of Brapnor Road",
+      "id": 384, "name": "Beginning of Brapnor Road",
+      "exits": { "west": 385, "southeast": 386, "north": 383 },
       "environment": -1,
-      "exits": {
-        "west": 385,
-        "southeast": 386,
-        "north": 383
-      },
       "weight": 1,
-      "id": 384,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brapnor Road",
+      "id": 385, "name": "Brapnor Road",
+      "exits": { "east": 384, "west": 300 },
       "environment": -1,
-      "exits": {
-        "east": 384,
-        "west": 300
-      },
       "weight": 1,
-      "id": 385,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Necrom's Gate",
+      "id": 386, "name": "Necrom's Gate",
+      "exits": { "northwest": 384, "southeast": 387 },
       "environment": -1,
-      "exits": {
-        "northwest": 384,
-        "southeast": 387
-      },
       "weight": 1,
-      "id": 386,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Paved intersection",
+      "id": 387, "name": "Paved intersection",
+      "exits": { "east": 388, "northwest": 386, "south": 527 },
       "environment": -1,
-      "exits": {
-        "east": 388,
-        "northwest": 386,
-        "south": 527
-      },
       "weight": 1,
-      "id": 387,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Eastern path through the University",
+      "id": 388, "name": "Eastern path through the University",
+      "exits": { "east": 389, "west": 387 },
       "environment": -1,
-      "exits": {
-        "east": 389,
-        "west": 387
-      },
       "weight": 1,
-      "id": 388,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Eastern path through the University",
+      "id": 389, "name": "Eastern path through the University",
+      "exits": { "east": 390, "west": 388 },
       "environment": -1,
-      "exits": {
-        "east": 390,
-        "west": 388
-      },
       "weight": 1,
-      "id": 389,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "In front of a temporary building",
+      "id": 390, "name": "In front of a temporary building",
+      "exits": { "west": 389, "east": 391, "south": 904 },
       "environment": -1,
-      "exits": {
-        "west": 389,
-        "east": 391,
-        "south": 904
-      },
       "weight": 1,
-      "id": 390,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Construction site",
+      "id": 391, "name": "Construction site",
+      "exits": { "west": 390 },
       "environment": -1,
-      "exits": {
-        "west": 390
-      },
       "weight": 1,
-      "id": 391,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Delilah's Deli",
+      "id": 392, "name": "Delilah's Deli",
+      "exits": { "north": 302 },
       "environment": -1,
-      "exits": {
-        "north": 302
-      },
       "weight": 1,
-      "id": 392,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Guard Tower Entrance",
+      "id": 393, "name": "Guard Tower Entrance",
+      "exits": { "south": 305 },
       "environment": -1,
-      "exits": {
-        "south": 305
-      },
       "weight": 1,
-      "id": 393,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Smoke House",
+      "id": 394, "name": "Smoke House",
+      "exits": { "south": 210 },
       "environment": -1,
-      "exits": {
-        "south": 210
-      },
       "weight": 1,
-      "id": 394,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The Lathe",
+      "id": 395, "name": "The Lathe",
+      "exits": { "south": 209 },
       "environment": -1,
-      "exits": {
-        "south": 209
-      },
       "weight": 1,
-      "id": 395,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Antique Shop",
+      "id": 396, "name": "Antique Shop",
+      "exits": { "south": 208 },
       "environment": -1,
-      "exits": {
-        "south": 208
-      },
       "weight": 1,
-      "id": 396,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Mage's House",
+      "id": 397, "name": "Mage's House",
+      "exits": { "east": 398, "south": 206 },
       "environment": -1,
-      "exits": {
-        "east": 398,
-        "south": 206
-      },
       "weight": 1,
-      "id": 397,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Mage's Apprentice House",
+      "id": 398, "name": "Mage's Apprentice House",
+      "exits": { "west": 397 },
       "environment": -1,
-      "exits": {
-        "west": 397
-      },
       "weight": 1,
-      "id": 398,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Retired Warrior's House",
+      "id": 399, "name": "Retired Warrior's House",
+      "exits": { "up": 734, "west": 213 },
       "environment": -1,
-      "exits": {
-        "up": 734,
-        "west": 213
-      },
       "weight": 1,
-      "id": 399,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Bell maker's shop",
+      "id": 400, "name": "Bell maker's shop",
+      "exits": { "east": 214 },
       "environment": -1,
-      "exits": {
-        "east": 214
-      },
       "weight": 1,
-      "id": 400,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Candle Shop",
+      "id": 401, "name": "Candle Shop",
+      "exits": { "west": 214 },
       "environment": -1,
-      "exits": {
-        "west": 214
-      },
       "weight": 1,
-      "id": 401,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Do-it-Yourself Distiller",
+      "id": 402, "name": "Do-it-Yourself Distiller",
+      "exits": { "east": 216 },
       "environment": -1,
-      "exits": {
-        "east": 216
-      },
       "weight": 1,
-      "id": 402,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Entrance to a temple",
+      "id": 403, "name": "Entrance to a temple",
+      "exits": { "east": 404, "west": 216 },
       "environment": -1,
-      "exits": {
-        "east": 404,
-        "west": 216
-      },
       "weight": 1,
-      "id": 403,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Temple of Amaterasu",
+      "id": 404, "name": "Temple of Amaterasu",
+      "exits": { "east": 405, "west": 403 },
       "environment": -1,
-      "exits": {
-        "east": 405,
-        "west": 403
-      },
       "weight": 1,
-      "id": 404,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Temple of Amaterasu",
+      "id": 405, "name": "Temple of Amaterasu",
+      "exits": { "west": 404, "south": 407, "north": 406 },
       "environment": -1,
-      "exits": {
-        "west": 404,
-        "south": 407,
-        "north": 406
-      },
       "weight": 1,
-      "id": 405,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Candle Room",
+      "id": 406, "name": "Candle Room",
+      "exits": { "south": 405 },
       "environment": -1,
-      "exits": {
-        "south": 405
-      },
       "weight": 1,
-      "id": 406,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Quiet Room",
+      "id": 407, "name": "Quiet Room",
+      "exits": { "north": 405 },
       "environment": -1,
-      "exits": {
-        "north": 405
-      },
       "weight": 1,
-      "id": 407,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "MD Banking",
+      "id": 408, "name": "MD Banking",
+      "exits": { "east": 217 },
       "environment": -1,
-      "exits": {
-        "east": 217
-      },
       "weight": 1,
-      "id": 408,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Bounty Room",
+      "id": 409, "name": "Bounty Room",
+      "exits": { "east": 219 },
       "environment": -1,
-      "exits": {
-        "east": 219
-      },
       "weight": 1,
-      "id": 409,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A dingy alleyway",
+      "id": 410, "name": "A dingy alleyway",
+      "exits": { "west": 411, "south": 122, "north": 792 },
       "environment": -1,
-      "exits": {
-        "west": 411,
-        "south": 122,
-        "north": 792
-      },
       "weight": 1,
-      "id": 410,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Vesla Times Press Office",
+      "id": 411, "name": "Vesla Times Press Office",
+      "exits": { "east": 410, "south": 123 },
       "environment": -1,
-      "exits": {
-        "east": 410,
-        "south": 123
-      },
       "weight": 1,
-      "id": 411,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Smithy",
+      "id": 412, "name": "Smithy",
+      "exits": { "west": 160, "south": 124 },
       "environment": -1,
-      "exits": {
-        "west": 160,
-        "south": 124
-      },
       "weight": 1,
-      "id": 412,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Hawaiian Ryan's",
+      "id": 413, "name": "Hawaiian Ryan's",
+      "exits": { "east": 238, "north": 414 },
       "environment": -1,
-      "exits": {
-        "east": 238,
-        "north": 414
-      },
       "weight": 1,
-      "id": 413,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad",
+      "id": 414, "name": "Beitel Straad",
+      "exits": { "south": 413, "west": 1147, "east": 239, "north": 415 },
       "environment": -1,
-      "exits": {
-        "south": 413,
-        "west": 1147,
-        "east": 239,
-        "north": 415
-      },
       "weight": 1,
-      "id": 414,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Club Femme Nu",
+      "id": 415, "name": "Club Femme Nu",
+      "exits": { "east": 240, "south": 414 },
       "environment": -1,
-      "exits": {
-        "east": 240,
-        "south": 414
-      },
       "weight": 1,
-      "id": 415,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "City Unemployment Office",
+      "id": 416, "name": "City Unemployment Office",
+      "exits": { "south": 1203, "west": 417, "east": 241, "north": 418 },
       "environment": -1,
-      "exits": {
-        "south": 1203,
-        "west": 417,
-        "east": 241,
-        "north": 418
-      },
       "weight": 1,
-      "id": 416,
-      "area": {
-        "id": 23
-      }
+      "area": {"id": 23}
     },
     {
-      "name": "City Unemployment Office",
+      "id": 417, "name": "City Unemployment Office",
+      "exits": { "east": 416 },
       "environment": -1,
-      "exits": {
-        "east": 416
-      },
       "weight": 1,
-      "id": 417,
-      "area": {
-        "id": 23
-      }
+      "area": {"id": 23}
     },
     {
-      "name": "City Unemployment Office",
+      "id": 418, "name": "City Unemployment Office",
+      "exits": { "south": 416 },
       "environment": -1,
-      "exits": {
-        "south": 416
-      },
       "weight": 1,
-      "id": 418,
-      "area": {
-        "id": 23
-      }
+      "area": {"id": 23}
     },
     {
-      "name": "A dark alleyway",
+      "id": 419, "name": "A dark alleyway",
+      "exits": { "north": 129 },
       "environment": -1,
-      "exits": {
-        "north": 129
-      },
       "weight": 1,
-      "id": 419,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The Old Temple",
+      "id": 420, "name": "The Old Temple",
+      "exits": { "north": 130 },
       "environment": -1,
-      "exits": {
-        "north": 130
-      },
       "weight": 1,
-      "id": 420,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Mage's Guild",
+      "id": 421, "name": "Mage's Guild",
+      "exits": { "north": 132 },
       "environment": -1,
-      "exits": {
-        "north": 132
-      },
       "weight": 1,
-      "id": 421,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Mercantile Guild Office",
+      "id": 422, "name": "Mercantile Guild Office",
+      "exits": { "east": 837, "west": 155 },
       "environment": -1,
-      "exits": {
-        "east": 837,
-        "west": 155
-      },
       "weight": 1,
-      "id": 422,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Glassblower",
+      "id": 423, "name": "Glassblower",
+      "exits": { "east": 155 },
       "environment": -1,
-      "exits": {
-        "east": 155
-      },
       "weight": 1,
-      "id": 423,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Fighter's Guild",
+      "id": 424, "name": "Fighter's Guild",
+      "exits": { "west": 156 },
       "environment": -1,
-      "exits": {
-        "west": 156
-      },
       "weight": 1,
-      "id": 424,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Omar's Oils II",
+      "id": 425, "name": "Omar's Oils II",
+      "exits": { "south": 121 },
       "environment": -1,
-      "exits": {
-        "south": 121
-      },
       "weight": 1,
-      "id": 425,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Deora's Outfitters",
+      "id": 426, "name": "Deora's Outfitters",
+      "exits": { "south": 231 },
       "environment": -1,
-      "exits": {
-        "south": 231
-      },
       "weight": 1,
-      "id": 426,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The Rabbit's Hole",
+      "id": 427, "name": "The Rabbit's Hole",
+      "exits": { "west": 64, "north": 94 },
       "environment": -1,
-      "exits": {
-        "west": 64,
-        "north": 94
-      },
       "weight": 1,
-      "id": 427,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "6 Feet Under",
+      "id": 428, "name": "6 Feet Under",
+      "exits": { "west": 977, "south": 97 },
       "environment": -1,
-      "exits": {
-        "west": 977,
-        "south": 97
-      },
       "weight": 1,
-      "id": 428,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Morbid Curiosity",
+      "id": 429, "name": "Morbid Curiosity",
+      "exits": { "east": 64, "north": 72 },
       "environment": -1,
-      "exits": {
-        "east": 64,
-        "north": 72
-      },
       "weight": 1,
-      "id": 429,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Scribe",
+      "id": 430, "name": "Scribe",
+      "exits": { "east": 65 },
       "environment": -1,
-      "exits": {
-        "east": 65
-      },
       "weight": 1,
-      "id": 430,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Servants Quarters",
+      "id": 431, "name": "Servants Quarters",
+      "exits": { "west": 68 },
       "environment": -1,
-      "exits": {
-        "west": 68
-      },
       "weight": 1,
-      "id": 431,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Bridge",
+      "id": 432, "name": "Bridge",
+      "exits": { "west": 433 },
       "environment": -1,
-      "exits": {
-        "west": 433
-      },
       "weight": 1,
-      "id": 432,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Waterfall",
+      "id": 433, "name": "Waterfall",
+      "exits": { "east": 432 },
       "environment": -1,
-      "exits": {
-        "east": 432
-      },
       "weight": 1,
-      "id": 433,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "",
+      "id": 434, "name": "",
+      "exits": { "north": 435 },
       "environment": -1,
-      "exits": {
-        "north": 435
-      },
       "weight": 1,
-      "id": 434,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 435, "name": "Canopy Trail",
+      "exits": { "west": 436, "south": 434 },
       "environment": -1,
-      "exits": {
-        "west": 436,
-        "south": 434
-      },
       "weight": 1,
-      "id": 435,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 436, "name": "Canopy Trail",
+      "exits": { "east": 435, "west": 437 },
       "environment": -1,
-      "exits": {
-        "east": 435,
-        "west": 437
-      },
       "weight": 1,
-      "id": 436,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 437, "name": "Canopy Trail",
+      "exits": { "east": 436, "west": 438 },
       "environment": -1,
-      "exits": {
-        "east": 436,
-        "west": 438
-      },
       "weight": 1,
-      "id": 437,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 438, "name": "Canopy Trail",
+      "exits": { "west": 439, "east": 437, "south": 440 },
       "environment": -1,
-      "exits": {
-        "west": 439,
-        "east": 437,
-        "south": 440
-      },
       "weight": 1,
-      "id": 438,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 439, "name": "Canopy Trail",
+      "exits": { "east": 438, "west": 445 },
       "environment": -1,
-      "exits": {
-        "east": 438,
-        "west": 445
-      },
       "weight": 1,
-      "id": 439,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 440, "name": "Nature Preserve",
+      "exits": { "south": 441, "north": 438 },
       "environment": -1,
-      "exits": {
-        "south": 441,
-        "north": 438
-      },
       "weight": 1,
-      "id": 440,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Tropical Forest",
+      "id": 441, "name": "Tropical Forest",
+      "exits": { "south": 442, "north": 440 },
       "environment": -1,
-      "exits": {
-        "south": 442,
-        "north": 440
-      },
       "weight": 1,
-      "id": 441,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 442, "name": "Nature Preserve",
+      "exits": { "west": 443, "east": 444, "north": 441 },
       "environment": -1,
-      "exits": {
-        "west": 443,
-        "east": 444,
-        "north": 441
-      },
       "weight": 1,
-      "id": 442,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Bird Sanctuary",
+      "id": 443, "name": "Bird Sanctuary",
+      "exits": { "east": 442 },
       "environment": -1,
-      "exits": {
-        "east": 442
-      },
       "weight": 1,
-      "id": 443,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 444, "name": "Nature Preserve",
+      "exits": { "west": 442 },
       "environment": -1,
-      "exits": {
-        "west": 442
-      },
       "weight": 1,
-      "id": 444,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 445, "name": "Canopy Trail",
+      "exits": { "west": 496, "east": 439, "north": 446 },
       "environment": -1,
-      "exits": {
-        "west": 496,
-        "east": 439,
-        "north": 446
-      },
       "weight": 1,
-      "id": 445,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Entrance to Queen's Meadow",
+      "id": 446, "name": "Entrance to Queen's Meadow",
+      "exits": { "south": 445, "north": 447 },
       "environment": -1,
-      "exits": {
-        "south": 445,
-        "north": 447
-      },
       "weight": 1,
-      "id": 446,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 447, "name": "Queen's Meadow",
+      "exits": { "south": 446, "north": 448 },
       "environment": -1,
-      "exits": {
-        "south": 446,
-        "north": 448
-      },
       "weight": 1,
-      "id": 447,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 448, "name": "Queen's Meadow",
+      "exits": { "south": 447, "north": 449 },
       "environment": -1,
-      "exits": {
-        "south": 447,
-        "north": 449
-      },
       "weight": 1,
-      "id": 448,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 449, "name": "Queen's Meadow",
+      "exits": { "west": 450, "south": 448, "north": 494 },
       "environment": -1,
-      "exits": {
-        "west": 450,
-        "south": 448,
-        "north": 494
-      },
       "weight": 1,
-      "id": 449,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 450, "name": "Nature Preserve",
+      "exits": { "east": 449, "west": 451 },
       "environment": -1,
-      "exits": {
-        "east": 449,
-        "west": 451
-      },
       "weight": 1,
-      "id": 450,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 451, "name": "Nature Preserve",
+      "exits": { "east": 450, "west": 452 },
       "environment": -1,
-      "exits": {
-        "east": 450,
-        "west": 452
-      },
       "weight": 1,
-      "id": 451,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 452, "name": "Nature Preserve",
+      "exits": { "east": 451, "west": 453 },
       "environment": -1,
-      "exits": {
-        "east": 451,
-        "west": 453
-      },
       "weight": 1,
-      "id": 452,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 453, "name": "Nature Preserve",
+      "exits": { "south": 455, "east": 452, "north": 454 },
       "environment": -1,
-      "exits": {
-        "south": 455,
-        "east": 452,
-        "north": 454
-      },
       "weight": 1,
-      "id": 453,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 454, "name": "Nature Preserve",
+      "exits": { "south": 453 },
       "environment": -1,
-      "exits": {
-        "south": 453
-      },
       "weight": 1,
-      "id": 454,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 455, "name": "Nature Preserve",
+      "exits": { "south": 456, "north": 453 },
       "environment": -1,
-      "exits": {
-        "south": 456,
-        "north": 453
-      },
       "weight": 1,
-      "id": 455,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 456, "name": "Nature Preserve",
+      "exits": { "west": 457, "north": 455 },
       "environment": -1,
-      "exits": {
-        "west": 457,
-        "north": 455
-      },
       "weight": 1,
-      "id": 456,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 457, "name": "Nature Preserve",
+      "exits": { "east": 456, "west": 458 },
       "environment": -1,
-      "exits": {
-        "east": 456,
-        "west": 458
-      },
       "weight": 1,
-      "id": 457,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 458, "name": "Nature Preserve",
+      "exits": { "east": 457, "north": 459 },
       "environment": -1,
-      "exits": {
-        "east": 457,
-        "north": 459
-      },
       "weight": 1,
-      "id": 458,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 459, "name": "Nature Preserve",
+      "exits": { "south": 458, "north": 460 },
       "environment": -1,
-      "exits": {
-        "south": 458,
-        "north": 460
-      },
       "weight": 1,
-      "id": 459,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 460, "name": "Nature Preserve",
+      "exits": { "west": 495, "south": 459, "north": 461 },
       "environment": -1,
-      "exits": {
-        "west": 495,
-        "south": 459,
-        "north": 461
-      },
       "weight": 1,
-      "id": 460,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 461, "name": "Nature Preserve",
+      "exits": { "west": 463, "east": 462, "south": 460 },
       "environment": -1,
-      "exits": {
-        "west": 463,
-        "east": 462,
-        "south": 460
-      },
       "weight": 1,
-      "id": 461,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 462, "name": "Nature Preserve",
+      "exits": { "west": 461, "north": 464 },
       "environment": -1,
-      "exits": {
-        "west": 461,
-        "north": 464
-      },
       "weight": 1,
-      "id": 462,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Sink Hole",
+      "id": 463, "name": "Sink Hole",
+      "exits": { "east": 461 },
       "environment": -1,
-      "exits": {
-        "east": 461
-      },
       "weight": 1,
-      "id": 463,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 464, "name": "Nature Preserve",
+      "exits": { "west": 486, "east": 465, "south": 462 },
       "environment": -1,
-      "exits": {
-        "west": 486,
-        "east": 465,
-        "south": 462
-      },
       "weight": 1,
-      "id": 464,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 465, "name": "Nature Preserve",
+      "exits": { "west": 464, "north": 466 },
       "environment": -1,
-      "exits": {
-        "west": 464,
-        "north": 466
-      },
       "weight": 1,
-      "id": 465,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 466, "name": "Nature Preserve",
+      "exits": { "east": 467, "south": 465 },
       "environment": -1,
-      "exits": {
-        "east": 467,
-        "south": 465
-      },
       "weight": 1,
-      "id": 466,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 467, "name": "Nature Preserve",
+      "exits": { "east": 468, "west": 466 },
       "environment": -1,
-      "exits": {
-        "east": 468,
-        "west": 466
-      },
       "weight": 1,
-      "id": 467,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 468, "name": "Nature Preserve",
+      "exits": { "east": 469, "west": 467 },
       "environment": -1,
-      "exits": {
-        "east": 469,
-        "west": 467
-      },
       "weight": 1,
-      "id": 468,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 469, "name": "Nature Preserve",
+      "exits": { "east": 470, "west": 468 },
       "environment": -1,
-      "exits": {
-        "east": 470,
-        "west": 468
-      },
       "weight": 1,
-      "id": 469,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 470, "name": "Queen's Meadow",
+      "exits": { "west": 469, "south": 493, "north": 471 },
       "environment": -1,
-      "exits": {
-        "west": 469,
-        "south": 493,
-        "north": 471
-      },
       "weight": 1,
-      "id": 470,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Tropical Landscape",
+      "id": 471, "name": "Tropical Landscape",
+      "exits": { "south": 470, "north": 472 },
       "environment": -1,
-      "exits": {
-        "south": 470,
-        "north": 472
-      },
       "weight": 1,
-      "id": 471,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 472, "name": "Nature Preserve",
+      "exits": { "south": 471, "north": 473 },
       "environment": -1,
-      "exits": {
-        "south": 471,
-        "north": 473
-      },
       "weight": 1,
-      "id": 472,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 473, "name": "Nature Preserve",
+      "exits": { "west": 476, "east": 474, "south": 472 },
       "environment": -1,
-      "exits": {
-        "west": 476,
-        "east": 474,
-        "south": 472
-      },
       "weight": 1,
-      "id": 473,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 474, "name": "Nature Preserve",
+      "exits": { "east": 475, "west": 473 },
       "environment": -1,
-      "exits": {
-        "east": 475,
-        "west": 473
-      },
       "weight": 1,
-      "id": 474,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 475, "name": "Nature Preserve",
+      "exits": { "west": 474 },
       "environment": -1,
-      "exits": {
-        "west": 474
-      },
       "weight": 1,
-      "id": 475,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 476, "name": "Nature Preserve",
+      "exits": { "northwest": 477, "east": 473 },
       "environment": -1,
-      "exits": {
-        "northwest": 477,
-        "east": 473
-      },
       "weight": 1,
-      "id": 476,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 477, "name": "Nature Preserve",
+      "exits": { "southwest": 478, "southeast": 476, "north": 490 },
       "environment": -1,
-      "exits": {
-        "southwest": 478,
-        "southeast": 476,
-        "north": 490
-      },
       "weight": 1,
-      "id": 477,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 478, "name": "Nature Preserve",
+      "exits": { "west": 479, "northeast": 477 },
       "environment": -1,
-      "exits": {
-        "west": 479,
-        "northeast": 477
-      },
       "weight": 1,
-      "id": 478,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 479, "name": "Nature Preserve",
+      "exits": { "west": 480, "east": 478, "south": 487 },
       "environment": -1,
-      "exits": {
-        "west": 480,
-        "east": 478,
-        "south": 487
-      },
       "weight": 1,
-      "id": 479,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 480, "name": "Nature Preserve",
+      "exits": { "east": 479, "west": 481 },
       "environment": -1,
-      "exits": {
-        "east": 479,
-        "west": 481
-      },
       "weight": 1,
-      "id": 480,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 481, "name": "Nature Preserve",
+      "exits": { "east": 480, "south": 482 },
       "environment": -1,
-      "exits": {
-        "east": 480,
-        "south": 482
-      },
       "weight": 1,
-      "id": 481,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 482, "name": "Nature Preserve",
+      "exits": { "west": 483, "south": 484, "north": 481 },
       "environment": -1,
-      "exits": {
-        "west": 483,
-        "south": 484,
-        "north": 481
-      },
       "weight": 1,
-      "id": 482,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 483, "name": "Nature Preserve",
+      "exits": { "east": 482 },
       "environment": -1,
-      "exits": {
-        "east": 482
-      },
       "weight": 1,
-      "id": 483,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 484, "name": "Nature Preserve",
+      "exits": { "south": 485, "north": 482 },
       "environment": -1,
-      "exits": {
-        "south": 485,
-        "north": 482
-      },
       "weight": 1,
-      "id": 484,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 485, "name": "Nature Preserve",
+      "exits": { "south": 486, "north": 484 },
       "environment": -1,
-      "exits": {
-        "south": 486,
-        "north": 484
-      },
       "weight": 1,
-      "id": 485,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 486, "name": "Nature Preserve",
+      "exits": { "east": 464, "north": 485 },
       "environment": -1,
-      "exits": {
-        "east": 464,
-        "north": 485
-      },
       "weight": 1,
-      "id": 486,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 487, "name": "Nature Preserve",
+      "exits": { "south": 488, "north": 479 },
       "environment": -1,
-      "exits": {
-        "south": 488,
-        "north": 479
-      },
       "weight": 1,
-      "id": 487,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 488, "name": "Nature Preserve",
+      "exits": { "east": 489, "north": 487 },
       "environment": -1,
-      "exits": {
-        "east": 489,
-        "north": 487
-      },
       "weight": 1,
-      "id": 488,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 489, "name": "Nature Preserve",
+      "exits": { "west": 488 },
       "environment": -1,
-      "exits": {
-        "west": 488
-      },
       "weight": 1,
-      "id": 489,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 490, "name": "Nature Preserve",
+      "exits": { "south": 477, "north": 491 },
       "environment": -1,
-      "exits": {
-        "south": 477,
-        "north": 491
-      },
       "weight": 1,
-      "id": 490,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 491, "name": "Nature Preserve",
+      "exits": { "east": 492, "south": 490 },
       "environment": -1,
-      "exits": {
-        "east": 492,
-        "south": 490
-      },
       "weight": 1,
-      "id": 491,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "A Hollowed Tree",
+      "id": 492, "name": "A Hollowed Tree",
+      "exits": { "west": 491 },
       "environment": -1,
-      "exits": {
-        "west": 491
-      },
       "weight": 1,
-      "id": 492,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 493, "name": "Queen's Meadow",
+      "exits": { "south": 494, "north": 470 },
       "environment": -1,
-      "exits": {
-        "south": 494,
-        "north": 470
-      },
       "weight": 1,
-      "id": 493,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Queen's Meadow",
+      "id": 494, "name": "Queen's Meadow",
+      "exits": { "south": 449, "north": 493 },
       "environment": -1,
-      "exits": {
-        "south": 449,
-        "north": 493
-      },
       "weight": 1,
-      "id": 494,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 495, "name": "Nature Preserve",
+      "exits": { "east": 460 },
       "environment": -1,
-      "exits": {
-        "east": 460
-      },
       "weight": 1,
-      "id": 495,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 496, "name": "Canopy Trail",
+      "exits": { "east": 445, "west": 497 },
       "environment": -1,
-      "exits": {
-        "east": 445,
-        "west": 497
-      },
       "weight": 1,
-      "id": 496,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 497, "name": "Canopy Trail",
+      "exits": { "west": 498, "east": 496, "south": 501 },
       "environment": -1,
-      "exits": {
-        "west": 498,
-        "east": 496,
-        "south": 501
-      },
       "weight": 1,
-      "id": 497,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Canopy Trail",
+      "id": 498, "name": "Canopy Trail",
+      "exits": { "east": 497, "north": 499 },
       "environment": -1,
-      "exits": {
-        "east": 497,
-        "north": 499
-      },
       "weight": 1,
-      "id": 498,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 499, "name": "Nature Preserve",
+      "exits": { "east": 500, "south": 498 },
       "environment": -1,
-      "exits": {
-        "east": 500,
-        "south": 498
-      },
       "weight": 1,
-      "id": 499,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Dragon's Den",
+      "id": 500, "name": "Dragon's Den",
+      "exits": { "west": 499 },
       "environment": -1,
-      "exits": {
-        "west": 499
-      },
       "weight": 1,
-      "id": 500,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 501, "name": "Nature Preserve",
+      "exits": { "south": 502, "north": 497 },
       "environment": -1,
-      "exits": {
-        "south": 502,
-        "north": 497
-      },
       "weight": 1,
-      "id": 501,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 502, "name": "Nature Preserve",
+      "exits": { "west": 504, "east": 503, "north": 501 },
       "environment": -1,
-      "exits": {
-        "west": 504,
-        "east": 503,
-        "north": 501
-      },
       "weight": 1,
-      "id": 502,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 503, "name": "Nature Preserve",
+      "exits": { "west": 502 },
       "environment": -1,
-      "exits": {
-        "west": 502
-      },
       "weight": 1,
-      "id": 503,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Nature Preserve",
+      "id": 504, "name": "Nature Preserve",
+      "exits": { "east": 502 },
       "environment": -1,
-      "exits": {
-        "east": 502
-      },
       "weight": 1,
-      "id": 504,
-      "area": {
-        "id": 5
-      }
+      "area": {"id": 5}
     },
     {
-      "name": "Slave Auction:",
+      "id": 505, "name": "Slave Auction:",
+      "exits": { "east": 100 },
       "environment": -1,
-      "exits": {
-        "east": 100
-      },
       "weight": 1,
-      "id": 505,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Entrance to Gorge",
+      "id": 506, "name": "Entrance to Gorge",
+      "exits": { "north": 507 },
       "environment": -1,
-      "exits": {
-        "north": 507
-      },
       "weight": 1,
-      "id": 506,
-      "area": {
-        "id": 6
-      }
+      "area": {"id": 6}
     },
     {
-      "name": "Narrow Gorge",
+      "id": 507, "name": "Narrow Gorge",
+      "exits": { "west": 508, "south": 506 },
       "environment": -1,
-      "exits": {
-        "west": 508,
-        "south": 506
-      },
       "weight": 1,
-      "id": 507,
-      "area": {
-        "id": 6
-      }
+      "area": {"id": 6}
     },
     {
-      "name": "Old Guard Room",
+      "id": 508, "name": "Old Guard Room",
+      "exits": { "east": 507 },
       "environment": -1,
-      "exits": {
-        "east": 507
-      },
       "weight": 1,
-      "id": 508,
-      "area": {
-        "id": 6
-      }
+      "area": {"id": 6}
     },
     {
-      "name": "",
+      "id": 509, "name": "",
       "environment": -1,
-      "id": 509,
       "weight": 1,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Barbarian Clearing",
+      "id": 510, "name": "Barbarian Clearing",
+      "exits": { "north": 511 },
       "environment": -1,
-      "exits": {
-        "north": 511
-      },
       "weight": 1,
-      "id": 510,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Underground Pond",
+      "id": 511, "name": "Underground Pond",
+      "exits": { "southwest": 512, "west": 518, "south": 510 },
       "environment": -1,
-      "exits": {
-        "southwest": 512,
-        "west": 518,
-        "south": 510
-      },
       "weight": 1,
-      "id": 511,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Cave Passage",
+      "id": 512, "name": "Cave Passage",
+      "exits": { "south": 513, "northeast": 511 },
       "environment": -1,
-      "exits": {
-        "south": 513,
-        "northeast": 511
-      },
       "weight": 1,
-      "id": 512,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Cave Passage",
+      "id": 513, "name": "Cave Passage",
+      "exits": { "south": 515, "north": 512 },
       "environment": -1,
-      "exits": {
-        "south": 515,
-        "north": 512
-      },
       "weight": 1,
-      "id": 513,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "You begin to climb into the pit, and the descent seems simple enough.",
+      "id": 514, "name": "You begin to climb into the pit, and the descent seems simple enough.",
       "environment": -1,
-      "id": 514,
       "weight": 1,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Bottom of a Deep Dark Pit",
+      "id": 515, "name": "Bottom of a Deep Dark Pit",
+      "exits": { "east": 516, "north": 513 },
       "environment": -1,
-      "exits": {
-        "east": 516,
-        "north": 513
-      },
       "weight": 1,
-      "id": 515,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Dark Barricade",
+      "id": 516, "name": "Dark Barricade",
+      "exits": { "east": 517, "west": 515 },
       "environment": -1,
-      "exits": {
-        "east": 517,
-        "west": 515
-      },
       "weight": 1,
-      "id": 516,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Corridor",
+      "id": 517, "name": "Corridor",
+      "exits": { "east": 519, "west": 516 },
       "environment": -1,
-      "exits": {
-        "east": 519,
-        "west": 516
-      },
       "weight": 1,
-      "id": 517,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Cave Passage",
+      "id": 518, "name": "Cave Passage",
+      "exits": { "southwest": 1292, "east": 511 },
       "environment": -1,
-      "exits": {
-        "southwest": 1292,
-        "east": 511
-      },
       "weight": 1,
-      "id": 518,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Passage Way",
+      "id": 519, "name": "Passage Way",
+      "exits": { "south": 520, "west": 517, "east": 523, "north": 521 },
       "environment": -1,
-      "exits": {
-        "south": 520,
-        "west": 517,
-        "east": 523,
-        "north": 521
-      },
       "weight": 1,
-      "id": 519,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Barracks",
+      "id": 520, "name": "Barracks",
+      "exits": { "north": 519 },
       "environment": -1,
-      "exits": {
-        "north": 519
-      },
       "weight": 1,
-      "id": 520,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Mess Hall",
+      "id": 521, "name": "Mess Hall",
+      "exits": { "south": 519, "north": 522 },
       "environment": -1,
-      "exits": {
-        "south": 519,
-        "north": 522
-      },
       "weight": 1,
-      "id": 521,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Kitchen",
+      "id": 522, "name": "Kitchen",
+      "exits": { "south": 521 },
       "environment": -1,
-      "exits": {
-        "south": 521
-      },
       "weight": 1,
-      "id": 522,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Passage Way",
+      "id": 523, "name": "Passage Way",
+      "exits": { "south": 524, "west": 519, "east": 1295, "north": 1294 },
       "environment": -1,
-      "exits": {
-        "south": 524,
-        "west": 519,
-        "east": 1295,
-        "north": 1294
-      },
       "weight": 1,
-      "id": 523,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Passage Way",
+      "id": 524, "name": "Passage Way",
+      "exits": { "south": 525, "north": 523 },
       "environment": -1,
-      "exits": {
-        "south": 525,
-        "north": 523
-      },
       "weight": 1,
-      "id": 524,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Passage Way",
+      "id": 525, "name": "Passage Way",
+      "exits": { "west": 1293, "south": 526, "north": 524 },
       "environment": -1,
-      "exits": {
-        "west": 1293,
-        "south": 526,
-        "north": 524
-      },
       "weight": 1,
-      "id": 525,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Circular room",
+      "id": 526, "name": "Circular room",
+      "exits": { "north": 525 },
       "environment": -1,
-      "exits": {
-        "north": 525
-      },
       "weight": 1,
-      "id": 526,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Southern path through the University",
+      "id": 527, "name": "Southern path through the University",
+      "exits": { "south": 528, "north": 387 },
       "environment": -1,
-      "exits": {
-        "south": 528,
-        "north": 387
-      },
       "weight": 1,
-      "id": 527,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern path through the University",
+      "id": 528, "name": "Southern path through the University",
+      "exits": { "south": 896, "east": 894, "north": 527 },
       "environment": -1,
-      "exits": {
-        "south": 896,
-        "east": 894,
-        "north": 527
-      },
       "weight": 1,
-      "id": 528,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "The start of a forest path",
+      "id": 529, "name": "The start of a forest path",
+      "exits": { "northeast": 530 },
       "environment": -1,
-      "exits": {
-        "northeast": 530
-      },
       "weight": 1,
-      "id": 529,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "The start of a forest path",
+      "id": 530, "name": "The start of a forest path",
+      "exits": { "southwest": 529, "northeast": 531, "northwest": 532 },
       "environment": -1,
-      "exits": {
-        "southwest": 529,
-        "northeast": 531,
-        "northwest": 532
-      },
       "weight": 1,
-      "id": 530,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 531, "name": "A forest path",
+      "exits": { "southwest": 530, "northeast": 539, "east": 551 },
       "environment": -1,
-      "exits": {
-        "southwest": 530,
-        "northeast": 539,
-        "east": 551
-      },
       "weight": 1,
-      "id": 531,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 532, "name": "A forest path",
+      "exits": { "west": 535, "northeast": 578, "southeast": 530, "north": 533 },
       "environment": -1,
-      "exits": {
-        "west": 535,
-        "northeast": 578,
-        "southeast": 530,
-        "north": 533
-      },
       "weight": 1,
-      "id": 532,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 533, "name": "A forest path",
+      "exits": { "west": 534, "south": 532, "southwest": 535, "northeast": 596, "east": 578, "north": 591 },
       "environment": -1,
-      "exits": {
-        "west": 534,
-        "south": 532,
-        "southwest": 535,
-        "northeast": 596,
-        "east": 578,
-        "north": 591
-      },
       "weight": 1,
-      "id": 533,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 534, "name": "A forest path",
+      "exits": { "south": 535, "west": 536, "northeast": 591, "east": 533, "north": 592 },
       "environment": -1,
-      "exits": {
-        "south": 535,
-        "west": 536,
-        "northeast": 591,
-        "east": 533,
-        "north": 592
-      },
       "weight": 1,
-      "id": 534,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 535, "name": "A forest path",
+      "exits": { "northeast": 533, "east": 532, "north": 534 },
       "environment": -1,
-      "exits": {
-        "northeast": 533,
-        "east": 532,
-        "north": 534
-      },
       "weight": 1,
-      "id": 535,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "River Bank",
+      "id": 536, "name": "River Bank",
+      "exits": { "southwest": 537, "northeast": 592, "east": 534 },
       "environment": -1,
-      "exits": {
-        "southwest": 537,
-        "northeast": 592,
-        "east": 534
-      },
       "weight": 1,
-      "id": 536,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "River Bank",
+      "id": 537, "name": "River Bank",
+      "exits": { "southwest": 538, "northeast": 536 },
       "environment": -1,
-      "exits": {
-        "southwest": 538,
-        "northeast": 536
-      },
       "weight": 1,
-      "id": 537,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Gryphon Nest",
+      "id": 538, "name": "Gryphon Nest",
+      "exits": { "northeast": 537 },
       "environment": -1,
-      "exits": {
-        "northeast": 537
-      },
       "weight": 1,
-      "id": 538,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A clearing in the forest",
+      "id": 539, "name": "A clearing in the forest",
+      "exits": { "southwest": 531, "northeast": 540, "east": 550, "south": 551 },
       "environment": -1,
-      "exits": {
-        "southwest": 531,
-        "northeast": 540,
-        "east": 550,
-        "south": 551
-      },
       "weight": 1,
-      "id": 539,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 540, "name": "A forest path",
+      "exits": { "southwest": 539, "northeast": 541, "east": 549, "south": 550 },
       "environment": -1,
-      "exits": {
-        "southwest": 539,
-        "northeast": 541,
-        "east": 549,
-        "south": 550
-      },
       "weight": 1,
-      "id": 540,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 541, "name": "A forest path",
+      "exits": { "south": 549, "southwest": 540, "northeast": 542, "east": 548, "west": 575 },
       "environment": -1,
-      "exits": {
-        "south": 549,
-        "southwest": 540,
-        "northeast": 542,
-        "east": 548,
-        "west": 575
-      },
       "weight": 1,
-      "id": 541,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 542, "name": "A forest",
+      "exits": { "southwest": 541, "northeast": 543, "east": 547, "south": 548 },
       "environment": -1,
-      "exits": {
-        "southwest": 541,
-        "northeast": 543,
-        "east": 547,
-        "south": 548
-      },
       "weight": 1,
-      "id": 542,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A dark forest",
+      "id": 543, "name": "A dark forest",
+      "exits": { "southwest": 542, "northeast": 544, "east": 546, "south": 547 },
       "environment": -1,
-      "exits": {
-        "southwest": 542,
-        "northeast": 544,
-        "east": 546,
-        "south": 547
-      },
       "weight": 1,
-      "id": 543,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 544, "name": "A forest",
+      "exits": { "southwest": 543, "east": 545, "south": 546 },
       "environment": -1,
-      "exits": {
-        "southwest": 543,
-        "east": 545,
-        "south": 546
-      },
       "weight": 1,
-      "id": 544,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 545, "name": "A forest glade",
+      "exits": { "southwest": 546, "west": 544, "east": 558, "south": 557 },
       "environment": -1,
-      "exits": {
-        "southwest": 546,
-        "west": 544,
-        "east": 558,
-        "south": 557
-      },
       "weight": 1,
-      "id": 545,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 546, "name": "A forest glade",
+      "exits": { "west": 543, "south": 556, "southwest": 547, "northeast": 545, "east": 557, "north": 544 },
       "environment": -1,
-      "exits": {
-        "west": 543,
-        "south": 556,
-        "southwest": 547,
-        "northeast": 545,
-        "east": 557,
-        "north": 544
-      },
       "weight": 1,
-      "id": 546,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 547, "name": "A forest path",
+      "exits": { "west": 542, "south": 555, "southwest": 548, "northeast": 546, "east": 556, "north": 543 },
       "environment": -1,
-      "exits": {
-        "west": 542,
-        "south": 555,
-        "southwest": 548,
-        "northeast": 546,
-        "east": 556,
-        "north": 543
-      },
       "weight": 1,
-      "id": 547,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A path in the forest",
+      "id": 548, "name": "A path in the forest",
+      "exits": { "west": 541, "south": 554, "southwest": 549, "northeast": 547, "east": 555, "north": 542 },
       "environment": -1,
-      "exits": {
-        "west": 541,
-        "south": 554,
-        "southwest": 549,
-        "northeast": 547,
-        "east": 555,
-        "north": 542
-      },
       "weight": 1,
-      "id": 548,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A clearing in the forest",
+      "id": 549, "name": "A clearing in the forest",
+      "exits": { "west": 540, "south": 553, "southwest": 550, "northeast": 548, "east": 554, "north": 541 },
       "environment": -1,
-      "exits": {
-        "west": 540,
-        "south": 553,
-        "southwest": 550,
-        "northeast": 548,
-        "east": 554,
-        "north": 541
-      },
       "weight": 1,
-      "id": 549,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 550, "name": "A forest",
+      "exits": { "west": 539, "south": 552, "southwest": 551, "northeast": 549, "east": 553, "north": 540 },
       "environment": -1,
-      "exits": {
-        "west": 539,
-        "south": 552,
-        "southwest": 551,
-        "northeast": 549,
-        "east": 553,
-        "north": 540
-      },
       "weight": 1,
-      "id": 550,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 551, "name": "A forest path",
+      "exits": { "south": 576, "west": 531, "northeast": 550, "east": 552, "north": 539 },
       "environment": -1,
-      "exits": {
-        "south": 576,
-        "west": 531,
-        "northeast": 550,
-        "east": 552,
-        "north": 539
-      },
       "weight": 1,
-      "id": 551,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 552, "name": "A forest path",
+      "exits": { "west": 551, "northeast": 553, "east": 565, "north": 550 },
       "environment": -1,
-      "exits": {
-        "west": 551,
-        "northeast": 553,
-        "east": 565,
-        "north": 550
-      },
       "weight": 1,
-      "id": 552,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 553, "name": "A forest path",
+      "exits": { "west": 550, "south": 565, "southwest": 552, "northeast": 554, "east": 564, "north": 549 },
       "environment": -1,
-      "exits": {
-        "west": 550,
-        "south": 565,
-        "southwest": 552,
-        "northeast": 554,
-        "east": 564,
-        "north": 549
-      },
       "weight": 1,
-      "id": 553,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 554, "name": "A forest path",
+      "exits": { "west": 549, "south": 564, "southwest": 553, "northeast": 555, "east": 563, "north": 548 },
       "environment": -1,
-      "exits": {
-        "west": 549,
-        "south": 564,
-        "southwest": 553,
-        "northeast": 555,
-        "east": 563,
-        "north": 548
-      },
       "weight": 1,
-      "id": 554,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A path through the forest",
+      "id": 555, "name": "A path through the forest",
+      "exits": { "west": 548, "south": 563, "southwest": 554, "northeast": 556, "east": 562, "north": 547 },
       "environment": -1,
-      "exits": {
-        "west": 548,
-        "south": 563,
-        "southwest": 554,
-        "northeast": 556,
-        "east": 562,
-        "north": 547
-      },
       "weight": 1,
-      "id": 555,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 556, "name": "A forest path",
+      "exits": { "west": 547, "south": 562, "southwest": 555, "northeast": 557, "east": 561, "north": 546 },
       "environment": -1,
-      "exits": {
-        "west": 547,
-        "south": 562,
-        "southwest": 555,
-        "northeast": 557,
-        "east": 561,
-        "north": 546
-      },
       "weight": 1,
-      "id": 556,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 557, "name": "A forest",
+      "exits": { "west": 546, "south": 561, "southwest": 556, "northeast": 558, "east": 560, "north": 545 },
       "environment": -1,
-      "exits": {
-        "west": 546,
-        "south": 561,
-        "southwest": 556,
-        "northeast": 558,
-        "east": 560,
-        "north": 545
-      },
       "weight": 1,
-      "id": 557,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 558, "name": "A forest path",
+      "exits": { "southwest": 557, "west": 545, "east": 559, "south": 560 },
       "environment": -1,
-      "exits": {
-        "southwest": 557,
-        "west": 545,
-        "east": 559,
-        "south": 560
-      },
       "weight": 1,
-      "id": 558,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 559, "name": "A forest path",
+      "exits": { "southwest": 560, "west": 558, "south": 573 },
       "environment": -1,
-      "exits": {
-        "southwest": 560,
-        "west": 558,
-        "south": 573
-      },
       "weight": 1,
-      "id": 559,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A path in the forest",
+      "id": 560, "name": "A path in the forest",
+      "exits": { "west": 557, "south": 572, "southwest": 561, "northeast": 559, "east": 573, "north": 558 },
       "environment": -1,
-      "exits": {
-        "west": 557,
-        "south": 572,
-        "southwest": 561,
-        "northeast": 559,
-        "east": 573,
-        "north": 558
-      },
       "weight": 1,
-      "id": 560,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 561, "name": "A forest path",
+      "exits": { "west": 556, "south": 571, "southwest": 562, "northeast": 560, "east": 572, "north": 557 },
       "environment": -1,
-      "exits": {
-        "west": 556,
-        "south": 571,
-        "southwest": 562,
-        "northeast": 560,
-        "east": 572,
-        "north": 557
-      },
       "weight": 1,
-      "id": 561,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 562, "name": "A forest path",
+      "exits": { "west": 555, "south": 570, "southwest": 563, "northeast": 561, "east": 571, "north": 556 },
       "environment": -1,
-      "exits": {
-        "west": 555,
-        "south": 570,
-        "southwest": 563,
-        "northeast": 561,
-        "east": 571,
-        "north": 556
-      },
       "weight": 1,
-      "id": 562,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 563, "name": "A forest",
+      "exits": { "west": 554, "south": 569, "southwest": 564, "northeast": 562, "east": 570, "north": 555 },
       "environment": -1,
-      "exits": {
-        "west": 554,
-        "south": 569,
-        "southwest": 564,
-        "northeast": 562,
-        "east": 570,
-        "north": 555
-      },
       "weight": 1,
-      "id": 563,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 564, "name": "A forest path",
+      "exits": { "west": 553, "south": 568, "southwest": 565, "northeast": 563, "east": 569, "north": 554 },
       "environment": -1,
-      "exits": {
-        "west": 553,
-        "south": 568,
-        "southwest": 565,
-        "northeast": 563,
-        "east": 569,
-        "north": 554
-      },
       "weight": 1,
-      "id": 564,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 565, "name": "A forest path",
+      "exits": { "west": 552, "south": 574, "southwest": 566, "northeast": 564, "east": 568, "north": 553 },
       "environment": -1,
-      "exits": {
-        "west": 552,
-        "south": 574,
-        "southwest": 566,
-        "northeast": 564,
-        "east": 568,
-        "north": 553
-      },
       "weight": 1,
-      "id": 565,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A dark forest glade",
+      "id": 566, "name": "A dark forest glade",
+      "exits": { "southwest": 567, "northeast": 565 },
       "environment": -1,
-      "exits": {
-        "southwest": 567,
-        "northeast": 565
-      },
       "weight": 1,
-      "id": 566,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 567, "name": "A forest path",
+      "exits": { "west": 601, "northeast": 566 },
       "environment": -1,
-      "exits": {
-        "west": 601,
-        "northeast": 566
-      },
       "weight": 1,
-      "id": 567,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 568, "name": "A forest path",
+      "exits": { "southwest": 574, "northeast": 569, "west": 565, "north": 564 },
       "environment": -1,
-      "exits": {
-        "southwest": 574,
-        "northeast": 569,
-        "west": 565,
-        "north": 564
-      },
       "weight": 1,
-      "id": 568,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A path through the forest",
+      "id": 569, "name": "A path through the forest",
+      "exits": { "southwest": 568, "northeast": 570, "west": 564, "north": 563 },
       "environment": -1,
-      "exits": {
-        "southwest": 568,
-        "northeast": 570,
-        "west": 564,
-        "north": 563
-      },
       "weight": 1,
-      "id": 569,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 570, "name": "A forest glade",
+      "exits": { "southwest": 569, "northeast": 571, "west": 563, "north": 562 },
       "environment": -1,
-      "exits": {
-        "southwest": 569,
-        "northeast": 571,
-        "west": 563,
-        "north": 562
-      },
       "weight": 1,
-      "id": 570,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 571, "name": "A forest path",
+      "exits": { "southwest": 570, "northeast": 572, "west": 562, "north": 561 },
       "environment": -1,
-      "exits": {
-        "southwest": 570,
-        "northeast": 572,
-        "west": 562,
-        "north": 561
-      },
       "weight": 1,
-      "id": 571,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 572, "name": "A forest path",
+      "exits": { "southwest": 571, "northeast": 573, "west": 561, "north": 560 },
       "environment": -1,
-      "exits": {
-        "southwest": 571,
-        "northeast": 573,
-        "west": 561,
-        "north": 560
-      },
       "weight": 1,
-      "id": 572,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 573, "name": "A forest path",
+      "exits": { "southwest": 572, "west": 560, "north": 559 },
       "environment": -1,
-      "exits": {
-        "southwest": 572,
-        "west": 560,
-        "north": 559
-      },
       "weight": 1,
-      "id": 573,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Forest Glade",
+      "id": 574, "name": "Forest Glade",
+      "exits": { "northeast": 568, "north": 565 },
       "environment": -1,
-      "exits": {
-        "northeast": 568,
-        "north": 565
-      },
       "weight": 1,
-      "id": 574,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 575, "name": "A forest",
+      "exits": { "east": 541 },
       "environment": -1,
-      "exits": {
-        "east": 541
-      },
       "weight": 1,
-      "id": 575,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "The start of a forest path",
+      "id": 576, "name": "The start of a forest path",
+      "exits": { "southwest": 577, "north": 551 },
       "environment": -1,
-      "exits": {
-        "southwest": 577,
-        "north": 551
-      },
       "weight": 1,
-      "id": 576,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "The start of a forest path",
+      "id": 577, "name": "The start of a forest path",
+      "exits": { "northeast": 576 },
       "environment": -1,
-      "exits": {
-        "northeast": 576
-      },
       "weight": 1,
-      "id": 577,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 578, "name": "A forest path",
+      "exits": { "west": 533, "southwest": 532, "northeast": 579, "east": 600, "north": 596 },
       "environment": -1,
-      "exits": {
-        "west": 533,
-        "southwest": 532,
-        "northeast": 579,
-        "east": 600,
-        "north": 596
-      },
       "weight": 1,
-      "id": 578,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 579, "name": "A forest path",
+      "exits": { "southwest": 578, "northeast": 580, "west": 596, "north": 597 },
       "environment": -1,
-      "exits": {
-        "southwest": 578,
-        "northeast": 580,
-        "west": 596,
-        "north": 597
-      },
       "weight": 1,
-      "id": 579,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A clearing in the forest",
+      "id": 580, "name": "A clearing in the forest",
+      "exits": { "southwest": 579, "northeast": 581, "west": 597, "north": 598 },
       "environment": -1,
-      "exits": {
-        "southwest": 579,
-        "northeast": 581,
-        "west": 597,
-        "north": 598
-      },
       "weight": 1,
-      "id": 580,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 581, "name": "A forest path",
+      "exits": { "southwest": 580, "northeast": 582, "west": 598, "north": 585 },
       "environment": -1,
-      "exits": {
-        "southwest": 580,
-        "northeast": 582,
-        "west": 598,
-        "north": 585
-      },
       "weight": 1,
-      "id": 581,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Forest Mound",
+      "id": 582, "name": "Forest Mound",
+      "exits": { "west": 585, "southwest": 581, "northeast": 583, "east": 599, "north": 584 },
       "environment": -1,
-      "exits": {
-        "west": 585,
-        "southwest": 581,
-        "northeast": 583,
-        "east": 599,
-        "north": 584
-      },
       "weight": 1,
-      "id": 582,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 583, "name": "A forest path",
+      "exits": { "southwest": 582, "west": 584 },
       "environment": -1,
-      "exits": {
-        "southwest": 582,
-        "west": 584
-      },
       "weight": 1,
-      "id": 583,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 584, "name": "A forest glade",
+      "exits": { "southwest": 585, "west": 586, "east": 583, "south": 582 },
       "environment": -1,
-      "exits": {
-        "southwest": 585,
-        "west": 586,
-        "east": 583,
-        "south": 582
-      },
       "weight": 1,
-      "id": 584,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 585, "name": "A forest path",
+      "exits": { "south": 581, "west": 595, "northeast": 584, "east": 582, "north": 586 },
       "environment": -1,
-      "exits": {
-        "south": 581,
-        "west": 595,
-        "northeast": 584,
-        "east": 582,
-        "north": 586
-      },
       "weight": 1,
-      "id": 585,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 586, "name": "A forest glade",
+      "exits": { "southwest": 588, "west": 587, "east": 584, "south": 585 },
       "environment": -1,
-      "exits": {
-        "southwest": 588,
-        "west": 587,
-        "east": 584,
-        "south": 585
-      },
       "weight": 1,
-      "id": 586,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A river bank",
+      "id": 587, "name": "A river bank",
+      "exits": { "southwest": 595, "east": 586, "south": 588 },
       "environment": -1,
-      "exits": {
-        "southwest": 595,
-        "east": 586,
-        "south": 588
-      },
       "weight": 1,
-      "id": 587,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A dark forest glade",
+      "id": 588, "name": "A dark forest glade",
+      "exits": { "west": 595, "south": 598, "southwest": 589, "northeast": 586, "east": 589, "north": 587 },
       "environment": -1,
-      "exits": {
-        "west": 595,
-        "south": 598,
-        "southwest": 589,
-        "northeast": 586,
-        "east": 589,
-        "north": 587
-      },
       "weight": 1,
-      "id": 588,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest glade",
+      "id": 589, "name": "A forest glade",
+      "exits": { "west": 594, "south": 597, "southwest": 590, "northeast": 588, "east": 598, "north": 595 },
       "environment": -1,
-      "exits": {
-        "west": 594,
-        "south": 597,
-        "southwest": 590,
-        "northeast": 588,
-        "east": 598,
-        "north": 595
-      },
       "weight": 1,
-      "id": 589,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 590, "name": "A forest",
+      "exits": { "west": 593, "south": 596, "southwest": 591, "northeast": 589, "east": 597, "north": 594 },
       "environment": -1,
-      "exits": {
-        "west": 593,
-        "south": 596,
-        "southwest": 591,
-        "northeast": 589,
-        "east": 597,
-        "north": 594
-      },
       "weight": 1,
-      "id": 590,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest",
+      "id": 591, "name": "A forest",
+      "exits": { "west": 592, "south": 533, "southwest": 534, "northeast": 590, "east": 596, "north": 593 },
       "environment": -1,
-      "exits": {
-        "west": 592,
-        "south": 533,
-        "southwest": 534,
-        "northeast": 590,
-        "east": 596,
-        "north": 593
-      },
       "weight": 1,
-      "id": 591,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A river bank",
+      "id": 592, "name": "A river bank",
+      "exits": { "southwest": 536, "northeast": 593, "east": 591, "south": 534 },
       "environment": -1,
-      "exits": {
-        "southwest": 536,
-        "northeast": 593,
-        "east": 591,
-        "south": 534
-      },
       "weight": 1,
-      "id": 592,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A river bank",
+      "id": 593, "name": "A river bank",
+      "exits": { "southwest": 592, "northeast": 594, "east": 590, "south": 591 },
       "environment": -1,
-      "exits": {
-        "southwest": 592,
-        "northeast": 594,
-        "east": 590,
-        "south": 591
-      },
       "weight": 1,
-      "id": 593,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A riverbank",
+      "id": 594, "name": "A riverbank",
+      "exits": { "southwest": 593, "northeast": 595, "east": 589, "south": 590 },
       "environment": -1,
-      "exits": {
-        "southwest": 593,
-        "northeast": 595,
-        "east": 589,
-        "south": 590
-      },
       "weight": 1,
-      "id": 594,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A river bank",
+      "id": 595, "name": "A river bank",
+      "exits": { "southwest": 594, "northeast": 587, "east": 585, "south": 589 },
       "environment": -1,
-      "exits": {
-        "southwest": 594,
-        "northeast": 587,
-        "east": 585,
-        "south": 589
-      },
       "weight": 1,
-      "id": 595,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A path through the forest",
+      "id": 596, "name": "A path through the forest",
+      "exits": { "west": 591, "south": 578, "southwest": 533, "northeast": 597, "east": 579, "north": 590 },
       "environment": -1,
-      "exits": {
-        "west": 591,
-        "south": 578,
-        "southwest": 533,
-        "northeast": 597,
-        "east": 579,
-        "north": 590
-      },
       "weight": 1,
-      "id": 596,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 597, "name": "A forest path",
+      "exits": { "west": 590, "south": 579, "southwest": 596, "northeast": 598, "east": 580, "north": 589 },
       "environment": -1,
-      "exits": {
-        "west": 590,
-        "south": 579,
-        "southwest": 596,
-        "northeast": 598,
-        "east": 580,
-        "north": 589
-      },
       "weight": 1,
-      "id": 597,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A forest path",
+      "id": 598, "name": "A forest path",
+      "exits": { "west": 589, "south": 580, "southwest": 597, "northeast": 589, "east": 581, "north": 588 },
       "environment": -1,
-      "exits": {
-        "west": 589,
-        "south": 580,
-        "southwest": 597,
-        "northeast": 589,
-        "east": 581,
-        "north": 588
-      },
       "weight": 1,
-      "id": 598,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "A small clearing",
+      "id": 599, "name": "A small clearing",
+      "exits": { "west": 582 },
       "environment": -1,
-      "exits": {
-        "west": 582
-      },
       "weight": 1,
-      "id": 599,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Druids Guild",
+      "id": 600, "name": "Druids Guild",
+      "exits": { "west": 578 },
       "environment": -1,
-      "exits": {
-        "west": 578
-      },
       "weight": 1,
-      "id": 600,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Large home",
+      "id": 601, "name": "Large home",
+      "exits": { "east": 567 },
       "environment": -1,
-      "exits": {
-        "east": 567
-      },
       "weight": 1,
-      "id": 601,
-      "area": {
-        "id": 8
-      }
+      "area": {"id": 8}
     },
     {
-      "name": "Railed entrance",
+      "id": 602, "name": "Railed entrance",
+      "exits": { "south": 336 },
       "environment": -1,
-      "exits": {
-        "south": 336
-      },
       "weight": 1,
-      "id": 602,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Flagstoned entry",
+      "id": 603, "name": "Flagstoned entry",
+      "exits": { "south": 915, "north": 337 },
       "environment": -1,
-      "exits": {
-        "south": 915,
-        "north": 337
-      },
       "weight": 1,
-      "id": 603,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "You rudely trespass on the private property.",
+      "id": 604, "name": "You rudely trespass on the private property.",
+      "exits": { "northeast": 907, "northwest": 910, "south": 338 },
       "environment": -1,
-      "exits": {
-        "northeast": 907,
-        "northwest": 910,
-        "south": 338
-      },
       "weight": 1,
-      "id": 604,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Ocean before Beachhead",
+      "id": 605, "name": "Ocean before Beachhead",
+      "exits": { "north": 606 },
       "environment": -1,
-      "exits": {
-        "north": 606
-      },
       "weight": 1,
-      "id": 605,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A sandy beachhead",
+      "id": 606, "name": "A sandy beachhead",
+      "exits": { "south": 605, "west": 623, "east": 626, "north": 607 },
       "environment": -1,
-      "exits": {
-        "south": 605,
-        "west": 623,
-        "east": 626,
-        "north": 607
-      },
       "weight": 1,
-      "id": 606,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A narrow path between the dunes",
+      "id": 607, "name": "A narrow path between the dunes",
+      "exits": { "south": 606, "east": 628, "north": 608 },
       "environment": -1,
-      "exits": {
-        "south": 606,
-        "east": 628,
-        "north": 608
-      },
       "weight": 1,
-      "id": 607,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A Dune Path",
+      "id": 608, "name": "A Dune Path",
+      "exits": { "south": 607, "north": 609 },
       "environment": -1,
-      "exits": {
-        "south": 607,
-        "north": 609
-      },
       "weight": 1,
-      "id": 608,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "The City Gate",
+      "id": 609, "name": "The City Gate",
+      "exits": { "south": 608, "west": 631, "east": 634, "north": 610 },
       "environment": -1,
-      "exits": {
-        "south": 608,
-        "west": 631,
-        "east": 634,
-        "north": 610
-      },
       "weight": 1,
-      "id": 609,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Intersection of Silver Street and Balin Road",
+      "id": 610, "name": "Intersection of Silver Street and Balin Road",
+      "exits": { "south": 609, "west": 635, "east": 660, "north": 611 },
       "environment": -1,
-      "exits": {
-        "south": 609,
-        "west": 635,
-        "east": 660,
-        "north": 611
-      },
       "weight": 1,
-      "id": 610,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 611, "name": "Silver Street",
+      "exits": { "south": 610, "east": 713, "north": 612 },
       "environment": -1,
-      "exits": {
-        "south": 610,
-        "east": 713,
-        "north": 612
-      },
       "weight": 1,
-      "id": 611,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 612, "name": "Silver Street",
+      "exits": { "south": 611, "east": 674, "north": 613 },
       "environment": -1,
-      "exits": {
-        "south": 611,
-        "east": 674,
-        "north": 613
-      },
       "weight": 1,
-      "id": 612,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 613, "name": "Silver Street",
+      "exits": { "south": 612, "west": 675, "east": 676, "north": 614 },
       "environment": -1,
-      "exits": {
-        "south": 612,
-        "west": 675,
-        "east": 676,
-        "north": 614
-      },
       "weight": 1,
-      "id": 613,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A Grand Plaza",
+      "id": 614, "name": "A Grand Plaza",
+      "exits": { "south": 613, "west": 678, "east": 677, "north": 615 },
       "environment": -1,
-      "exits": {
-        "south": 613,
-        "west": 678,
-        "east": 677,
-        "north": 615
-      },
       "weight": 1,
-      "id": 614,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 615, "name": "Silver Street",
+      "exits": { "west": 688, "south": 614, "north": 616 },
       "environment": -1,
-      "exits": {
-        "west": 688,
-        "south": 614,
-        "north": 616
-      },
       "weight": 1,
-      "id": 615,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 616, "name": "Silver Street",
+      "exits": { "south": 615, "east": 689, "north": 617 },
       "environment": -1,
-      "exits": {
-        "south": 615,
-        "east": 689,
-        "north": 617
-      },
       "weight": 1,
-      "id": 616,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 617, "name": "Silver Street",
+      "exits": { "west": 690, "south": 616, "north": 618 },
       "environment": -1,
-      "exits": {
-        "west": 690,
-        "south": 616,
-        "north": 618
-      },
       "weight": 1,
-      "id": 617,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Silver Street",
+      "id": 618, "name": "Silver Street",
+      "exits": { "south": 617, "west": 622, "east": 691, "north": 619 },
       "environment": -1,
-      "exits": {
-        "south": 617,
-        "west": 622,
-        "east": 691,
-        "north": 619
-      },
       "weight": 1,
-      "id": 618,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "End of Silver Street",
+      "id": 619, "name": "End of Silver Street",
+      "exits": { "east": 620, "south": 618 },
       "environment": -1,
-      "exits": {
-        "east": 620,
-        "south": 618
-      },
       "weight": 1,
-      "id": 619,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Island smeltery",
+      "id": 620, "name": "Island smeltery",
+      "exits": { "east": 621, "west": 619 },
       "environment": -1,
-      "exits": {
-        "east": 621,
-        "west": 619
-      },
       "weight": 1,
-      "id": 620,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Repair Shop",
+      "id": 621, "name": "Repair Shop",
+      "exits": { "west": 620 },
       "environment": -1,
-      "exits": {
-        "west": 620
-      },
       "weight": 1,
-      "id": 621,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A Bloody Arena.",
+      "id": 622, "name": "A Bloody Arena.",
       "environment": -1,
-      "id": 622,
       "weight": 1,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Western Part of Beach",
+      "id": 623, "name": "Western Part of Beach",
+      "exits": { "east": 606, "west": 624 },
       "environment": -1,
-      "exits": {
-        "east": 606,
-        "west": 624
-      },
       "weight": 1,
-      "id": 623,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "East of the waterfall",
+      "id": 624, "name": "East of the waterfall",
+      "exits": { "east": 623, "west": 625 },
       "environment": -1,
-      "exits": {
-        "east": 623,
-        "west": 625
-      },
       "weight": 1,
-      "id": 624,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "The base of a waterfall",
+      "id": 625, "name": "The base of a waterfall",
+      "exits": { "east": 624 },
       "environment": -1,
-      "exits": {
-        "east": 624
-      },
       "weight": 1,
-      "id": 625,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Ruins",
+      "id": 626, "name": "Ruins",
+      "exits": { "east": 627, "west": 606 },
       "environment": -1,
-      "exits": {
-        "east": 627,
-        "west": 606
-      },
       "weight": 1,
-      "id": 626,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Eastern Beach",
+      "id": 627, "name": "Eastern Beach",
+      "exits": { "west": 626 },
       "environment": -1,
-      "exits": {
-        "west": 626
-      },
       "weight": 1,
-      "id": 627,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A valley between two large dunes",
+      "id": 628, "name": "A valley between two large dunes",
+      "exits": { "east": 629, "west": 607 },
       "environment": -1,
-      "exits": {
-        "east": 629,
-        "west": 607
-      },
       "weight": 1,
-      "id": 628,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A desert plain",
+      "id": 629, "name": "A desert plain",
+      "exits": { "west": 628, "north": 630 },
       "environment": -1,
-      "exits": {
-        "west": 628,
-        "north": 630
-      },
       "weight": 1,
-      "id": 629,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A dead end",
+      "id": 630, "name": "A dead end",
+      "exits": { "south": 629 },
       "environment": -1,
-      "exits": {
-        "south": 629
-      },
       "weight": 1,
-      "id": 630,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Guard Room",
+      "id": 631, "name": "Guard Room",
+      "exits": { "east": 609, "west": 632 },
       "environment": -1,
-      "exits": {
-        "east": 609,
-        "west": 632
-      },
       "weight": 1,
-      "id": 631,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Armoury",
+      "id": 632, "name": "Armoury",
+      "exits": { "east": 631, "west": 633 },
       "environment": -1,
-      "exits": {
-        "east": 631,
-        "west": 633
-      },
       "weight": 1,
-      "id": 632,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Elderoak's Quarters",
+      "id": 633, "name": "Elderoak's Quarters",
+      "exits": { "east": 632 },
       "environment": -1,
-      "exits": {
-        "east": 632
-      },
       "weight": 1,
-      "id": 633,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "A guard house",
+      "id": 634, "name": "A guard house",
+      "exits": { "west": 609 },
       "environment": -1,
-      "exits": {
-        "west": 609
-      },
       "weight": 1,
-      "id": 634,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 635, "name": "Balin Road",
+      "exits": { "northwest": 719, "south": 717, "northeast": 718, "east": 610, "west": 636 },
       "environment": -1,
-      "exits": {
-        "northwest": 719,
-        "south": 717,
-        "northeast": 718,
-        "east": 610,
-        "west": 636
-      },
       "weight": 1,
-      "id": 635,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 636, "name": "Balin Road",
+      "exits": { "southwest": 722, "east": 635, "southeast": 721, "west": 637 },
       "environment": -1,
-      "exits": {
-        "southwest": 722,
-        "east": 635,
-        "southeast": 721,
-        "west": 637
-      },
       "weight": 1,
-      "id": 636,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "West End of Balin Road",
+      "id": 637, "name": "West End of Balin Road",
+      "exits": { "west": 638, "northeast": 720, "east": 636, "south": 723 },
       "environment": -1,
-      "exits": {
-        "west": 638,
-        "northeast": 720,
-        "east": 636,
-        "south": 723
-      },
       "weight": 1,
-      "id": 637,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Tunnel Under Canal",
+      "id": 638, "name": "Tunnel Under Canal",
+      "exits": { "east": 637, "west": 639 },
       "environment": -1,
-      "exits": {
-        "east": 637,
-        "west": 639
-      },
       "weight": 1,
-      "id": 638,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "South End of Highland Avenue",
+      "id": 639, "name": "South End of Highland Avenue",
+      "exits": { "east": 638, "west": 640 },
       "environment": -1,
-      "exits": {
-        "east": 638,
-        "west": 640
-      },
       "weight": 1,
-      "id": 639,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 640, "name": "Highland Avenue",
+      "exits": { "south": 657, "east": 639, "north": 641 },
       "environment": -1,
-      "exits": {
-        "south": 657,
-        "east": 639,
-        "north": 641
-      },
       "weight": 1,
-      "id": 640,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 641, "name": "Highland Avenue",
+      "exits": { "south": 640, "north": 642 },
       "environment": -1,
-      "exits": {
-        "south": 640,
-        "north": 642
-      },
       "weight": 1,
-      "id": 641,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 642, "name": "Highland Avenue",
+      "exits": { "west": 643, "south": 641 },
       "environment": -1,
-      "exits": {
-        "west": 643,
-        "south": 641
-      },
       "weight": 1,
-      "id": 642,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 643, "name": "Highland Avenue",
+      "exits": { "south": 647, "east": 642, "north": 644 },
       "environment": -1,
-      "exits": {
-        "south": 647,
-        "east": 642,
-        "north": 644
-      },
       "weight": 1,
-      "id": 643,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 644, "name": "Highland Avenue",
+      "exits": { "south": 643, "west": 646, "east": 648, "north": 645 },
       "environment": -1,
-      "exits": {
-        "south": 643,
-        "west": 646,
-        "east": 648,
-        "north": 645
-      },
       "weight": 1,
-      "id": 644,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Dwarven Hut",
+      "id": 645, "name": "Dwarven Hut",
+      "exits": { "south": 644 },
       "environment": -1,
-      "exits": {
-        "south": 644
-      },
       "weight": 1,
-      "id": 645,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "You trundle past the facade and arrive on a beautiful street.",
+      "id": 646, "name": "You trundle past the facade and arrive on a beautiful street.",
+      "exits": { "east": 644 },
       "environment": -1,
-      "exits": {
-        "east": 644
-      },
       "weight": 1,
-      "id": 646,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Gnome Hut",
+      "id": 647, "name": "Gnome Hut",
+      "exits": { "north": 643 },
       "environment": -1,
-      "exits": {
-        "north": 643
-      },
       "weight": 1,
-      "id": 647,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 648, "name": "Highland Avenue",
+      "exits": { "south": 651, "west": 644, "east": 649, "north": 650 },
       "environment": -1,
-      "exits": {
-        "south": 651,
-        "west": 644,
-        "east": 649,
-        "north": 650
-      },
       "weight": 1,
-      "id": 648,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Dwarven Home",
+      "id": 649, "name": "Dwarven Home",
+      "exits": { "west": 648 },
       "environment": -1,
-      "exits": {
-        "west": 648
-      },
       "weight": 1,
-      "id": 649,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 650, "name": "Highland Avenue",
+      "exits": { "west": 652, "south": 648 },
       "environment": -1,
-      "exits": {
-        "west": 652,
-        "south": 648
-      },
       "weight": 1,
-      "id": 650,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Dwarven Shack",
+      "id": 651, "name": "Dwarven Shack",
+      "exits": { "north": 648 },
       "environment": -1,
-      "exits": {
-        "north": 648
-      },
       "weight": 1,
-      "id": 651,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 652, "name": "Highland Avenue",
+      "exits": { "west": 653, "east": 650, "north": 654 },
       "environment": -1,
-      "exits": {
-        "west": 653,
-        "east": 650,
-        "north": 654
-      },
       "weight": 1,
-      "id": 652,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Dwarven Home",
+      "id": 653, "name": "Dwarven Home",
+      "exits": { "east": 652, "south": 656 },
       "environment": -1,
-      "exits": {
-        "east": 652,
-        "south": 656
-      },
       "weight": 1,
-      "id": 653,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Highland Avenue",
+      "id": 654, "name": "Highland Avenue",
+      "exits": { "south": 652, "north": 655 },
       "environment": -1,
-      "exits": {
-        "south": 652,
-        "north": 655
-      },
       "weight": 1,
-      "id": 654,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "House of Balin",
+      "id": 655, "name": "House of Balin",
+      "exits": { "west": 712, "south": 654 },
       "environment": -1,
-      "exits": {
-        "west": 712,
-        "south": 654
-      },
       "weight": 1,
-      "id": 655,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Dwarven Home",
+      "id": 656, "name": "Dwarven Home",
+      "exits": { "north": 653 },
       "environment": -1,
-      "exits": {
-        "north": 653
-      },
       "weight": 1,
-      "id": 656,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Keep Of Alcibiades",
+      "id": 657, "name": "Keep Of Alcibiades",
+      "exits": { "west": 659, "east": 658, "north": 640 },
       "environment": -1,
-      "exits": {
-        "west": 659,
-        "east": 658,
-        "north": 640
-      },
       "weight": 1,
-      "id": 657,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Study",
+      "id": 658, "name": "Study",
+      "exits": { "west": 657 },
       "environment": -1,
-      "exits": {
-        "west": 657
-      },
       "weight": 1,
-      "id": 658,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Bedroom:",
+      "id": 659, "name": "Bedroom:",
+      "exits": { "east": 657 },
       "environment": -1,
-      "exits": {
-        "east": 657
-      },
       "weight": 1,
-      "id": 659,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 660, "name": "Balin Road",
+      "exits": { "east": 661, "west": 610 },
       "environment": -1,
-      "exits": {
-        "east": 661,
-        "west": 610
-      },
       "weight": 1,
-      "id": 660,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 661, "name": "Balin Road",
+      "exits": { "west": 660, "east": 662, "south": 673 },
       "environment": -1,
-      "exits": {
-        "west": 660,
-        "east": 662,
-        "south": 673
-      },
       "weight": 1,
-      "id": 661,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 662, "name": "Balin Road",
+      "exits": { "west": 661, "east": 663, "north": 672 },
       "environment": -1,
-      "exits": {
-        "west": 661,
-        "east": 663,
-        "north": 672
-      },
       "weight": 1,
-      "id": 662,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 663, "name": "Balin Road",
+      "exits": { "south": 670, "west": 662, "east": 664, "north": 671 },
       "environment": -1,
-      "exits": {
-        "south": 670,
-        "west": 662,
-        "east": 664,
-        "north": 671
-      },
       "weight": 1,
-      "id": 663,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road",
+      "id": 664, "name": "Balin Road",
+      "exits": { "south": 667, "west": 663, "east": 665, "north": 668 },
       "environment": -1,
-      "exits": {
-        "south": 667,
-        "west": 663,
-        "east": 665,
-        "north": 668
-      },
       "weight": 1,
-      "id": 664,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "East End of Balin Road",
+      "id": 665, "name": "East End of Balin Road",
+      "exits": { "west": 664, "south": 666 },
       "environment": -1,
-      "exits": {
-        "west": 664,
-        "south": 666
-      },
       "weight": 1,
-      "id": 665,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Arched Gates",
+      "id": 666, "name": "Arched Gates",
+      "exits": { "north": 665 },
       "environment": -1,
-      "exits": {
-        "north": 665
-      },
       "weight": 1,
-      "id": 666,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 667, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 664 },
       "environment": -1,
-      "exits": {
-        "north": 664
-      },
       "weight": 1,
-      "id": 667,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Island Historical Society",
+      "id": 668, "name": "Island Historical Society",
+      "exits": { "south": 664, "north": 669 },
       "environment": -1,
-      "exits": {
-        "south": 664,
-        "north": 669
-      },
       "weight": 1,
-      "id": 668,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Office",
+      "id": 669, "name": "Office",
+      "exits": { "south": 668 },
       "environment": -1,
-      "exits": {
-        "south": 668
-      },
       "weight": 1,
-      "id": 669,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Elven Mercantile",
+      "id": 670, "name": "Elven Mercantile",
+      "exits": { "north": 663 },
       "environment": -1,
-      "exits": {
-        "north": 663
-      },
       "weight": 1,
-      "id": 670,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Temple Shop",
+      "id": 671, "name": "Temple Shop",
+      "exits": { "west": 672, "south": 663 },
       "environment": -1,
-      "exits": {
-        "west": 672,
-        "south": 663
-      },
       "weight": 1,
-      "id": 671,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Temple Plaza",
+      "id": 672, "name": "Temple Plaza",
+      "exits": { "west": 715, "east": 671, "south": 662 },
       "environment": -1,
-      "exits": {
-        "west": 715,
-        "east": 671,
-        "south": 662
-      },
       "weight": 1,
-      "id": 672,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Seed Shop",
+      "id": 673, "name": "Seed Shop",
+      "exits": { "north": 661 },
       "environment": -1,
-      "exits": {
-        "north": 661
-      },
       "weight": 1,
-      "id": 673,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "City Pastry Shop",
+      "id": 674, "name": "City Pastry Shop",
+      "exits": { "west": 612 },
       "environment": -1,
-      "exits": {
-        "west": 612
-      },
       "weight": 1,
-      "id": 674,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Soylent Green",
+      "id": 675, "name": "Soylent Green",
+      "exits": { "east": 613 },
       "environment": -1,
-      "exits": {
-        "east": 613
-      },
       "weight": 1,
-      "id": 675,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Mariner's Revenge",
+      "id": 676, "name": "Mariner's Revenge",
+      "exits": { "west": 613, "north": 677 },
       "environment": -1,
-      "exits": {
-        "west": 613,
-        "north": 677
-      },
       "weight": 1,
-      "id": 676,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Gate House",
+      "id": 677, "name": "Gate House",
+      "exits": { "south": 676, "west": 614, "east": 693, "north": 686 },
       "environment": -1,
-      "exits": {
-        "south": 676,
-        "west": 614,
-        "east": 693,
-        "north": 686
-      },
       "weight": 1,
-      "id": 677,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Gate House",
+      "id": 678, "name": "Gate House",
+      "exits": { "east": 614, "west": 679 },
       "environment": -1,
-      "exits": {
-        "east": 614,
-        "west": 679
-      },
       "weight": 1,
-      "id": 678,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Foyer",
+      "id": 679, "name": "Foyer",
+      "exits": { "south": 684, "east": 678, "north": 680 },
       "environment": -1,
-      "exits": {
-        "south": 684,
-        "east": 678,
-        "north": 680
-      },
       "weight": 1,
-      "id": 679,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Hallway",
+      "id": 680, "name": "Hallway",
+      "exits": { "south": 679, "north": 681 },
       "environment": -1,
-      "exits": {
-        "south": 679,
-        "north": 681
-      },
       "weight": 1,
-      "id": 680,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Audience Hall",
+      "id": 681, "name": "Audience Hall",
+      "exits": { "west": 682, "south": 680 },
       "environment": -1,
-      "exits": {
-        "west": 682,
-        "south": 680
-      },
       "weight": 1,
-      "id": 681,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Council Chamber",
+      "id": 682, "name": "Council Chamber",
+      "exits": { "east": 681, "west": 683 },
       "environment": -1,
-      "exits": {
-        "east": 681,
-        "west": 683
-      },
       "weight": 1,
-      "id": 682,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Trophy Room",
+      "id": 683, "name": "Trophy Room",
+      "exits": { "east": 682 },
       "environment": -1,
-      "exits": {
-        "east": 682
-      },
       "weight": 1,
-      "id": 683,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Hallway",
+      "id": 684, "name": "Hallway",
+      "exits": { "south": 685, "north": 679 },
       "environment": -1,
-      "exits": {
-        "south": 685,
-        "north": 679
-      },
       "weight": 1,
-      "id": 684,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Lady Roland's Bedroom",
+      "id": 685, "name": "Lady Roland's Bedroom",
+      "exits": { "north": 684 },
       "environment": -1,
-      "exits": {
-        "north": 684
-      },
       "weight": 1,
-      "id": 685,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "RIIS",
+      "id": 686, "name": "RIIS",
+      "exits": { "down": 687, "south": 677 },
       "environment": -1,
-      "exits": {
-        "down": 687,
-        "south": 677
-      },
       "weight": 1,
-      "id": 686,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Crack of Doom",
+      "id": 687, "name": "Crack of Doom",
+      "exits": { "up": 686 },
       "environment": -1,
-      "exits": {
-        "up": 686
-      },
       "weight": 1,
-      "id": 687,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Rhian's Potion Shop",
+      "id": 688, "name": "Rhian's Potion Shop",
+      "exits": { "east": 615 },
       "environment": -1,
-      "exits": {
-        "east": 615
-      },
       "weight": 1,
-      "id": 688,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Alchemist Shop",
+      "id": 689, "name": "Alchemist Shop",
+      "exits": { "west": 616 },
       "environment": -1,
-      "exits": {
-        "west": 616
-      },
       "weight": 1,
-      "id": 689,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Entrance to the Hall of Records",
+      "id": 690, "name": "Entrance to the Hall of Records",
+      "exits": { "east": 617 },
       "environment": -1,
-      "exits": {
-        "east": 617
-      },
       "weight": 1,
-      "id": 690,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Power System Generator",
+      "id": 691, "name": "Power System Generator",
+      "exits": { "east": 692, "west": 618 },
       "environment": -1,
-      "exits": {
-        "east": 692,
-        "west": 618
-      },
       "weight": 1,
-      "id": 691,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Power System Internals",
+      "id": 692, "name": "Power System Internals",
+      "exits": { "west": 691 },
       "environment": -1,
-      "exits": {
-        "west": 691
-      },
       "weight": 1,
-      "id": 692,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Entryway",
+      "id": 693, "name": "Entryway",
+      "exits": { "west": 677, "south": 694, "north": 696 },
       "environment": -1,
-      "exits": {
-        "west": 677,
-        "south": 694,
-        "north": 696
-      },
       "weight": 1,
-      "id": 693,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "South Corridor",
+      "id": 694, "name": "South Corridor",
+      "exits": { "south": 695, "north": 693 },
       "environment": -1,
-      "exits": {
-        "south": 695,
-        "north": 693
-      },
       "weight": 1,
-      "id": 694,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Guard Post",
+      "id": 695, "name": "Guard Post",
+      "exits": { "north": 694 },
       "environment": -1,
-      "exits": {
-        "north": 694
-      },
       "weight": 1,
-      "id": 695,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "North Corridor",
+      "id": 696, "name": "North Corridor",
+      "exits": { "south": 693, "north": 697 },
       "environment": -1,
-      "exits": {
-        "south": 693,
-        "north": 697
-      },
       "weight": 1,
-      "id": 696,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Guard Room",
+      "id": 697, "name": "Guard Room",
+      "exits": { "east": 698, "south": 696 },
       "environment": -1,
-      "exits": {
-        "east": 698,
-        "south": 696
-      },
       "weight": 1,
-      "id": 697,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "West Harem",
+      "id": 698, "name": "West Harem",
+      "exits": { "east": 699, "west": 697 },
       "environment": -1,
-      "exits": {
-        "east": 699,
-        "west": 697
-      },
       "weight": 1,
-      "id": 698,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "East Harem",
+      "id": 699, "name": "East Harem",
+      "exits": { "east": 700, "west": 698 },
       "environment": -1,
-      "exits": {
-        "east": 700,
-        "west": 698
-      },
       "weight": 1,
-      "id": 699,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Bedchamber",
+      "id": 700, "name": "Bedchamber",
+      "exits": { "east": 701, "west": 699 },
       "environment": -1,
-      "exits": {
-        "east": 701,
-        "west": 699
-      },
       "weight": 1,
-      "id": 700,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Entryway",
+      "id": 701, "name": "Entryway",
+      "exits": { "west": 700, "south": 702 },
       "environment": -1,
-      "exits": {
-        "west": 700,
-        "south": 702
-      },
       "weight": 1,
-      "id": 701,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 702, "name": "Turkish Bath",
+      "exits": { "south": 703, "east": 708, "north": 701 },
       "environment": -1,
-      "exits": {
-        "south": 703,
-        "east": 708,
-        "north": 701
-      },
       "weight": 1,
-      "id": 702,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 703, "name": "Turkish Bath",
+      "exits": { "south": 704, "east": 707, "north": 702 },
       "environment": -1,
-      "exits": {
-        "south": 704,
-        "east": 707,
-        "north": 702
-      },
       "weight": 1,
-      "id": 703,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 704, "name": "Turkish Bath",
+      "exits": { "south": 705, "east": 706, "north": 703 },
       "environment": -1,
-      "exits": {
-        "south": 705,
-        "east": 706,
-        "north": 703
-      },
       "weight": 1,
-      "id": 704,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "South Entryway",
+      "id": 705, "name": "South Entryway",
+      "exits": { "north": 704 },
       "environment": -1,
-      "exits": {
-        "north": 704
-      },
       "weight": 1,
-      "id": 705,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 706, "name": "Turkish Bath",
+      "exits": { "west": 704, "south": 710, "north": 707 },
       "environment": -1,
-      "exits": {
-        "west": 704,
-        "south": 710,
-        "north": 707
-      },
       "weight": 1,
-      "id": 706,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 707, "name": "Turkish Bath",
+      "exits": { "west": 703, "south": 706, "north": 708 },
       "environment": -1,
-      "exits": {
-        "west": 703,
-        "south": 706,
-        "north": 708
-      },
       "weight": 1,
-      "id": 707,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 708, "name": "Turkish Bath",
+      "exits": { "west": 702, "south": 707, "north": 709 },
       "environment": -1,
-      "exits": {
-        "west": 702,
-        "south": 707,
-        "north": 709
-      },
       "weight": 1,
-      "id": 708,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 709, "name": "Turkish Bath",
+      "exits": { "south": 708 },
       "environment": -1,
-      "exits": {
-        "south": 708
-      },
       "weight": 1,
-      "id": 709,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Turkish Bath",
+      "id": 710, "name": "Turkish Bath",
+      "exits": { "north": 706 },
       "environment": -1,
-      "exits": {
-        "north": 706
-      },
       "weight": 1,
-      "id": 710,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "The hermit says: Is there anything you would like to talk about?",
+      "id": 711, "name": "The hermit says: Is there anything you would like to talk about?",
       "environment": -1,
-      "id": 711,
       "weight": 1,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Hermit's Chamber",
+      "id": 712, "name": "Hermit's Chamber",
+      "exits": { "east": 655 },
       "environment": -1,
-      "exits": {
-        "east": 655
-      },
       "weight": 1,
-      "id": 712,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Temple",
+      "id": 713, "name": "Temple",
+      "exits": { "west": 611, "east": 714, "north": 716 },
       "environment": -1,
-      "exits": {
-        "west": 611,
-        "east": 714,
-        "north": 716
-      },
       "weight": 1,
-      "id": 713,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Central Chamber",
+      "id": 714, "name": "Central Chamber",
+      "exits": { "east": 715, "west": 713 },
       "environment": -1,
-      "exits": {
-        "east": 715,
-        "west": 713
-      },
       "weight": 1,
-      "id": 714,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Eastern Chamber",
+      "id": 715, "name": "Eastern Chamber",
+      "exits": { "east": 672, "west": 714 },
       "environment": -1,
-      "exits": {
-        "east": 672,
-        "west": 714
-      },
       "weight": 1,
-      "id": 715,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "id": 716, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 713 },
       "environment": -1,
-      "exits": {
-        "south": 713
-      },
       "weight": 1,
-      "id": 716,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Poison Shop",
+      "id": 717, "name": "Poison Shop",
+      "exits": { "north": 635 },
       "environment": -1,
-      "exits": {
-        "north": 635
-      },
       "weight": 1,
-      "id": 717,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Taxidermist",
+      "id": 718, "name": "Taxidermist",
+      "exits": { "southwest": 635 },
       "environment": -1,
-      "exits": {
-        "southwest": 635
-      },
       "weight": 1,
-      "id": 718,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Weaver's",
+      "id": 719, "name": "Weaver's",
+      "exits": { "southeast": 635 },
       "environment": -1,
-      "exits": {
-        "southeast": 635
-      },
       "weight": 1,
-      "id": 719,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Foyer of House of Ill Repute",
+      "id": 720, "name": "Foyer of House of Ill Repute",
+      "exits": { "southwest": 637 },
       "environment": -1,
-      "exits": {
-        "southwest": 637
-      },
       "weight": 1,
-      "id": 720,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Balin Road Pub",
+      "id": 721, "name": "Balin Road Pub",
+      "exits": { "northwest": 636 },
       "environment": -1,
-      "exits": {
-        "northwest": 636
-      },
       "weight": 1,
-      "id": 721,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Wheelwright",
+      "id": 722, "name": "Wheelwright",
+      "exits": { "northeast": 636 },
       "environment": -1,
-      "exits": {
-        "northeast": 636
-      },
       "weight": 1,
-      "id": 722,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Crowded Thoroughfare",
+      "id": 723, "name": "Crowded Thoroughfare",
+      "exits": { "south": 724, "north": 637 },
       "environment": -1,
-      "exits": {
-        "south": 724,
-        "north": 637
-      },
       "weight": 1,
-      "id": 723,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Archway of Servitude",
+      "id": 724, "name": "Archway of Servitude",
+      "exits": { "south": 725, "north": 723 },
       "environment": -1,
-      "exits": {
-        "south": 725,
-        "north": 723
-      },
       "weight": 1,
-      "id": 724,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Bazaar Crossroad",
+      "id": 725, "name": "Bazaar Crossroad",
+      "exits": { "west": 726, "east": 729, "north": 724 },
       "environment": -1,
-      "exits": {
-        "west": 726,
-        "east": 729,
-        "north": 724
-      },
       "weight": 1,
-      "id": 725,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Western District",
+      "id": 726, "name": "Western District",
+      "exits": { "east": 725, "south": 727 },
       "environment": -1,
-      "exits": {
-        "east": 725,
-        "south": 727
-      },
       "weight": 1,
-      "id": 726,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Western District",
+      "id": 727, "name": "Western District",
+      "exits": { "south": 728, "north": 726 },
       "environment": -1,
-      "exits": {
-        "south": 728,
-        "north": 726
-      },
       "weight": 1,
-      "id": 727,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Western slave bazaar",
+      "id": 728, "name": "Western slave bazaar",
+      "exits": { "east": 732, "north": 727 },
       "environment": -1,
-      "exits": {
-        "east": 732,
-        "north": 727
-      },
       "weight": 1,
-      "id": 728,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Eastern District",
+      "id": 729, "name": "Eastern District",
+      "exits": { "west": 725, "south": 730 },
       "environment": -1,
-      "exits": {
-        "west": 725,
-        "south": 730
-      },
       "weight": 1,
-      "id": 729,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Eastern District",
+      "id": 730, "name": "Eastern District",
+      "exits": { "south": 731, "north": 729 },
       "environment": -1,
-      "exits": {
-        "south": 731,
-        "north": 729
-      },
       "weight": 1,
-      "id": 730,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Eastern slave bazaar",
+      "id": 731, "name": "Eastern slave bazaar",
+      "exits": { "west": 732, "north": 730 },
       "environment": -1,
-      "exits": {
-        "west": 732,
-        "north": 730
-      },
       "weight": 1,
-      "id": 731,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Central slave bazaar",
+      "id": 732, "name": "Central slave bazaar",
+      "exits": { "west": 728, "east": 731, "south": 733 },
       "environment": -1,
-      "exits": {
-        "west": 728,
-        "east": 731,
-        "south": 733
-      },
       "weight": 1,
-      "id": 732,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Administrative hallway",
+      "id": 733, "name": "Administrative hallway",
+      "exits": { "north": 732 },
       "environment": -1,
-      "exits": {
-        "north": 732
-      },
       "weight": 1,
-      "id": 733,
-      "area": {
-        "id": 9
-      }
+      "area": {"id": 9}
     },
     {
-      "name": "Weapon Master's Bedroom",
+      "id": 734, "name": "Weapon Master's Bedroom",
+      "exits": { "down": 399 },
       "environment": -1,
-      "exits": {
-        "down": 399
-      },
       "weight": 1,
-      "id": 734,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 735, "name": "Guild/Shop Space for rent",
+      "exits": { "west": 172 },
       "environment": -1,
-      "exits": {
-        "west": 172
-      },
       "weight": 1,
-      "id": 735,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 736, "name": "Guild/Shop Space for rent",
+      "exits": { "west": 173 },
       "environment": -1,
-      "exits": {
-        "west": 173
-      },
       "weight": 1,
-      "id": 736,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Chamber of Commerce",
+      "id": 737, "name": "Chamber of Commerce",
+      "exits": { "south": 187 },
       "environment": -1,
-      "exits": {
-        "south": 187
-      },
       "weight": 1,
-      "id": 737,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Alley",
+      "id": 738, "name": "Alley",
+      "exits": { "south": 188 },
       "environment": -1,
-      "exits": {
-        "south": 188
-      },
       "weight": 1,
-      "id": 738,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The School of Guild Skills",
+      "id": 739, "name": "The School of Guild Skills",
+      "exits": { "north": 189 },
       "environment": -1,
-      "exits": {
-        "north": 189
-      },
       "weight": 1,
-      "id": 739,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stationery Store",
+      "id": 740, "name": "Stationery Store",
+      "exits": { "north": 190 },
       "environment": -1,
-      "exits": {
-        "north": 190
-      },
       "weight": 1,
-      "id": 740,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormitory Hallway",
+      "id": 741, "name": "Dormitory Hallway",
+      "exits": { "up": 748, "south": 190, "east": 747, "north": 745 },
       "environment": -1,
-      "exits": {
-        "up": 748,
-        "south": 190,
-        "east": 747,
-        "north": 745
-      },
       "weight": 1,
-      "id": 741,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Magoo's Bookstore",
+      "id": 742, "name": "Magoo's Bookstore",
+      "exits": { "north": 191 },
       "environment": -1,
-      "exits": {
-        "north": 191
-      },
       "weight": 1,
-      "id": 742,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Frenchie's Cafe",
+      "id": 743, "name": "Frenchie's Cafe",
+      "exits": { "south": 191 },
       "environment": -1,
-      "exits": {
-        "south": 191
-      },
       "weight": 1,
-      "id": 743,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "An empty lot.",
+      "id": 744, "name": "An empty lot.",
+      "exits": { "north": 192 },
       "environment": -1,
-      "exits": {
-        "north": 192
-      },
       "weight": 1,
-      "id": 744,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormitory Kitchen",
+      "id": 745, "name": "Dormitory Kitchen",
+      "exits": { "east": 746, "south": 741 },
       "environment": -1,
-      "exits": {
-        "east": 746,
-        "south": 741
-      },
       "weight": 1,
-      "id": 745,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Store Room",
+      "id": 746, "name": "Store Room",
+      "exits": { "west": 745 },
       "environment": -1,
-      "exits": {
-        "west": 745
-      },
       "weight": 1,
-      "id": 746,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormitory Administrator's Room",
+      "id": 747, "name": "Dormitory Administrator's Room",
+      "exits": { "west": 741 },
       "environment": -1,
-      "exits": {
-        "west": 741
-      },
       "weight": 1,
-      "id": 747,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormitory Hallway",
+      "id": 748, "name": "Dormitory Hallway",
+      "exits": { "west": 751, "down": 741, "south": 752, "east": 750, "north": 749 },
       "environment": -1,
-      "exits": {
-        "west": 751,
-        "down": 741,
-        "south": 752,
-        "east": 750,
-        "north": 749
-      },
       "weight": 1,
-      "id": 748,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormer",
+      "id": 749, "name": "Dormer",
+      "exits": { "south": 748 },
       "environment": -1,
-      "exits": {
-        "south": 748
-      },
       "weight": 1,
-      "id": 749,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormer",
+      "id": 750, "name": "Dormer",
+      "exits": { "west": 748 },
       "environment": -1,
-      "exits": {
-        "west": 748
-      },
       "weight": 1,
-      "id": 750,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormer",
+      "id": 751, "name": "Dormer",
+      "exits": { "east": 748 },
       "environment": -1,
-      "exits": {
-        "east": 748
-      },
       "weight": 1,
-      "id": 751,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormer",
+      "id": 752, "name": "Dormer",
+      "exits": { "north": 748 },
       "environment": -1,
-      "exits": {
-        "north": 748
-      },
       "weight": 1,
-      "id": 752,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The drawbridge",
+      "id": 753, "name": "The drawbridge",
+      "exits": { "southwest": 169, "north": 754 },
       "environment": -1,
-      "exits": {
-        "southwest": 169,
-        "north": 754
-      },
       "weight": 1,
-      "id": 753,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Between the towers",
+      "id": 754, "name": "Between the towers",
+      "exits": { "south": 753, "north": 755 },
       "environment": -1,
-      "exits": {
-        "south": 753,
-        "north": 755
-      },
       "weight": 1,
-      "id": 754,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Between the towers",
+      "id": 755, "name": "Between the towers",
+      "exits": { "south": 754, "north": 756 },
       "environment": -1,
-      "exits": {
-        "south": 754,
-        "north": 756
-      },
       "weight": 1,
-      "id": 755,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 756, "name": "The inner ward",
+      "exits": { "south": 755, "north": 757 },
       "environment": -1,
-      "exits": {
-        "south": 755,
-        "north": 757
-      },
       "weight": 1,
-      "id": 756,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 757, "name": "The inner ward",
+      "exits": { "south": 756, "northeast": 765, "east": 758, "north": 766 },
       "environment": -1,
-      "exits": {
-        "south": 756,
-        "northeast": 765,
-        "east": 758,
-        "north": 766
-      },
       "weight": 1,
-      "id": 757,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 758, "name": "The inner ward",
+      "exits": { "west": 757, "south": 759, "northwest": 766, "north": 765 },
       "environment": -1,
-      "exits": {
-        "west": 757,
-        "south": 759,
-        "northwest": 766,
-        "north": 765
-      },
       "weight": 1,
-      "id": 758,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Eastern guard room",
+      "id": 759, "name": "Eastern guard room",
+      "exits": { "northeast": 760, "north": 758 },
       "environment": -1,
-      "exits": {
-        "northeast": 760,
-        "north": 758
-      },
       "weight": 1,
-      "id": 759,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Lower eastern stairwell",
+      "id": 760, "name": "Lower eastern stairwell",
+      "exits": { "southwest": 759, "up": 761 },
       "environment": -1,
-      "exits": {
-        "southwest": 759,
-        "up": 761
-      },
       "weight": 1,
-      "id": 760,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Middle eastern stairwell",
+      "id": 761, "name": "Middle eastern stairwell",
+      "exits": { "southwest": 762, "down": 760, "up": 763 },
       "environment": -1,
-      "exits": {
-        "southwest": 762,
-        "down": 760,
-        "up": 763
-      },
       "weight": 1,
-      "id": 761,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Eastern guard quarters",
+      "id": 762, "name": "Eastern guard quarters",
+      "exits": { "northeast": 761 },
       "environment": -1,
-      "exits": {
-        "northeast": 761
-      },
       "weight": 1,
-      "id": 762,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Upper eastern stairwell",
+      "id": 763, "name": "Upper eastern stairwell",
+      "exits": { "southwest": 764, "down": 761 },
       "environment": -1,
-      "exits": {
-        "southwest": 764,
-        "down": 761
-      },
       "weight": 1,
-      "id": 763,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Eastern tower observatory",
+      "id": 764, "name": "Eastern tower observatory",
+      "exits": { "northeast": 763 },
       "environment": -1,
-      "exits": {
-        "northeast": 763
-      },
       "weight": 1,
-      "id": 764,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 765, "name": "The inner ward",
+      "exits": { "west": 766, "northwest": 767, "south": 758, "southwest": 757, "northeast": 769, "east": 770, "north": 768 },
       "environment": -1,
-      "exits": {
-        "west": 766,
-        "northwest": 767,
-        "south": 758,
-        "southwest": 757,
-        "northeast": 769,
-        "east": 770,
-        "north": 768
-      },
       "weight": 1,
-      "id": 765,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 766, "name": "The inner ward",
+      "exits": { "southeast": 758, "south": 757, "northeast": 768, "east": 765, "north": 767 },
       "environment": -1,
-      "exits": {
-        "southeast": 758,
-        "south": 757,
-        "northeast": 768,
-        "east": 765,
-        "north": 767
-      },
       "weight": 1,
-      "id": 766,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 767, "name": "The inner ward",
+      "exits": { "east": 768, "southeast": 765, "south": 766 },
       "environment": -1,
-      "exits": {
-        "east": 768,
-        "southeast": 765,
-        "south": 766
-      },
       "weight": 1,
-      "id": 767,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The inner ward",
+      "id": 768, "name": "The inner ward",
+      "exits": { "southwest": 766, "west": 767, "east": 769, "south": 765 },
       "environment": -1,
-      "exits": {
-        "southwest": 766,
-        "west": 767,
-        "east": 769,
-        "south": 765
-      },
       "weight": 1,
-      "id": 768,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The well",
+      "id": 769, "name": "The well",
+      "exits": { "southwest": 765, "east": 771, "west": 768 },
       "environment": -1,
-      "exits": {
-        "southwest": 765,
-        "east": 771,
-        "west": 768
-      },
       "weight": 1,
-      "id": 769,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle stables",
+      "id": 770, "name": "Castle stables",
+      "exits": { "south": 790, "west": 765, "east": 773, "north": 791 },
       "environment": -1,
-      "exits": {
-        "south": 790,
-        "west": 765,
-        "east": 773,
-        "north": 791
-      },
       "weight": 1,
-      "id": 770,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The blacksmith",
+      "id": 771, "name": "The blacksmith",
+      "exits": { "east": 772, "west": 769 },
       "environment": -1,
-      "exits": {
-        "east": 772,
-        "west": 769
-      },
       "weight": 1,
-      "id": 771,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The storage room",
+      "id": 772, "name": "The storage room",
+      "exits": { "west": 771 },
       "environment": -1,
-      "exits": {
-        "west": 771
-      },
       "weight": 1,
-      "id": 772,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle stables",
+      "id": 773, "name": "Castle stables",
+      "exits": { "south": 789, "west": 770, "east": 774, "north": 788 },
       "environment": -1,
-      "exits": {
-        "south": 789,
-        "west": 770,
-        "east": 774,
-        "north": 788
-      },
       "weight": 1,
-      "id": 773,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle stables",
+      "id": 774, "name": "Castle stables",
+      "exits": { "south": 787, "west": 773, "east": 775, "north": 786 },
       "environment": -1,
-      "exits": {
-        "south": 787,
-        "west": 773,
-        "east": 775,
-        "north": 786
-      },
       "weight": 1,
-      "id": 774,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle stables",
+      "id": 775, "name": "Castle stables",
+      "exits": { "south": 784, "west": 774, "east": 776, "north": 785 },
       "environment": -1,
-      "exits": {
-        "south": 784,
-        "west": 774,
-        "east": 776,
-        "north": 785
-      },
       "weight": 1,
-      "id": 775,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle stables",
+      "id": 776, "name": "Castle stables",
+      "exits": { "south": 782, "west": 775, "east": 777, "north": 781 },
       "environment": -1,
-      "exits": {
-        "south": 782,
-        "west": 775,
-        "east": 777,
-        "north": 781
-      },
       "weight": 1,
-      "id": 776,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Small paddock",
+      "id": 777, "name": "Small paddock",
+      "exits": { "southeast": 779, "south": 783, "west": 776, "east": 778, "north": 780 },
       "environment": -1,
-      "exits": {
-        "southeast": 779,
-        "south": 783,
-        "west": 776,
-        "east": 778,
-        "north": 780
-      },
       "weight": 1,
-      "id": 777,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Small paddock",
+      "id": 778, "name": "Small paddock",
+      "exits": { "southwest": 783, "west": 777, "northwest": 780, "south": 779 },
       "environment": -1,
-      "exits": {
-        "southwest": 783,
-        "west": 777,
-        "northwest": 780,
-        "south": 779
-      },
       "weight": 1,
-      "id": 778,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Small paddock",
+      "id": 779, "name": "Small paddock",
+      "exits": { "west": 783, "northwest": 777, "north": 778 },
       "environment": -1,
-      "exits": {
-        "west": 783,
-        "northwest": 777,
-        "north": 778
-      },
       "weight": 1,
-      "id": 779,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Wash area",
+      "id": 780, "name": "Wash area",
+      "exits": { "southeast": 778, "south": 777 },
       "environment": -1,
-      "exits": {
-        "southeast": 778,
-        "south": 777
-      },
       "weight": 1,
-      "id": 780,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 781, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 776 },
       "environment": -1,
-      "exits": {
-        "south": 776
-      },
       "weight": 1,
-      "id": 781,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 782, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 776 },
       "environment": -1,
-      "exits": {
-        "north": 776
-      },
       "weight": 1,
-      "id": 782,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Small paddock",
+      "id": 783, "name": "Small paddock",
+      "exits": { "northeast": 778, "east": 779, "north": 777 },
       "environment": -1,
-      "exits": {
-        "northeast": 778,
-        "east": 779,
-        "north": 777
-      },
       "weight": 1,
-      "id": 783,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 784, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 775 },
       "environment": -1,
-      "exits": {
-        "north": 775
-      },
       "weight": 1,
-      "id": 784,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 785, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 775 },
       "environment": -1,
-      "exits": {
-        "south": 775
-      },
       "weight": 1,
-      "id": 785,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Tack room",
+      "id": 786, "name": "Tack room",
+      "exits": { "south": 774 },
       "environment": -1,
-      "exits": {
-        "south": 774
-      },
       "weight": 1,
-      "id": 786,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Feed room",
+      "id": 787, "name": "Feed room",
+      "exits": { "north": 774 },
       "environment": -1,
-      "exits": {
-        "north": 774
-      },
       "weight": 1,
-      "id": 787,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 788, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 773 },
       "environment": -1,
-      "exits": {
-        "south": 773
-      },
       "weight": 1,
-      "id": 788,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 789, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 773 },
       "environment": -1,
-      "exits": {
-        "north": 773
-      },
       "weight": 1,
-      "id": 789,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 790, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 770 },
       "environment": -1,
-      "exits": {
-        "north": 770
-      },
       "weight": 1,
-      "id": 790,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "You swing open the wooden door and enter the stall.",
+      "id": 791, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 770 },
       "environment": -1,
-      "exits": {
-        "south": 770
-      },
       "weight": 1,
-      "id": 791,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A dingy alleyway",
+      "id": 792, "name": "A dingy alleyway",
+      "exits": { "south": 410, "east": 795, "north": 794 },
       "environment": -1,
-      "exits": {
-        "south": 410,
-        "east": 795,
-        "north": 794
-      },
       "weight": 1,
-      "id": 792,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Effortlessly, you scale the brick wall and drop into a garden on the opposite",
+      "id": 793, "name": "Effortlessly, you scale the brick wall and drop into a garden on the opposite",
+      "exits": { "east": 168 },
       "environment": -1,
-      "exits": {
-        "east": 168
-      },
       "weight": 1,
-      "id": 793,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A small building.",
+      "id": 794, "name": "A small building.",
+      "exits": { "south": 792 },
       "environment": -1,
-      "exits": {
-        "south": 792
-      },
       "weight": 1,
-      "id": 794,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A dingy alleyway",
+      "id": 795, "name": "A dingy alleyway",
+      "exits": { "south": 813, "west": 792, "east": 796, "north": 797 },
       "environment": -1,
-      "exits": {
-        "south": 813,
-        "west": 792,
-        "east": 796,
-        "north": 797
-      },
       "weight": 1,
-      "id": 795,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "An alley",
+      "id": 796, "name": "An alley",
+      "exits": { "south": 814, "west": 795, "east": 231, "north": 961 },
       "environment": -1,
-      "exits": {
-        "south": 814,
-        "west": 795,
-        "east": 231,
-        "north": 961
-      },
       "weight": 1,
-      "id": 796,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A dingy alley",
+      "id": 797, "name": "A dingy alley",
+      "exits": { "south": 795, "north": 798 },
       "environment": -1,
-      "exits": {
-        "south": 795,
-        "north": 798
-      },
       "weight": 1,
-      "id": 797,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "A Dingy Alley",
+      "id": 798, "name": "A Dingy Alley",
+      "exits": { "south": 797, "north": 799 },
       "environment": -1,
-      "exits": {
-        "south": 797,
-        "north": 799
-      },
       "weight": 1,
-      "id": 798,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stink Alley Way",
+      "id": 799, "name": "Stink Alley Way",
+      "exits": { "west": 802, "east": 800, "south": 798 },
       "environment": -1,
-      "exits": {
-        "west": 802,
-        "east": 800,
-        "south": 798
-      },
       "weight": 1,
-      "id": 799,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stink Alley Way",
+      "id": 800, "name": "Stink Alley Way",
+      "exits": { "west": 799, "east": 801, "north": 806 },
       "environment": -1,
-      "exits": {
-        "west": 799,
-        "east": 801,
-        "north": 806
-      },
       "weight": 1,
-      "id": 800,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stink Alley Way",
+      "id": 801, "name": "Stink Alley Way",
+      "exits": { "west": 800 },
       "environment": -1,
-      "exits": {
-        "west": 800
-      },
       "weight": 1,
-      "id": 801,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stink Alley Way",
+      "id": 802, "name": "Stink Alley Way",
+      "exits": { "south": 805, "west": 803, "east": 799, "north": 807 },
       "environment": -1,
-      "exits": {
-        "south": 805,
-        "west": 803,
-        "east": 799,
-        "north": 807
-      },
       "weight": 1,
-      "id": 802,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Stink Alley Way",
+      "id": 803, "name": "Stink Alley Way",
+      "exits": { "east": 802, "south": 804 },
       "environment": -1,
-      "exits": {
-        "east": 802,
-        "south": 804
-      },
       "weight": 1,
-      "id": 803,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Fish Mongery",
+      "id": 804, "name": "Fish Mongery",
+      "exits": { "north": 803 },
       "environment": -1,
-      "exits": {
-        "north": 803
-      },
       "weight": 1,
-      "id": 804,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Crazy Habib's Fertilizer",
+      "id": 805, "name": "Crazy Habib's Fertilizer",
+      "exits": { "north": 802 },
       "environment": -1,
-      "exits": {
-        "north": 802
-      },
       "weight": 1,
-      "id": 805,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Barber Shop",
+      "id": 806, "name": "Barber Shop",
+      "exits": { "south": 800 },
       "environment": -1,
-      "exits": {
-        "south": 800
-      },
       "weight": 1,
-      "id": 806,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Pornographers Den",
+      "id": 807, "name": "Pornographers Den",
+      "exits": { "south": 802 },
       "environment": -1,
-      "exits": {
-        "south": 802
-      },
       "weight": 1,
-      "id": 807,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Livery",
+      "id": 808, "name": "Livery",
+      "exits": { "up": 809, "west": 161 },
       "environment": -1,
-      "exits": {
-        "up": 809,
-        "west": 161
-      },
       "weight": 1,
-      "id": 808,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Hayloft",
+      "id": 809, "name": "Hayloft",
+      "exits": { "down": 808 },
       "environment": -1,
-      "exits": {
-        "down": 808
-      },
       "weight": 1,
-      "id": 809,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Tailor's Shop",
+      "id": 810, "name": "Tailor's Shop",
+      "exits": { "west": 162 },
       "environment": -1,
-      "exits": {
-        "west": 162
-      },
       "weight": 1,
-      "id": 810,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Hardware Store",
+      "id": 811, "name": "Hardware Store",
+      "exits": { "west": 163 },
       "environment": -1,
-      "exits": {
-        "west": 163
-      },
       "weight": 1,
-      "id": 811,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Haseltine Engravers",
+      "id": 812, "name": "Haseltine Engravers",
+      "exits": { "west": 164 },
       "environment": -1,
-      "exits": {
-        "west": 164
-      },
       "weight": 1,
-      "id": 812,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 813, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 795 },
       "environment": -1,
-      "exits": {
-        "north": 795
-      },
       "weight": 1,
-      "id": 813,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Flea Market",
+      "id": 814, "name": "Flea Market",
+      "exits": { "north": 796 },
       "environment": -1,
-      "exits": {
-        "north": 796
-      },
       "weight": 1,
-      "id": 814,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "The Back Room",
+      "id": 815, "name": "The Back Room",
+      "exits": { "east": 230, "north": 814 },
       "environment": -1,
-      "exits": {
-        "east": 230,
-        "north": 814
-      },
       "weight": 1,
-      "id": 815,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Castle Bridge",
+      "id": 816, "name": "Castle Bridge",
+      "exits": { "north": 151 },
       "environment": -1,
-      "exits": {
-        "north": 151
-      },
       "weight": 1,
-      "id": 816,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Manor House",
+      "id": 817, "name": "Manor House",
+      "exits": { "up": 818, "west": 152 },
       "environment": -1,
-      "exits": {
-        "up": 818,
-        "west": 152
-      },
       "weight": 1,
-      "id": 817,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Manor House",
+      "id": 818, "name": "Manor House",
+      "exits": { "down": 817 },
       "environment": -1,
-      "exits": {
-        "down": 817
-      },
       "weight": 1,
-      "id": 818,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 819, "name": "Guild/Shop Space for rent",
+      "exits": { "east": 152 },
       "environment": -1,
-      "exits": {
-        "east": 152
-      },
       "weight": 1,
-      "id": 819,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Cleric Guild",
+      "id": 820, "name": "Cleric Guild",
+      "exits": { "west": 839, "east": 153, "north": 838 },
       "environment": -1,
-      "exits": {
-        "west": 839,
-        "east": 153,
-        "north": 838
-      },
       "weight": 1,
-      "id": 820,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Hall of the builders guild",
+      "id": 821, "name": "Hall of the builders guild",
+      "exits": { "west": 154 },
       "environment": -1,
-      "exits": {
-        "west": 154
-      },
       "weight": 1,
-      "id": 821,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "City Hall",
+      "id": 822, "name": "City Hall",
+      "exits": { "east": 156, "up": 831 },
       "environment": -1,
-      "exits": {
-        "east": 156,
-        "up": 831
-      },
       "weight": 1,
-      "id": 822,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Tea Shop",
+      "id": 823, "name": "Tea Shop",
+      "exits": { "east": 157 },
       "environment": -1,
-      "exits": {
-        "east": 157
-      },
       "weight": 1,
-      "id": 823,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Whore House",
+      "id": 824, "name": "Whore House",
+      "exits": { "east": 158, "up": 825 },
       "environment": -1,
-      "exits": {
-        "east": 158,
-        "up": 825
-      },
       "weight": 1,
-      "id": 824,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Second floor of whore house.",
+      "id": 825, "name": "Second floor of whore house.",
+      "exits": { "south": 828, "west": 826, "up": 829, "down": 824, "north": 827 },
       "environment": -1,
-      "exits": {
-        "south": 828,
-        "west": 826,
-        "up": 829,
-        "down": 824,
-        "north": 827
-      },
       "weight": 1,
-      "id": 825,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Viking's room",
+      "id": 826, "name": "Viking's room",
+      "exits": { "east": 825 },
       "environment": -1,
-      "exits": {
-        "east": 825
-      },
       "weight": 1,
-      "id": 826,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Sandra's room",
+      "id": 827, "name": "Sandra's room",
+      "exits": { "south": 825 },
       "environment": -1,
-      "exits": {
-        "south": 825
-      },
       "weight": 1,
-      "id": 827,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Kathy's room",
+      "id": 828, "name": "Kathy's room",
+      "exits": { "north": 825 },
       "environment": -1,
-      "exits": {
-        "north": 825
-      },
       "weight": 1,
-      "id": 828,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Robert's room",
+      "id": 829, "name": "Robert's room",
+      "exits": { "down": 825 },
       "environment": -1,
-      "exits": {
-        "down": 825
-      },
       "weight": 1,
-      "id": 829,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Baker's Shop",
+      "id": 830, "name": "Baker's Shop",
+      "exits": { "west": 157 },
       "environment": -1,
-      "exits": {
-        "west": 157
-      },
       "weight": 1,
-      "id": 830,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "First Floor",
+      "id": 831, "name": "First Floor",
+      "exits": { "up": 833, "down": 822, "west": 832 },
       "environment": -1,
-      "exits": {
-        "up": 833,
-        "down": 822,
-        "west": 832
-      },
       "weight": 1,
-      "id": 831,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Chamber of Commerce",
+      "id": 832, "name": "Chamber of Commerce",
+      "exits": { "east": 831 },
       "environment": -1,
-      "exits": {
-        "east": 831
-      },
       "weight": 1,
-      "id": 832,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Second Floor",
+      "id": 833, "name": "Second Floor",
+      "exits": { "up": 835, "down": 831, "west": 834 },
       "environment": -1,
-      "exits": {
-        "up": 835,
-        "down": 831,
-        "west": 834
-      },
       "weight": 1,
-      "id": 833,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Magistrate",
+      "id": 834, "name": "Magistrate",
+      "exits": { "east": 833 },
       "environment": -1,
-      "exits": {
-        "east": 833
-      },
       "weight": 1,
-      "id": 834,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "City Archives",
+      "id": 835, "name": "City Archives",
+      "exits": { "down": 833, "west": 836 },
       "environment": -1,
-      "exits": {
-        "down": 833,
-        "west": 836
-      },
       "weight": 1,
-      "id": 835,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Inner Sanctum",
+      "id": 836, "name": "Inner Sanctum",
+      "exits": { "east": 835 },
       "environment": -1,
-      "exits": {
-        "east": 835
-      },
       "weight": 1,
-      "id": 836,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Open Air Market:",
+      "id": 837, "name": "Open Air Market:",
+      "exits": { "west": 422 },
       "environment": -1,
-      "exits": {
-        "west": 422
-      },
       "weight": 1,
-      "id": 837,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Chapel of War",
+      "id": 838, "name": "Chapel of War",
+      "exits": { "south": 820 },
       "environment": -1,
-      "exits": {
-        "south": 820
-      },
       "weight": 1,
-      "id": 838,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Reconciliation Chapel",
+      "id": 839, "name": "Reconciliation Chapel",
+      "exits": { "east": 820 },
       "environment": -1,
-      "exits": {
-        "east": 820
-      },
       "weight": 1,
-      "id": 839,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 840, "name": "Burned Area",
+      "exits": { "west": 841, "south": 148 },
       "environment": -1,
-      "exits": {
-        "west": 841,
-        "south": 148
-      },
       "weight": 1,
-      "id": 840,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 841, "name": "Burned Area",
+      "exits": { "south": 147, "west": 842, "east": 840, "north": 843 },
       "environment": -1,
-      "exits": {
-        "south": 147,
-        "west": 842,
-        "east": 840,
-        "north": 843
-      },
       "weight": 1,
-      "id": 841,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 842, "name": "Burned Area",
+      "exits": { "south": 146, "east": 841, "north": 844 },
       "environment": -1,
-      "exits": {
-        "south": 146,
-        "east": 841,
-        "north": 844
-      },
       "weight": 1,
-      "id": 842,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 843, "name": "Burned Area",
+      "exits": { "west": 844, "south": 841, "north": 201 },
       "environment": -1,
-      "exits": {
-        "west": 844,
-        "south": 841,
-        "north": 201
-      },
       "weight": 1,
-      "id": 843,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 844, "name": "Burned Area",
+      "exits": { "south": 842, "east": 843, "north": 202 },
       "environment": -1,
-      "exits": {
-        "south": 842,
-        "east": 843,
-        "north": 202
-      },
       "weight": 1,
-      "id": 844,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 845, "name": "Burned Area",
+      "exits": { "east": 846, "north": 146 },
       "environment": -1,
-      "exits": {
-        "east": 846,
-        "north": 146
-      },
       "weight": 1,
-      "id": 845,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Burned Area",
+      "id": 846, "name": "Burned Area",
+      "exits": { "west": 845, "north": 147 },
       "environment": -1,
-      "exits": {
-        "west": 845,
-        "north": 147
-      },
       "weight": 1,
-      "id": 846,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Old City Offices",
+      "id": 847, "name": "Old City Offices",
+      "exits": { "west": 849, "east": 848, "north": 144 },
       "environment": -1,
-      "exits": {
-        "west": 849,
-        "east": 848,
-        "north": 144
-      },
       "weight": 1,
-      "id": 847,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Old Office",
+      "id": 848, "name": "Old Office",
+      "exits": { "west": 847 },
       "environment": -1,
-      "exits": {
-        "west": 847
-      },
       "weight": 1,
-      "id": 848,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Old Office",
+      "id": 849, "name": "Old Office",
+      "exits": { "east": 847 },
       "environment": -1,
-      "exits": {
-        "east": 847
-      },
       "weight": 1,
-      "id": 849,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Howling Wolf Inn",
+      "id": 850, "name": "Howling Wolf Inn",
+      "exits": { "west": 142, "east": 852, "north": 851 },
       "environment": -1,
-      "exits": {
-        "west": 142,
-        "east": 852,
-        "north": 851
-      },
       "weight": 1,
-      "id": 850,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Howling Wolf Inn",
+      "id": 851, "name": "Howling Wolf Inn",
+      "exits": { "south": 850 },
       "environment": -1,
-      "exits": {
-        "south": 850
-      },
       "weight": 1,
-      "id": 851,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Howling Wolf Inn",
+      "id": 852, "name": "Howling Wolf Inn",
+      "exits": { "west": 850 },
       "environment": -1,
-      "exits": {
-        "west": 850
-      },
       "weight": 1,
-      "id": 852,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Abandoned Building",
+      "id": 853, "name": "Abandoned Building",
+      "exits": { "east": 139 },
       "environment": -1,
-      "exits": {
-        "east": 139
-      },
       "weight": 1,
-      "id": 853,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Spice Merchant",
+      "id": 854, "name": "Spice Merchant",
+      "exits": { "west": 139 },
       "environment": -1,
-      "exits": {
-        "west": 139
-      },
       "weight": 1,
-      "id": 854,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Abandoned Building",
+      "id": 855, "name": "Abandoned Building",
+      "exits": { "west": 138 },
       "environment": -1,
-      "exits": {
-        "west": 138
-      },
       "weight": 1,
-      "id": 855,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Carvings Shop",
+      "id": 856, "name": "Carvings Shop",
+      "exits": { "east": 138 },
       "environment": -1,
-      "exits": {
-        "east": 138
-      },
       "weight": 1,
-      "id": 856,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Abandoned Warehouse",
+      "id": 857, "name": "Abandoned Warehouse",
+      "exits": { "west": 198 },
       "environment": -1,
-      "exits": {
-        "west": 198
-      },
       "weight": 1,
-      "id": 857,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Entrance of a village",
+      "id": 858, "name": "Entrance of a village",
+      "exits": { "west": 859, "east": 877, "south": 131 },
       "environment": -1,
-      "exits": {
-        "west": 859,
-        "east": 877,
-        "south": 131
-      },
       "weight": 1,
-      "id": 858,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 859, "name": "On a dusty path",
+      "exits": { "east": 858, "northwest": 860, "north": 864 },
       "environment": -1,
-      "exits": {
-        "east": 858,
-        "northwest": 860,
-        "north": 864
-      },
       "weight": 1,
-      "id": 859,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "A living room made of glass",
+      "id": 860, "name": "A living room made of glass",
+      "exits": { "southwest": 863, "northwest": 861, "southeast": 859 },
       "environment": -1,
-      "exits": {
-        "southwest": 863,
-        "northwest": 861,
-        "southeast": 859
-      },
       "weight": 1,
-      "id": 860,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "A kitchen made of glass",
+      "id": 861, "name": "A kitchen made of glass",
+      "exits": { "southwest": 862, "southeast": 860 },
       "environment": -1,
-      "exits": {
-        "southwest": 862,
-        "southeast": 860
-      },
       "weight": 1,
-      "id": 861,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Sylvia's workroom",
+      "id": 862, "name": "Sylvia's workroom",
+      "exits": { "southeast": 863, "northeast": 861 },
       "environment": -1,
-      "exits": {
-        "southeast": 863,
-        "northeast": 861
-      },
       "weight": 1,
-      "id": 862,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "A bedroom made of glass",
+      "id": 863, "name": "A bedroom made of glass",
+      "exits": { "northwest": 862, "northeast": 860 },
       "environment": -1,
-      "exits": {
-        "northwest": 862,
-        "northeast": 860
-      },
       "weight": 1,
-      "id": 863,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 864, "name": "On a dusty path",
+      "exits": { "south": 859, "north": 865 },
       "environment": -1,
-      "exits": {
-        "south": 859,
-        "north": 865
-      },
       "weight": 1,
-      "id": 864,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 865, "name": "On a dusty path",
+      "exits": { "east": 868, "northwest": 866, "south": 864 },
       "environment": -1,
-      "exits": {
-        "east": 868,
-        "northwest": 866,
-        "south": 864
-      },
       "weight": 1,
-      "id": 865,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Inside a small home",
+      "id": 866, "name": "Inside a small home",
+      "exits": { "southeast": 865, "west": 867 },
       "environment": -1,
-      "exits": {
-        "southeast": 865,
-        "west": 867
-      },
       "weight": 1,
-      "id": 866,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "A large kitchen",
+      "id": 867, "name": "A large kitchen",
+      "exits": { "east": 866 },
       "environment": -1,
-      "exits": {
-        "east": 866
-      },
       "weight": 1,
-      "id": 867,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 868, "name": "On a dusty path",
+      "exits": { "west": 865, "east": 875, "north": 869 },
       "environment": -1,
-      "exits": {
-        "west": 865,
-        "east": 875,
-        "north": 869
-      },
       "weight": 1,
-      "id": 868,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Bottom floor of the silo",
+      "id": 869, "name": "Bottom floor of the silo",
+      "exits": { "up": 870, "south": 868 },
       "environment": -1,
-      "exits": {
-        "up": 870,
-        "south": 868
-      },
       "weight": 1,
-      "id": 869,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In Rohan's bedroom",
+      "id": 870, "name": "In Rohan's bedroom",
+      "exits": { "down": 869, "up": 871 },
       "environment": -1,
-      "exits": {
-        "down": 869,
-        "up": 871
-      },
       "weight": 1,
-      "id": 870,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "In Gwyneth's bedroom",
+      "id": 871, "name": "In Gwyneth's bedroom",
+      "exits": { "down": 873, "up": 872 },
       "environment": -1,
-      "exits": {
-        "down": 873,
-        "up": 872
-      },
       "weight": 1,
-      "id": 871,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "In Vella's bedroom",
+      "id": 872, "name": "In Vella's bedroom",
+      "exits": { "down": 871 },
       "environment": -1,
-      "exits": {
-        "down": 871
-      },
       "weight": 1,
-      "id": 872,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "<> Aladrin escapes reality and falls into Moral Decay. <>",
+      "id": 873, "name": "<> Aladrin escapes reality and falls into Moral Decay. <>",
+      "exits": { "down": 874, "up": 871 },
       "environment": -1,
-      "exits": {
-        "down": 874,
-        "up": 871
-      },
       "weight": 1,
-      "id": 873,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Bottom floor of the silo",
+      "id": 874, "name": "Bottom floor of the silo",
+      "exits": { "up": 873 },
       "environment": -1,
-      "exits": {
-        "up": 873
-      },
       "weight": 1,
-      "id": 874,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "On a dusty path",
+      "id": 875, "name": "On a dusty path",
+      "exits": { "west": 868, "south": 876 },
       "environment": -1,
-      "exits": {
-        "west": 868,
-        "south": 876
-      },
       "weight": 1,
-      "id": 875,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 876, "name": "On a dusty path",
+      "exits": { "south": 877, "east": 953, "north": 875 },
       "environment": -1,
-      "exits": {
-        "south": 877,
-        "east": 953,
-        "north": 875
-      },
       "weight": 1,
-      "id": 876,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "On a dusty path",
+      "id": 877, "name": "On a dusty path",
+      "exits": { "west": 858, "north": 876 },
       "environment": -1,
-      "exits": {
-        "west": 858,
-        "north": 876
-      },
       "weight": 1,
-      "id": 877,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 878, "name": "Guild/Shop Space for rent",
+      "exits": { "south": 127 },
       "environment": -1,
-      "exits": {
-        "south": 127
-      },
       "weight": 1,
-      "id": 878,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Vesla Post Office",
+      "id": 879, "name": "Vesla Post Office",
+      "exits": { "south": 126 },
       "environment": -1,
-      "exits": {
-        "south": 126
-      },
       "weight": 1,
-      "id": 879,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Old Adventurer's Guild",
+      "id": 880, "name": "Old Adventurer's Guild",
+      "exits": { "north": 126 },
       "environment": -1,
-      "exits": {
-        "north": 126
-      },
       "weight": 1,
-      "id": 880,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Cemetery Lane.",
+      "id": 881, "name": "Cemetery Lane.",
+      "exits": { "south": 128, "north": 882 },
       "environment": -1,
-      "exits": {
-        "south": 128,
-        "north": 882
-      },
       "weight": 1,
-      "id": 881,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "Cemetery Lane.",
+      "id": 882, "name": "Cemetery Lane.",
+      "exits": { "south": 881, "north": 883 },
       "environment": -1,
-      "exits": {
-        "south": 881,
-        "north": 883
-      },
       "weight": 1,
-      "id": 882,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 883, "name": "A cemetery.",
+      "exits": { "east": 884, "south": 882 },
       "environment": -1,
-      "exits": {
-        "east": 884,
-        "south": 882
-      },
       "weight": 1,
-      "id": 883,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 884, "name": "A cemetery.",
+      "exits": { "west": 883, "north": 885 },
       "environment": -1,
-      "exits": {
-        "west": 883,
-        "north": 885
-      },
       "weight": 1,
-      "id": 884,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 885, "name": "A cemetery.",
+      "exits": { "west": 886, "south": 884 },
       "environment": -1,
-      "exits": {
-        "west": 886,
-        "south": 884
-      },
       "weight": 1,
-      "id": 885,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 886, "name": "A cemetery.",
+      "exits": { "east": 885, "north": 887 },
       "environment": -1,
-      "exits": {
-        "east": 885,
-        "north": 887
-      },
       "weight": 1,
-      "id": 886,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 887, "name": "A cemetery.",
+      "exits": { "south": 886, "west": 889, "east": 892, "north": 888 },
       "environment": -1,
-      "exits": {
-        "south": 886,
-        "west": 889,
-        "east": 892,
-        "north": 888
-      },
       "weight": 1,
-      "id": 887,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 888, "name": "A cemetery.",
+      "exits": { "south": 887 },
       "environment": -1,
-      "exits": {
-        "south": 887
-      },
       "weight": 1,
-      "id": 888,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 889, "name": "A cemetery.",
+      "exits": { "east": 887, "south": 890 },
       "environment": -1,
-      "exits": {
-        "east": 887,
-        "south": 890
-      },
       "weight": 1,
-      "id": 889,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 890, "name": "A cemetery.",
+      "exits": { "south": 891, "north": 889 },
       "environment": -1,
-      "exits": {
-        "south": 891,
-        "north": 889
-      },
       "weight": 1,
-      "id": 890,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "Thieves Guild",
+      "id": 891, "name": "Thieves Guild",
+      "exits": { "north": 890 },
       "environment": -1,
-      "exits": {
-        "north": 890
-      },
       "weight": 1,
-      "id": 891,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "A cemetery.",
+      "id": 892, "name": "A cemetery.",
+      "exits": { "west": 887 },
       "environment": -1,
-      "exits": {
-        "west": 887
-      },
       "weight": 1,
-      "id": 892,
-      "area": {
-        "id": 12
-      }
+      "area": {"id": 12}
     },
     {
-      "name": "The Players' lounge",
+      "id": 893, "name": "The Players' lounge",
+      "exits": { "down": 229 },
       "environment": -1,
-      "exits": {
-        "down": 229
-      },
       "weight": 1,
-      "id": 893,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Dormitory foyer",
+      "id": 894, "name": "Dormitory foyer",
+      "exits": { "west": 528, "south": 895, "north": 903 },
       "environment": -1,
-      "exits": {
-        "west": 528,
-        "south": 895,
-        "north": 903
-      },
       "weight": 1,
-      "id": 894,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dining commons",
+      "id": 895, "name": "Dining commons",
+      "exits": { "north": 894 },
       "environment": -1,
-      "exits": {
-        "north": 894
-      },
       "weight": 1,
-      "id": 895,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern path through the University",
+      "id": 896, "name": "Southern path through the University",
+      "exits": { "south": 897, "north": 528 },
       "environment": -1,
-      "exits": {
-        "south": 897,
-        "north": 528
-      },
       "weight": 1,
-      "id": 896,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern path through the University",
+      "id": 897, "name": "Southern path through the University",
+      "exits": { "south": 898, "north": 896 },
       "environment": -1,
-      "exits": {
-        "south": 898,
-        "north": 896
-      },
       "weight": 1,
-      "id": 897,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern path through the University",
+      "id": 898, "name": "Southern path through the University",
+      "exits": { "south": 899, "north": 897 },
       "environment": -1,
-      "exits": {
-        "south": 899,
-        "north": 897
-      },
       "weight": 1,
-      "id": 898,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Southern path through the University",
+      "id": 899, "name": "Southern path through the University",
+      "exits": { "south": 902, "east": 900, "north": 898 },
       "environment": -1,
-      "exits": {
-        "south": 902,
-        "east": 900,
-        "north": 898
-      },
       "weight": 1,
-      "id": 899,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "School of Business",
+      "id": 900, "name": "School of Business",
+      "exits": { "west": 899, "north": 901 },
       "environment": -1,
-      "exits": {
-        "west": 899,
-        "north": 901
-      },
       "weight": 1,
-      "id": 900,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dean's office",
+      "id": 901, "name": "Dean's office",
+      "exits": { "south": 900 },
       "environment": -1,
-      "exits": {
-        "south": 900
-      },
       "weight": 1,
-      "id": 901,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Construction site",
+      "id": 902, "name": "Construction site",
+      "exits": { "north": 899 },
       "environment": -1,
-      "exits": {
-        "north": 899
-      },
       "weight": 1,
-      "id": 902,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Resident Advisor's office",
+      "id": 903, "name": "Resident Advisor's office",
+      "exits": { "south": 894 },
       "environment": -1,
-      "exits": {
-        "south": 894
-      },
       "weight": 1,
-      "id": 903,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Science building's entry",
+      "id": 904, "name": "Science building's entry",
+      "exits": { "west": 905, "east": 906, "north": 390 },
       "environment": -1,
-      "exits": {
-        "west": 905,
-        "east": 906,
-        "north": 390
-      },
       "weight": 1,
-      "id": 904,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Science laboratory",
+      "id": 905, "name": "Science laboratory",
+      "exits": { "east": 904 },
       "environment": -1,
-      "exits": {
-        "east": 904
-      },
       "weight": 1,
-      "id": 905,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Science lecture hall",
+      "id": 906, "name": "Science lecture hall",
+      "exits": { "west": 904 },
       "environment": -1,
-      "exits": {
-        "west": 904
-      },
       "weight": 1,
-      "id": 906,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gravel Path",
+      "id": 907, "name": "Gravel Path",
+      "exits": { "northwest": 908, "southwest": 604 },
       "environment": -1,
-      "exits": {
-        "northwest": 908,
-        "southwest": 604
-      },
       "weight": 1,
-      "id": 907,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Vine-covered Entry",
+      "id": 908, "name": "Vine-covered Entry",
+      "exits": { "southwest": 910, "southeast": 907, "north": 909 },
       "environment": -1,
-      "exits": {
-        "southwest": 910,
-        "southeast": 907,
-        "north": 909
-      },
       "weight": 1,
-      "id": 908,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Grand Foyer",
+      "id": 909, "name": "Grand Foyer",
+      "exits": { "up": 914, "west": 911, "east": 912, "south": 908 },
       "environment": -1,
-      "exits": {
-        "up": 914,
-        "west": 911,
-        "east": 912,
-        "south": 908
-      },
       "weight": 1,
-      "id": 909,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gravel Path",
+      "id": 910, "name": "Gravel Path",
+      "exits": { "southeast": 604, "northeast": 908 },
       "environment": -1,
-      "exits": {
-        "southeast": 604,
-        "northeast": 908
-      },
       "weight": 1,
-      "id": 910,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Child's Den",
+      "id": 911, "name": "Child's Den",
+      "exits": { "east": 909 },
       "environment": -1,
-      "exits": {
-        "east": 909
-      },
       "weight": 1,
-      "id": 911,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Wooded Hallway",
+      "id": 912, "name": "Wooded Hallway",
+      "exits": { "east": 913, "west": 909 },
       "environment": -1,
-      "exits": {
-        "east": 913,
-        "west": 909
-      },
       "weight": 1,
-      "id": 912,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
+      "id": 913, "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
+      "exits": { "west": 912 },
       "environment": -1,
-      "exits": {
-        "west": 912
-      },
       "weight": 1,
-      "id": 913,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Treetop Bedroom",
+      "id": 914, "name": "Treetop Bedroom",
+      "exits": { "down": 909 },
       "environment": -1,
-      "exits": {
-        "down": 909
-      },
       "weight": 1,
-      "id": 914,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Flagstoned path",
+      "id": 915, "name": "Flagstoned path",
+      "exits": { "south": 916, "west": 919, "east": 918, "north": 603 },
       "environment": -1,
-      "exits": {
-        "south": 916,
-        "west": 919,
-        "east": 918,
-        "north": 603
-      },
       "weight": 1,
-      "id": 915,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gray foyer",
+      "id": 916, "name": "Gray foyer",
+      "exits": { "south": 917, "north": 915 },
       "environment": -1,
-      "exits": {
-        "south": 917,
-        "north": 915
-      },
       "weight": 1,
-      "id": 916,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Trinian merchant's office",
+      "id": 917, "name": "Trinian merchant's office",
+      "exits": { "north": 916 },
       "environment": -1,
-      "exits": {
-        "north": 916
-      },
       "weight": 1,
-      "id": 917,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Carriage house",
+      "id": 918, "name": "Carriage house",
+      "exits": { "west": 915 },
       "environment": -1,
-      "exits": {
-        "west": 915
-      },
       "weight": 1,
-      "id": 918,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Slave quarters",
+      "id": 919, "name": "Slave quarters",
+      "exits": { "east": 915 },
       "environment": -1,
-      "exits": {
-        "east": 915
-      },
       "weight": 1,
-      "id": 919,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dwarven Embassy foyer",
+      "id": 920, "name": "Dwarven Embassy foyer",
+      "exits": { "west": 923, "up": 921, "south": 333, "east": 925, "north": 924 },
       "environment": -1,
-      "exits": {
-        "west": 923,
-        "up": 921,
-        "south": 333,
-        "east": 925,
-        "north": 924
-      },
       "weight": 1,
-      "id": 920,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dwarven watchtower",
+      "id": 921, "name": "Dwarven watchtower",
+      "exits": { "down": 920, "north": 922 },
       "environment": -1,
-      "exits": {
-        "down": 920,
-        "north": 922
-      },
       "weight": 1,
-      "id": 921,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Ambassadors Suite",
+      "id": 922, "name": "Ambassadors Suite",
+      "exits": { "south": 921 },
       "environment": -1,
-      "exits": {
-        "south": 921
-      },
       "weight": 1,
-      "id": 922,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dwarven brewery",
+      "id": 923, "name": "Dwarven brewery",
+      "exits": { "east": 920 },
       "environment": -1,
-      "exits": {
-        "east": 920
-      },
       "weight": 1,
-      "id": 923,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dwarven Ambassador's office",
+      "id": 924, "name": "Dwarven Ambassador's office",
+      "exits": { "south": 920 },
       "environment": -1,
-      "exits": {
-        "south": 920
-      },
       "weight": 1,
-      "id": 924,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Dwarven armoury",
+      "id": 925, "name": "Dwarven armoury",
+      "exits": { "west": 920 },
       "environment": -1,
-      "exits": {
-        "west": 920
-      },
       "weight": 1,
-      "id": 925,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Ground Floor of the Windmill",
+      "id": 926, "name": "Ground Floor of the Windmill",
+      "exits": { "up": 929, "west": 927, "east": 928, "south": 319 },
       "environment": -1,
-      "exits": {
-        "up": 929,
-        "west": 927,
-        "east": 928,
-        "south": 319
-      },
       "weight": 1,
-      "id": 926,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Garden of Machines",
+      "id": 927, "name": "Garden of Machines",
+      "exits": { "east": 926 },
       "environment": -1,
-      "exits": {
-        "east": 926
-      },
       "weight": 1,
-      "id": 927,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Cemetery",
+      "id": 928, "name": "Cemetery",
+      "exits": { "west": 926 },
       "environment": -1,
-      "exits": {
-        "west": 926
-      },
       "weight": 1,
-      "id": 928,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Gnome Laboratory",
+      "id": 929, "name": "Gnome Laboratory",
+      "exits": { "down": 926, "up": 930 },
       "environment": -1,
-      "exits": {
-        "down": 926,
-        "up": 930
-      },
       "weight": 1,
-      "id": 929,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Machinery Room",
+      "id": 930, "name": "Machinery Room",
+      "exits": { "down": 929 },
       "environment": -1,
-      "exits": {
-        "down": 929
-      },
       "weight": 1,
-      "id": 930,
-      "area": {
-        "id": 4
-      }
+      "area": {"id": 4}
     },
     {
-      "name": "Entryway",
+      "id": 931, "name": "Entryway",
+      "exits": { "south": 201, "north": 932 },
       "environment": -1,
-      "exits": {
-        "south": 201,
-        "north": 932
-      },
       "weight": 1,
-      "id": 931,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 932, "name": "Hallway",
+      "exits": { "south": 931, "west": 933, "east": 934, "north": 937 },
       "environment": -1,
-      "exits": {
-        "south": 931,
-        "west": 933,
-        "east": 934,
-        "north": 937
-      },
       "weight": 1,
-      "id": 932,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Corner",
+      "id": 933, "name": "Corner",
+      "exits": { "east": 932, "north": 939 },
       "environment": -1,
-      "exits": {
-        "east": 932,
-        "north": 939
-      },
       "weight": 1,
-      "id": 933,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Corner",
+      "id": 934, "name": "Corner",
+      "exits": { "west": 932, "north": 935 },
       "environment": -1,
-      "exits": {
-        "west": 932,
-        "north": 935
-      },
       "weight": 1,
-      "id": 934,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 935, "name": "Hallway",
+      "exits": { "south": 934, "east": 945, "north": 936 },
       "environment": -1,
-      "exits": {
-        "south": 934,
-        "east": 945,
-        "north": 936
-      },
       "weight": 1,
-      "id": 935,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 936, "name": "Hallway",
+      "exits": { "south": 935, "east": 946, "north": 947 },
       "environment": -1,
-      "exits": {
-        "south": 935,
-        "east": 946,
-        "north": 947
-      },
       "weight": 1,
-      "id": 936,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Courtyard",
+      "id": 937, "name": "Courtyard",
+      "exits": { "south": 932, "north": 938 },
       "environment": -1,
-      "exits": {
-        "south": 932,
-        "north": 938
-      },
       "weight": 1,
-      "id": 937,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Courtyard",
+      "id": 938, "name": "Courtyard",
+      "exits": { "south": 937, "north": 941 },
       "environment": -1,
-      "exits": {
-        "south": 937,
-        "north": 941
-      },
       "weight": 1,
-      "id": 938,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 939, "name": "Hallway",
+      "exits": { "west": 942, "south": 933, "north": 940 },
       "environment": -1,
-      "exits": {
-        "west": 942,
-        "south": 933,
-        "north": 940
-      },
       "weight": 1,
-      "id": 939,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 940, "name": "Hallway",
+      "exits": { "west": 943, "south": 939, "north": 944 },
       "environment": -1,
-      "exits": {
-        "west": 943,
-        "south": 939,
-        "north": 944
-      },
       "weight": 1,
-      "id": 940,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Archway",
+      "id": 941, "name": "Archway",
+      "exits": { "south": 938, "west": 944, "east": 947, "north": 948 },
       "environment": -1,
-      "exits": {
-        "south": 938,
-        "west": 944,
-        "east": 947,
-        "north": 948
-      },
       "weight": 1,
-      "id": 941,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Quarters",
+      "id": 942, "name": "Quarters",
+      "exits": { "east": 939 },
       "environment": -1,
-      "exits": {
-        "east": 939
-      },
       "weight": 1,
-      "id": 942,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Quarters",
+      "id": 943, "name": "Quarters",
+      "exits": { "east": 940 },
       "environment": -1,
-      "exits": {
-        "east": 940
-      },
       "weight": 1,
-      "id": 943,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Corner",
+      "id": 944, "name": "Corner",
+      "exits": { "east": 941, "south": 940 },
       "environment": -1,
-      "exits": {
-        "east": 941,
-        "south": 940
-      },
       "weight": 1,
-      "id": 944,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Quarters",
+      "id": 945, "name": "Quarters",
+      "exits": { "west": 935 },
       "environment": -1,
-      "exits": {
-        "west": 935
-      },
       "weight": 1,
-      "id": 945,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Quarters",
+      "id": 946, "name": "Quarters",
+      "exits": { "west": 936 },
       "environment": -1,
-      "exits": {
-        "west": 936
-      },
       "weight": 1,
-      "id": 946,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Corner",
+      "id": 947, "name": "Corner",
+      "exits": { "west": 941, "south": 936 },
       "environment": -1,
-      "exits": {
-        "west": 941,
-        "south": 936
-      },
       "weight": 1,
-      "id": 947,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Temple Chamber",
+      "id": 948, "name": "Temple Chamber",
+      "exits": { "south": 941, "west": 951, "east": 952, "north": 949 },
       "environment": -1,
-      "exits": {
-        "south": 941,
-        "west": 951,
-        "east": 952,
-        "north": 949
-      },
       "weight": 1,
-      "id": 948,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Hallway",
+      "id": 949, "name": "Hallway",
+      "exits": { "south": 948, "north": 950 },
       "environment": -1,
-      "exits": {
-        "south": 948,
-        "north": 950
-      },
       "weight": 1,
-      "id": 949,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Library",
+      "id": 950, "name": "Library",
+      "exits": { "south": 949 },
       "environment": -1,
-      "exits": {
-        "south": 949
-      },
       "weight": 1,
-      "id": 950,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Kitchen",
+      "id": 951, "name": "Kitchen",
+      "exits": { "east": 948 },
       "environment": -1,
-      "exits": {
-        "east": 948
-      },
       "weight": 1,
-      "id": 951,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "Storage",
+      "id": 952, "name": "Storage",
+      "exits": { "west": 948 },
       "environment": -1,
-      "exits": {
-        "west": 948
-      },
       "weight": 1,
-      "id": 952,
-      "area": {
-        "id": 10
-      }
+      "area": {"id": 10}
     },
     {
-      "name": "On the porch",
+      "id": 953, "name": "On the porch",
+      "exits": { "east": 954, "west": 876 },
       "environment": -1,
-      "exits": {
-        "east": 954,
-        "west": 876
-      },
       "weight": 1,
-      "id": 953,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In the sitting room",
+      "id": 954, "name": "In the sitting room",
+      "exits": { "west": 953, "east": 955, "south": 958 },
       "environment": -1,
-      "exits": {
-        "west": 953,
-        "east": 955,
-        "south": 958
-      },
       "weight": 1,
-      "id": 954,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In the kitchen",
+      "id": 955, "name": "In the kitchen",
+      "exits": { "west": 954, "south": 956 },
       "environment": -1,
-      "exits": {
-        "west": 954,
-        "south": 956
-      },
       "weight": 1,
-      "id": 955,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In the dining room",
+      "id": 956, "name": "In the dining room",
+      "exits": { "west": 958, "east": 957, "north": 955 },
       "environment": -1,
-      "exits": {
-        "west": 958,
-        "east": 957,
-        "north": 955
-      },
       "weight": 1,
-      "id": 956,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "You leave the farmhouse and enter the backyard.",
+      "id": 957, "name": "You leave the farmhouse and enter the backyard.",
+      "exits": { "east": 959, "west": 956 },
       "environment": -1,
-      "exits": {
-        "east": 959,
-        "west": 956
-      },
       "weight": 1,
-      "id": 957,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In the study",
+      "id": 958, "name": "In the study",
+      "exits": { "east": 956, "north": 954 },
       "environment": -1,
-      "exits": {
-        "east": 956,
-        "north": 954
-      },
       "weight": 1,
-      "id": 958,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "In a shed",
+      "id": 959, "name": "In a shed",
+      "exits": { "up": 960, "west": 957 },
       "environment": -1,
-      "exits": {
-        "up": 960,
-        "west": 957
-      },
       "weight": 1,
-      "id": 959,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Above the shed",
+      "id": 960, "name": "Above the shed",
+      "exits": { "down": 959 },
       "environment": -1,
-      "exits": {
-        "down": 959
-      },
       "weight": 1,
-      "id": 960,
-      "area": {
-        "id": 11
-      }
+      "area": {"id": 11}
     },
     {
-      "name": "Rising Phoenix",
+      "id": 961, "name": "Rising Phoenix",
+      "exits": { "south": 796 },
       "environment": -1,
-      "exits": {
-        "south": 796
-      },
       "weight": 1,
-      "id": 961,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Abandoned Store",
+      "id": 962, "name": "Abandoned Store",
+      "exits": { "west": 199 },
       "environment": -1,
-      "exits": {
-        "west": 199
-      },
       "weight": 1,
-      "id": 962,
-      "area": {
-        "id": 2
-      }
+      "area": {"id": 2}
     },
     {
-      "name": "Eastern Entrance",
+      "id": 963, "name": "Eastern Entrance",
+      "exits": { "east": 57, "west": 1027 },
       "environment": -1,
-      "exits": {
-        "east": 57,
-        "west": 1027
-      },
       "weight": 1,
-      "id": 963,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Widow's House",
+      "id": 964, "name": "Widow's House",
+      "exits": { "west": 57 },
       "environment": -1,
-      "exits": {
-        "west": 57
-      },
       "weight": 1,
-      "id": 964,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "A Jeweler's Shop",
+      "id": 965, "name": "A Jeweler's Shop",
+      "exits": { "east": 58 },
       "environment": -1,
-      "exits": {
-        "east": 58
-      },
       "weight": 1,
-      "id": 965,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Farmer's Smith",
+      "id": 966, "name": "Farmer's Smith",
+      "exits": { "east": 989, "west": 58 },
       "environment": -1,
-      "exits": {
-        "east": 989,
-        "west": 58
-      },
       "weight": 1,
-      "id": 966,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Candera Information Bureau",
+      "id": 967, "name": "Candera Information Bureau",
+      "exits": { "east": 59, "north": 1125 },
       "environment": -1,
-      "exits": {
-        "east": 59,
-        "north": 1125
-      },
       "weight": 1,
-      "id": 967,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Lizard Skin Trader",
+      "id": 968, "name": "Lizard Skin Trader",
+      "exits": { "east": 60 },
       "environment": -1,
-      "exits": {
-        "east": 60
-      },
       "weight": 1,
-      "id": 968,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Shaman's Shack",
+      "id": 969, "name": "Shaman's Shack",
+      "exits": { "west": 60 },
       "environment": -1,
-      "exits": {
-        "west": 60
-      },
       "weight": 1,
-      "id": 969,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Silk Shop",
+      "id": 970, "name": "Silk Shop",
+      "exits": { "east": 61 },
       "environment": -1,
-      "exits": {
-        "east": 61
-      },
       "weight": 1,
-      "id": 970,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Barbarian's Guild",
+      "id": 971, "name": "Barbarian's Guild",
+      "exits": { "east": 62 },
       "environment": -1,
-      "exits": {
-        "east": 62
-      },
       "weight": 1,
-      "id": 971,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Trader's Shack",
+      "id": 972, "name": "Trader's Shack",
+      "exits": { "west": 62, "south": 94 },
       "environment": -1,
-      "exits": {
-        "west": 62,
-        "south": 94
-      },
       "weight": 1,
-      "id": 972,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "East Wall Guard Station",
+      "id": 973, "name": "East Wall Guard Station",
+      "exits": { "west": 15, "south": 974, "north": 986 },
       "environment": -1,
-      "exits": {
-        "west": 15,
-        "south": 974,
-        "north": 986
-      },
       "weight": 1,
-      "id": 973,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Living Quarters",
+      "id": 974, "name": "Living Quarters",
+      "exits": { "north": 973 },
       "environment": -1,
-      "exits": {
-        "north": 973
-      },
       "weight": 1,
-      "id": 974,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 975, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 95 },
       "environment": -1,
-      "exits": {
-        "north": 95
-      },
       "weight": 1,
-      "id": 975,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Back Alley",
+      "id": 976, "name": "Back Alley",
+      "exits": { "north": 96 },
       "environment": -1,
-      "exits": {
-        "north": 96
-      },
       "weight": 1,
-      "id": 976,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 977, "name": "Great Bazaar of Candera",
+      "exits": { "south": 96, "east": 428, "north": 995 },
       "environment": -1,
-      "exits": {
-        "south": 96,
-        "east": 428,
-        "north": 995
-      },
       "weight": 1,
-      "id": 977,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Nut Shop",
+      "id": 978, "name": "Nut Shop",
+      "exits": { "south": 989 },
       "environment": -1,
-      "exits": {
-        "south": 989
-      },
       "weight": 1,
-      "id": 978,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 979, "name": "Great Bazaar of Candera",
+      "exits": { "south": 980, "west": 984, "east": 991, "north": 989 },
       "environment": -1,
-      "exits": {
-        "south": 980,
-        "west": 984,
-        "east": 991,
-        "north": 989
-      },
       "weight": 1,
-      "id": 979,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 980, "name": "Great Bazaar of Candera",
+      "exits": { "south": 981, "west": 983, "east": 993, "north": 979 },
       "environment": -1,
-      "exits": {
-        "south": 981,
-        "west": 983,
-        "east": 993,
-        "north": 979
-      },
       "weight": 1,
-      "id": 980,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 981, "name": "Great Bazaar of Candera",
+      "exits": { "west": 982, "east": 995, "north": 980 },
       "environment": -1,
-      "exits": {
-        "west": 982,
-        "east": 995,
-        "north": 980
-      },
       "weight": 1,
-      "id": 981,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Shader's Scales",
+      "id": 982, "name": "Shader's Scales",
+      "exits": { "east": 981 },
       "environment": -1,
-      "exits": {
-        "east": 981
-      },
       "weight": 1,
-      "id": 982,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Omars' Oil:",
+      "id": 983, "name": "Omars' Oil:",
+      "exits": { "east": 980 },
       "environment": -1,
-      "exits": {
-        "east": 980
-      },
       "weight": 1,
-      "id": 983,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Smithy",
+      "id": 984, "name": "Smithy",
+      "exits": { "east": 979 },
       "environment": -1,
-      "exits": {
-        "east": 979
-      },
       "weight": 1,
-      "id": 984,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 985, "name": "Great Bazaar of Candera",
+      "exits": { "south": 991, "west": 989, "east": 987, "north": 988 },
       "environment": -1,
-      "exits": {
-        "south": 991,
-        "west": 989,
-        "east": 987,
-        "north": 988
-      },
       "weight": 1,
-      "id": 985,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Sleeping Quarters",
+      "id": 986, "name": "Sleeping Quarters",
+      "exits": { "south": 973 },
       "environment": -1,
-      "exits": {
-        "south": 973
-      },
       "weight": 1,
-      "id": 986,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Lord Candera's Lottery",
+      "id": 987, "name": "Lord Candera's Lottery",
+      "exits": { "west": 985 },
       "environment": -1,
-      "exits": {
-        "west": 985
-      },
       "weight": 1,
-      "id": 987,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Empty Tent",
+      "id": 988, "name": "Empty Tent",
+      "exits": { "south": 985 },
       "environment": -1,
-      "exits": {
-        "south": 985
-      },
       "weight": 1,
-      "id": 988,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 989, "name": "Great Bazaar of Candera",
+      "exits": { "south": 979, "west": 966, "east": 985, "north": 978 },
       "environment": -1,
-      "exits": {
-        "south": 979,
-        "west": 966,
-        "east": 985,
-        "north": 978
-      },
       "weight": 1,
-      "id": 989,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Oak Treehouse landing",
+      "id": 990, "name": "Oak Treehouse landing",
+      "exits": { "southwest": 1725, "northeast": 1726, "southeast": 1724 },
       "environment": -1,
-      "exits": {
-        "southwest": 1725,
-        "northeast": 1726,
-        "southeast": 1724
-      },
       "weight": 1,
-      "id": 990,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 991, "name": "Great Bazaar of Candera",
+      "exits": { "south": 993, "west": 979, "east": 992, "north": 985 },
       "environment": -1,
-      "exits": {
-        "south": 993,
-        "west": 979,
-        "east": 992,
-        "north": 985
-      },
       "weight": 1,
-      "id": 991,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Kamal's Camel Lot:",
+      "id": 992, "name": "Kamal's Camel Lot:",
+      "exits": { "west": 991 },
       "environment": -1,
-      "exits": {
-        "west": 991
-      },
       "weight": 1,
-      "id": 992,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 993, "name": "Great Bazaar of Candera",
+      "exits": { "south": 995, "west": 980, "east": 994, "north": 991 },
       "environment": -1,
-      "exits": {
-        "south": 995,
-        "west": 980,
-        "east": 994,
-        "north": 991
-      },
       "weight": 1,
-      "id": 993,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Perfume Tent:",
+      "id": 994, "name": "Perfume Tent:",
+      "exits": { "west": 993 },
       "environment": -1,
-      "exits": {
-        "west": 993
-      },
       "weight": 1,
-      "id": 994,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Great Bazaar of Candera",
+      "id": 995, "name": "Great Bazaar of Candera",
+      "exits": { "south": 977, "west": 981, "east": 1739, "north": 993 },
       "environment": -1,
-      "exits": {
-        "south": 977,
-        "west": 981,
-        "east": 1739,
-        "north": 993
-      },
       "weight": 1,
-      "id": 995,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Candera Priest's Hut",
+      "id": 996, "name": "Candera Priest's Hut",
+      "exits": { "west": 111 },
       "environment": -1,
-      "exits": {
-        "west": 111
-      },
       "weight": 1,
-      "id": 996,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Pillow Shop:",
+      "id": 997, "name": "Pillow Shop:",
+      "exits": { "west": 100 },
       "environment": -1,
-      "exits": {
-        "west": 100
-      },
       "weight": 1,
-      "id": 997,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Relic Shop:",
+      "id": 998, "name": "Relic Shop:",
+      "exits": { "east": 103 },
       "environment": -1,
-      "exits": {
-        "east": 103
-      },
       "weight": 1,
-      "id": 998,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Butcher Shop:",
+      "id": 999, "name": "Butcher Shop:",
+      "exits": { "west": 103 },
       "environment": -1,
-      "exits": {
-        "west": 103
-      },
       "weight": 1,
-      "id": 999,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Foyer",
+      "id": 1000, "name": "Foyer",
+      "exits": { "west": 98, "up": 1011, "south": 1010, "east": 1001, "north": 1009 },
       "environment": -1,
-      "exits": {
-        "west": 98,
-        "up": 1011,
-        "south": 1010,
-        "east": 1001,
-        "north": 1009
-      },
       "weight": 1,
-      "id": 1000,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Hallway",
+      "id": 1001, "name": "Hallway",
+      "exits": { "northeast": 1008, "east": 1002, "west": 1000 },
       "environment": -1,
-      "exits": {
-        "northeast": 1008,
-        "east": 1002,
-        "west": 1000
-      },
       "weight": 1,
-      "id": 1001,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Ballroom",
+      "id": 1002, "name": "Ballroom",
+      "exits": { "south": 1007, "west": 1001, "east": 1003, "north": 1014 },
       "environment": -1,
-      "exits": {
-        "south": 1007,
-        "west": 1001,
-        "east": 1003,
-        "north": 1014
-      },
       "weight": 1,
-      "id": 1002,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Dance Floor",
+      "id": 1003, "name": "Dance Floor",
+      "exits": { "west": 1002, "east": 1004, "south": 1006 },
       "environment": -1,
-      "exits": {
-        "west": 1002,
-        "east": 1004,
-        "south": 1006
-      },
       "weight": 1,
-      "id": 1003,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Gaston's table",
+      "id": 1004, "name": "Gaston's table",
+      "exits": { "west": 1003, "south": 1005, "north": 1013 },
       "environment": -1,
-      "exits": {
-        "west": 1003,
-        "south": 1005,
-        "north": 1013
-      },
       "weight": 1,
-      "id": 1004,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Dance Floor",
+      "id": 1005, "name": "Dance Floor",
+      "exits": { "west": 1006, "south": 1012, "north": 1004 },
       "environment": -1,
-      "exits": {
-        "west": 1006,
-        "south": 1012,
-        "north": 1004
-      },
       "weight": 1,
-      "id": 1005,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Dance Floor",
+      "id": 1006, "name": "Dance Floor",
+      "exits": { "west": 1007, "east": 1005, "north": 1003 },
       "environment": -1,
-      "exits": {
-        "west": 1007,
-        "east": 1005,
-        "north": 1003
-      },
       "weight": 1,
-      "id": 1006,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Buffet table",
+      "id": 1007, "name": "Buffet table",
+      "exits": { "east": 1006, "north": 1002 },
       "environment": -1,
-      "exits": {
-        "east": 1006,
-        "north": 1002
-      },
       "weight": 1,
-      "id": 1007,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Kitchen",
+      "id": 1008, "name": "Kitchen",
+      "exits": { "southwest": 1001 },
       "environment": -1,
-      "exits": {
-        "southwest": 1001
-      },
       "weight": 1,
-      "id": 1008,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Library",
+      "id": 1009, "name": "Library",
+      "exits": { "south": 1000 },
       "environment": -1,
-      "exits": {
-        "south": 1000
-      },
       "weight": 1,
-      "id": 1009,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Map Room",
+      "id": 1010, "name": "Map Room",
+      "exits": { "north": 1000 },
       "environment": -1,
-      "exits": {
-        "north": 1000
-      },
       "weight": 1,
-      "id": 1010,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "House of Clan Lord Gaston",
+      "id": 1011, "name": "House of Clan Lord Gaston",
+      "exits": { "down": 1000 },
       "environment": -1,
-      "exits": {
-        "down": 1000
-      },
       "weight": 1,
-      "id": 1011,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Deck",
+      "id": 1012, "name": "Deck",
+      "exits": { "north": 1005 },
       "environment": -1,
-      "exits": {
-        "north": 1005
-      },
       "weight": 1,
-      "id": 1012,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Bandstand",
+      "id": 1013, "name": "Bandstand",
+      "exits": { "west": 1014, "south": 1004 },
       "environment": -1,
-      "exits": {
-        "west": 1014,
-        "south": 1004
-      },
       "weight": 1,
-      "id": 1013,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Dark corner",
+      "id": 1014, "name": "Dark corner",
+      "exits": { "east": 1013, "south": 1002 },
       "environment": -1,
-      "exits": {
-        "east": 1013,
-        "south": 1002
-      },
       "weight": 1,
-      "id": 1014,
-      "area": {
-        "id": 13
-      }
+      "area": {"id": 13}
     },
     {
-      "name": "Snake Charmer",
+      "id": 1015, "name": "Snake Charmer",
+      "exits": { "west": 65 },
       "environment": -1,
-      "exits": {
-        "west": 65
-      },
       "weight": 1,
-      "id": 1015,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 1016, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 73 },
       "environment": -1,
-      "exits": {
-        "north": 73
-      },
       "weight": 1,
-      "id": 1016,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Kaimuki Q's",
+      "id": 1017, "name": "Kaimuki Q's",
+      "exits": { "west": 1018, "south": 73 },
       "environment": -1,
-      "exits": {
-        "west": 1018,
-        "south": 73
-      },
       "weight": 1,
-      "id": 1017,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Headquarter Entrance",
+      "id": 1018, "name": "Headquarter Entrance",
+      "exits": { "south": 74, "east": 1017, "north": 1020 },
       "environment": -1,
-      "exits": {
-        "south": 74,
-        "east": 1017,
-        "north": 1020
-      },
       "weight": 1,
-      "id": 1018,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 1019, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 74 },
       "environment": -1,
-      "exits": {
-        "north": 74
-      },
       "weight": 1,
-      "id": 1019,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Hallway",
+      "id": 1020, "name": "Hallway",
+      "exits": { "south": 1018, "north": 1021 },
       "environment": -1,
-      "exits": {
-        "south": 1018,
-        "north": 1021
-      },
       "weight": 1,
-      "id": 1020,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Hallway",
+      "id": 1021, "name": "Hallway",
+      "exits": { "south": 1020, "east": 1022, "north": 1024 },
       "environment": -1,
-      "exits": {
-        "south": 1020,
-        "east": 1022,
-        "north": 1024
-      },
       "weight": 1,
-      "id": 1021,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Bunk Area",
+      "id": 1022, "name": "Bunk Area",
+      "exits": { "west": 1021, "south": 1023 },
       "environment": -1,
-      "exits": {
-        "west": 1021,
-        "south": 1023
-      },
       "weight": 1,
-      "id": 1022,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Banquet Hall",
+      "id": 1023, "name": "Banquet Hall",
+      "exits": { "north": 1022 },
       "environment": -1,
-      "exits": {
-        "north": 1022
-      },
       "weight": 1,
-      "id": 1023,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Hallway",
+      "id": 1024, "name": "Hallway",
+      "exits": { "south": 1021, "east": 1029, "north": 1025 },
       "environment": -1,
-      "exits": {
-        "south": 1021,
-        "east": 1029,
-        "north": 1025
-      },
       "weight": 1,
-      "id": 1024,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Ready Room",
+      "id": 1025, "name": "Ready Room",
+      "exits": { "south": 1024, "east": 1028, "north": 1026 },
       "environment": -1,
-      "exits": {
-        "south": 1024,
-        "east": 1028,
-        "north": 1026
-      },
       "weight": 1,
-      "id": 1025,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Outer Wall",
+      "id": 1026, "name": "Outer Wall",
+      "exits": { "east": 1027, "south": 1025 },
       "environment": -1,
-      "exits": {
-        "east": 1027,
-        "south": 1025
-      },
       "weight": 1,
-      "id": 1026,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Outer Wall",
+      "id": 1027, "name": "Outer Wall",
+      "exits": { "east": 963, "west": 1026 },
       "environment": -1,
-      "exits": {
-        "east": 963,
-        "west": 1026
-      },
       "weight": 1,
-      "id": 1027,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Armoury",
+      "id": 1028, "name": "Armoury",
+      "exits": { "west": 1025 },
       "environment": -1,
-      "exits": {
-        "west": 1025
-      },
       "weight": 1,
-      "id": 1028,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "Strategist's Room",
+      "id": 1029, "name": "Strategist's Room",
+      "exits": { "west": 1024 },
       "environment": -1,
-      "exits": {
-        "west": 1024
-      },
       "weight": 1,
-      "id": 1029,
-      "area": {
-        "id": 14
-      }
+      "area": {"id": 14}
     },
     {
-      "name": "South Wall Guard Station",
+      "id": 1030, "name": "South Wall Guard Station",
+      "exits": { "west": 1031, "east": 1032, "north": 29 },
       "environment": -1,
-      "exits": {
-        "west": 1031,
-        "east": 1032,
-        "north": 29
-      },
       "weight": 1,
-      "id": 1030,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Living Quarters",
+      "id": 1031, "name": "Living Quarters",
+      "exits": { "east": 1030 },
       "environment": -1,
-      "exits": {
-        "east": 1030
-      },
       "weight": 1,
-      "id": 1031,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Sleeping Quarters",
+      "id": 1032, "name": "Sleeping Quarters",
+      "exits": { "west": 1030 },
       "environment": -1,
-      "exits": {
-        "west": 1030
-      },
       "weight": 1,
-      "id": 1032,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "West Wall Guard Station",
+      "id": 1033, "name": "West Wall Guard Station",
+      "exits": { "south": 1034, "east": 43, "north": 1035 },
       "environment": -1,
-      "exits": {
-        "south": 1034,
-        "east": 43,
-        "north": 1035
-      },
       "weight": 1,
-      "id": 1033,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Living Quarters",
+      "id": 1034, "name": "Living Quarters",
+      "exits": { "north": 1033 },
       "environment": -1,
-      "exits": {
-        "north": 1033
-      },
       "weight": 1,
-      "id": 1034,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Sleeping Quarters",
+      "id": 1035, "name": "Sleeping Quarters",
+      "exits": { "south": 1033 },
       "environment": -1,
-      "exits": {
-        "south": 1033
-      },
       "weight": 1,
-      "id": 1035,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Southwest Tower",
+      "id": 1036, "name": "Southwest Tower",
       "environment": -1,
-      "id": 1036,
       "weight": 1,
-      "area": {
-        "id": 16
-      }
+      "area": {"id": 16}
     },
     {
-      "name": "Empty Closet",
+      "id": 1037, "name": "Empty Closet",
       "environment": -1,
-      "id": 1037,
       "weight": 1,
-      "area": {
-        "id": 16
-      }
+      "area": {"id": 16}
     },
     {
-      "name": "Thief Hideout Entrance",
+      "id": 1038, "name": "Thief Hideout Entrance",
+      "exits": { "up": 1037 },
       "environment": -1,
-      "exits": {
-        "up": 1037
-      },
       "weight": 1,
-      "id": 1038,
-      "area": {
-        "id": 16
-      }
+      "area": {"id": 16}
     },
     {
-      "name": "Guard Post",
+      "id": 1039, "name": "Guard Post",
+      "exits": { "east": 1049, "north": 1040 },
       "environment": -1,
-      "exits": {
-        "east": 1049,
-        "north": 1040
-      },
       "weight": 1,
-      "id": 1039,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "A bend in the hallway",
+      "id": 1040, "name": "A bend in the hallway",
+      "exits": { "east": 1041, "south": 1039 },
       "environment": -1,
-      "exits": {
-        "east": 1041,
-        "south": 1039
-      },
       "weight": 1,
-      "id": 1040,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Cobwebs brush against the left side of your face as you walk through them.",
+      "id": 1041, "name": "Cobwebs brush against the left side of your face as you walk through them.",
+      "exits": { "east": 1042, "west": 1040 },
       "environment": -1,
-      "exits": {
-        "east": 1042,
-        "west": 1040
-      },
       "weight": 1,
-      "id": 1041,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "The Great Hall",
+      "id": 1042, "name": "The Great Hall",
+      "exits": { "east": 1043, "west": 1041 },
       "environment": -1,
-      "exits": {
-        "east": 1043,
-        "west": 1041
-      },
       "weight": 1,
-      "id": 1042,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "A bend in the hallway",
+      "id": 1043, "name": "A bend in the hallway",
+      "exits": { "west": 1042, "south": 1044 },
       "environment": -1,
-      "exits": {
-        "west": 1042,
-        "south": 1044
-      },
       "weight": 1,
-      "id": 1043,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Barrack",
+      "id": 1044, "name": "Barrack",
+      "exits": { "west": 1045, "south": 1046, "north": 1043 },
       "environment": -1,
-      "exits": {
-        "west": 1045,
-        "south": 1046,
-        "north": 1043
-      },
       "weight": 1,
-      "id": 1044,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "First floor landing",
+      "id": 1045, "name": "First floor landing",
+      "exits": { "east": 1044, "up": 1050 },
       "environment": -1,
-      "exits": {
-        "east": 1044,
-        "up": 1050
-      },
       "weight": 1,
-      "id": 1045,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Barrack",
+      "id": 1046, "name": "Barrack",
+      "exits": { "south": 1047, "north": 1044 },
       "environment": -1,
-      "exits": {
-        "south": 1047,
-        "north": 1044
-      },
       "weight": 1,
-      "id": 1046,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Staging Room",
+      "id": 1047, "name": "Staging Room",
+      "exits": { "west": 1048, "north": 1046 },
       "environment": -1,
-      "exits": {
-        "west": 1048,
-        "north": 1046
-      },
       "weight": 1,
-      "id": 1047,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Sally Port",
+      "id": 1048, "name": "Sally Port",
+      "exits": { "east": 1047 },
       "environment": -1,
-      "exits": {
-        "east": 1047
-      },
       "weight": 1,
-      "id": 1048,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "An office",
+      "id": 1049, "name": "An office",
+      "exits": { "west": 1039 },
       "environment": -1,
-      "exits": {
-        "west": 1039
-      },
       "weight": 1,
-      "id": 1049,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Second floor landing",
+      "id": 1050, "name": "Second floor landing",
+      "exits": { "up": 1051, "down": 1045, "north": 1069 },
       "environment": -1,
-      "exits": {
-        "up": 1051,
-        "down": 1045,
-        "north": 1069
-      },
       "weight": 1,
-      "id": 1050,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Third floor landing",
+      "id": 1051, "name": "Third floor landing",
+      "exits": { "down": 1050, "up": 1052, "east": 1065, "north": 1064 },
       "environment": -1,
-      "exits": {
-        "down": 1050,
-        "up": 1052,
-        "east": 1065,
-        "north": 1064
-      },
       "weight": 1,
-      "id": 1051,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Stairwell",
+      "id": 1052, "name": "Stairwell",
+      "exits": { "west": 1060, "down": 1051, "south": 1053, "east": 1059, "north": 1057 },
       "environment": -1,
-      "exits": {
-        "west": 1060,
-        "down": 1051,
-        "south": 1053,
-        "east": 1059,
-        "north": 1057
-      },
       "weight": 1,
-      "id": 1052,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1053, "name": "Northeast Tower Roof",
+      "exits": { "south": 1054, "east": 1056, "north": 1052 },
       "environment": -1,
-      "exits": {
-        "south": 1054,
-        "east": 1056,
-        "north": 1052
-      },
       "weight": 1,
-      "id": 1053,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1054, "name": "Northeast Tower Roof",
+      "exits": { "east": 1055, "north": 1053 },
       "environment": -1,
-      "exits": {
-        "east": 1055,
-        "north": 1053
-      },
       "weight": 1,
-      "id": 1054,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Southeast corner of roof",
+      "id": 1055, "name": "Southeast corner of roof",
+      "exits": { "west": 1054, "north": 1056 },
       "environment": -1,
-      "exits": {
-        "west": 1054,
-        "north": 1056
-      },
       "weight": 1,
-      "id": 1055,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1056, "name": "Northeast Tower Roof",
+      "exits": { "west": 1053, "south": 1055, "north": 1059 },
       "environment": -1,
-      "exits": {
-        "west": 1053,
-        "south": 1055,
-        "north": 1059
-      },
       "weight": 1,
-      "id": 1056,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1057, "name": "Northeast Tower Roof",
+      "exits": { "east": 1058, "south": 1052 },
       "environment": -1,
-      "exits": {
-        "east": 1058,
-        "south": 1052
-      },
       "weight": 1,
-      "id": 1057,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast corner of roof",
+      "id": 1058, "name": "Northeast corner of roof",
+      "exits": { "west": 1057, "south": 1059 },
       "environment": -1,
-      "exits": {
-        "west": 1057,
-        "south": 1059
-      },
       "weight": 1,
-      "id": 1058,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1059, "name": "Northeast Tower Roof",
+      "exits": { "west": 1052, "south": 1056, "north": 1058 },
       "environment": -1,
-      "exits": {
-        "west": 1052,
-        "south": 1056,
-        "north": 1058
-      },
       "weight": 1,
-      "id": 1059,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1060, "name": "Northeast Tower Roof",
+      "exits": { "west": 1063, "east": 1052, "north": 1061 },
       "environment": -1,
-      "exits": {
-        "west": 1063,
-        "east": 1052,
-        "north": 1061
-      },
       "weight": 1,
-      "id": 1060,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1061, "name": "Northeast Tower Roof",
+      "exits": { "west": 1062, "south": 1060 },
       "environment": -1,
-      "exits": {
-        "west": 1062,
-        "south": 1060
-      },
       "weight": 1,
-      "id": 1061,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northwest corner of roof",
+      "id": 1062, "name": "Northwest corner of roof",
+      "exits": { "east": 1061, "south": 1063 },
       "environment": -1,
-      "exits": {
-        "east": 1061,
-        "south": 1063
-      },
       "weight": 1,
-      "id": 1062,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Northeast Tower Roof",
+      "id": 1063, "name": "Northeast Tower Roof",
+      "exits": { "east": 1060, "north": 1062 },
       "environment": -1,
-      "exits": {
-        "east": 1060,
-        "north": 1062
-      },
       "weight": 1,
-      "id": 1063,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Guard Post",
+      "id": 1064, "name": "Guard Post",
+      "exits": { "south": 1051 },
       "environment": -1,
-      "exits": {
-        "south": 1051
-      },
       "weight": 1,
-      "id": 1064,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Hallway",
+      "id": 1065, "name": "Hallway",
+      "exits": { "west": 1051, "south": 1066 },
       "environment": -1,
-      "exits": {
-        "west": 1051,
-        "south": 1066
-      },
       "weight": 1,
-      "id": 1065,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Hall",
+      "id": 1066, "name": "Hall",
+      "exits": { "south": 1067, "north": 1065 },
       "environment": -1,
-      "exits": {
-        "south": 1067,
-        "north": 1065
-      },
       "weight": 1,
-      "id": 1066,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "War Room",
+      "id": 1067, "name": "War Room",
+      "exits": { "west": 1068, "north": 1066 },
       "environment": -1,
-      "exits": {
-        "west": 1068,
-        "north": 1066
-      },
       "weight": 1,
-      "id": 1067,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Portal Chamber",
+      "id": 1068, "name": "Portal Chamber",
+      "exits": { "east": 1067 },
       "environment": -1,
-      "exits": {
-        "east": 1067
-      },
       "weight": 1,
-      "id": 1068,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Guard Post",
+      "id": 1069, "name": "Guard Post",
+      "exits": { "west": 1070, "east": 1072, "south": 1050 },
       "environment": -1,
-      "exits": {
-        "west": 1070,
-        "east": 1072,
-        "south": 1050
-      },
       "weight": 1,
-      "id": 1069,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Prison Wing",
+      "id": 1070, "name": "Prison Wing",
+      "exits": { "west": 1071, "east": 1069, "south": 1077 },
       "environment": -1,
-      "exits": {
-        "west": 1071,
-        "east": 1069,
-        "south": 1077
-      },
       "weight": 1,
-      "id": 1070,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Prison cell",
+      "id": 1071, "name": "Prison cell",
+      "exits": { "east": 1070 },
       "environment": -1,
-      "exits": {
-        "east": 1070
-      },
       "weight": 1,
-      "id": 1071,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Hallway",
+      "id": 1072, "name": "Hallway",
+      "exits": { "west": 1069, "south": 1073 },
       "environment": -1,
-      "exits": {
-        "west": 1069,
-        "south": 1073
-      },
       "weight": 1,
-      "id": 1072,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "An alarm sounds as you pass the threshold of the magic barrier.",
+      "id": 1073, "name": "An alarm sounds as you pass the threshold of the magic barrier.",
+      "exits": { "south": 1074, "north": 1072 },
       "environment": -1,
-      "exits": {
-        "south": 1074,
-        "north": 1072
-      },
       "weight": 1,
-      "id": 1073,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Witch's Workroom",
+      "id": 1074, "name": "Witch's Workroom",
+      "exits": { "west": 1075, "south": 1076, "north": 1073 },
       "environment": -1,
-      "exits": {
-        "west": 1075,
-        "south": 1076,
-        "north": 1073
-      },
       "weight": 1,
-      "id": 1074,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Library",
+      "id": 1075, "name": "Library",
+      "exits": { "east": 1074 },
       "environment": -1,
-      "exits": {
-        "east": 1074
-      },
       "weight": 1,
-      "id": 1075,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Morgue",
+      "id": 1076, "name": "Morgue",
+      "exits": { "north": 1074 },
       "environment": -1,
-      "exits": {
-        "north": 1074
-      },
       "weight": 1,
-      "id": 1076,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Prison cell",
+      "id": 1077, "name": "Prison cell",
+      "exits": { "north": 1070 },
       "environment": -1,
-      "exits": {
-        "north": 1070
-      },
       "weight": 1,
-      "id": 1077,
-      "area": {
-        "id": 17
-      }
+      "area": {"id": 17}
     },
     {
-      "name": "Lord's Stable",
+      "id": 1078, "name": "Lord's Stable",
+      "exits": { "south": 77 },
       "environment": -1,
-      "exits": {
-        "south": 77
-      },
       "weight": 1,
-      "id": 1078,
-      "area": {
-        "id": 18
-      }
+      "area": {"id": 18}
     },
     {
-      "name": "Kitchen",
+      "id": 1079, "name": "Kitchen",
+      "exits": { "north": 77 },
       "environment": -1,
-      "exits": {
-        "north": 77
-      },
       "weight": 1,
-      "id": 1079,
-      "area": {
-        "id": 18
-      }
+      "area": {"id": 18}
     },
     {
-      "name": "Bracknar's Garden",
+      "id": 1080, "name": "Bracknar's Garden",
+      "exits": { "east": 77 },
       "environment": -1,
-      "exits": {
-        "east": 77
-      },
       "weight": 1,
-      "id": 1080,
-      "area": {
-        "id": 18
-      }
+      "area": {"id": 18}
     },
     {
-      "name": "House of Clan Lord Bracknar",
+      "id": 1081, "name": "House of Clan Lord Bracknar",
+      "exits": { "down": 77 },
       "environment": -1,
-      "exits": {
-        "down": 77
-      },
       "weight": 1,
-      "id": 1081,
-      "area": {
-        "id": 18
-      }
+      "area": {"id": 18}
     },
     {
-      "name": "Gatehouse",
+      "id": 1082, "name": "Gatehouse",
+      "exits": { "up": 1083, "east": 87, "west": 1084 },
       "environment": -1,
-      "exits": {
-        "up": 1083,
-        "east": 87,
-        "west": 1084
-      },
       "weight": 1,
-      "id": 1082,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Blockhouse",
+      "id": 1083, "name": "Blockhouse",
+      "exits": { "down": 1082 },
       "environment": -1,
-      "exits": {
-        "down": 1082
-      },
       "weight": 1,
-      "id": 1083,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
+      "id": 1084, "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
+      "exits": { "south": 1087, "west": 1085, "east": 1082, "north": 1092 },
       "environment": -1,
-      "exits": {
-        "south": 1087,
-        "west": 1085,
-        "east": 1082,
-        "north": 1092
-      },
       "weight": 1,
-      "id": 1084,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Eastern bailey",
+      "id": 1085, "name": "Eastern bailey",
+      "exits": { "east": 1084, "west": 1086 },
       "environment": -1,
-      "exits": {
-        "east": 1084,
-        "west": 1086
-      },
       "weight": 1,
-      "id": 1085,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Western bailey",
+      "id": 1086, "name": "Western bailey",
+      "exits": { "south": 1871, "east": 1085, "north": 1870 },
       "environment": -1,
-      "exits": {
-        "south": 1871,
-        "east": 1085,
-        "north": 1870
-      },
       "weight": 1,
-      "id": 1086,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Long hallway",
+      "id": 1087, "name": "Long hallway",
+      "exits": { "west": 1089, "south": 1088, "north": 1084 },
       "environment": -1,
-      "exits": {
-        "west": 1089,
-        "south": 1088,
-        "north": 1084
-      },
       "weight": 1,
-      "id": 1087,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Passage",
+      "id": 1088, "name": "Passage",
+      "exits": { "up": 1090, "north": 1087 },
       "environment": -1,
-      "exits": {
-        "up": 1090,
-        "north": 1087
-      },
       "weight": 1,
-      "id": 1088,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Sun Court",
+      "id": 1089, "name": "Sun Court",
+      "exits": { "east": 1087 },
       "environment": -1,
-      "exits": {
-        "east": 1087
-      },
       "weight": 1,
-      "id": 1089,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Stairwell",
+      "id": 1090, "name": "Stairwell",
+      "exits": { "down": 1088, "up": 1091 },
       "environment": -1,
-      "exits": {
-        "down": 1088,
-        "up": 1091
-      },
       "weight": 1,
-      "id": 1090,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Southeast Watchtower",
+      "id": 1091, "name": "Southeast Watchtower",
+      "exits": { "down": 1090 },
       "environment": -1,
-      "exits": {
-        "down": 1090
-      },
       "weight": 1,
-      "id": 1091,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Long hallway",
+      "id": 1092, "name": "Long hallway",
+      "exits": { "south": 1084 },
       "environment": -1,
-      "exits": {
-        "south": 1084
-      },
       "weight": 1,
-      "id": 1092,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Goondala's Flowers",
+      "id": 1093, "name": "Goondala's Flowers",
+      "exits": { "east": 90 },
       "environment": -1,
-      "exits": {
-        "east": 90
-      },
       "weight": 1,
-      "id": 1093,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Weapon Master's Shop",
+      "id": 1094, "name": "Weapon Master's Shop",
+      "exits": { "west": 90 },
       "environment": -1,
-      "exits": {
-        "west": 90
-      },
       "weight": 1,
-      "id": 1094,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 1095, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 75 },
       "environment": -1,
-      "exits": {
-        "north": 75
-      },
       "weight": 1,
-      "id": 1095,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Alchemist's Shop",
+      "id": 1096, "name": "Alchemist's Shop",
+      "exits": { "west": 79 },
       "environment": -1,
-      "exits": {
-        "west": 79
-      },
       "weight": 1,
-      "id": 1096,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Canderan Guard House",
+      "id": 1097, "name": "Canderan Guard House",
+      "exits": { "east": 82 },
       "environment": -1,
-      "exits": {
-        "east": 82
-      },
       "weight": 1,
-      "id": 1097,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1098, "name": "Crypt of the Honored Dead",
+      "exits": { "down": 1099, "west": 82 },
       "environment": -1,
-      "exits": {
-        "down": 1099,
-        "west": 82
-      },
       "weight": 1,
-      "id": 1098,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1099, "name": "Crypt of the Honored Dead",
+      "exits": { "up": 1098, "east": 1100, "south": 1101 },
       "environment": -1,
-      "exits": {
-        "up": 1098,
-        "east": 1100,
-        "south": 1101
-      },
       "weight": 1,
-      "id": 1099,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1100, "name": "Crypt of the Honored Dead",
+      "exits": { "northeast": 1103, "southeast": 1102, "west": 1099 },
       "environment": -1,
-      "exits": {
-        "northeast": 1103,
-        "southeast": 1102,
-        "west": 1099
-      },
       "weight": 1,
-      "id": 1100,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead.",
+      "id": 1101, "name": "Crypt of the Honored Dead.",
+      "exits": { "north": 1099 },
       "environment": -1,
-      "exits": {
-        "north": 1099
-      },
       "weight": 1,
-      "id": 1101,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1102, "name": "Crypt of the Honored Dead",
+      "exits": { "northwest": 1100, "southeast": 1115 },
       "environment": -1,
-      "exits": {
-        "northwest": 1100,
-        "southeast": 1115
-      },
       "weight": 1,
-      "id": 1102,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1103, "name": "Crypt of the Honored Dead",
+      "exits": { "southwest": 1100, "northeast": 1104 },
       "environment": -1,
-      "exits": {
-        "southwest": 1100,
-        "northeast": 1104
-      },
       "weight": 1,
-      "id": 1103,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1104, "name": "Crypt of the Honored Dead",
+      "exits": { "southwest": 1103, "east": 1105 },
       "environment": -1,
-      "exits": {
-        "southwest": 1103,
-        "east": 1105
-      },
       "weight": 1,
-      "id": 1104,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1105, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1108, "west": 1104, "east": 1106, "north": 1107 },
       "environment": -1,
-      "exits": {
-        "south": 1108,
-        "west": 1104,
-        "east": 1106,
-        "north": 1107
-      },
       "weight": 1,
-      "id": 1105,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1106, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1111, "west": 1105, "east": 1110, "north": 1109 },
       "environment": -1,
-      "exits": {
-        "south": 1111,
-        "west": 1105,
-        "east": 1110,
-        "north": 1109
-      },
       "weight": 1,
-      "id": 1106,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1107, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1105 },
       "environment": -1,
-      "exits": {
-        "south": 1105
-      },
       "weight": 1,
-      "id": 1107,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1108, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1105 },
       "environment": -1,
-      "exits": {
-        "north": 1105
-      },
       "weight": 1,
-      "id": 1108,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1109, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1106 },
       "environment": -1,
-      "exits": {
-        "south": 1106
-      },
       "weight": 1,
-      "id": 1109,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1110, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1113, "west": 1106, "east": 1114, "north": 1112 },
       "environment": -1,
-      "exits": {
-        "south": 1113,
-        "west": 1106,
-        "east": 1114,
-        "north": 1112
-      },
       "weight": 1,
-      "id": 1110,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1111, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1106 },
       "environment": -1,
-      "exits": {
-        "north": 1106
-      },
       "weight": 1,
-      "id": 1111,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1112, "name": "Battle of the Sand Gargoyles",
+      "exits": { "south": 1110 },
       "environment": -1,
-      "exits": {
-        "south": 1110
-      },
       "weight": 1,
-      "id": 1112,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1113, "name": "Battle of the Sand Gargoyles",
+      "exits": { "north": 1110 },
       "environment": -1,
-      "exits": {
-        "north": 1110
-      },
       "weight": 1,
-      "id": 1113,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of the Sand Gargoyles",
+      "id": 1114, "name": "Battle of the Sand Gargoyles",
+      "exits": { "west": 1110 },
       "environment": -1,
-      "exits": {
-        "west": 1110
-      },
       "weight": 1,
-      "id": 1114,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Crypt of the Honored Dead",
+      "id": 1115, "name": "Crypt of the Honored Dead",
+      "exits": { "northwest": 1102, "east": 1116 },
       "environment": -1,
-      "exits": {
-        "northwest": 1102,
-        "east": 1116
-      },
       "weight": 1,
-      "id": 1115,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1116, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1123, "west": 1115, "east": 1117, "north": 1124 },
       "environment": -1,
-      "exits": {
-        "south": 1123,
-        "west": 1115,
-        "east": 1117,
-        "north": 1124
-      },
       "weight": 1,
-      "id": 1116,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1117, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1121, "west": 1116, "east": 1118, "north": 1122 },
       "environment": -1,
-      "exits": {
-        "south": 1121,
-        "west": 1116,
-        "east": 1118,
-        "north": 1122
-      },
       "weight": 1,
-      "id": 1117,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1118, "name": "Battle of Maiden's Kiss",
+      "exits": { "west": 1117, "south": 1119, "north": 1120 },
       "environment": -1,
-      "exits": {
-        "west": 1117,
-        "south": 1119,
-        "north": 1120
-      },
       "weight": 1,
-      "id": 1118,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1119, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1118 },
       "environment": -1,
-      "exits": {
-        "north": 1118
-      },
       "weight": 1,
-      "id": 1119,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1120, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1118 },
       "environment": -1,
-      "exits": {
-        "south": 1118
-      },
       "weight": 1,
-      "id": 1120,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1121, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1117 },
       "environment": -1,
-      "exits": {
-        "north": 1117
-      },
       "weight": 1,
-      "id": 1121,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1122, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1117 },
       "environment": -1,
-      "exits": {
-        "south": 1117
-      },
       "weight": 1,
-      "id": 1122,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1123, "name": "Battle of Maiden's Kiss",
+      "exits": { "north": 1116 },
       "environment": -1,
-      "exits": {
-        "north": 1116
-      },
       "weight": 1,
-      "id": 1123,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "Battle of Maiden's Kiss",
+      "id": 1124, "name": "Battle of Maiden's Kiss",
+      "exits": { "south": 1116 },
       "environment": -1,
-      "exits": {
-        "south": 1116
-      },
       "weight": 1,
-      "id": 1124,
-      "area": {
-        "id": 20
-      }
+      "area": {"id": 20}
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "id": 1125, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "south": 967 },
       "environment": -1,
-      "exits": {
-        "south": 967
-      },
       "weight": 1,
-      "id": 1125,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Earth",
+      "id": 1126, "name": "Temple of Earth",
+      "exits": { "down": 106 },
       "environment": -1,
-      "exits": {
-        "down": 106
-      },
       "weight": 1,
-      "id": 1126,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Earth",
+      "id": 1127, "name": "Temple of Earth",
+      "exits": { "down": 105 },
       "environment": -1,
-      "exits": {
-        "down": 105
-      },
       "weight": 1,
-      "id": 1127,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Fire",
+      "id": 1128, "name": "Temple of Fire",
+      "exits": { "down": 114 },
       "environment": -1,
-      "exits": {
-        "down": 114
-      },
       "weight": 1,
-      "id": 1128,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Fire",
+      "id": 1129, "name": "Temple of Fire",
+      "exits": { "down": 113 },
       "environment": -1,
-      "exits": {
-        "down": 113
-      },
       "weight": 1,
-      "id": 1129,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Air",
+      "id": 1130, "name": "Temple of Air",
+      "exits": { "down": 84 },
       "environment": -1,
-      "exits": {
-        "down": 84
-      },
       "weight": 1,
-      "id": 1130,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Air",
+      "id": 1131, "name": "Temple of Air",
+      "exits": { "down": 85 },
       "environment": -1,
-      "exits": {
-        "down": 85
-      },
       "weight": 1,
-      "id": 1131,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Water",
+      "id": 1132, "name": "Temple of Water",
+      "exits": { "down": 92 },
       "environment": -1,
-      "exits": {
-        "down": 92
-      },
       "weight": 1,
-      "id": 1132,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Temple of Water",
+      "id": 1133, "name": "Temple of Water",
+      "exits": { "down": 93 },
       "environment": -1,
-      "exits": {
-        "down": 93
-      },
       "weight": 1,
-      "id": 1133,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "House of Lord Candera",
+      "id": 1134, "name": "House of Lord Candera",
+      "exits": { "down": 69 },
       "environment": -1,
-      "exits": {
-        "down": 69
-      },
       "weight": 1,
-      "id": 1134,
-      "area": {
-        "id": 1
-      }
+      "area": {"id": 1}
     },
     {
-      "name": "Western Guard Post",
+      "id": 1135, "name": "Western Guard Post",
+      "exits": { "up": 1136, "northeast": 237 },
       "environment": -1,
-      "exits": {
-        "up": 1136,
-        "northeast": 237
-      },
       "weight": 1,
-      "id": 1135,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Arleg bows to you.",
+      "id": 1136, "name": "Arleg bows to you.",
+      "exits": { "down": 1135, "up": 1137 },
       "environment": -1,
-      "exits": {
-        "down": 1135,
-        "up": 1137
-      },
       "weight": 1,
-      "id": 1136,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Second Floor Landing",
+      "id": 1137, "name": "Second Floor Landing",
+      "exits": { "down": 1136, "east": 1142, "up": 1138 },
       "environment": -1,
-      "exits": {
-        "down": 1136,
-        "east": 1142,
-        "up": 1138
-      },
       "weight": 1,
-      "id": 1137,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Third Floor Passage",
+      "id": 1138, "name": "Third Floor Passage",
+      "exits": { "down": 1137, "east": 1144, "up": 1139 },
       "environment": -1,
-      "exits": {
-        "down": 1137,
-        "east": 1144,
-        "up": 1139
-      },
       "weight": 1,
-      "id": 1138,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western Spire Stairwell",
+      "id": 1139, "name": "Western Spire Stairwell",
+      "exits": { "down": 1138, "up": 1140 },
       "environment": -1,
-      "exits": {
-        "down": 1138,
-        "up": 1140
-      },
       "weight": 1,
-      "id": 1139,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Roof of the Western Spire",
+      "id": 1140, "name": "Roof of the Western Spire",
+      "exits": { "down": 1139 },
       "environment": -1,
-      "exits": {
-        "down": 1139
-      },
       "weight": 1,
-      "id": 1140,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western Stairwell",
+      "id": 1141, "name": "Western Stairwell",
+      "exits": { "up": 1137 },
       "environment": -1,
-      "exits": {
-        "up": 1137
-      },
       "weight": 1,
-      "id": 1141,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Killing Room",
+      "id": 1142, "name": "Killing Room",
+      "exits": { "east": 1153, "west": 1137 },
       "environment": -1,
-      "exits": {
-        "east": 1153,
-        "west": 1137
-      },
       "weight": 1,
-      "id": 1142,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Anshelm Lounge",
+      "id": 1143, "name": "Anshelm Lounge",
+      "exits": { "east": 236, "west": 1204 },
       "environment": -1,
-      "exits": {
-        "east": 236,
-        "west": 1204
-      },
       "weight": 1,
-      "id": 1143,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Gatehouse Mess Hall",
+      "id": 1144, "name": "Gatehouse Mess Hall",
+      "exits": { "east": 1145, "west": 1138 },
       "environment": -1,
-      "exits": {
-        "east": 1145,
-        "west": 1138
-      },
       "weight": 1,
-      "id": 1144,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Gatehouse Barracks",
+      "id": 1145, "name": "Gatehouse Barracks",
+      "exits": { "east": 1146, "west": 1144 },
       "environment": -1,
-      "exits": {
-        "east": 1146,
-        "west": 1144
-      },
       "weight": 1,
-      "id": 1145,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Third Floor Passage",
+      "id": 1146, "name": "Third Floor Passage",
+      "exits": { "up": 1151, "west": 1145 },
       "environment": -1,
-      "exits": {
-        "up": 1151,
-        "west": 1145
-      },
       "weight": 1,
-      "id": 1146,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad at the Promenade",
+      "id": 1147, "name": "Beitel Straad at the Promenade",
+      "exits": { "west": 1150, "east": 414, "north": 1169 },
       "environment": -1,
-      "exits": {
-        "west": 1150,
-        "east": 414,
-        "north": 1169
-      },
       "weight": 1,
-      "id": 1147,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern Stairwell",
+      "id": 1148, "name": "Eastern Stairwell",
+      "exits": { "down": 1149 },
       "environment": -1,
-      "exits": {
-        "down": 1149
-      },
       "weight": 1,
-      "id": 1148,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Base of the Eastern Stairwell",
+      "id": 1149, "name": "Base of the Eastern Stairwell",
+      "exits": { "up": 1148 },
       "environment": -1,
-      "exits": {
-        "up": 1148
-      },
       "weight": 1,
-      "id": 1149,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad",
+      "id": 1150, "name": "Beitel Straad",
+      "exits": { "west": 1157, "east": 1147, "south": 1168 },
       "environment": -1,
-      "exits": {
-        "west": 1157,
-        "east": 1147,
-        "south": 1168
-      },
       "weight": 1,
-      "id": 1150,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern Spire Stairwell",
+      "id": 1151, "name": "Eastern Spire Stairwell",
+      "exits": { "down": 1149, "up": 1152 },
       "environment": -1,
-      "exits": {
-        "down": 1149,
-        "up": 1152
-      },
       "weight": 1,
-      "id": 1151,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Roof of the Eastern Spire",
+      "id": 1152, "name": "Roof of the Eastern Spire",
+      "exits": { "down": 1151 },
       "environment": -1,
-      "exits": {
-        "down": 1151
-      },
       "weight": 1,
-      "id": 1152,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Tider bows to you.",
+      "id": 1153, "name": "Tider bows to you.",
+      "exits": { "west": 1142 },
       "environment": -1,
-      "exits": {
-        "west": 1142
-      },
       "weight": 1,
-      "id": 1153,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern Guard Post",
+      "id": 1154, "name": "Eastern Guard Post",
+      "exits": { "northwest": 237, "east": 1155 },
       "environment": -1,
-      "exits": {
-        "northwest": 237,
-        "east": 1155
-      },
       "weight": 1,
-      "id": 1154,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Ganran bows to you.",
+      "id": 1155, "name": "Ganran bows to you.",
+      "exits": { "up": 1158, "down": 1156, "west": 1154 },
       "environment": -1,
-      "exits": {
-        "up": 1158,
-        "down": 1156,
-        "west": 1154
-      },
       "weight": 1,
-      "id": 1155,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Gatehouse Armoury",
+      "id": 1156, "name": "Gatehouse Armoury",
+      "exits": { "up": 1155 },
       "environment": -1,
-      "exits": {
-        "up": 1155
-      },
       "weight": 1,
-      "id": 1156,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western end of Beitel Straad",
+      "id": 1157, "name": "Western end of Beitel Straad",
+      "exits": { "east": 1150, "north": 1164 },
       "environment": -1,
-      "exits": {
-        "east": 1150,
-        "north": 1164
-      },
       "weight": 1,
-      "id": 1157,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern Stairwell",
+      "id": 1158, "name": "Eastern Stairwell",
+      "exits": { "down": 1155, "up": 1159 },
       "environment": -1,
-      "exits": {
-        "down": 1155,
-        "up": 1159
-      },
       "weight": 1,
-      "id": 1158,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Olotia bows to you.",
+      "id": 1159, "name": "Olotia bows to you.",
+      "exits": { "down": 1158, "west": 1160 },
       "environment": -1,
-      "exits": {
-        "down": 1158,
-        "west": 1160
-      },
       "weight": 1,
-      "id": 1159,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Tiran bows to you.",
+      "id": 1160, "name": "Tiran bows to you.",
+      "exits": { "east": 1159, "west": 1161 },
       "environment": -1,
-      "exits": {
-        "east": 1159,
-        "west": 1161
-      },
       "weight": 1,
-      "id": 1160,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Killing Room",
+      "id": 1161, "name": "Killing Room",
+      "exits": { "east": 1160, "west": 1162 },
       "environment": -1,
-      "exits": {
-        "east": 1160,
-        "west": 1162
-      },
       "weight": 1,
-      "id": 1161,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Second Floor Landing",
+      "id": 1162, "name": "Second Floor Landing",
+      "exits": { "east": 1161, "down": 1163 },
       "environment": -1,
-      "exits": {
-        "east": 1161,
-        "down": 1163
-      },
       "weight": 1,
-      "id": 1162,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Western Stairwell",
+      "id": 1163, "name": "Western Stairwell",
+      "exits": { "down": 1135, "up": 1162 },
       "environment": -1,
-      "exits": {
-        "down": 1135,
-        "up": 1162
-      },
       "weight": 1,
-      "id": 1163,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Living room",
+      "id": 1164, "name": "Living room",
+      "exits": { "south": 1157, "northeast": 1167, "northwest": 1165, "north": 1166 },
       "environment": -1,
-      "exits": {
-        "south": 1157,
-        "northeast": 1167,
-        "northwest": 1165,
-        "north": 1166
-      },
       "weight": 1,
-      "id": 1164,
-      "area": {
-        "id": 21
-      }
+      "area": {"id": 21}
     },
     {
-      "name": "You brush aside the blanket and duck to pass through the small door.",
+      "id": 1165, "name": "You brush aside the blanket and duck to pass through the small door.",
+      "exits": { "southeast": 1164 },
       "environment": -1,
-      "exits": {
-        "southeast": 1164
-      },
       "weight": 1,
-      "id": 1165,
-      "area": {
-        "id": 21
-      }
+      "area": {"id": 21}
     },
     {
-      "name": "You feel strange walking into the kitchen - that's where women belong.",
+      "id": 1166, "name": "You feel strange walking into the kitchen - that's where women belong.",
+      "exits": { "south": 1164 },
       "environment": -1,
-      "exits": {
-        "south": 1164
-      },
       "weight": 1,
-      "id": 1166,
-      "area": {
-        "id": 21
-      }
+      "area": {"id": 21}
     },
     {
-      "name": "You brush aside the blanket and duck to pass through the small door.",
+      "id": 1167, "name": "You brush aside the blanket and duck to pass through the small door.",
+      "exits": { "southwest": 1164 },
       "environment": -1,
-      "exits": {
-        "southwest": 1164
-      },
       "weight": 1,
-      "id": 1167,
-      "area": {
-        "id": 21
-      }
+      "area": {"id": 21}
     },
     {
-      "name": "The Inner Bailey",
+      "id": 1168, "name": "The Inner Bailey",
+      "exits": { "north": 1150 },
       "environment": -1,
-      "exits": {
-        "north": 1150
-      },
       "weight": 1,
-      "id": 1168,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Promenade des Trafficants",
+      "id": 1169, "name": "Promenade des Trafficants",
+      "exits": { "south": 1147, "north": 1170 },
       "environment": -1,
-      "exits": {
-        "south": 1147,
-        "north": 1170
-      },
       "weight": 1,
-      "id": 1169,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "The Promenade's gate",
+      "id": 1170, "name": "The Promenade's gate",
+      "exits": { "south": 1169, "north": 1171 },
       "environment": -1,
-      "exits": {
-        "south": 1169,
-        "north": 1171
-      },
       "weight": 1,
-      "id": 1170,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
+      "id": 1171, "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
+      "exits": { "south": 1170, "east": 1184, "north": 1172 },
       "environment": -1,
-      "exits": {
-        "south": 1170,
-        "east": 1184,
-        "north": 1172
-      },
       "weight": 1,
-      "id": 1171,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Moonlit Promenade",
+      "id": 1172, "name": "Moonlit Promenade",
+      "exits": { "west": 1173, "south": 1171, "north": 1174 },
       "environment": -1,
-      "exits": {
-        "west": 1173,
-        "south": 1171,
-        "north": 1174
-      },
       "weight": 1,
-      "id": 1172,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Mekalar's Outdoor Gear",
+      "id": 1173, "name": "Mekalar's Outdoor Gear",
+      "exits": { "east": 1172 },
       "environment": -1,
-      "exits": {
-        "east": 1172
-      },
       "weight": 1,
-      "id": 1173,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Moonlit Promenade",
+      "id": 1174, "name": "Moonlit Promenade",
+      "exits": { "south": 1172, "east": 1183, "north": 1175 },
       "environment": -1,
-      "exits": {
-        "south": 1172,
-        "east": 1183,
-        "north": 1175
-      },
       "weight": 1,
-      "id": 1174,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Middle of the moonlit Promenade",
+      "id": 1175, "name": "Middle of the moonlit Promenade",
+      "exits": { "south": 1174, "north": 1176 },
       "environment": -1,
-      "exits": {
-        "south": 1174,
-        "north": 1176
-      },
       "weight": 1,
-      "id": 1175,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Moonlit Promenade",
+      "id": 1176, "name": "Moonlit Promenade",
+      "exits": { "south": 1175, "north": 1177 },
       "environment": -1,
-      "exits": {
-        "south": 1175,
-        "north": 1177
-      },
       "weight": 1,
-      "id": 1176,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Moonlit Promenade",
+      "id": 1177, "name": "Moonlit Promenade",
+      "exits": { "west": 1182, "south": 1176, "north": 1178 },
       "environment": -1,
-      "exits": {
-        "west": 1182,
-        "south": 1176,
-        "north": 1178
-      },
       "weight": 1,
-      "id": 1177,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Moonlit Promenade",
+      "id": 1178, "name": "Moonlit Promenade",
+      "exits": { "south": 1177, "north": 1179 },
       "environment": -1,
-      "exits": {
-        "south": 1177,
-        "north": 1179
-      },
       "weight": 1,
-      "id": 1178,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Northern end of the moonlit Promenade",
+      "id": 1179, "name": "Northern end of the moonlit Promenade",
+      "exits": { "west": 1181, "south": 1178, "north": 1180 },
       "environment": -1,
-      "exits": {
-        "west": 1181,
-        "south": 1178,
-        "north": 1180
-      },
       "weight": 1,
-      "id": 1179,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Enchanter's Store",
+      "id": 1180, "name": "Enchanter's Store",
+      "exits": { "south": 1179 },
       "environment": -1,
-      "exits": {
-        "south": 1179
-      },
       "weight": 1,
-      "id": 1180,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Gere's Petshop",
+      "id": 1181, "name": "Gere's Petshop",
+      "exits": { "east": 1179 },
       "environment": -1,
-      "exits": {
-        "east": 1179
-      },
       "weight": 1,
-      "id": 1181,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Carpenter's shop",
+      "id": 1182, "name": "Carpenter's shop",
+      "exits": { "east": 1177 },
       "environment": -1,
-      "exits": {
-        "east": 1177
-      },
       "weight": 1,
-      "id": 1182,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Roget's Furrier",
+      "id": 1183, "name": "Roget's Furrier",
+      "exits": { "west": 1174 },
       "environment": -1,
-      "exits": {
-        "west": 1174
-      },
       "weight": 1,
-      "id": 1183,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Volshev's Advertising Agency",
+      "id": 1184, "name": "Volshev's Advertising Agency",
+      "exits": { "west": 1171 },
       "environment": -1,
-      "exits": {
-        "west": 1171
-      },
       "weight": 1,
-      "id": 1184,
-      "area": {
-        "id": 22
-      }
+      "area": {"id": 22}
     },
     {
-      "name": "Beitel Straad",
+      "id": 1185, "name": "Beitel Straad",
+      "exits": { "west": 239, "east": 1186, "north": 1191 },
       "environment": -1,
-      "exits": {
-        "west": 239,
-        "east": 1186,
-        "north": 1191
-      },
       "weight": 1,
-      "id": 1185,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad",
+      "id": 1186, "name": "Beitel Straad",
+      "exits": { "west": 1185, "east": 1187, "north": 1190 },
       "environment": -1,
-      "exits": {
-        "west": 1185,
-        "east": 1187,
-        "north": 1190
-      },
       "weight": 1,
-      "id": 1186,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad",
+      "id": 1187, "name": "Beitel Straad",
+      "exits": { "east": 1188, "west": 1186 },
       "environment": -1,
-      "exits": {
-        "east": 1188,
-        "west": 1186
-      },
       "weight": 1,
-      "id": 1187,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Beitel Straad",
+      "id": 1188, "name": "Beitel Straad",
+      "exits": { "east": 1189, "west": 1187 },
       "environment": -1,
-      "exits": {
-        "east": 1189,
-        "west": 1187
-      },
       "weight": 1,
-      "id": 1188,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern end of Beitel Straad",
+      "id": 1189, "name": "Eastern end of Beitel Straad",
+      "exits": { "west": 1188 },
       "environment": -1,
-      "exits": {
-        "west": 1188
-      },
       "weight": 1,
-      "id": 1189,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "The Banana Hammock",
+      "id": 1190, "name": "The Banana Hammock",
+      "exits": { "west": 1191, "south": 1186 },
       "environment": -1,
-      "exits": {
-        "west": 1191,
-        "south": 1186
-      },
       "weight": 1,
-      "id": 1190,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Jack's Bistro",
+      "id": 1191, "name": "Jack's Bistro",
+      "exits": { "east": 1190, "south": 1185 },
       "environment": -1,
-      "exits": {
-        "east": 1190,
-        "south": 1185
-      },
       "weight": 1,
-      "id": 1191,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Second Bank of Anshelm",
+      "id": 1192, "name": "Second Bank of Anshelm",
+      "exits": { "west": 240 },
       "environment": -1,
-      "exits": {
-        "west": 240
-      },
       "weight": 1,
-      "id": 1192,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "The Anshelmish General Store",
+      "id": 1193, "name": "The Anshelmish General Store",
+      "exits": { "west": 251 },
       "environment": -1,
-      "exits": {
-        "west": 251
-      },
       "weight": 1,
-      "id": 1193,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 1194, "name": "Construction site",
+      "exits": { "west": 255 },
       "environment": -1,
-      "exits": {
-        "west": 255
-      },
       "weight": 1,
-      "id": 1194,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Anshelmish Keep's drawbridge",
+      "id": 1195, "name": "Anshelmish Keep's drawbridge",
+      "exits": { "east": 255, "west": 1196 },
       "environment": -1,
-      "exits": {
-        "east": 255,
-        "west": 1196
-      },
       "weight": 1,
-      "id": 1195,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 1196, "name": "Construction site",
+      "exits": { "east": 1195 },
       "environment": -1,
-      "exits": {
-        "east": 1195
-      },
       "weight": 1,
-      "id": 1196,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Private Entry",
+      "id": 1197, "name": "Private Entry",
+      "exits": { "south": 281 },
       "environment": -1,
-      "exits": {
-        "south": 281
-      },
       "weight": 1,
-      "id": 1197,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "id": 1198, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
+      "exits": { "west": 265 },
       "environment": -1,
-      "exits": {
-        "west": 265
-      },
       "weight": 1,
-      "id": 1198,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Armourer's Shack",
+      "id": 1199, "name": "Armourer's Shack",
+      "exits": { "north": 270 },
       "environment": -1,
-      "exits": {
-        "north": 270
-      },
       "weight": 1,
-      "id": 1199,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 1200, "name": "Construction site",
+      "exits": { "south": 276 },
       "environment": -1,
-      "exits": {
-        "south": 276
-      },
       "weight": 1,
-      "id": 1200,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 1201, "name": "Construction site",
+      "exits": { "north": 280 },
       "environment": -1,
-      "exits": {
-        "north": 280
-      },
       "weight": 1,
-      "id": 1201,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Construction site",
+      "id": 1202, "name": "Construction site",
+      "exits": { "southeast": 273 },
       "environment": -1,
-      "exits": {
-        "southeast": 273
-      },
       "weight": 1,
-      "id": 1202,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "City Unemployment Office",
+      "id": 1203, "name": "City Unemployment Office",
+      "exits": { "north": 416 },
       "environment": -1,
-      "exits": {
-        "north": 416
-      },
       "weight": 1,
-      "id": 1203,
-      "area": {
-        "id": 23
-      }
+      "area": {"id": 23}
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "id": 1204, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
+      "exits": { "east": 1143 },
       "environment": -1,
-      "exits": {
-        "east": 1143
-      },
       "weight": 1,
-      "id": 1204,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "End of Pylus road",
+      "id": 1205, "name": "End of Pylus road",
+      "exits": { "south": 1206 },
       "environment": -1,
-      "exits": {
-        "south": 1206
-      },
       "weight": 1,
-      "id": 1205,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1206, "name": "Pylus road",
+      "exits": { "south": 1207, "north": 1205 },
       "environment": -1,
-      "exits": {
-        "south": 1207,
-        "north": 1205
-      },
       "weight": 1,
-      "id": 1206,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1207, "name": "Pylus road",
+      "exits": { "south": 1208, "east": 1212, "north": 1206 },
       "environment": -1,
-      "exits": {
-        "south": 1208,
-        "east": 1212,
-        "north": 1206
-      },
       "weight": 1,
-      "id": 1207,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1208, "name": "Pylus road",
+      "exits": { "west": 1209, "south": 1213, "north": 1207 },
       "environment": -1,
-      "exits": {
-        "west": 1209,
-        "south": 1213,
-        "north": 1207
-      },
       "weight": 1,
-      "id": 1208,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Freemason's",
+      "id": 1209, "name": "Freemason's",
+      "exits": { "south": 1210, "east": 1208, "north": 1211 },
       "environment": -1,
-      "exits": {
-        "south": 1210,
-        "east": 1208,
-        "north": 1211
-      },
       "weight": 1,
-      "id": 1209,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Apprentice's",
+      "id": 1210, "name": "Apprentice's",
+      "exits": { "north": 1209 },
       "environment": -1,
-      "exits": {
-        "north": 1209
-      },
       "weight": 1,
-      "id": 1210,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Master stonemason's",
+      "id": 1211, "name": "Master stonemason's",
+      "exits": { "south": 1209 },
       "environment": -1,
-      "exits": {
-        "south": 1209
-      },
       "weight": 1,
-      "id": 1211,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Mausoleum entrance",
+      "id": 1212, "name": "Mausoleum entrance",
+      "exits": { "west": 1207 },
       "environment": -1,
-      "exits": {
-        "west": 1207
-      },
       "weight": 1,
-      "id": 1212,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1213, "name": "Pylus road",
+      "exits": { "south": 1214, "north": 1208 },
       "environment": -1,
-      "exits": {
-        "south": 1214,
-        "north": 1208
-      },
       "weight": 1,
-      "id": 1213,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1214, "name": "Pylus road",
+      "exits": { "south": 1215, "west": 1218, "east": 1219, "north": 1213 },
       "environment": -1,
-      "exits": {
-        "south": 1215,
-        "west": 1218,
-        "east": 1219,
-        "north": 1213
-      },
       "weight": 1,
-      "id": 1214,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road",
+      "id": 1215, "name": "Pylus road",
+      "exits": { "southwest": 1216, "east": 1222, "southeast": 1217, "north": 1214 },
       "environment": -1,
-      "exits": {
-        "southwest": 1216,
-        "east": 1222,
-        "southeast": 1217,
-        "north": 1214
-      },
       "weight": 1,
-      "id": 1215,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Porch",
+      "id": 1216, "name": "Porch",
+      "exits": { "northeast": 1215 },
       "environment": -1,
-      "exits": {
-        "northeast": 1215
-      },
       "weight": 1,
-      "id": 1216,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Sanity's Requiem",
+      "id": 1217, "name": "Sanity's Requiem",
+      "exits": { "northwest": 1215 },
       "environment": -1,
-      "exits": {
-        "northwest": 1215
-      },
       "weight": 1,
-      "id": 1217,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hall of Bacchus",
+      "id": 1218, "name": "Hall of Bacchus",
+      "exits": { "east": 1214 },
       "environment": -1,
-      "exits": {
-        "east": 1214
-      },
       "weight": 1,
-      "id": 1218,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Triage",
+      "id": 1219, "name": "Triage",
+      "exits": { "west": 1214, "north": 1220 },
       "environment": -1,
-      "exits": {
-        "west": 1214,
-        "north": 1220
-      },
       "weight": 1,
-      "id": 1219,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Waiting room",
+      "id": 1220, "name": "Waiting room",
+      "exits": { "east": 1221, "south": 1219 },
       "environment": -1,
-      "exits": {
-        "east": 1221,
-        "south": 1219
-      },
       "weight": 1,
-      "id": 1220,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Operating room",
+      "id": 1221, "name": "Operating room",
+      "exits": { "west": 1220 },
       "environment": -1,
-      "exits": {
-        "west": 1220
-      },
       "weight": 1,
-      "id": 1221,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Pylus road checkpoint",
+      "id": 1222, "name": "Pylus road checkpoint",
+      "exits": { "east": 1289, "west": 1215 },
       "environment": -1,
-      "exits": {
-        "east": 1289,
-        "west": 1215
-      },
       "weight": 1,
-      "id": 1222,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "A short entryway",
+      "id": 1223, "name": "A short entryway",
+      "exits": { "north": 1263 },
       "environment": -1,
-      "exits": {
-        "north": 1263
-      },
       "weight": 1,
-      "id": 1223,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Iola square",
+      "id": 1224, "name": "Iola square",
+      "exits": { "west": 1289, "south": 1227, "north": 1225 },
       "environment": -1,
-      "exits": {
-        "west": 1289,
-        "south": 1227,
-        "north": 1225
-      },
       "weight": 1,
-      "id": 1224,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola way",
+      "id": 1225, "name": "Iola way",
+      "exits": { "west": 1363, "south": 1224, "north": 1226 },
       "environment": -1,
-      "exits": {
-        "west": 1363,
-        "south": 1224,
-        "north": 1226
-      },
       "weight": 1,
-      "id": 1225,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola way",
+      "id": 1226, "name": "Iola way",
+      "exits": { "south": 1225, "north": 1248 },
       "environment": -1,
-      "exits": {
-        "south": 1225,
-        "north": 1248
-      },
       "weight": 1,
-      "id": 1226,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola way",
+      "id": 1227, "name": "Iola way",
+      "exits": { "south": 1228, "west": 1247, "east": 1246, "north": 1224 },
       "environment": -1,
-      "exits": {
-        "south": 1228,
-        "west": 1247,
-        "east": 1246,
-        "north": 1224
-      },
       "weight": 1,
-      "id": 1227,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola way",
+      "id": 1228, "name": "Iola way",
+      "exits": { "south": 1229, "west": 1244, "east": 1243, "north": 1227 },
       "environment": -1,
-      "exits": {
-        "south": 1229,
-        "west": 1244,
-        "east": 1243,
-        "north": 1227
-      },
       "weight": 1,
-      "id": 1228,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola bridge",
+      "id": 1229, "name": "Iola bridge",
+      "exits": { "southwest": 1230, "east": 1231, "north": 1228 },
       "environment": -1,
-      "exits": {
-        "southwest": 1230,
-        "east": 1231,
-        "north": 1228
-      },
       "weight": 1,
-      "id": 1229,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Large field",
+      "id": 1230, "name": "Large field",
+      "exits": { "west": 1239, "northeast": 1229 },
       "environment": -1,
-      "exits": {
-        "west": 1239,
-        "northeast": 1229
-      },
       "weight": 1,
-      "id": 1230,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Polema street",
+      "id": 1231, "name": "Polema street",
+      "exits": { "west": 1229, "east": 1233, "south": 1232 },
       "environment": -1,
-      "exits": {
-        "west": 1229,
-        "east": 1233,
-        "south": 1232
-      },
       "weight": 1,
-      "id": 1231,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Gay house",
+      "id": 1232, "name": "Gay house",
+      "exits": { "north": 1231 },
       "environment": -1,
-      "exits": {
-        "north": 1231
-      },
       "weight": 1,
-      "id": 1232,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Polema street",
+      "id": 1233, "name": "Polema street",
+      "exits": { "south": 1234, "west": 1231, "east": 1235, "north": 1238 },
       "environment": -1,
-      "exits": {
-        "south": 1234,
-        "west": 1231,
-        "east": 1235,
-        "north": 1238
-      },
       "weight": 1,
-      "id": 1233,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Short house",
+      "id": 1234, "name": "Short house",
+      "exits": { "north": 1233 },
       "environment": -1,
-      "exits": {
-        "north": 1233
-      },
       "weight": 1,
-      "id": 1234,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Polema street",
+      "id": 1235, "name": "Polema street",
+      "exits": { "west": 1233, "east": 1237, "north": 1236 },
       "environment": -1,
-      "exits": {
-        "west": 1233,
-        "east": 1237,
-        "north": 1236
-      },
       "weight": 1,
-      "id": 1235,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Bright house",
+      "id": 1236, "name": "Bright house",
+      "exits": { "south": 1235 },
       "environment": -1,
-      "exits": {
-        "south": 1235
-      },
       "weight": 1,
-      "id": 1236,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Foyer",
+      "id": 1237, "name": "Foyer",
+      "exits": { "west": 1235 },
       "environment": -1,
-      "exits": {
-        "west": 1235
-      },
       "weight": 1,
-      "id": 1237,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Tall house",
+      "id": 1238, "name": "Tall house",
+      "exits": { "south": 1233 },
       "environment": -1,
-      "exits": {
-        "south": 1233
-      },
       "weight": 1,
-      "id": 1238,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Gymnasium foyer",
+      "id": 1239, "name": "Gymnasium foyer",
+      "exits": { "west": 1240, "east": 1230, "south": 1241 },
       "environment": -1,
-      "exits": {
-        "west": 1240,
-        "east": 1230,
-        "south": 1241
-      },
       "weight": 1,
-      "id": 1239,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Changing room",
+      "id": 1240, "name": "Changing room",
+      "exits": { "east": 1239 },
       "environment": -1,
-      "exits": {
-        "east": 1239
-      },
       "weight": 1,
-      "id": 1240,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Gymnasium hallway",
+      "id": 1241, "name": "Gymnasium hallway",
+      "exits": { "south": 1242, "north": 1239 },
       "environment": -1,
-      "exits": {
-        "south": 1242,
-        "north": 1239
-      },
       "weight": 1,
-      "id": 1241,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Natatorium",
+      "id": 1242, "name": "Natatorium",
+      "exits": { "north": 1241 },
       "environment": -1,
-      "exits": {
-        "north": 1241
-      },
       "weight": 1,
-      "id": 1242,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Vegetable seller's",
+      "id": 1243, "name": "Vegetable seller's",
+      "exits": { "west": 1228 },
       "environment": -1,
-      "exits": {
-        "west": 1228
-      },
       "weight": 1,
-      "id": 1243,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Herbarium",
+      "id": 1244, "name": "Herbarium",
+      "exits": { "east": 1228, "south": 1245 },
       "environment": -1,
-      "exits": {
-        "east": 1228,
-        "south": 1245
-      },
       "weight": 1,
-      "id": 1244,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Herb garden",
+      "id": 1245, "name": "Herb garden",
+      "exits": { "north": 1244 },
       "environment": -1,
-      "exits": {
-        "north": 1244
-      },
       "weight": 1,
-      "id": 1245,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Butcher shop",
+      "id": 1246, "name": "Butcher shop",
+      "exits": { "west": 1227 },
       "environment": -1,
-      "exits": {
-        "west": 1227
-      },
       "weight": 1,
-      "id": 1246,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Guild/Shop Space for rent",
+      "id": 1247, "name": "Guild/Shop Space for rent",
+      "exits": { "east": 1227 },
       "environment": -1,
-      "exits": {
-        "east": 1227
-      },
       "weight": 1,
-      "id": 1247,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Iola way",
+      "id": 1248, "name": "Iola way",
+      "exits": { "west": 1249, "east": 1252, "south": 1226 },
       "environment": -1,
-      "exits": {
-        "west": 1249,
-        "east": 1252,
-        "south": 1226
-      },
       "weight": 1,
-      "id": 1248,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Garden entry",
+      "id": 1249, "name": "Garden entry",
+      "exits": { "east": 1248, "north": 1250 },
       "environment": -1,
-      "exits": {
-        "east": 1248,
-        "north": 1250
-      },
       "weight": 1,
-      "id": 1249,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Garden clearing",
+      "id": 1250, "name": "Garden clearing",
+      "exits": { "west": 1251, "south": 1249 },
       "environment": -1,
-      "exits": {
-        "west": 1251,
-        "south": 1249
-      },
       "weight": 1,
-      "id": 1250,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Entry to akademos",
+      "id": 1251, "name": "Entry to akademos",
+      "exits": { "east": 1250, "west": 1374 },
       "environment": -1,
-      "exits": {
-        "east": 1250,
-        "west": 1374
-      },
       "weight": 1,
-      "id": 1251,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Ithsma street",
+      "id": 1252, "name": "Ithsma street",
+      "exits": { "east": 1253, "west": 1248 },
       "environment": -1,
-      "exits": {
-        "east": 1253,
-        "west": 1248
-      },
       "weight": 1,
-      "id": 1252,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Ithsma street",
+      "id": 1253, "name": "Ithsma street",
+      "exits": { "west": 1252, "east": 1255, "south": 1254 },
       "environment": -1,
-      "exits": {
-        "west": 1252,
-        "east": 1255,
-        "south": 1254
-      },
       "weight": 1,
-      "id": 1253,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Short path",
+      "id": 1254, "name": "Short path",
+      "exits": { "south": 1375, "north": 1253 },
       "environment": -1,
-      "exits": {
-        "south": 1375,
-        "north": 1253
-      },
       "weight": 1,
-      "id": 1254,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Ithsma street",
+      "id": 1255, "name": "Ithsma street",
+      "exits": { "west": 1253, "east": 1389, "north": 1256 },
       "environment": -1,
-      "exits": {
-        "west": 1253,
-        "east": 1389,
-        "north": 1256
-      },
       "weight": 1,
-      "id": 1255,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Before the Palace",
+      "id": 1256, "name": "Before the Palace",
+      "exits": { "south": 1255, "north": 1257 },
       "environment": -1,
-      "exits": {
-        "south": 1255,
-        "north": 1257
-      },
       "weight": 1,
-      "id": 1256,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Threshold to the Grand Rotunda",
+      "id": 1257, "name": "Threshold to the Grand Rotunda",
+      "exits": { "south": 1256, "north": 1258 },
       "environment": -1,
-      "exits": {
-        "south": 1256,
-        "north": 1258
-      },
       "weight": 1,
-      "id": 1257,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Grand Rotunda",
+      "id": 1258, "name": "Grand Rotunda",
+      "exits": { "west": 1259, "east": 1362, "south": 1257 },
       "environment": -1,
-      "exits": {
-        "west": 1259,
-        "east": 1362,
-        "south": 1257
-      },
       "weight": 1,
-      "id": 1258,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Administrative hallway",
+      "id": 1259, "name": "Administrative hallway",
+      "exits": { "west": 1261, "east": 1258, "north": 1260 },
       "environment": -1,
-      "exits": {
-        "west": 1261,
-        "east": 1258,
-        "north": 1260
-      },
       "weight": 1,
-      "id": 1259,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Office of the Magistrate",
+      "id": 1260, "name": "Office of the Magistrate",
+      "exits": { "south": 1259 },
       "environment": -1,
-      "exits": {
-        "south": 1259
-      },
       "weight": 1,
-      "id": 1260,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Administrative hallway",
+      "id": 1261, "name": "Administrative hallway",
+      "exits": { "west": 1262, "east": 1259, "south": 1391 },
       "environment": -1,
-      "exits": {
-        "west": 1262,
-        "east": 1259,
-        "south": 1391
-      },
       "weight": 1,
-      "id": 1261,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Royal Throne Room",
+      "id": 1262, "name": "Royal Throne Room",
+      "exits": { "east": 1261 },
       "environment": -1,
-      "exits": {
-        "east": 1261
-      },
       "weight": 1,
-      "id": 1262,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hallway",
+      "id": 1263, "name": "Hallway",
+      "exits": { "south": 1223, "west": 1276, "east": 1278, "north": 1264 },
       "environment": -1,
-      "exits": {
-        "south": 1223,
-        "west": 1276,
-        "east": 1278,
-        "north": 1264
-      },
       "weight": 1,
-      "id": 1263,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Hallway",
+      "id": 1264, "name": "Hallway",
+      "exits": { "south": 1263, "north": 1265 },
       "environment": -1,
-      "exits": {
-        "south": 1263,
-        "north": 1265
-      },
       "weight": 1,
-      "id": 1264,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Hallway",
+      "id": 1265, "name": "Hallway",
+      "exits": { "south": 1264, "east": 1275, "north": 1266 },
       "environment": -1,
-      "exits": {
-        "south": 1264,
-        "east": 1275,
-        "north": 1266
-      },
       "weight": 1,
-      "id": 1265,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Hallway",
+      "id": 1266, "name": "Hallway",
+      "exits": { "south": 1265, "west": 1271, "east": 1273, "north": 1267 },
       "environment": -1,
-      "exits": {
-        "south": 1265,
-        "west": 1271,
-        "east": 1273,
-        "north": 1267
-      },
       "weight": 1,
-      "id": 1266,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "End of Hallway",
+      "id": 1267, "name": "End of Hallway",
+      "exits": { "west": 1268, "east": 1269, "south": 1266 },
       "environment": -1,
-      "exits": {
-        "west": 1268,
-        "east": 1269,
-        "south": 1266
-      },
       "weight": 1,
-      "id": 1267,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Romper Room",
+      "id": 1268, "name": "Munchkin Romper Room",
+      "exits": { "east": 1267 },
       "environment": -1,
-      "exits": {
-        "east": 1267
-      },
       "weight": 1,
-      "id": 1268,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Mages' Barracks",
+      "id": 1269, "name": "Mages' Barracks",
+      "exits": { "east": 1270, "west": 1267 },
       "environment": -1,
-      "exits": {
-        "east": 1270,
-        "west": 1267
-      },
       "weight": 1,
-      "id": 1269,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Library",
+      "id": 1270, "name": "Munchkin Library",
+      "exits": { "west": 1269 },
       "environment": -1,
-      "exits": {
-        "west": 1269
-      },
       "weight": 1,
-      "id": 1270,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Mess Hall",
+      "id": 1271, "name": "Munchkin Mess Hall",
+      "exits": { "east": 1266, "west": 1272 },
       "environment": -1,
-      "exits": {
-        "east": 1266,
-        "west": 1272
-      },
       "weight": 1,
-      "id": 1271,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Kitchen",
+      "id": 1272, "name": "Kitchen",
+      "exits": { "east": 1271 },
       "environment": -1,
-      "exits": {
-        "east": 1271
-      },
       "weight": 1,
-      "id": 1272,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Fighters' Barracks",
+      "id": 1273, "name": "Fighters' Barracks",
+      "exits": { "east": 1274, "west": 1266 },
       "environment": -1,
-      "exits": {
-        "east": 1274,
-        "west": 1266
-      },
       "weight": 1,
-      "id": 1273,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Fighters' Barracks",
+      "id": 1274, "name": "Fighters' Barracks",
+      "exits": { "west": 1273, "south": 1288 },
       "environment": -1,
-      "exits": {
-        "west": 1273,
-        "south": 1288
-      },
       "weight": 1,
-      "id": 1274,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Smithy",
+      "id": 1275, "name": "Munchkin Smithy",
+      "exits": { "west": 1265 },
       "environment": -1,
-      "exits": {
-        "west": 1265
-      },
       "weight": 1,
-      "id": 1275,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Hallway",
+      "id": 1276, "name": "Hallway",
+      "exits": { "east": 1263, "west": 1277 },
       "environment": -1,
-      "exits": {
-        "east": 1263,
-        "west": 1277
-      },
       "weight": 1,
-      "id": 1276,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Hallway",
+      "id": 1277, "name": "Hallway",
+      "exits": { "west": 1281, "east": 1276, "south": 1280 },
       "environment": -1,
-      "exits": {
-        "west": 1281,
-        "east": 1276,
-        "south": 1280
-      },
       "weight": 1,
-      "id": 1277,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Narrow Hallway",
+      "id": 1278, "name": "Narrow Hallway",
+      "exits": { "west": 1263, "east": 1279, "north": 1286 },
       "environment": -1,
-      "exits": {
-        "west": 1263,
-        "east": 1279,
-        "north": 1286
-      },
       "weight": 1,
-      "id": 1278,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "End of Narrow Hallway",
+      "id": 1279, "name": "End of Narrow Hallway",
+      "exits": { "west": 1278, "north": 1287 },
       "environment": -1,
-      "exits": {
-        "west": 1278,
-        "north": 1287
-      },
       "weight": 1,
-      "id": 1279,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "A Dark Tunnel",
+      "id": 1280, "name": "A Dark Tunnel",
+      "exits": { "south": 1284, "north": 1277 },
       "environment": -1,
-      "exits": {
-        "south": 1284,
-        "north": 1277
-      },
       "weight": 1,
-      "id": 1280,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "End of Hallway",
+      "id": 1281, "name": "End of Hallway",
+      "exits": { "south": 1282, "east": 1277, "north": 1283 },
       "environment": -1,
-      "exits": {
-        "south": 1282,
-        "east": 1277,
-        "north": 1283
-      },
       "weight": 1,
-      "id": 1281,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Leader's Quarters",
+      "id": 1282, "name": "Munchkin Leader's Quarters",
+      "exits": { "north": 1281 },
       "environment": -1,
-      "exits": {
-        "north": 1281
-      },
       "weight": 1,
-      "id": 1282,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Munchkin Leader's Harem",
+      "id": 1283, "name": "Munchkin Leader's Harem",
+      "exits": { "south": 1281 },
       "environment": -1,
-      "exits": {
-        "south": 1281
-      },
       "weight": 1,
-      "id": 1283,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "A Dark Tunnel",
+      "id": 1284, "name": "A Dark Tunnel",
+      "exits": { "northeast": 1285, "north": 1280 },
       "environment": -1,
-      "exits": {
-        "northeast": 1285,
-        "north": 1280
-      },
       "weight": 1,
-      "id": 1284,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "A Dark Tunnel",
+      "id": 1285, "name": "A Dark Tunnel",
+      "exits": { "southwest": 1284 },
       "environment": -1,
-      "exits": {
-        "southwest": 1284
-      },
       "weight": 1,
-      "id": 1285,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Dank Cell",
+      "id": 1286, "name": "Dank Cell",
+      "exits": { "south": 1278 },
       "environment": -1,
-      "exits": {
-        "south": 1278
-      },
       "weight": 1,
-      "id": 1286,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Dank Cell",
+      "id": 1287, "name": "Dank Cell",
+      "exits": { "south": 1279 },
       "environment": -1,
-      "exits": {
-        "south": 1279
-      },
       "weight": 1,
-      "id": 1287,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "The Lollipop Guild",
+      "id": 1288, "name": "The Lollipop Guild",
+      "exits": { "north": 1274 },
       "environment": -1,
-      "exits": {
-        "north": 1274
-      },
       "weight": 1,
-      "id": 1288,
-      "area": {
-        "id": 25
-      }
+      "area": {"id": 25}
     },
     {
-      "name": "Gate of Triumph",
+      "id": 1289, "name": "Gate of Triumph",
+      "exits": { "south": 1290, "west": 1222, "east": 1224, "north": 1291 },
       "environment": -1,
-      "exits": {
-        "south": 1290,
-        "west": 1222,
-        "east": 1224,
-        "north": 1291
-      },
       "weight": 1,
-      "id": 1289,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Southern niche",
+      "id": 1290, "name": "Southern niche",
+      "exits": { "north": 1289 },
       "environment": -1,
-      "exits": {
-        "north": 1289
-      },
       "weight": 1,
-      "id": 1290,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Northern niche",
+      "id": 1291, "name": "Northern niche",
+      "exits": { "south": 1289 },
       "environment": -1,
-      "exits": {
-        "south": 1289
-      },
       "weight": 1,
-      "id": 1291,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Cave Waterfall",
+      "id": 1292, "name": "Cave Waterfall",
+      "exits": { "northeast": 518 },
       "environment": -1,
-      "exits": {
-        "northeast": 518
-      },
       "weight": 1,
-      "id": 1292,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Throne Room",
+      "id": 1293, "name": "Throne Room",
+      "exits": { "east": 525 },
       "environment": -1,
-      "exits": {
-        "east": 525
-      },
       "weight": 1,
-      "id": 1293,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Mess Hall",
+      "id": 1294, "name": "Mess Hall",
+      "exits": { "south": 523 },
       "environment": -1,
-      "exits": {
-        "south": 523
-      },
       "weight": 1,
-      "id": 1294,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "New Tunnel",
+      "id": 1295, "name": "New Tunnel",
+      "exits": { "east": 1296, "west": 523 },
       "environment": -1,
-      "exits": {
-        "east": 1296,
-        "west": 523
-      },
       "weight": 1,
-      "id": 1295,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "New Tunnel",
+      "id": 1296, "name": "New Tunnel",
+      "exits": { "west": 1295 },
       "environment": -1,
-      "exits": {
-        "west": 1295
-      },
       "weight": 1,
-      "id": 1296,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "New Tunnel",
+      "id": 1297, "name": "New Tunnel",
+      "exits": { "south": 1299, "west": 1298, "east": 1301, "north": 1300 },
       "environment": -1,
-      "exits": {
-        "south": 1299,
-        "west": 1298,
-        "east": 1301,
-        "north": 1300
-      },
       "weight": 1,
-      "id": 1297,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "You pass through the door and it closes and locks behind you.",
+      "id": 1298, "name": "You pass through the door and it closes and locks behind you.",
+      "exits": { "east": 1297 },
       "environment": -1,
-      "exits": {
-        "east": 1297
-      },
       "weight": 1,
-      "id": 1298,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Nursery",
+      "id": 1299, "name": "Nursery",
+      "exits": { "north": 1297 },
       "environment": -1,
-      "exits": {
-        "north": 1297
-      },
       "weight": 1,
-      "id": 1299,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Barracks",
+      "id": 1300, "name": "Barracks",
+      "exits": { "south": 1297 },
       "environment": -1,
-      "exits": {
-        "south": 1297
-      },
       "weight": 1,
-      "id": 1300,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "New Tunnel: Checkpoint",
+      "id": 1301, "name": "New Tunnel: Checkpoint",
+      "exits": { "east": 1302, "west": 1297 },
       "environment": -1,
-      "exits": {
-        "east": 1302,
-        "west": 1297
-      },
       "weight": 1,
-      "id": 1301,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Top of the mine shaft",
+      "id": 1302, "name": "Top of the mine shaft",
+      "exits": { "down": 1303, "west": 1301 },
       "environment": -1,
-      "exits": {
-        "down": 1303,
-        "west": 1301
-      },
       "weight": 1,
-      "id": 1302,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "id": 1303, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "exits": { "down": 1304, "up": 1302 },
       "environment": -1,
-      "exits": {
-        "down": 1304,
-        "up": 1302
-      },
       "weight": 1,
-      "id": 1303,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "id": 1304, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
+      "exits": { "southwest": 1305, "up": 1303, "east": 1320, "north": 1311 },
       "environment": -1,
-      "exits": {
-        "southwest": 1305,
-        "up": 1303,
-        "east": 1320,
-        "north": 1311
-      },
       "weight": 1,
-      "id": 1304,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1305, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1306, "northeast": 1304, "southeast": 1309 },
       "environment": -1,
-      "exits": {
-        "southwest": 1306,
-        "northeast": 1304,
-        "southeast": 1309
-      },
       "weight": 1,
-      "id": 1305,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1306, "name": "Twisting Tunnel",
+      "exits": { "northeast": 1305, "northwest": 1308, "southeast": 1307 },
       "environment": -1,
-      "exits": {
-        "northeast": 1305,
-        "northwest": 1308,
-        "southeast": 1307
-      },
       "weight": 1,
-      "id": 1306,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1307, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1306 },
       "environment": -1,
-      "exits": {
-        "northwest": 1306
-      },
       "weight": 1,
-      "id": 1307,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1308, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1306 },
       "environment": -1,
-      "exits": {
-        "southeast": 1306
-      },
       "weight": 1,
-      "id": 1308,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1309, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1305, "northeast": 1310 },
       "environment": -1,
-      "exits": {
-        "northwest": 1305,
-        "northeast": 1310
-      },
       "weight": 1,
-      "id": 1309,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1310, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1309 },
       "environment": -1,
-      "exits": {
-        "southwest": 1309
-      },
       "weight": 1,
-      "id": 1310,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1311, "name": "Twisting Tunnel",
+      "exits": { "south": 1304, "northeast": 1312 },
       "environment": -1,
-      "exits": {
-        "south": 1304,
-        "northeast": 1312
-      },
       "weight": 1,
-      "id": 1311,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1312, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1311, "north": 1313 },
       "environment": -1,
-      "exits": {
-        "southwest": 1311,
-        "north": 1313
-      },
       "weight": 1,
-      "id": 1312,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1313, "name": "Twisting Tunnel",
+      "exits": { "east": 1314, "northwest": 1316, "south": 1312 },
       "environment": -1,
-      "exits": {
-        "east": 1314,
-        "northwest": 1316,
-        "south": 1312
-      },
       "weight": 1,
-      "id": 1313,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1314, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1315, "west": 1313 },
       "environment": -1,
-      "exits": {
-        "southeast": 1315,
-        "west": 1313
-      },
       "weight": 1,
-      "id": 1314,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Your left arm is now in full health.",
+      "id": 1315, "name": "Your left arm is now in full health.",
+      "exits": { "northwest": 1314 },
       "environment": -1,
-      "exits": {
-        "northwest": 1314
-      },
       "weight": 1,
-      "id": 1315,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1316, "name": "Twisting Tunnel",
+      "exits": { "northeast": 1319, "southeast": 1313, "north": 1317 },
       "environment": -1,
-      "exits": {
-        "northeast": 1319,
-        "southeast": 1313,
-        "north": 1317
-      },
       "weight": 1,
-      "id": 1316,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1317, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1318, "south": 1316 },
       "environment": -1,
-      "exits": {
-        "northwest": 1318,
-        "south": 1316
-      },
       "weight": 1,
-      "id": 1317,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1318, "name": "Twisting Tunnel",
+      "exits": { "southeast": 1317 },
       "environment": -1,
-      "exits": {
-        "southeast": 1317
-      },
       "weight": 1,
-      "id": 1318,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1319, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1316 },
       "environment": -1,
-      "exits": {
-        "southwest": 1316
-      },
       "weight": 1,
-      "id": 1319,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1320, "name": "Twisting Tunnel",
+      "exits": { "west": 1304, "northeast": 1321 },
       "environment": -1,
-      "exits": {
-        "west": 1304,
-        "northeast": 1321
-      },
       "weight": 1,
-      "id": 1320,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1321, "name": "Twisting Tunnel",
+      "exits": { "southwest": 1320, "west": 1325, "southeast": 1322, "north": 1324 },
       "environment": -1,
-      "exits": {
-        "southwest": 1320,
-        "west": 1325,
-        "southeast": 1322,
-        "north": 1324
-      },
       "weight": 1,
-      "id": 1321,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1322, "name": "Twisting Tunnel",
+      "exits": { "northwest": 1321, "east": 1323 },
       "environment": -1,
-      "exits": {
-        "northwest": 1321,
-        "east": 1323
-      },
       "weight": 1,
-      "id": 1322,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1323, "name": "Twisting Tunnel",
+      "exits": { "west": 1322 },
       "environment": -1,
-      "exits": {
-        "west": 1322
-      },
       "weight": 1,
-      "id": 1323,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1324, "name": "Twisting Tunnel",
+      "exits": { "south": 1321 },
       "environment": -1,
-      "exits": {
-        "south": 1321
-      },
       "weight": 1,
-      "id": 1324,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "Twisting Tunnel",
+      "id": 1325, "name": "Twisting Tunnel",
+      "exits": { "east": 1321 },
       "environment": -1,
-      "exits": {
-        "east": 1321
-      },
       "weight": 1,
-      "id": 1325,
-      "area": {
-        "id": 7
-      }
+      "area": {"id": 7}
     },
     {
-      "name": "La Cosa Nostra",
+      "id": 1326, "name": "La Cosa Nostra",
+      "exits": { "south": 283 },
       "environment": -1,
-      "exits": {
-        "south": 283
-      },
       "weight": 1,
-      "id": 1326,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Anshelm Stables",
+      "id": 1327, "name": "Anshelm Stables",
+      "exits": { "south": 284 },
       "environment": -1,
-      "exits": {
-        "south": 284
-      },
       "weight": 1,
-      "id": 1327,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Eastern end of Geld Strasse",
+      "id": 1328, "name": "Eastern end of Geld Strasse",
+      "exits": { "east": 1329, "west": 281 },
       "environment": -1,
-      "exits": {
-        "east": 1329,
-        "west": 281
-      },
       "weight": 1,
-      "id": 1328,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "With a little strain, you are able to pull open the heavy doors and enter",
+      "id": 1329, "name": "With a little strain, you are able to pull open the heavy doors and enter",
+      "exits": { "east": 1330, "west": 1328 },
       "environment": -1,
-      "exits": {
-        "east": 1330,
-        "west": 1328
-      },
       "weight": 1,
-      "id": 1329,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Naive",
+      "id": 1330, "name": "Naive",
+      "exits": { "south": 1332, "west": 1329, "east": 1331, "north": 1333 },
       "environment": -1,
-      "exits": {
-        "south": 1332,
-        "west": 1329,
-        "east": 1331,
-        "north": 1333
-      },
       "weight": 1,
-      "id": 1330,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Altar of the Rose",
+      "id": 1331, "name": "Altar of the Rose",
+      "exits": { "west": 1330 },
       "environment": -1,
-      "exits": {
-        "west": 1330
-      },
       "weight": 1,
-      "id": 1331,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Southern statuary",
+      "id": 1332, "name": "Southern statuary",
+      "exits": { "north": 1330 },
       "environment": -1,
-      "exits": {
-        "north": 1330
-      },
       "weight": 1,
-      "id": 1332,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Northern statuary",
+      "id": 1333, "name": "Northern statuary",
+      "exits": { "south": 1330 },
       "environment": -1,
-      "exits": {
-        "south": 1330
-      },
       "weight": 1,
-      "id": 1333,
-      "area": {
-        "id": 3
-      }
+      "area": {"id": 3}
     },
     {
-      "name": "Tiled Entryway",
+      "id": 1334, "name": "Tiled Entryway",
+      "exits": { "west": 1336, "south": 1335 },
       "environment": -1,
-      "exits": {
-        "west": 1336,
-        "south": 1335
-      },
       "weight": 1,
-      "id": 1334,
-      "area": {
-        "id": 27
-      }
+      "area": {"id": 27}
     },
     {
-      "name": "Inside of Bracknar Gate",
+      "id": 1335, "name": "Inside of Bracknar Gate",
+      "exits": { "south": 261, "north": 1334 },
       "environment": -1,
-      "exits": {
-        "south": 261,
-        "north": 1334
-      },
       "weight": 1,
-      "id": 1335,
-      "area": {
-        "id": 27
-      }
+      "area": {"id": 27}
     },
     {
-      "name": "Sitting Room",
+      "id": 1336, "name": "Sitting Room",
+      "exits": { "east": 1334, "north": 1337 },
       "environment": -1,
-      "exits": {
-        "east": 1334,
-        "north": 1337
-      },
       "weight": 1,
-      "id": 1336,
-      "area": {
-        "id": 27
-      }
+      "area": {"id": 27}
     },
     {
-      "name": "Guarded hallway",
+      "id": 1337, "name": "Guarded hallway",
+      "exits": { "south": 1336, "north": 1361 },
       "environment": -1,
-      "exits": {
-        "south": 1336,
-        "north": 1361
-      },
       "weight": 1,
-      "id": 1337,
-      "area": {
-        "id": 27
-      }
+      "area": {"id": 27}
     },
     {
-      "name": "Ice Dragon's Den",
+      "id": 1338, "name": "Ice Dragon's Den",
+      "exits": { "down": 1339 },
       "environment": -1,
-      "exits": {
-        "down": 1339
-      },
       "weight": 1,
-      "id": 1338,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Near a Frozen Waterfall",
+      "id": 1339, "name": "Near a Frozen Waterfall",
+      "exits": { "northwest": 1340, "east": 1342 },
       "environment": -1,
-      "exits": {
-        "northwest": 1340,
-        "east": 1342
-      },
       "weight": 1,
-      "id": 1339,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "By an Icy Gate",
+      "id": 1340, "name": "By an Icy Gate",
+      "exits": { "southeast": 1339, "east": 1341 },
       "environment": -1,
-      "exits": {
-        "southeast": 1339,
-        "east": 1341
-      },
       "weight": 1,
-      "id": 1340,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Edge of an Icy Cliff",
+      "id": 1341, "name": "Edge of an Icy Cliff",
+      "exits": { "west": 1340 },
       "environment": -1,
-      "exits": {
-        "west": 1340
-      },
       "weight": 1,
-      "id": 1341,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of a Frozen River",
+      "id": 1342, "name": "On Top of a Frozen River",
+      "exits": { "west": 1339, "north": 1343 },
       "environment": -1,
-      "exits": {
-        "west": 1339,
-        "north": 1343
-      },
       "weight": 1,
-      "id": 1342,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of a Frozen River",
+      "id": 1343, "name": "On Top of a Frozen River",
+      "exits": { "south": 1342, "north": 1344 },
       "environment": -1,
-      "exits": {
-        "south": 1342,
-        "north": 1344
-      },
       "weight": 1,
-      "id": 1343,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Under a Snowy Overhang",
+      "id": 1344, "name": "Under a Snowy Overhang",
+      "exits": { "northwest": 1345, "south": 1343 },
       "environment": -1,
-      "exits": {
-        "northwest": 1345,
-        "south": 1343
-      },
       "weight": 1,
-      "id": 1344,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Stream",
+      "id": 1345, "name": "On Top of an Icy Stream",
+      "exits": { "southeast": 1344, "west": 1346 },
       "environment": -1,
-      "exits": {
-        "southeast": 1344,
-        "west": 1346
-      },
       "weight": 1,
-      "id": 1345,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1346, "name": "On Top of an Icy Lake",
+      "exits": { "east": 1345, "northwest": 1347, "southeast": 1360, "west": 1358 },
       "environment": -1,
-      "exits": {
-        "east": 1345,
-        "northwest": 1347,
-        "southeast": 1360,
-        "west": 1358
-      },
       "weight": 1,
-      "id": 1346,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1347, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1351, "northeast": 1348, "southeast": 1346, "south": 1358 },
       "environment": -1,
-      "exits": {
-        "west": 1351,
-        "northeast": 1348,
-        "southeast": 1346,
-        "south": 1358
-      },
       "weight": 1,
-      "id": 1347,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Entrance to a Frozen Cavern",
+      "id": 1348, "name": "Entrance to a Frozen Cavern",
+      "exits": { "southwest": 1347, "southeast": 1349 },
       "environment": -1,
-      "exits": {
-        "southwest": 1347,
-        "southeast": 1349
-      },
       "weight": 1,
-      "id": 1348,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Frozen Cavern",
+      "id": 1349, "name": "Frozen Cavern",
+      "exits": { "northwest": 1348, "east": 1350 },
       "environment": -1,
-      "exits": {
-        "northwest": 1348,
-        "east": 1350
-      },
       "weight": 1,
-      "id": 1349,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "End of a Frozen Cavern",
+      "id": 1350, "name": "End of a Frozen Cavern",
+      "exits": { "west": 1349 },
       "environment": -1,
-      "exits": {
-        "west": 1349
-      },
       "weight": 1,
-      "id": 1350,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1351, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1352, "east": 1347, "south": 1356 },
       "environment": -1,
-      "exits": {
-        "west": 1352,
-        "east": 1347,
-        "south": 1356
-      },
       "weight": 1,
-      "id": 1351,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1352, "name": "On Top of an Icy Lake",
+      "exits": { "east": 1351, "northwest": 1359, "south": 1353 },
       "environment": -1,
-      "exits": {
-        "east": 1351,
-        "northwest": 1359,
-        "south": 1353
-      },
       "weight": 1,
-      "id": 1352,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1353, "name": "On Top of an Icy Lake",
+      "exits": { "southwest": 1354, "east": 1356, "north": 1352 },
       "environment": -1,
-      "exits": {
-        "southwest": 1354,
-        "east": 1356,
-        "north": 1352
-      },
       "weight": 1,
-      "id": 1353,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Ice Cave Entrance",
+      "id": 1354, "name": "Ice Cave Entrance",
+      "exits": { "east": 1355, "northeast": 1353 },
       "environment": -1,
-      "exits": {
-        "east": 1355,
-        "northeast": 1353
-      },
       "weight": 1,
-      "id": 1354,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Inside an Ice Cave",
+      "id": 1355, "name": "Inside an Ice Cave",
+      "exits": { "west": 1354 },
       "environment": -1,
-      "exits": {
-        "west": 1354
-      },
       "weight": 1,
-      "id": 1355,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1356, "name": "On Top of an Icy Lake",
+      "exits": { "south": 1357, "west": 1353, "east": 1358, "north": 1351 },
       "environment": -1,
-      "exits": {
-        "south": 1357,
-        "west": 1353,
-        "east": 1358,
-        "north": 1351
-      },
       "weight": 1,
-      "id": 1356,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Isolated Icy Area",
+      "id": 1357, "name": "Isolated Icy Area",
+      "exits": { "north": 1356 },
       "environment": -1,
-      "exits": {
-        "north": 1356
-      },
       "weight": 1,
-      "id": 1357,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "On Top of an Icy Lake",
+      "id": 1358, "name": "On Top of an Icy Lake",
+      "exits": { "west": 1356, "east": 1346, "north": 1347 },
       "environment": -1,
-      "exits": {
-        "west": 1356,
-        "east": 1346,
-        "north": 1347
-      },
       "weight": 1,
-      "id": 1358,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Northern Shore of an Icy Lake",
+      "id": 1359, "name": "Northern Shore of an Icy Lake",
+      "exits": { "southeast": 1352 },
       "environment": -1,
-      "exits": {
-        "southeast": 1352
-      },
       "weight": 1,
-      "id": 1359,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Snowy Overhang",
+      "id": 1360, "name": "Snowy Overhang",
+      "exits": { "northwest": 1346 },
       "environment": -1,
-      "exits": {
-        "northwest": 1346
-      },
       "weight": 1,
-      "id": 1360,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Clan Lord's Private Chambers",
+      "id": 1361, "name": "Clan Lord's Private Chambers",
+      "exits": { "south": 1337 },
       "environment": -1,
-      "exits": {
-        "south": 1337
-      },
       "weight": 1,
-      "id": 1361,
-      "area": {
-        "id": 27
-      }
+      "area": {"id": 27}
     },
     {
-      "name": "Guard Post",
+      "id": 1362, "name": "Guard Post",
+      "exits": { "west": 1258, "east": 1392, "north": 1395 },
       "environment": -1,
-      "exits": {
-        "west": 1258,
-        "east": 1392,
-        "north": 1395
-      },
       "weight": 1,
-      "id": 1362,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Doorway",
+      "id": 1363, "name": "Doorway",
+      "exits": { "east": 1225, "west": 1364 },
       "environment": -1,
-      "exits": {
-        "east": 1225,
-        "west": 1364
-      },
       "weight": 1,
-      "id": 1363,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Statued hallway",
+      "id": 1364, "name": "Statued hallway",
+      "exits": { "east": 1363, "west": 1365 },
       "environment": -1,
-      "exits": {
-        "east": 1363,
-        "west": 1365
-      },
       "weight": 1,
-      "id": 1364,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hallway",
+      "id": 1365, "name": "Hallway",
+      "exits": { "west": 1366, "east": 1364, "north": 1367 },
       "environment": -1,
-      "exits": {
-        "west": 1366,
-        "east": 1364,
-        "north": 1367
-      },
       "weight": 1,
-      "id": 1365,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Captain's office",
+      "id": 1366, "name": "Captain's office",
+      "exits": { "east": 1365 },
       "environment": -1,
-      "exits": {
-        "east": 1365
-      },
       "weight": 1,
-      "id": 1366,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Courtyard",
+      "id": 1367, "name": "Courtyard",
+      "exits": { "south": 1365, "north": 1368 },
       "environment": -1,
-      "exits": {
-        "south": 1365,
-        "north": 1368
-      },
       "weight": 1,
-      "id": 1367,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Courtyard",
+      "id": 1368, "name": "Courtyard",
+      "exits": { "south": 1367, "north": 1369 },
       "environment": -1,
-      "exits": {
-        "south": 1367,
-        "north": 1369
-      },
       "weight": 1,
-      "id": 1368,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hallway",
+      "id": 1369, "name": "Hallway",
+      "exits": { "up": 1373, "west": 1370, "east": 1371, "south": 1368 },
       "environment": -1,
-      "exits": {
-        "up": 1373,
-        "west": 1370,
-        "east": 1371,
-        "south": 1368
-      },
       "weight": 1,
-      "id": 1369,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "West wing",
+      "id": 1370, "name": "West wing",
+      "exits": { "east": 1369 },
       "environment": -1,
-      "exits": {
-        "east": 1369
-      },
       "weight": 1,
-      "id": 1370,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "East wing",
+      "id": 1371, "name": "East wing",
+      "exits": { "west": 1369, "south": 1372 },
       "environment": -1,
-      "exits": {
-        "west": 1369,
-        "south": 1372
-      },
       "weight": 1,
-      "id": 1371,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "East wing hallway",
+      "id": 1372, "name": "East wing hallway",
+      "exits": { "north": 1371 },
       "environment": -1,
-      "exits": {
-        "north": 1371
-      },
       "weight": 1,
-      "id": 1372,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
+      "id": 1373, "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
+      "exits": { "down": 1369 },
       "environment": -1,
-      "exits": {
-        "down": 1369
-      },
       "weight": 1,
-      "id": 1373,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Akademos",
+      "id": 1374, "name": "Akademos",
+      "exits": { "east": 1251 },
       "environment": -1,
-      "exits": {
-        "east": 1251
-      },
       "weight": 1,
-      "id": 1374,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Temple entry",
+      "id": 1375, "name": "Temple entry",
+      "exits": { "south": 1376, "north": 1254 },
       "environment": -1,
-      "exits": {
-        "south": 1376,
-        "north": 1254
-      },
       "weight": 1,
-      "id": 1375,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Temple rotunda",
+      "id": 1376, "name": "Temple rotunda",
+      "exits": { "south": 1377, "west": 1381, "east": 1384, "north": 1375 },
       "environment": -1,
-      "exits": {
-        "south": 1377,
-        "west": 1381,
-        "east": 1384,
-        "north": 1375
-      },
       "weight": 1,
-      "id": 1376,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Temple hallway",
+      "id": 1377, "name": "Temple hallway",
+      "exits": { "south": 1378, "north": 1376 },
       "environment": -1,
-      "exits": {
-        "south": 1378,
-        "north": 1376
-      },
       "weight": 1,
-      "id": 1377,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "End of temple hallway",
+      "id": 1378, "name": "End of temple hallway",
+      "exits": { "west": 1380, "east": 1379, "north": 1377 },
       "environment": -1,
-      "exits": {
-        "west": 1380,
-        "east": 1379,
-        "north": 1377
-      },
       "weight": 1,
-      "id": 1378,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Folio depository",
+      "id": 1379, "name": "Folio depository",
+      "exits": { "west": 1378 },
       "environment": -1,
-      "exits": {
-        "west": 1378
-      },
       "weight": 1,
-      "id": 1379,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Reliquary",
+      "id": 1380, "name": "Reliquary",
+      "exits": { "east": 1378 },
       "environment": -1,
-      "exits": {
-        "east": 1378
-      },
       "weight": 1,
-      "id": 1380,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hall of Peace",
+      "id": 1381, "name": "Hall of Peace",
+      "exits": { "east": 1376, "west": 1382 },
       "environment": -1,
-      "exits": {
-        "east": 1376,
-        "west": 1382
-      },
       "weight": 1,
-      "id": 1381,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hall of Peace",
+      "id": 1382, "name": "Hall of Peace",
+      "exits": { "west": 1383, "east": 1381, "south": 1387 },
       "environment": -1,
-      "exits": {
-        "west": 1383,
-        "east": 1381,
-        "south": 1387
-      },
       "weight": 1,
-      "id": 1382,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Rotunda of Peace",
+      "id": 1383, "name": "Rotunda of Peace",
+      "exits": { "east": 1382 },
       "environment": -1,
-      "exits": {
-        "east": 1382
-      },
       "weight": 1,
-      "id": 1383,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hall of War",
+      "id": 1384, "name": "Hall of War",
+      "exits": { "west": 1376, "east": 1385, "south": 1388 },
       "environment": -1,
-      "exits": {
-        "west": 1376,
-        "east": 1385,
-        "south": 1388
-      },
       "weight": 1,
-      "id": 1384,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Hall of War",
+      "id": 1385, "name": "Hall of War",
+      "exits": { "east": 1386, "west": 1384 },
       "environment": -1,
-      "exits": {
-        "east": 1386,
-        "west": 1384
-      },
       "weight": 1,
-      "id": 1385,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Rotunda of War",
+      "id": 1386, "name": "Rotunda of War",
+      "exits": { "west": 1385 },
       "environment": -1,
-      "exits": {
-        "west": 1385
-      },
       "weight": 1,
-      "id": 1386,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Chapel of Peace",
+      "id": 1387, "name": "Chapel of Peace",
+      "exits": { "north": 1382 },
       "environment": -1,
-      "exits": {
-        "north": 1382
-      },
       "weight": 1,
-      "id": 1387,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Chapel of War",
+      "id": 1388, "name": "Chapel of War",
+      "exits": { "north": 1384 },
       "environment": -1,
-      "exits": {
-        "north": 1384
-      },
       "weight": 1,
-      "id": 1388,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Ithsma street",
+      "id": 1389, "name": "Ithsma street",
+      "exits": { "east": 1390, "west": 1255 },
       "environment": -1,
-      "exits": {
-        "east": 1390,
-        "west": 1255
-      },
       "weight": 1,
-      "id": 1389,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "End of Ithsma street",
+      "id": 1390, "name": "End of Ithsma street",
+      "exits": { "west": 1389 },
       "environment": -1,
-      "exits": {
-        "west": 1389
-      },
       "weight": 1,
-      "id": 1390,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Office of the Secretary",
+      "id": 1391, "name": "Office of the Secretary",
+      "exits": { "north": 1261 },
       "environment": -1,
-      "exits": {
-        "north": 1261
-      },
       "weight": 1,
-      "id": 1391,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Formal gardens",
+      "id": 1392, "name": "Formal gardens",
+      "exits": { "west": 1362, "east": 1393, "south": 1394 },
       "environment": -1,
-      "exits": {
-        "west": 1362,
-        "east": 1393,
-        "south": 1394
-      },
       "weight": 1,
-      "id": 1392,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "A private corner in the garden",
+      "id": 1393, "name": "A private corner in the garden",
+      "exits": { "west": 1392 },
       "environment": -1,
-      "exits": {
-        "west": 1392
-      },
       "weight": 1,
-      "id": 1393,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "A private corner in the garden",
+      "id": 1394, "name": "A private corner in the garden",
+      "exits": { "north": 1392 },
       "environment": -1,
-      "exits": {
-        "north": 1392
-      },
       "weight": 1,
-      "id": 1394,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Residential hallway",
+      "id": 1395, "name": "Residential hallway",
+      "exits": { "east": 1396, "south": 1362 },
       "environment": -1,
-      "exits": {
-        "east": 1396,
-        "south": 1362
-      },
       "weight": 1,
-      "id": 1395,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "Residential hallway",
+      "id": 1396, "name": "Residential hallway",
+      "exits": { "west": 1395, "east": 1397, "north": 1398 },
       "environment": -1,
-      "exits": {
-        "west": 1395,
-        "east": 1397,
-        "north": 1398
-      },
       "weight": 1,
-      "id": 1396,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "The harem",
+      "id": 1397, "name": "The harem",
+      "exits": { "west": 1396, "north": 1400 },
       "environment": -1,
-      "exits": {
-        "west": 1396,
-        "north": 1400
-      },
       "weight": 1,
-      "id": 1397,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "The Royal Chambers",
+      "id": 1398, "name": "The Royal Chambers",
+      "exits": { "west": 1399, "south": 1396 },
       "environment": -1,
-      "exits": {
-        "west": 1399,
-        "south": 1396
-      },
       "weight": 1,
-      "id": 1398,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "The royal dressing room",
+      "id": 1399, "name": "The royal dressing room",
+      "exits": { "east": 1398 },
       "environment": -1,
-      "exits": {
-        "east": 1398
-      },
       "weight": 1,
-      "id": 1399,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "The Consort's chambers",
+      "id": 1400, "name": "The Consort's chambers",
+      "exits": { "south": 1397 },
       "environment": -1,
-      "exits": {
-        "south": 1397
-      },
       "weight": 1,
-      "id": 1400,
-      "area": {
-        "id": 24
-      }
+      "area": {"id": 24}
     },
     {
-      "name": "City of Indel, Wilderness Gate",
+      "id": 1401, "name": "City of Indel, Wilderness Gate",
+      "exits": { "west": 1635, "east": 1636, "south": 1402 },
       "environment": -1,
-      "exits": {
-        "west": 1635,
-        "east": 1636,
-        "south": 1402
-      },
       "weight": 1,
-      "id": 1401,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Road",
+      "id": 1402, "name": "Castle Road",
+      "exits": { "south": 1403, "west": 1631, "east": 1633, "north": 1401 },
       "environment": -1,
-      "exits": {
-        "south": 1403,
-        "west": 1631,
-        "east": 1633,
-        "north": 1401
-      },
       "weight": 1,
-      "id": 1402,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Road",
+      "id": 1403, "name": "Castle Road",
+      "exits": { "south": 1404, "west": 1628, "east": 1630, "north": 1402 },
       "environment": -1,
-      "exits": {
-        "south": 1404,
-        "west": 1628,
-        "east": 1630,
-        "north": 1402
-      },
       "weight": 1,
-      "id": 1403,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Road Courtyard",
+      "id": 1404, "name": "Castle Road Courtyard",
+      "exits": { "south": 1405, "west": 1626, "east": 1627, "north": 1403 },
       "environment": -1,
-      "exits": {
-        "south": 1405,
-        "west": 1626,
-        "east": 1627,
-        "north": 1403
-      },
       "weight": 1,
-      "id": 1404,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Road",
+      "id": 1405, "name": "Castle Road",
+      "exits": { "west": 1625, "south": 1406, "north": 1404 },
       "environment": -1,
-      "exits": {
-        "west": 1625,
-        "south": 1406,
-        "north": 1404
-      },
       "weight": 1,
-      "id": 1405,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Intersection of Castle Road and Merchant's Row",
+      "id": 1406, "name": "Intersection of Castle Road and Merchant's Row",
+      "exits": { "south": 1584, "west": 1407, "east": 1508, "north": 1405 },
       "environment": -1,
-      "exits": {
-        "south": 1584,
-        "west": 1407,
-        "east": 1508,
-        "north": 1405
-      },
       "weight": 1,
-      "id": 1406,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1407, "name": "West Merchant's Row",
+      "exits": { "east": 1406, "west": 1408 },
       "environment": -1,
-      "exits": {
-        "east": 1406,
-        "west": 1408
-      },
       "weight": 1,
-      "id": 1407,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row, north of the Silver Griffin",
+      "id": 1408, "name": "West Merchant's Row, north of the Silver Griffin",
+      "exits": { "west": 1409, "east": 1407, "south": 1589 },
       "environment": -1,
-      "exits": {
-        "west": 1409,
-        "east": 1407,
-        "south": 1589
-      },
       "weight": 1,
-      "id": 1408,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row, south of Big Bob's Sign Shop",
+      "id": 1409, "name": "West Merchant's Row, south of Big Bob's Sign Shop",
+      "exits": { "west": 1410, "east": 1408, "south": 1590 },
       "environment": -1,
-      "exits": {
-        "west": 1410,
-        "east": 1408,
-        "south": 1590
-      },
       "weight": 1,
-      "id": 1409,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1410, "name": "West Merchant's Row",
+      "exits": { "east": 1409, "west": 1411 },
       "environment": -1,
-      "exits": {
-        "east": 1409,
-        "west": 1411
-      },
       "weight": 1,
-      "id": 1410,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1411, "name": "West Merchant's Row",
+      "exits": { "east": 1410, "west": 1412 },
       "environment": -1,
-      "exits": {
-        "east": 1410,
-        "west": 1412
-      },
       "weight": 1,
-      "id": 1411,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1412, "name": "West Merchant's Row",
+      "exits": { "east": 1411, "west": 1413 },
       "environment": -1,
-      "exits": {
-        "east": 1411,
-        "west": 1413
-      },
       "weight": 1,
-      "id": 1412,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row, south of Knights of Solamnia",
+      "id": 1413, "name": "West Merchant's Row, south of Knights of Solamnia",
+      "exits": { "east": 1412, "west": 1414 },
       "environment": -1,
-      "exits": {
-        "east": 1412,
-        "west": 1414
-      },
       "weight": 1,
-      "id": 1413,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1414, "name": "West Merchant's Row",
+      "exits": { "east": 1413, "west": 1415 },
       "environment": -1,
-      "exits": {
-        "east": 1413,
-        "west": 1415
-      },
       "weight": 1,
-      "id": 1414,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row, south of the Cobbler's Shop",
+      "id": 1415, "name": "West Merchant's Row, south of the Cobbler's Shop",
+      "exits": { "east": 1414, "west": 1416 },
       "environment": -1,
-      "exits": {
-        "east": 1414,
-        "west": 1416
-      },
       "weight": 1,
-      "id": 1415,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row, south of Laird's Forge",
+      "id": 1416, "name": "West Merchant's Row, south of Laird's Forge",
+      "exits": { "east": 1415, "west": 1417 },
       "environment": -1,
-      "exits": {
-        "east": 1415,
-        "west": 1417
-      },
       "weight": 1,
-      "id": 1416,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Merchant's Row",
+      "id": 1417, "name": "West Merchant's Row",
+      "exits": { "east": 1416, "west": 1418 },
       "environment": -1,
-      "exits": {
-        "east": 1416,
-        "west": 1418
-      },
       "weight": 1,
-      "id": 1417,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street and Merchant's Row",
+      "id": 1418, "name": "Pier Street and Merchant's Row",
+      "exits": { "south": 1419, "east": 1417, "north": 1448 },
       "environment": -1,
-      "exits": {
-        "south": 1419,
-        "east": 1417,
-        "north": 1448
-      },
       "weight": 1,
-      "id": 1418,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1419, "name": "Pier Street",
+      "exits": { "south": 1420, "north": 1418 },
       "environment": -1,
-      "exits": {
-        "south": 1420,
-        "north": 1418
-      },
       "weight": 1,
-      "id": 1419,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1420, "name": "Pier Street",
+      "exits": { "south": 1421, "north": 1419 },
       "environment": -1,
-      "exits": {
-        "south": 1421,
-        "north": 1419
-      },
       "weight": 1,
-      "id": 1420,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1421, "name": "Pier Street",
+      "exits": { "south": 1422, "north": 1420 },
       "environment": -1,
-      "exits": {
-        "south": 1422,
-        "north": 1420
-      },
       "weight": 1,
-      "id": 1421,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street west of the Waterfront Gate",
+      "id": 1422, "name": "Pier Street west of the Waterfront Gate",
+      "exits": { "south": 1423, "north": 1421 },
       "environment": -1,
-      "exits": {
-        "south": 1423,
-        "north": 1421
-      },
       "weight": 1,
-      "id": 1422,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1423, "name": "Pier Street",
+      "exits": { "south": 1424, "north": 1422 },
       "environment": -1,
-      "exits": {
-        "south": 1424,
-        "north": 1422
-      },
       "weight": 1,
-      "id": 1423,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1424, "name": "Pier Street",
+      "exits": { "south": 1425, "north": 1423 },
       "environment": -1,
-      "exits": {
-        "south": 1425,
-        "north": 1423
-      },
       "weight": 1,
-      "id": 1424,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1425, "name": "Pier Street",
+      "exits": { "south": 1426, "north": 1424 },
       "environment": -1,
-      "exits": {
-        "south": 1426,
-        "north": 1424
-      },
       "weight": 1,
-      "id": 1425,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1426, "name": "Pier Street",
+      "exits": { "south": 1427, "north": 1425 },
       "environment": -1,
-      "exits": {
-        "south": 1427,
-        "north": 1425
-      },
       "weight": 1,
-      "id": 1426,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1427, "name": "Pier Street",
+      "exits": { "south": 1428, "north": 1426 },
       "environment": -1,
-      "exits": {
-        "south": 1428,
-        "north": 1426
-      },
       "weight": 1,
-      "id": 1427,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pier Street",
+      "id": 1428, "name": "Pier Street",
+      "exits": { "south": 1429, "north": 1427 },
       "environment": -1,
-      "exits": {
-        "south": 1429,
-        "north": 1427
-      },
       "weight": 1,
-      "id": 1428,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1429, "name": "South Pier Street",
+      "exits": { "south": 1430, "north": 1428 },
       "environment": -1,
-      "exits": {
-        "south": 1430,
-        "north": 1428
-      },
       "weight": 1,
-      "id": 1429,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1430, "name": "South Pier Street",
+      "exits": { "south": 1431, "north": 1429 },
       "environment": -1,
-      "exits": {
-        "south": 1431,
-        "north": 1429
-      },
       "weight": 1,
-      "id": 1430,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1431, "name": "South Pier Street",
+      "exits": { "south": 1432, "north": 1430 },
       "environment": -1,
-      "exits": {
-        "south": 1432,
-        "north": 1430
-      },
       "weight": 1,
-      "id": 1431,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1432, "name": "South Pier Street",
+      "exits": { "south": 1433, "north": 1431 },
       "environment": -1,
-      "exits": {
-        "south": 1433,
-        "north": 1431
-      },
       "weight": 1,
-      "id": 1432,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1433, "name": "South Pier Street",
+      "exits": { "south": 1434, "north": 1432 },
       "environment": -1,
-      "exits": {
-        "south": 1434,
-        "north": 1432
-      },
       "weight": 1,
-      "id": 1433,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1434, "name": "South Pier Street",
+      "exits": { "south": 1435, "east": 1545, "north": 1433 },
       "environment": -1,
-      "exits": {
-        "south": 1435,
-        "east": 1545,
-        "north": 1433
-      },
       "weight": 1,
-      "id": 1434,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1435, "name": "South Pier Street",
+      "exits": { "south": 1436, "north": 1434 },
       "environment": -1,
-      "exits": {
-        "south": 1436,
-        "north": 1434
-      },
       "weight": 1,
-      "id": 1435,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1436, "name": "South Pier Street",
+      "exits": { "south": 1437, "north": 1435 },
       "environment": -1,
-      "exits": {
-        "south": 1437,
-        "north": 1435
-      },
       "weight": 1,
-      "id": 1436,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1437, "name": "South Pier Street",
+      "exits": { "south": 1438, "north": 1436 },
       "environment": -1,
-      "exits": {
-        "south": 1438,
-        "north": 1436
-      },
       "weight": 1,
-      "id": 1437,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "South Pier Street",
+      "id": 1438, "name": "South Pier Street",
+      "exits": { "south": 1439, "north": 1437 },
       "environment": -1,
-      "exits": {
-        "south": 1439,
-        "north": 1437
-      },
       "weight": 1,
-      "id": 1438,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Forester's Gate",
+      "id": 1439, "name": "Forester's Gate",
+      "exits": { "north": 1438 },
       "environment": -1,
-      "exits": {
-        "north": 1438
-      },
       "weight": 1,
-      "id": 1439,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Light forest",
+      "id": 1440, "name": "Light forest",
+      "exits": { "west": 1492, "east": 1496, "south": 1441 },
       "environment": -1,
-      "exits": {
-        "west": 1492,
-        "east": 1496,
-        "south": 1441
-      },
       "weight": 1,
-      "id": 1440,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1441, "name": "Light forest",
+      "exits": { "south": 1442, "west": 1493, "east": 1495, "north": 1440 },
       "environment": -1,
-      "exits": {
-        "south": 1442,
-        "west": 1493,
-        "east": 1495,
-        "north": 1440
-      },
       "weight": 1,
-      "id": 1441,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1442, "name": "The Valley",
+      "exits": { "south": 1475, "west": 1494, "east": 1443, "north": 1441 },
       "environment": -1,
-      "exits": {
-        "south": 1475,
-        "west": 1494,
-        "east": 1443,
-        "north": 1441
-      },
       "weight": 1,
-      "id": 1442,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1443, "name": "The Valley",
+      "exits": { "south": 1476, "west": 1442, "east": 1444, "north": 1495 },
       "environment": -1,
-      "exits": {
-        "south": 1476,
-        "west": 1442,
-        "east": 1444,
-        "north": 1495
-      },
       "weight": 1,
-      "id": 1443,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1444, "name": "The Valley",
+      "exits": { "south": 1477, "west": 1443, "east": 1445, "north": 1498 },
       "environment": -1,
-      "exits": {
-        "south": 1477,
-        "west": 1443,
-        "east": 1445,
-        "north": 1498
-      },
       "weight": 1,
-      "id": 1444,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1445, "name": "Light forest",
+      "exits": { "west": 1444, "east": 1446, "south": 1460 },
       "environment": -1,
-      "exits": {
-        "west": 1444,
-        "east": 1446,
-        "south": 1460
-      },
       "weight": 1,
-      "id": 1445,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1446, "name": "Meadow",
+      "exits": { "west": 1445, "east": 1447, "south": 1459 },
       "environment": -1,
-      "exits": {
-        "west": 1445,
-        "east": 1447,
-        "south": 1459
-      },
       "weight": 1,
-      "id": 1446,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1447, "name": "Meadow",
+      "exits": { "west": 1446, "east": 1449, "south": 1452 },
       "environment": -1,
-      "exits": {
-        "west": 1446,
-        "east": 1449,
-        "south": 1452
-      },
       "weight": 1,
-      "id": 1447,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "North Pier Street",
+      "id": 1448, "name": "North Pier Street",
+      "exits": { "south": 1418, "north": 1507 },
       "environment": -1,
-      "exits": {
-        "south": 1418,
-        "north": 1507
-      },
       "weight": 1,
-      "id": 1448,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Light forest",
+      "id": 1449, "name": "Light forest",
+      "exits": { "east": 1450, "west": 1447 },
       "environment": -1,
-      "exits": {
-        "east": 1450,
-        "west": 1447
-      },
       "weight": 1,
-      "id": 1449,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1450, "name": "Light forest",
+      "exits": { "east": 1451, "west": 1449 },
       "environment": -1,
-      "exits": {
-        "east": 1451,
-        "west": 1449
-      },
       "weight": 1,
-      "id": 1450,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1451, "name": "Light forest",
+      "exits": { "west": 1450 },
       "environment": -1,
-      "exits": {
-        "west": 1450
-      },
       "weight": 1,
-      "id": 1451,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1452, "name": "Light forest",
+      "exits": { "west": 1459, "south": 1453, "north": 1447 },
       "environment": -1,
-      "exits": {
-        "west": 1459,
-        "south": 1453,
-        "north": 1447
-      },
       "weight": 1,
-      "id": 1452,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1453, "name": "Light forest",
+      "exits": { "west": 1458, "south": 1454, "north": 1452 },
       "environment": -1,
-      "exits": {
-        "west": 1458,
-        "south": 1454,
-        "north": 1452
-      },
       "weight": 1,
-      "id": 1453,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1454, "name": "Dense forest",
+      "exits": { "west": 1457, "south": 1455, "north": 1453 },
       "environment": -1,
-      "exits": {
-        "west": 1457,
-        "south": 1455,
-        "north": 1453
-      },
       "weight": 1,
-      "id": 1454,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1455, "name": "Light forest",
+      "exits": { "west": 1456, "north": 1454 },
       "environment": -1,
-      "exits": {
-        "west": 1456,
-        "north": 1454
-      },
       "weight": 1,
-      "id": 1455,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1456, "name": "Dense forest",
+      "exits": { "south": 1499, "west": 1463, "east": 1455, "north": 1457 },
       "environment": -1,
-      "exits": {
-        "south": 1499,
-        "west": 1463,
-        "east": 1455,
-        "north": 1457
-      },
       "weight": 1,
-      "id": 1456,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1457, "name": "Dense forest",
+      "exits": { "south": 1456, "west": 1462, "east": 1454, "north": 1458 },
       "environment": -1,
-      "exits": {
-        "south": 1456,
-        "west": 1462,
-        "east": 1454,
-        "north": 1458
-      },
       "weight": 1,
-      "id": 1457,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1458, "name": "Light forest",
+      "exits": { "south": 1457, "west": 1461, "east": 1453, "north": 1459 },
       "environment": -1,
-      "exits": {
-        "south": 1457,
-        "west": 1461,
-        "east": 1453,
-        "north": 1459
-      },
       "weight": 1,
-      "id": 1458,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1459, "name": "Meadow",
+      "exits": { "south": 1458, "west": 1460, "east": 1452, "north": 1446 },
       "environment": -1,
-      "exits": {
-        "south": 1458,
-        "west": 1460,
-        "east": 1452,
-        "north": 1446
-      },
       "weight": 1,
-      "id": 1459,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1460, "name": "Meadow",
+      "exits": { "south": 1461, "west": 1477, "east": 1459, "north": 1445 },
       "environment": -1,
-      "exits": {
-        "south": 1461,
-        "west": 1477,
-        "east": 1459,
-        "north": 1445
-      },
       "weight": 1,
-      "id": 1460,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1461, "name": "Meadow",
+      "exits": { "south": 1462, "west": 1478, "east": 1458, "north": 1460 },
       "environment": -1,
-      "exits": {
-        "south": 1462,
-        "west": 1478,
-        "east": 1458,
-        "north": 1460
-      },
       "weight": 1,
-      "id": 1461,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1462, "name": "Dense forest",
+      "exits": { "south": 1463, "west": 1479, "east": 1457, "north": 1461 },
       "environment": -1,
-      "exits": {
-        "south": 1463,
-        "west": 1479,
-        "east": 1457,
-        "north": 1461
-      },
       "weight": 1,
-      "id": 1462,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1463, "name": "Dense forest",
+      "exits": { "south": 1464, "west": 1480, "east": 1456, "north": 1462 },
       "environment": -1,
-      "exits": {
-        "south": 1464,
-        "west": 1480,
-        "east": 1456,
-        "north": 1462
-      },
       "weight": 1,
-      "id": 1463,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1464, "name": "Mountain Range",
+      "exits": { "west": 1465, "east": 1499, "north": 1463 },
       "environment": -1,
-      "exits": {
-        "west": 1465,
-        "east": 1499,
-        "north": 1463
-      },
       "weight": 1,
-      "id": 1464,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1465, "name": "Mountain Range",
+      "exits": { "west": 1466, "east": 1464, "north": 1480 },
       "environment": -1,
-      "exits": {
-        "west": 1466,
-        "east": 1464,
-        "north": 1480
-      },
       "weight": 1,
-      "id": 1465,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1466, "name": "Mountain Range",
+      "exits": { "west": 1467, "east": 1465, "north": 1481 },
       "environment": -1,
-      "exits": {
-        "west": 1467,
-        "east": 1465,
-        "north": 1481
-      },
       "weight": 1,
-      "id": 1466,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1467, "name": "Mountain Range",
+      "exits": { "west": 1468, "east": 1466, "north": 1482 },
       "environment": -1,
-      "exits": {
-        "west": 1468,
-        "east": 1466,
-        "north": 1482
-      },
       "weight": 1,
-      "id": 1467,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1468, "name": "Mountain Range",
+      "exits": { "east": 1467, "west": 1469 },
       "environment": -1,
-      "exits": {
-        "east": 1467,
-        "west": 1469
-      },
       "weight": 1,
-      "id": 1468,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1469, "name": "Mountain Range",
+      "exits": { "east": 1468, "north": 1470 },
       "environment": -1,
-      "exits": {
-        "east": 1468,
-        "north": 1470
-      },
       "weight": 1,
-      "id": 1469,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1470, "name": "Mountain Range",
+      "exits": { "south": 1469, "north": 1471 },
       "environment": -1,
-      "exits": {
-        "south": 1469,
-        "north": 1471
-      },
       "weight": 1,
-      "id": 1470,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1471, "name": "Mountain Range",
+      "exits": { "south": 1470, "east": 1484, "north": 1472 },
       "environment": -1,
-      "exits": {
-        "south": 1470,
-        "east": 1484,
-        "north": 1472
-      },
       "weight": 1,
-      "id": 1471,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1472, "name": "Mountain Range",
+      "exits": { "south": 1471, "east": 1485, "north": 1473 },
       "environment": -1,
-      "exits": {
-        "south": 1471,
-        "east": 1485,
-        "north": 1473
-      },
       "weight": 1,
-      "id": 1472,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1473, "name": "Mountain Range",
+      "exits": { "south": 1472, "east": 1474, "north": 1489 },
       "environment": -1,
-      "exits": {
-        "south": 1472,
-        "east": 1474,
-        "north": 1489
-      },
       "weight": 1,
-      "id": 1473,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1474, "name": "Light forest",
+      "exits": { "south": 1485, "west": 1473, "east": 1475, "north": 1494 },
       "environment": -1,
-      "exits": {
-        "south": 1485,
-        "west": 1473,
-        "east": 1475,
-        "north": 1494
-      },
       "weight": 1,
-      "id": 1474,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1475, "name": "Light forest",
+      "exits": { "south": 1486, "west": 1474, "east": 1476, "north": 1442 },
       "environment": -1,
-      "exits": {
-        "south": 1486,
-        "west": 1474,
-        "east": 1476,
-        "north": 1442
-      },
       "weight": 1,
-      "id": 1475,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1476, "name": "Light forest",
+      "exits": { "south": 1487, "west": 1475, "east": 1477, "north": 1443 },
       "environment": -1,
-      "exits": {
-        "south": 1487,
-        "west": 1475,
-        "east": 1477,
-        "north": 1443
-      },
       "weight": 1,
-      "id": 1476,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1477, "name": "The Valley",
+      "exits": { "south": 1478, "west": 1476, "east": 1460, "north": 1444 },
       "environment": -1,
-      "exits": {
-        "south": 1478,
-        "west": 1476,
-        "east": 1460,
-        "north": 1444
-      },
       "weight": 1,
-      "id": 1477,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1478, "name": "The Valley",
+      "exits": { "south": 1479, "west": 1487, "east": 1461, "north": 1477 },
       "environment": -1,
-      "exits": {
-        "south": 1479,
-        "west": 1487,
-        "east": 1461,
-        "north": 1477
-      },
       "weight": 1,
-      "id": 1478,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1479, "name": "The Valley",
+      "exits": { "south": 1480, "west": 1488, "east": 1462, "north": 1478 },
       "environment": -1,
-      "exits": {
-        "south": 1480,
-        "west": 1488,
-        "east": 1462,
-        "north": 1478
-      },
       "weight": 1,
-      "id": 1479,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1480, "name": "The Valley",
+      "exits": { "south": 1465, "west": 1481, "east": 1463, "north": 1479 },
       "environment": -1,
-      "exits": {
-        "south": 1465,
-        "west": 1481,
-        "east": 1463,
-        "north": 1479
-      },
       "weight": 1,
-      "id": 1480,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1481, "name": "Dense forest",
+      "exits": { "south": 1466, "west": 1482, "east": 1480, "north": 1488 },
       "environment": -1,
-      "exits": {
-        "south": 1466,
-        "west": 1482,
-        "east": 1480,
-        "north": 1488
-      },
       "weight": 1,
-      "id": 1481,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1482, "name": "Dense forest",
+      "exits": { "south": 1467, "east": 1481, "north": 1483 },
       "environment": -1,
-      "exits": {
-        "south": 1467,
-        "east": 1481,
-        "north": 1483
-      },
       "weight": 1,
-      "id": 1482,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1483, "name": "Dense forest",
+      "exits": { "south": 1482, "west": 1484, "east": 1488, "north": 1486 },
       "environment": -1,
-      "exits": {
-        "south": 1482,
-        "west": 1484,
-        "east": 1488,
-        "north": 1486
-      },
       "weight": 1,
-      "id": 1483,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1484, "name": "Dense forest",
+      "exits": { "west": 1471, "east": 1483, "north": 1485 },
       "environment": -1,
-      "exits": {
-        "west": 1471,
-        "east": 1483,
-        "north": 1485
-      },
       "weight": 1,
-      "id": 1484,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1485, "name": "Light forest",
+      "exits": { "south": 1484, "west": 1472, "east": 1486, "north": 1474 },
       "environment": -1,
-      "exits": {
-        "south": 1484,
-        "west": 1472,
-        "east": 1486,
-        "north": 1474
-      },
       "weight": 1,
-      "id": 1485,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1486, "name": "Light forest",
+      "exits": { "south": 1483, "west": 1485, "east": 1487, "north": 1475 },
       "environment": -1,
-      "exits": {
-        "south": 1483,
-        "west": 1485,
-        "east": 1487,
-        "north": 1475
-      },
       "weight": 1,
-      "id": 1486,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1487, "name": "Light forest",
+      "exits": { "south": 1488, "west": 1486, "east": 1478, "north": 1476 },
       "environment": -1,
-      "exits": {
-        "south": 1488,
-        "west": 1486,
-        "east": 1478,
-        "north": 1476
-      },
       "weight": 1,
-      "id": 1487,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Dense forest",
+      "id": 1488, "name": "Dense forest",
+      "exits": { "south": 1481, "west": 1483, "east": 1479, "north": 1487 },
       "environment": -1,
-      "exits": {
-        "south": 1481,
-        "west": 1483,
-        "east": 1479,
-        "north": 1487
-      },
       "weight": 1,
-      "id": 1488,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1489, "name": "Mountain Range",
+      "exits": { "south": 1473, "east": 1494, "north": 1490 },
       "environment": -1,
-      "exits": {
-        "south": 1473,
-        "east": 1494,
-        "north": 1490
-      },
       "weight": 1,
-      "id": 1489,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1490, "name": "Mountain Range",
+      "exits": { "south": 1489, "east": 1493, "north": 1491 },
       "environment": -1,
-      "exits": {
-        "south": 1489,
-        "east": 1493,
-        "north": 1491
-      },
       "weight": 1,
-      "id": 1490,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1491, "name": "Mountain Range",
+      "exits": { "down": 1506, "east": 1492, "south": 1490 },
       "environment": -1,
-      "exits": {
-        "down": 1506,
-        "east": 1492,
-        "south": 1490
-      },
       "weight": 1,
-      "id": 1491,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1492, "name": "The Valley",
+      "exits": { "west": 1491, "east": 1440, "south": 1493 },
       "environment": -1,
-      "exits": {
-        "west": 1491,
-        "east": 1440,
-        "south": 1493
-      },
       "weight": 1,
-      "id": 1492,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1493, "name": "The Valley",
+      "exits": { "south": 1494, "west": 1490, "east": 1441, "north": 1492 },
       "environment": -1,
-      "exits": {
-        "south": 1494,
-        "west": 1490,
-        "east": 1441,
-        "north": 1492
-      },
       "weight": 1,
-      "id": 1493,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "The Valley",
+      "id": 1494, "name": "The Valley",
+      "exits": { "south": 1474, "west": 1489, "east": 1442, "north": 1493 },
       "environment": -1,
-      "exits": {
-        "south": 1474,
-        "west": 1489,
-        "east": 1442,
-        "north": 1493
-      },
       "weight": 1,
-      "id": 1494,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1495, "name": "Light forest",
+      "exits": { "south": 1443, "west": 1441, "east": 1498, "north": 1496 },
       "environment": -1,
-      "exits": {
-        "south": 1443,
-        "west": 1441,
-        "east": 1498,
-        "north": 1496
-      },
       "weight": 1,
-      "id": 1495,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1496, "name": "Light forest",
+      "exits": { "west": 1440, "east": 1497, "south": 1495 },
       "environment": -1,
-      "exits": {
-        "west": 1440,
-        "east": 1497,
-        "south": 1495
-      },
       "weight": 1,
-      "id": 1496,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1497, "name": "Light forest",
+      "exits": { "west": 1496, "south": 1498 },
       "environment": -1,
-      "exits": {
-        "west": 1496,
-        "south": 1498
-      },
       "weight": 1,
-      "id": 1497,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Light forest",
+      "id": 1498, "name": "Light forest",
+      "exits": { "west": 1495, "south": 1444, "north": 1497 },
       "environment": -1,
-      "exits": {
-        "west": 1495,
-        "south": 1444,
-        "north": 1497
-      },
       "weight": 1,
-      "id": 1498,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Meadow",
+      "id": 1499, "name": "Meadow",
+      "exits": { "west": 1464, "south": 1505, "north": 1456 },
       "environment": -1,
-      "exits": {
-        "west": 1464,
-        "south": 1505,
-        "north": 1456
-      },
       "weight": 1,
-      "id": 1499,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Path",
+      "id": 1500, "name": "Path",
+      "exits": { "south": 1501, "west": 1503, "east": 1473, "north": 1504 },
       "environment": -1,
-      "exits": {
-        "south": 1501,
-        "west": 1503,
-        "east": 1473,
-        "north": 1504
-      },
       "weight": 1,
-      "id": 1500,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Forest",
+      "id": 1501, "name": "Forest",
+      "exits": { "west": 1502, "north": 1500 },
       "environment": -1,
-      "exits": {
-        "west": 1502,
-        "north": 1500
-      },
       "weight": 1,
-      "id": 1501,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Beach",
+      "id": 1502, "name": "Beach",
+      "exits": { "east": 1501, "north": 1503 },
       "environment": -1,
-      "exits": {
-        "east": 1501,
-        "north": 1503
-      },
       "weight": 1,
-      "id": 1502,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Beach",
+      "id": 1503, "name": "Beach",
+      "exits": { "east": 1500, "south": 1502 },
       "environment": -1,
-      "exits": {
-        "east": 1500,
-        "south": 1502
-      },
       "weight": 1,
-      "id": 1503,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Lighthouse Base",
+      "id": 1504, "name": "Lighthouse Base",
+      "exits": { "south": 1500 },
       "environment": -1,
-      "exits": {
-        "south": 1500
-      },
       "weight": 1,
-      "id": 1504,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mountain Range",
+      "id": 1505, "name": "Mountain Range",
+      "exits": { "north": 1499 },
       "environment": -1,
-      "exits": {
-        "north": 1499
-      },
       "weight": 1,
-      "id": 1505,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Mine Entrance",
+      "id": 1506, "name": "Mine Entrance",
+      "exits": { "up": 1491 },
       "environment": -1,
-      "exits": {
-        "up": 1491
-      },
       "weight": 1,
-      "id": 1506,
-      "area": {
-        "id": 29
-      }
+      "area": {"id": 29}
     },
     {
-      "name": "Cobblestone courtyard",
+      "id": 1507, "name": "Cobblestone courtyard",
+      "exits": { "south": 1448 },
       "environment": -1,
-      "exits": {
-        "south": 1448
-      },
       "weight": 1,
-      "id": 1507,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1508, "name": "East Merchant's Row",
+      "exits": { "east": 1509, "west": 1406 },
       "environment": -1,
-      "exits": {
-        "east": 1509,
-        "west": 1406
-      },
       "weight": 1,
-      "id": 1508,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row, south of Saul's Formal Wear",
+      "id": 1509, "name": "East Merchant's Row, south of Saul's Formal Wear",
+      "exits": { "west": 1508, "east": 1510, "north": 1624 },
       "environment": -1,
-      "exits": {
-        "west": 1508,
-        "east": 1510,
-        "north": 1624
-      },
       "weight": 1,
-      "id": 1509,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row, south of a livestock lot",
+      "id": 1510, "name": "East Merchant's Row, south of a livestock lot",
+      "exits": { "west": 1509, "east": 1511, "north": 1623 },
       "environment": -1,
-      "exits": {
-        "west": 1509,
-        "east": 1511,
-        "north": 1623
-      },
       "weight": 1,
-      "id": 1510,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row, south of Mother Whitman's",
+      "id": 1511, "name": "East Merchant's Row, south of Mother Whitman's",
+      "exits": { "west": 1510, "east": 1512, "north": 1622 },
       "environment": -1,
-      "exits": {
-        "west": 1510,
-        "east": 1512,
-        "north": 1622
-      },
       "weight": 1,
-      "id": 1511,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1512, "name": "East Merchant's Row",
+      "exits": { "east": 1513, "west": 1511 },
       "environment": -1,
-      "exits": {
-        "east": 1513,
-        "west": 1511
-      },
       "weight": 1,
-      "id": 1512,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1513, "name": "East Merchant's Row",
+      "exits": { "east": 1514, "west": 1512 },
       "environment": -1,
-      "exits": {
-        "east": 1514,
-        "west": 1512
-      },
       "weight": 1,
-      "id": 1513,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row, south of Sithicus",
+      "id": 1514, "name": "East Merchant's Row, south of Sithicus",
+      "exits": { "west": 1513, "east": 1515, "north": 1621 },
       "environment": -1,
-      "exits": {
-        "west": 1513,
-        "east": 1515,
-        "north": 1621
-      },
       "weight": 1,
-      "id": 1514,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1515, "name": "East Merchant's Row",
+      "exits": { "east": 1516, "west": 1514 },
       "environment": -1,
-      "exits": {
-        "east": 1516,
-        "west": 1514
-      },
       "weight": 1,
-      "id": 1515,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Merchant's Row and Pensji Lane",
+      "id": 1516, "name": "Merchant's Row and Pensji Lane",
+      "exits": { "west": 1515, "east": 1517, "south": 1520 },
       "environment": -1,
-      "exits": {
-        "west": 1515,
-        "east": 1517,
-        "south": 1520
-      },
       "weight": 1,
-      "id": 1516,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1517, "name": "East Merchant's Row",
+      "exits": { "east": 1518, "west": 1516 },
       "environment": -1,
-      "exits": {
-        "east": 1518,
-        "west": 1516
-      },
       "weight": 1,
-      "id": 1517,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Merchant's Row",
+      "id": 1518, "name": "East Merchant's Row",
+      "exits": { "east": 1519, "west": 1517 },
       "environment": -1,
-      "exits": {
-        "east": 1519,
-        "west": 1517
-      },
       "weight": 1,
-      "id": 1518,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "End of Merchant's Row",
+      "id": 1519, "name": "End of Merchant's Row",
+      "exits": { "west": 1518 },
       "environment": -1,
-      "exits": {
-        "west": 1518
-      },
       "weight": 1,
-      "id": 1519,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1520, "name": "Pensji Lane",
+      "exits": { "south": 1521, "north": 1516 },
       "environment": -1,
-      "exits": {
-        "south": 1521,
-        "north": 1516
-      },
       "weight": 1,
-      "id": 1520,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1521, "name": "Pensji Lane",
+      "exits": { "south": 1522, "north": 1520 },
       "environment": -1,
-      "exits": {
-        "south": 1522,
-        "north": 1520
-      },
       "weight": 1,
-      "id": 1521,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1522, "name": "Pensji Lane",
+      "exits": { "south": 1523, "north": 1521 },
       "environment": -1,
-      "exits": {
-        "south": 1523,
-        "north": 1521
-      },
       "weight": 1,
-      "id": 1522,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1523, "name": "Pensji Lane",
+      "exits": { "south": 1524, "north": 1522 },
       "environment": -1,
-      "exits": {
-        "south": 1524,
-        "north": 1522
-      },
       "weight": 1,
-      "id": 1523,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1524, "name": "Pensji Lane",
+      "exits": { "south": 1525, "north": 1523 },
       "environment": -1,
-      "exits": {
-        "south": 1525,
-        "north": 1523
-      },
       "weight": 1,
-      "id": 1524,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1525, "name": "Pensji Lane",
+      "exits": { "south": 1526, "east": 1606, "north": 1524 },
       "environment": -1,
-      "exits": {
-        "south": 1526,
-        "east": 1606,
-        "north": 1524
-      },
       "weight": 1,
-      "id": 1525,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1526, "name": "Pensji Lane",
+      "exits": { "south": 1527, "north": 1525 },
       "environment": -1,
-      "exits": {
-        "south": 1527,
-        "north": 1525
-      },
       "weight": 1,
-      "id": 1526,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1527, "name": "Pensji Lane",
+      "exits": { "south": 1528, "north": 1526 },
       "environment": -1,
-      "exits": {
-        "south": 1528,
-        "north": 1526
-      },
       "weight": 1,
-      "id": 1527,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1528, "name": "Pensji Lane",
+      "exits": { "south": 1529, "north": 1527 },
       "environment": -1,
-      "exits": {
-        "south": 1529,
-        "north": 1527
-      },
       "weight": 1,
-      "id": 1528,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1529, "name": "Pensji Lane",
+      "exits": { "south": 1530, "north": 1528 },
       "environment": -1,
-      "exits": {
-        "south": 1530,
-        "north": 1528
-      },
       "weight": 1,
-      "id": 1529,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1530, "name": "Pensji Lane",
+      "exits": { "south": 1531, "north": 1529 },
       "environment": -1,
-      "exits": {
-        "south": 1531,
-        "north": 1529
-      },
       "weight": 1,
-      "id": 1530,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1531, "name": "Pensji Lane",
+      "exits": { "south": 1532, "north": 1530 },
       "environment": -1,
-      "exits": {
-        "south": 1532,
-        "north": 1530
-      },
       "weight": 1,
-      "id": 1531,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1532, "name": "Pensji Lane",
+      "exits": { "south": 1533, "north": 1531 },
       "environment": -1,
-      "exits": {
-        "south": 1533,
-        "north": 1531
-      },
       "weight": 1,
-      "id": 1532,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1533, "name": "Pensji Lane",
+      "exits": { "south": 1534, "east": 1597, "north": 1532 },
       "environment": -1,
-      "exits": {
-        "south": 1534,
-        "east": 1597,
-        "north": 1532
-      },
       "weight": 1,
-      "id": 1533,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Pensji Lane",
+      "id": 1534, "name": "Pensji Lane",
+      "exits": { "south": 1542, "north": 1533 },
       "environment": -1,
-      "exits": {
-        "south": 1542,
-        "north": 1533
-      },
       "weight": 1,
-      "id": 1534,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1535, "name": "Embassy Row",
+      "exits": { "east": 1536, "west": 1557 },
       "environment": -1,
-      "exits": {
-        "east": 1536,
-        "west": 1557
-      },
       "weight": 1,
-      "id": 1535,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1536, "name": "Embassy Row",
+      "exits": { "east": 1537, "west": 1535 },
       "environment": -1,
-      "exits": {
-        "east": 1537,
-        "west": 1535
-      },
       "weight": 1,
-      "id": 1536,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1537, "name": "Embassy Row",
+      "exits": { "east": 1538, "west": 1536 },
       "environment": -1,
-      "exits": {
-        "east": 1538,
-        "west": 1536
-      },
       "weight": 1,
-      "id": 1537,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "City Barracks Gate",
+      "id": 1538, "name": "City Barracks Gate",
+      "exits": { "east": 1539, "west": 1537 },
       "environment": -1,
-      "exits": {
-        "east": 1539,
-        "west": 1537
-      },
       "weight": 1,
-      "id": 1538,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Martial Row",
+      "id": 1539, "name": "West Martial Row",
+      "exits": { "east": 1540, "west": 1538 },
       "environment": -1,
-      "exits": {
-        "east": 1540,
-        "west": 1538
-      },
       "weight": 1,
-      "id": 1539,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Martial Row",
+      "id": 1540, "name": "West Martial Row",
+      "exits": { "east": 1541, "west": 1539 },
       "environment": -1,
-      "exits": {
-        "east": 1541,
-        "west": 1539
-      },
       "weight": 1,
-      "id": 1540,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Martial Row",
+      "id": 1541, "name": "West Martial Row",
+      "exits": { "east": 1542, "west": 1540 },
       "environment": -1,
-      "exits": {
-        "east": 1542,
-        "west": 1540
-      },
       "weight": 1,
-      "id": 1541,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Intersection of Martial Row and Pensji Lane",
+      "id": 1542, "name": "Intersection of Martial Row and Pensji Lane",
+      "exits": { "west": 1541, "east": 1591, "north": 1534 },
       "environment": -1,
-      "exits": {
-        "west": 1541,
-        "east": 1591,
-        "north": 1534
-      },
       "weight": 1,
-      "id": 1542,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1543, "name": "West Church Road",
+      "exits": { "south": 1546, "north": 1544 },
       "environment": -1,
-      "exits": {
-        "south": 1546,
-        "north": 1544
-      },
       "weight": 1,
-      "id": 1543,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1544, "name": "West Church Road",
+      "exits": { "south": 1543, "north": 1558 },
       "environment": -1,
-      "exits": {
-        "south": 1543,
-        "north": 1558
-      },
       "weight": 1,
-      "id": 1544,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Ambassador Gate",
+      "id": 1545, "name": "Ambassador Gate",
+      "exits": { "east": 1546, "west": 1434 },
       "environment": -1,
-      "exits": {
-        "east": 1546,
-        "west": 1434
-      },
       "weight": 1,
-      "id": 1545,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Intersection of Church Road and Embassy Row",
+      "id": 1546, "name": "Intersection of Church Road and Embassy Row",
+      "exits": { "west": 1545, "east": 1547, "north": 1543 },
       "environment": -1,
-      "exits": {
-        "west": 1545,
-        "east": 1547,
-        "north": 1543
-      },
       "weight": 1,
-      "id": 1546,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1547, "name": "Embassy Row",
+      "exits": { "east": 1548, "west": 1546 },
       "environment": -1,
-      "exits": {
-        "east": 1548,
-        "west": 1546
-      },
       "weight": 1,
-      "id": 1547,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1548, "name": "Embassy Row",
+      "exits": { "east": 1549, "west": 1547 },
       "environment": -1,
-      "exits": {
-        "east": 1549,
-        "west": 1547
-      },
       "weight": 1,
-      "id": 1548,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1549, "name": "Embassy Row",
+      "exits": { "east": 1550, "west": 1548 },
       "environment": -1,
-      "exits": {
-        "east": 1550,
-        "west": 1548
-      },
       "weight": 1,
-      "id": 1549,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1550, "name": "Embassy Row",
+      "exits": { "east": 1551, "west": 1549 },
       "environment": -1,
-      "exits": {
-        "east": 1551,
-        "west": 1549
-      },
       "weight": 1,
-      "id": 1550,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1551, "name": "Embassy Row",
+      "exits": { "east": 1552, "west": 1550 },
       "environment": -1,
-      "exits": {
-        "east": 1552,
-        "west": 1550
-      },
       "weight": 1,
-      "id": 1551,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1552, "name": "Embassy Row",
+      "exits": { "east": 1553, "west": 1551 },
       "environment": -1,
-      "exits": {
-        "east": 1553,
-        "west": 1551
-      },
       "weight": 1,
-      "id": 1552,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1553, "name": "Embassy Row",
+      "exits": { "east": 1554, "west": 1552 },
       "environment": -1,
-      "exits": {
-        "east": 1554,
-        "west": 1552
-      },
       "weight": 1,
-      "id": 1553,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1554, "name": "Embassy Row",
+      "exits": { "east": 1555, "west": 1553 },
       "environment": -1,
-      "exits": {
-        "east": 1555,
-        "west": 1553
-      },
       "weight": 1,
-      "id": 1554,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1555, "name": "Embassy Row",
+      "exits": { "east": 1556, "west": 1554 },
       "environment": -1,
-      "exits": {
-        "east": 1556,
-        "west": 1554
-      },
       "weight": 1,
-      "id": 1555,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1556, "name": "Embassy Row",
+      "exits": { "east": 1557, "west": 1555 },
       "environment": -1,
-      "exits": {
-        "east": 1557,
-        "west": 1555
-      },
       "weight": 1,
-      "id": 1556,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Embassy Row",
+      "id": 1557, "name": "Embassy Row",
+      "exits": { "east": 1535, "west": 1556 },
       "environment": -1,
-      "exits": {
-        "east": 1535,
-        "west": 1556
-      },
       "weight": 1,
-      "id": 1557,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1558, "name": "West Church Road",
+      "exits": { "south": 1544, "north": 1559 },
       "environment": -1,
-      "exits": {
-        "south": 1544,
-        "north": 1559
-      },
       "weight": 1,
-      "id": 1558,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1559, "name": "West Church Road",
+      "exits": { "south": 1558, "north": 1560 },
       "environment": -1,
-      "exits": {
-        "south": 1558,
-        "north": 1560
-      },
       "weight": 1,
-      "id": 1559,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1560, "name": "West Church Road",
+      "exits": { "south": 1559, "north": 1561 },
       "environment": -1,
-      "exits": {
-        "south": 1559,
-        "north": 1561
-      },
       "weight": 1,
-      "id": 1560,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1561, "name": "West Church Road",
+      "exits": { "south": 1560, "north": 1562 },
       "environment": -1,
-      "exits": {
-        "south": 1560,
-        "north": 1562
-      },
       "weight": 1,
-      "id": 1561,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1562, "name": "West Church Road",
+      "exits": { "south": 1561, "north": 1563 },
       "environment": -1,
-      "exits": {
-        "south": 1561,
-        "north": 1563
-      },
       "weight": 1,
-      "id": 1562,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1563, "name": "West Church Road",
+      "exits": { "south": 1562, "north": 1564 },
       "environment": -1,
-      "exits": {
-        "south": 1562,
-        "north": 1564
-      },
       "weight": 1,
-      "id": 1563,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1564, "name": "West Church Road",
+      "exits": { "south": 1563, "north": 1565 },
       "environment": -1,
-      "exits": {
-        "south": 1563,
-        "north": 1565
-      },
       "weight": 1,
-      "id": 1564,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1565, "name": "West Church Road",
+      "exits": { "south": 1564, "north": 1566 },
       "environment": -1,
-      "exits": {
-        "south": 1564,
-        "north": 1566
-      },
       "weight": 1,
-      "id": 1565,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1566, "name": "West Church Road",
+      "exits": { "south": 1565, "north": 1567 },
       "environment": -1,
-      "exits": {
-        "south": 1565,
-        "north": 1567
-      },
       "weight": 1,
-      "id": 1566,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1567, "name": "West Church Road",
+      "exits": { "south": 1566, "north": 1568 },
       "environment": -1,
-      "exits": {
-        "south": 1566,
-        "north": 1568
-      },
       "weight": 1,
-      "id": 1567,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Church Road",
+      "id": 1568, "name": "West Church Road",
+      "exits": { "south": 1567, "north": 1569 },
       "environment": -1,
-      "exits": {
-        "south": 1567,
-        "north": 1569
-      },
       "weight": 1,
-      "id": 1568,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Church Road Bend",
+      "id": 1569, "name": "Church Road Bend",
+      "exits": { "east": 1570, "south": 1568 },
       "environment": -1,
-      "exits": {
-        "east": 1570,
-        "south": 1568
-      },
       "weight": 1,
-      "id": 1569,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1570, "name": "North Church Road",
+      "exits": { "east": 1571, "west": 1569 },
       "environment": -1,
-      "exits": {
-        "east": 1571,
-        "west": 1569
-      },
       "weight": 1,
-      "id": 1570,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1571, "name": "North Church Road",
+      "exits": { "east": 1572, "west": 1570 },
       "environment": -1,
-      "exits": {
-        "east": 1572,
-        "west": 1570
-      },
       "weight": 1,
-      "id": 1571,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1572, "name": "North Church Road",
+      "exits": { "east": 1573, "west": 1571 },
       "environment": -1,
-      "exits": {
-        "east": 1573,
-        "west": 1571
-      },
       "weight": 1,
-      "id": 1572,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1573, "name": "North Church Road",
+      "exits": { "east": 1574, "west": 1572 },
       "environment": -1,
-      "exits": {
-        "east": 1574,
-        "west": 1572
-      },
       "weight": 1,
-      "id": 1573,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1574, "name": "North Church Road",
+      "exits": { "east": 1575, "west": 1573 },
       "environment": -1,
-      "exits": {
-        "east": 1575,
-        "west": 1573
-      },
       "weight": 1,
-      "id": 1574,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1575, "name": "North Church Road",
+      "exits": { "east": 1576, "west": 1574 },
       "environment": -1,
-      "exits": {
-        "east": 1576,
-        "west": 1574
-      },
       "weight": 1,
-      "id": 1575,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1576, "name": "North Church Road",
+      "exits": { "east": 1577, "west": 1575 },
       "environment": -1,
-      "exits": {
-        "east": 1577,
-        "west": 1575
-      },
       "weight": 1,
-      "id": 1576,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1577, "name": "North Church Road",
+      "exits": { "east": 1578, "west": 1576 },
       "environment": -1,
-      "exits": {
-        "east": 1578,
-        "west": 1576
-      },
       "weight": 1,
-      "id": 1577,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1578, "name": "North Church Road",
+      "exits": { "east": 1579, "west": 1577 },
       "environment": -1,
-      "exits": {
-        "east": 1579,
-        "west": 1577
-      },
       "weight": 1,
-      "id": 1578,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Intersection of Castle Road and Church Road",
+      "id": 1579, "name": "Intersection of Castle Road and Church Road",
+      "exits": { "south": 1585, "west": 1578, "east": 1580, "north": 1584 },
       "environment": -1,
-      "exits": {
-        "south": 1585,
-        "west": 1578,
-        "east": 1580,
-        "north": 1584
-      },
       "weight": 1,
-      "id": 1579,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1580, "name": "North Church Road",
+      "exits": { "east": 1581, "west": 1579 },
       "environment": -1,
-      "exits": {
-        "east": 1581,
-        "west": 1579
-      },
       "weight": 1,
-      "id": 1580,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1581, "name": "North Church Road",
+      "exits": { "east": 1582, "west": 1580 },
       "environment": -1,
-      "exits": {
-        "east": 1582,
-        "west": 1580
-      },
       "weight": 1,
-      "id": 1581,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1582, "name": "North Church Road",
+      "exits": { "east": 1583, "west": 1581 },
       "environment": -1,
-      "exits": {
-        "east": 1583,
-        "west": 1581
-      },
       "weight": 1,
-      "id": 1582,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Church Road",
+      "id": 1583, "name": "North Church Road",
+      "exits": { "down": 1653, "west": 1582 },
       "environment": -1,
-      "exits": {
-        "down": 1653,
-        "west": 1582
-      },
       "weight": 1,
-      "id": 1583,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Olde City Gate",
+      "id": 1584, "name": "Olde City Gate",
+      "exits": { "south": 1579, "west": 1588, "east": 1587, "north": 1406 },
       "environment": -1,
-      "exits": {
-        "south": 1579,
-        "west": 1588,
-        "east": 1587,
-        "north": 1406
-      },
       "weight": 1,
-      "id": 1584,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Drawbridge",
+      "id": 1585, "name": "Castle Drawbridge",
+      "exits": { "south": 1586, "north": 1579 },
       "environment": -1,
-      "exits": {
-        "south": 1586,
-        "north": 1579
-      },
       "weight": 1,
-      "id": 1585,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Castle Gatehouse",
+      "id": 1586, "name": "Castle Gatehouse",
+      "exits": { "north": 1585 },
       "environment": -1,
-      "exits": {
-        "north": 1585
-      },
       "weight": 1,
-      "id": 1586,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Krakenwater",
+      "id": 1587, "name": "Krakenwater",
+      "exits": { "west": 1584 },
       "environment": -1,
-      "exits": {
-        "west": 1584
-      },
       "weight": 1,
-      "id": 1587,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Deep Sea Thunder",
+      "id": 1588, "name": "Deep Sea Thunder",
+      "exits": { "east": 1584, "west": 1589 },
       "environment": -1,
-      "exits": {
-        "east": 1584,
-        "west": 1589
-      },
       "weight": 1,
-      "id": 1588,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "The Silver Griffin",
+      "id": 1589, "name": "The Silver Griffin",
+      "exits": { "west": 1590, "east": 1588, "north": 1408 },
       "environment": -1,
-      "exits": {
-        "west": 1590,
-        "east": 1588,
-        "north": 1408
-      },
       "weight": 1,
-      "id": 1589,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Horrors of the Deep",
+      "id": 1590, "name": "Horrors of the Deep",
+      "exits": { "east": 1589, "north": 1409 },
       "environment": -1,
-      "exits": {
-        "east": 1589,
-        "north": 1409
-      },
       "weight": 1,
-      "id": 1590,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Martial Row",
+      "id": 1591, "name": "East Martial Row",
+      "exits": { "east": 1592, "west": 1542 },
       "environment": -1,
-      "exits": {
-        "east": 1592,
-        "west": 1542
-      },
       "weight": 1,
-      "id": 1591,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Martial Row",
+      "id": 1592, "name": "East Martial Row",
+      "exits": { "east": 1593, "west": 1591 },
       "environment": -1,
-      "exits": {
-        "east": 1593,
-        "west": 1591
-      },
       "weight": 1,
-      "id": 1592,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Martial Row",
+      "id": 1593, "name": "East Martial Row",
+      "exits": { "west": 1592, "north": 1594 },
       "environment": -1,
-      "exits": {
-        "west": 1592,
-        "north": 1594
-      },
       "weight": 1,
-      "id": 1593,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Army Encampment Gate",
+      "id": 1594, "name": "Army Encampment Gate",
+      "exits": { "west": 1595, "south": 1593 },
       "environment": -1,
-      "exits": {
-        "west": 1595,
-        "south": 1593
-      },
       "weight": 1,
-      "id": 1594,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Punishment Grounds",
+      "id": 1595, "name": "Punishment Grounds",
+      "exits": { "east": 1594, "west": 1596 },
       "environment": -1,
-      "exits": {
-        "east": 1594,
-        "west": 1596
-      },
       "weight": 1,
-      "id": 1595,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Parade Grounds",
+      "id": 1596, "name": "Parade Grounds",
+      "exits": { "east": 1595, "north": 1597 },
       "environment": -1,
-      "exits": {
-        "east": 1595,
-        "north": 1597
-      },
       "weight": 1,
-      "id": 1596,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Cavalry Gate",
+      "id": 1597, "name": "Cavalry Gate",
+      "exits": { "west": 1533, "south": 1596, "north": 1598 },
       "environment": -1,
-      "exits": {
-        "west": 1533,
-        "south": 1596,
-        "north": 1598
-      },
       "weight": 1,
-      "id": 1597,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Training Grounds",
+      "id": 1598, "name": "Training Grounds",
+      "exits": { "south": 1597, "east": 1600, "north": 1599 },
       "environment": -1,
-      "exits": {
-        "south": 1597,
-        "east": 1600,
-        "north": 1599
-      },
       "weight": 1,
-      "id": 1598,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Combat Training",
+      "id": 1599, "name": "Combat Training",
+      "exits": { "south": 1598 },
       "environment": -1,
-      "exits": {
-        "south": 1598
-      },
       "weight": 1,
-      "id": 1599,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Post Exchange",
+      "id": 1600, "name": "Post Exchange",
+      "exits": { "south": 1602, "west": 1598, "east": 1601, "north": 1603 },
       "environment": -1,
-      "exits": {
-        "south": 1602,
-        "west": 1598,
-        "east": 1601,
-        "north": 1603
-      },
       "weight": 1,
-      "id": 1600,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Stockade",
+      "id": 1601, "name": "Stockade",
+      "exits": { "west": 1600 },
       "environment": -1,
-      "exits": {
-        "west": 1600
-      },
       "weight": 1,
-      "id": 1601,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Infirmary",
+      "id": 1602, "name": "Infirmary",
+      "exits": { "east": 1605, "north": 1600 },
       "environment": -1,
-      "exits": {
-        "east": 1605,
-        "north": 1600
-      },
       "weight": 1,
-      "id": 1602,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Soldiers' Tent",
+      "id": 1603, "name": "Soldiers' Tent",
+      "exits": { "east": 1604, "south": 1600 },
       "environment": -1,
-      "exits": {
-        "east": 1604,
-        "south": 1600
-      },
       "weight": 1,
-      "id": 1603,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Soldiers' Tent",
+      "id": 1604, "name": "Soldiers' Tent",
+      "exits": { "west": 1603 },
       "environment": -1,
-      "exits": {
-        "west": 1603
-      },
       "weight": 1,
-      "id": 1604,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "You move the partition to the side and walk into the back of the tent.",
+      "id": 1605, "name": "You move the partition to the side and walk into the back of the tent.",
+      "exits": { "west": 1602 },
       "environment": -1,
-      "exits": {
-        "west": 1602
-      },
       "weight": 1,
-      "id": 1605,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Indel City Park",
+      "id": 1606, "name": "Indel City Park",
+      "exits": { "west": 1525, "east": 1607, "north": 1608 },
       "environment": -1,
-      "exits": {
-        "west": 1525,
-        "east": 1607,
-        "north": 1608
-      },
       "weight": 1,
-      "id": 1606,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1607, "name": "Indel City Park",
+      "exits": { "west": 1606, "east": 1613, "north": 1609 },
       "environment": -1,
-      "exits": {
-        "west": 1606,
-        "east": 1613,
-        "north": 1609
-      },
       "weight": 1,
-      "id": 1607,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1608, "name": "Indel City Park",
+      "exits": { "south": 1606, "east": 1609, "north": 1611 },
       "environment": -1,
-      "exits": {
-        "south": 1606,
-        "east": 1609,
-        "north": 1611
-      },
       "weight": 1,
-      "id": 1608,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1609, "name": "Indel City Park",
+      "exits": { "south": 1607, "west": 1608, "east": 1610, "north": 1612 },
       "environment": -1,
-      "exits": {
-        "south": 1607,
-        "west": 1608,
-        "east": 1610,
-        "north": 1612
-      },
       "weight": 1,
-      "id": 1609,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1610, "name": "Indel City Park",
+      "exits": { "west": 1609, "south": 1613, "north": 1614 },
       "environment": -1,
-      "exits": {
-        "west": 1609,
-        "south": 1613,
-        "north": 1614
-      },
       "weight": 1,
-      "id": 1610,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1611, "name": "Indel City Park",
+      "exits": { "south": 1608, "east": 1612, "north": 1615 },
       "environment": -1,
-      "exits": {
-        "south": 1608,
-        "east": 1612,
-        "north": 1615
-      },
       "weight": 1,
-      "id": 1611,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1612, "name": "Indel City Park",
+      "exits": { "south": 1609, "west": 1611, "east": 1614, "north": 1616 },
       "environment": -1,
-      "exits": {
-        "south": 1609,
-        "west": 1611,
-        "east": 1614,
-        "north": 1616
-      },
       "weight": 1,
-      "id": 1612,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Gazebo in the Park",
+      "id": 1613, "name": "Gazebo in the Park",
+      "exits": { "west": 1607, "north": 1610 },
       "environment": -1,
-      "exits": {
-        "west": 1607,
-        "north": 1610
-      },
       "weight": 1,
-      "id": 1613,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1614, "name": "Indel City Park",
+      "exits": { "west": 1612, "south": 1610, "north": 1617 },
       "environment": -1,
-      "exits": {
-        "west": 1612,
-        "south": 1610,
-        "north": 1617
-      },
       "weight": 1,
-      "id": 1614,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1615, "name": "Indel City Park",
+      "exits": { "south": 1611, "east": 1616, "north": 1619 },
       "environment": -1,
-      "exits": {
-        "south": 1611,
-        "east": 1616,
-        "north": 1619
-      },
       "weight": 1,
-      "id": 1615,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1616, "name": "Indel City Park",
+      "exits": { "south": 1612, "west": 1615, "east": 1617, "north": 1618 },
       "environment": -1,
-      "exits": {
-        "south": 1612,
-        "west": 1615,
-        "east": 1617,
-        "north": 1618
-      },
       "weight": 1,
-      "id": 1616,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1617, "name": "Indel City Park",
+      "exits": { "west": 1616, "south": 1614, "north": 1620 },
       "environment": -1,
-      "exits": {
-        "west": 1616,
-        "south": 1614,
-        "north": 1620
-      },
       "weight": 1,
-      "id": 1617,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1618, "name": "Indel City Park",
+      "exits": { "west": 1619, "east": 1620, "south": 1616 },
       "environment": -1,
-      "exits": {
-        "west": 1619,
-        "east": 1620,
-        "south": 1616
-      },
       "weight": 1,
-      "id": 1618,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1619, "name": "Indel City Park",
+      "exits": { "east": 1618, "south": 1615 },
       "environment": -1,
-      "exits": {
-        "east": 1618,
-        "south": 1615
-      },
       "weight": 1,
-      "id": 1619,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Indel City Park",
+      "id": 1620, "name": "Indel City Park",
+      "exits": { "west": 1618, "south": 1617 },
       "environment": -1,
-      "exits": {
-        "west": 1618,
-        "south": 1617
-      },
       "weight": 1,
-      "id": 1620,
-      "area": {
-        "id": 30
-      }
+      "area": {"id": 30}
     },
     {
-      "name": "Sithicus",
+      "id": 1621, "name": "Sithicus",
+      "exits": { "south": 1514 },
       "environment": -1,
-      "exits": {
-        "south": 1514
-      },
       "weight": 1,
-      "id": 1621,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Mother Whitman's Confections Shop",
+      "id": 1622, "name": "Mother Whitman's Confections Shop",
+      "exits": { "south": 1511 },
       "environment": -1,
-      "exits": {
-        "south": 1511
-      },
       "weight": 1,
-      "id": 1622,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Livestock Lot",
+      "id": 1623, "name": "Livestock Lot",
+      "exits": { "south": 1510, "north": 1643 },
       "environment": -1,
-      "exits": {
-        "south": 1510,
-        "north": 1643
-      },
       "weight": 1,
-      "id": 1623,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Saul's formal wear",
+      "id": 1624, "name": "Saul's formal wear",
+      "exits": { "south": 1509 },
       "environment": -1,
-      "exits": {
-        "south": 1509
-      },
       "weight": 1,
-      "id": 1624,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Quicksilver Delivery Service",
+      "id": 1625, "name": "Quicksilver Delivery Service",
+      "exits": { "east": 1405 },
       "environment": -1,
-      "exits": {
-        "east": 1405
-      },
       "weight": 1,
-      "id": 1625,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Jusonah's Pawn and Polearms",
+      "id": 1626, "name": "Jusonah's Pawn and Polearms",
+      "exits": { "east": 1404 },
       "environment": -1,
-      "exits": {
-        "east": 1404
-      },
       "weight": 1,
-      "id": 1626,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
+      "id": 1627, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
+      "exits": { "west": 1404, "south": 1637 },
       "environment": -1,
-      "exits": {
-        "west": 1404,
-        "south": 1637
-      },
       "weight": 1,
-      "id": 1627,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Zomar's Dry Goods",
+      "id": 1628, "name": "Zomar's Dry Goods",
+      "exits": { "east": 1403, "down": 1629 },
       "environment": -1,
-      "exits": {
-        "east": 1403,
-        "down": 1629
-      },
       "weight": 1,
-      "id": 1628,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "The Art of Darkness",
+      "id": 1629, "name": "The Art of Darkness",
+      "exits": { "up": 1628 },
       "environment": -1,
-      "exits": {
-        "up": 1628
-      },
       "weight": 1,
-      "id": 1629,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Burrow's Map Shop",
+      "id": 1630, "name": "Burrow's Map Shop",
+      "exits": { "west": 1403 },
       "environment": -1,
-      "exits": {
-        "west": 1403
-      },
       "weight": 1,
-      "id": 1630,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Muddy Lane",
+      "id": 1631, "name": "Muddy Lane",
+      "exits": { "east": 1402, "west": 1632 },
       "environment": -1,
-      "exits": {
-        "east": 1402,
-        "west": 1632
-      },
       "weight": 1,
-      "id": 1631,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Muddy Lane",
+      "id": 1632, "name": "Muddy Lane",
+      "exits": { "east": 1631 },
       "environment": -1,
-      "exits": {
-        "east": 1631
-      },
       "weight": 1,
-      "id": 1632,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Muddy Lane",
+      "id": 1633, "name": "Muddy Lane",
+      "exits": { "east": 1634, "west": 1402 },
       "environment": -1,
-      "exits": {
-        "east": 1634,
-        "west": 1402
-      },
       "weight": 1,
-      "id": 1633,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Farm Road",
+      "id": 1634, "name": "Farm Road",
+      "exits": { "west": 1633 },
       "environment": -1,
-      "exits": {
-        "west": 1633
-      },
       "weight": 1,
-      "id": 1634,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "West Ready Room",
+      "id": 1635, "name": "West Ready Room",
+      "exits": { "east": 1401 },
       "environment": -1,
-      "exits": {
-        "east": 1401
-      },
       "weight": 1,
-      "id": 1635,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "East Ready Room",
+      "id": 1636, "name": "East Ready Room",
+      "exits": { "west": 1401 },
       "environment": -1,
-      "exits": {
-        "west": 1401
-      },
       "weight": 1,
-      "id": 1636,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Player Appreciation Week Discussions",
+      "id": 1637, "name": "Player Appreciation Week Discussions",
+      "exits": { "north": 1627 },
       "environment": -1,
-      "exits": {
-        "north": 1627
-      },
       "weight": 1,
-      "id": 1637,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "Road Through a Wheatfield",
+      "id": 1638, "name": "Road Through a Wheatfield",
+      "exits": { "east": 1639, "southeast": 1641, "south": 1640 },
       "environment": -1,
-      "exits": {
-        "east": 1639,
-        "southeast": 1641,
-        "south": 1640
-      },
       "weight": 1,
-      "id": 1638,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Road Through a Wheatfield",
+      "id": 1639, "name": "Road Through a Wheatfield",
+      "exits": { "southeast": 1648, "south": 1641, "southwest": 1640, "east": 1649, "west": 1638 },
       "environment": -1,
-      "exits": {
-        "southeast": 1648,
-        "south": 1641,
-        "southwest": 1640,
-        "east": 1649,
-        "west": 1638
-      },
       "weight": 1,
-      "id": 1639,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1640, "name": "Wheatfield",
+      "exits": { "west": 1645, "southeast": 1642, "south": 1643, "southwest": 1644, "northeast": 1639, "east": 1641, "north": 1638 },
       "environment": -1,
-      "exits": {
-        "west": 1645,
-        "southeast": 1642,
-        "south": 1643,
-        "southwest": 1644,
-        "northeast": 1639,
-        "east": 1641,
-        "north": 1638
-      },
       "weight": 1,
-      "id": 1640,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Road Through A Wheatfield",
+      "id": 1641, "name": "Road Through A Wheatfield",
+      "exits": { "west": 1640, "northwest": 1638, "south": 1642, "southwest": 1643, "northeast": 1649, "east": 1648, "north": 1639 },
       "environment": -1,
-      "exits": {
-        "west": 1640,
-        "northwest": 1638,
-        "south": 1642,
-        "southwest": 1643,
-        "northeast": 1649,
-        "east": 1648,
-        "north": 1639
-      },
       "weight": 1,
-      "id": 1641,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1642, "name": "Wheatfield",
+      "exits": { "northwest": 1640, "west": 1643, "northeast": 1648, "east": 1646, "north": 1641 },
       "environment": -1,
-      "exits": {
-        "northwest": 1640,
-        "west": 1643,
-        "northeast": 1648,
-        "east": 1646,
-        "north": 1641
-      },
       "weight": 1,
-      "id": 1642,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1643, "name": "Wheatfield",
+      "exits": { "northwest": 1645, "south": 1623, "west": 1644, "northeast": 1641, "east": 1642, "north": 1640 },
       "environment": -1,
-      "exits": {
-        "northwest": 1645,
-        "south": 1623,
-        "west": 1644,
-        "northeast": 1641,
-        "east": 1642,
-        "north": 1640
-      },
       "weight": 1,
-      "id": 1643,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1644, "name": "Wheatfield",
+      "exits": { "northeast": 1640, "east": 1643, "north": 1645 },
       "environment": -1,
-      "exits": {
-        "northeast": 1640,
-        "east": 1643,
-        "north": 1645
-      },
       "weight": 1,
-      "id": 1644,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1645, "name": "Wheatfield",
+      "exits": { "east": 1640, "southeast": 1643, "south": 1644 },
       "environment": -1,
-      "exits": {
-        "east": 1640,
-        "southeast": 1643,
-        "south": 1644
-      },
       "weight": 1,
-      "id": 1645,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1646, "name": "Wheatfield",
+      "exits": { "west": 1642, "east": 1647, "north": 1648 },
       "environment": -1,
-      "exits": {
-        "west": 1642,
-        "east": 1647,
-        "north": 1648
-      },
       "weight": 1,
-      "id": 1646,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1647, "name": "Wheatfield",
+      "exits": { "west": 1646 },
       "environment": -1,
-      "exits": {
-        "west": 1646
-      },
       "weight": 1,
-      "id": 1647,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Road Through a Wheatfield",
+      "id": 1648, "name": "Road Through a Wheatfield",
+      "exits": { "northwest": 1639, "south": 1646, "southwest": 1642, "west": 1641, "north": 1649 },
       "environment": -1,
-      "exits": {
-        "northwest": 1639,
-        "south": 1646,
-        "southwest": 1642,
-        "west": 1641,
-        "north": 1649
-      },
       "weight": 1,
-      "id": 1648,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "Wheatfield",
+      "id": 1649, "name": "Wheatfield",
+      "exits": { "southwest": 1641, "west": 1639, "south": 1648 },
       "environment": -1,
-      "exits": {
-        "southwest": 1641,
-        "west": 1639,
-        "south": 1648
-      },
       "weight": 1,
-      "id": 1649,
-      "area": {
-        "id": 31
-      }
+      "area": {"id": 31}
     },
     {
-      "name": "North Moat",
+      "id": 1650, "name": "North Moat",
+      "exits": { "east": 1651, "west": 1673 },
       "environment": -1,
-      "exits": {
-        "east": 1651,
-        "west": 1673
-      },
       "weight": 1,
-      "id": 1650,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1651, "name": "North Moat",
+      "exits": { "east": 1652, "west": 1650 },
       "environment": -1,
-      "exits": {
-        "east": 1652,
-        "west": 1650
-      },
       "weight": 1,
-      "id": 1651,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1652, "name": "North Moat",
+      "exits": { "east": 1654, "west": 1651 },
       "environment": -1,
-      "exits": {
-        "east": 1654,
-        "west": 1651
-      },
       "weight": 1,
-      "id": 1652,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "Mudball Arena Entrance",
+      "id": 1653, "name": "Mudball Arena Entrance",
+      "exits": { "up": 1583 },
       "environment": -1,
-      "exits": {
-        "up": 1583
-      },
       "weight": 1,
-      "id": 1653,
-      "area": {
-        "id": 28
-      }
+      "area": {"id": 28}
     },
     {
-      "name": "North Moat",
+      "id": 1654, "name": "North Moat",
+      "exits": { "west": 1652, "south": 1655 },
       "environment": -1,
-      "exits": {
-        "west": 1652,
-        "south": 1655
-      },
       "weight": 1,
-      "id": 1654,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1655, "name": "East Moat",
+      "exits": { "south": 1656, "north": 1654 },
       "environment": -1,
-      "exits": {
-        "south": 1656,
-        "north": 1654
-      },
       "weight": 1,
-      "id": 1655,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1656, "name": "East Moat",
+      "exits": { "south": 1657, "north": 1655 },
       "environment": -1,
-      "exits": {
-        "south": 1657,
-        "north": 1655
-      },
       "weight": 1,
-      "id": 1656,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1657, "name": "East Moat",
+      "exits": { "south": 1658, "north": 1656 },
       "environment": -1,
-      "exits": {
-        "south": 1658,
-        "north": 1656
-      },
       "weight": 1,
-      "id": 1657,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1658, "name": "East Moat",
+      "exits": { "south": 1659, "north": 1657 },
       "environment": -1,
-      "exits": {
-        "south": 1659,
-        "north": 1657
-      },
       "weight": 1,
-      "id": 1658,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1659, "name": "East Moat",
+      "exits": { "south": 1660, "north": 1658 },
       "environment": -1,
-      "exits": {
-        "south": 1660,
-        "north": 1658
-      },
       "weight": 1,
-      "id": 1659,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1660, "name": "East Moat",
+      "exits": { "south": 1661, "north": 1659 },
       "environment": -1,
-      "exits": {
-        "south": 1661,
-        "north": 1659
-      },
       "weight": 1,
-      "id": 1660,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1661, "name": "East Moat",
+      "exits": { "south": 1662, "north": 1660 },
       "environment": -1,
-      "exits": {
-        "south": 1662,
-        "north": 1660
-      },
       "weight": 1,
-      "id": 1661,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1662, "name": "East Moat",
+      "exits": { "south": 1663, "north": 1661 },
       "environment": -1,
-      "exits": {
-        "south": 1663,
-        "north": 1661
-      },
       "weight": 1,
-      "id": 1662,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "East Moat",
+      "id": 1663, "name": "East Moat",
+      "exits": { "south": 1664, "north": 1662 },
       "environment": -1,
-      "exits": {
-        "south": 1664,
-        "north": 1662
-      },
       "weight": 1,
-      "id": 1663,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1664, "name": "South Moat",
+      "exits": { "west": 1665, "north": 1663 },
       "environment": -1,
-      "exits": {
-        "west": 1665,
-        "north": 1663
-      },
       "weight": 1,
-      "id": 1664,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1665, "name": "South Moat",
+      "exits": { "east": 1664, "west": 1666 },
       "environment": -1,
-      "exits": {
-        "east": 1664,
-        "west": 1666
-      },
       "weight": 1,
-      "id": 1665,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1666, "name": "South Moat",
+      "exits": { "east": 1665, "west": 1667 },
       "environment": -1,
-      "exits": {
-        "east": 1665,
-        "west": 1667
-      },
       "weight": 1,
-      "id": 1666,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1667, "name": "South Moat",
+      "exits": { "east": 1666, "west": 1668 },
       "environment": -1,
-      "exits": {
-        "east": 1666,
-        "west": 1668
-      },
       "weight": 1,
-      "id": 1667,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1668, "name": "South Moat",
+      "exits": { "east": 1667, "west": 1669 },
       "environment": -1,
-      "exits": {
-        "east": 1667,
-        "west": 1669
-      },
       "weight": 1,
-      "id": 1668,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1669, "name": "South Moat",
+      "exits": { "east": 1668, "west": 1670 },
       "environment": -1,
-      "exits": {
-        "east": 1668,
-        "west": 1670
-      },
       "weight": 1,
-      "id": 1669,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1670, "name": "South Moat",
+      "exits": { "east": 1669, "west": 1671 },
       "environment": -1,
-      "exits": {
-        "east": 1669,
-        "west": 1671
-      },
       "weight": 1,
-      "id": 1670,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1671, "name": "South Moat",
+      "exits": { "east": 1670, "west": 1672 },
       "environment": -1,
-      "exits": {
-        "east": 1670,
-        "west": 1672
-      },
       "weight": 1,
-      "id": 1671,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "South Moat",
+      "id": 1672, "name": "South Moat",
+      "exits": { "east": 1671, "north": 1686 },
       "environment": -1,
-      "exits": {
-        "east": 1671,
-        "north": 1686
-      },
       "weight": 1,
-      "id": 1672,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat - Under Draw Bridge",
+      "id": 1673, "name": "North Moat - Under Draw Bridge",
+      "exits": { "east": 1650, "west": 1674 },
       "environment": -1,
-      "exits": {
-        "east": 1650,
-        "west": 1674
-      },
       "weight": 1,
-      "id": 1673,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1674, "name": "North Moat",
+      "exits": { "east": 1673, "west": 1675 },
       "environment": -1,
-      "exits": {
-        "east": 1673,
-        "west": 1675
-      },
       "weight": 1,
-      "id": 1674,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1675, "name": "North Moat",
+      "exits": { "east": 1674, "west": 1676 },
       "environment": -1,
-      "exits": {
-        "east": 1674,
-        "west": 1676
-      },
       "weight": 1,
-      "id": 1675,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1676, "name": "North Moat",
+      "exits": { "east": 1675, "west": 1677 },
       "environment": -1,
-      "exits": {
-        "east": 1675,
-        "west": 1677
-      },
       "weight": 1,
-      "id": 1676,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "North Moat",
+      "id": 1677, "name": "North Moat",
+      "exits": { "east": 1676, "south": 1678 },
       "environment": -1,
-      "exits": {
-        "east": 1676,
-        "south": 1678
-      },
       "weight": 1,
-      "id": 1677,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1678, "name": "West Moat",
+      "exits": { "south": 1679, "north": 1677 },
       "environment": -1,
-      "exits": {
-        "south": 1679,
-        "north": 1677
-      },
       "weight": 1,
-      "id": 1678,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1679, "name": "West Moat",
+      "exits": { "south": 1680, "north": 1678 },
       "environment": -1,
-      "exits": {
-        "south": 1680,
-        "north": 1678
-      },
       "weight": 1,
-      "id": 1679,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1680, "name": "West Moat",
+      "exits": { "south": 1681, "north": 1679 },
       "environment": -1,
-      "exits": {
-        "south": 1681,
-        "north": 1679
-      },
       "weight": 1,
-      "id": 1680,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1681, "name": "West Moat",
+      "exits": { "south": 1682, "north": 1680 },
       "environment": -1,
-      "exits": {
-        "south": 1682,
-        "north": 1680
-      },
       "weight": 1,
-      "id": 1681,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1682, "name": "West Moat",
+      "exits": { "south": 1683, "north": 1681 },
       "environment": -1,
-      "exits": {
-        "south": 1683,
-        "north": 1681
-      },
       "weight": 1,
-      "id": 1682,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1683, "name": "West Moat",
+      "exits": { "south": 1684, "north": 1682 },
       "environment": -1,
-      "exits": {
-        "south": 1684,
-        "north": 1682
-      },
       "weight": 1,
-      "id": 1683,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1684, "name": "West Moat",
+      "exits": { "south": 1685, "north": 1683 },
       "environment": -1,
-      "exits": {
-        "south": 1685,
-        "north": 1683
-      },
       "weight": 1,
-      "id": 1684,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1685, "name": "West Moat",
+      "exits": { "south": 1686, "north": 1684 },
       "environment": -1,
-      "exits": {
-        "south": 1686,
-        "north": 1684
-      },
       "weight": 1,
-      "id": 1685,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "West Moat",
+      "id": 1686, "name": "West Moat",
+      "exits": { "south": 1672, "north": 1685 },
       "environment": -1,
-      "exits": {
-        "south": 1672,
-        "north": 1685
-      },
       "weight": 1,
-      "id": 1686,
-      "area": {
-        "id": 32
-      }
+      "area": {"id": 32}
     },
     {
-      "name": "Gate to the Village Green",
+      "id": 1687, "name": "Gate to the Village Green",
+      "exits": { "east": 1693, "south": 1688 },
       "environment": -1,
-      "exits": {
-        "east": 1693,
-        "south": 1688
-      },
       "weight": 1,
-      "id": 1687,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1688, "name": "Northwest Green",
+      "exits": { "south": 1689, "east": 1694, "north": 1687 },
       "environment": -1,
-      "exits": {
-        "south": 1689,
-        "east": 1694,
-        "north": 1687
-      },
       "weight": 1,
-      "id": 1688,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1689, "name": "Northwest Green",
+      "exits": { "south": 1699, "east": 1690, "north": 1688 },
       "environment": -1,
-      "exits": {
-        "south": 1699,
-        "east": 1690,
-        "north": 1688
-      },
       "weight": 1,
-      "id": 1689,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1690, "name": "Northwest Green",
+      "exits": { "south": 1700, "west": 1689, "east": 1691, "north": 1694 },
       "environment": -1,
-      "exits": {
-        "south": 1700,
-        "west": 1689,
-        "east": 1691,
-        "north": 1694
-      },
       "weight": 1,
-      "id": 1690,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1691, "name": "Northwest Green",
+      "exits": { "south": 1701, "west": 1690, "east": 1692, "north": 1704 },
       "environment": -1,
-      "exits": {
-        "south": 1701,
-        "west": 1690,
-        "east": 1692,
-        "north": 1704
-      },
       "weight": 1,
-      "id": 1691,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1692, "name": "Northeast Green",
+      "exits": { "south": 1702, "west": 1691, "east": 1706, "north": 1703 },
       "environment": -1,
-      "exits": {
-        "south": 1702,
-        "west": 1691,
-        "east": 1706,
-        "north": 1703
-      },
       "weight": 1,
-      "id": 1692,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwestern Green",
+      "id": 1693, "name": "Northwestern Green",
+      "exits": { "west": 1687, "east": 1695, "south": 1694 },
       "environment": -1,
-      "exits": {
-        "west": 1687,
-        "east": 1695,
-        "south": 1694
-      },
       "weight": 1,
-      "id": 1693,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1694, "name": "Northwest Green",
+      "exits": { "south": 1690, "west": 1688, "east": 1704, "north": 1693 },
       "environment": -1,
-      "exits": {
-        "south": 1690,
-        "west": 1688,
-        "east": 1704,
-        "north": 1693
-      },
       "weight": 1,
-      "id": 1694,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwestern Green",
+      "id": 1695, "name": "Northwestern Green",
+      "exits": { "west": 1693, "east": 1696, "south": 1704 },
       "environment": -1,
-      "exits": {
-        "west": 1693,
-        "east": 1696,
-        "south": 1704
-      },
       "weight": 1,
-      "id": 1695,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeastern Green",
+      "id": 1696, "name": "Northeastern Green",
+      "exits": { "west": 1695, "east": 1697, "south": 1703 },
       "environment": -1,
-      "exits": {
-        "west": 1695,
-        "east": 1697,
-        "south": 1703
-      },
       "weight": 1,
-      "id": 1696,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1697, "name": "Northeast Green",
+      "exits": { "west": 1696, "east": 1698, "south": 1705 },
       "environment": -1,
-      "exits": {
-        "west": 1696,
-        "east": 1698,
-        "south": 1705
-      },
       "weight": 1,
-      "id": 1697,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1698, "name": "Northeast Green",
+      "exits": { "west": 1697, "south": 1710 },
       "environment": -1,
-      "exits": {
-        "west": 1697,
-        "south": 1710
-      },
       "weight": 1,
-      "id": 1698,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1699, "name": "Southwest Green",
+      "exits": { "south": 1713, "east": 1700, "north": 1689 },
       "environment": -1,
-      "exits": {
-        "south": 1713,
-        "east": 1700,
-        "north": 1689
-      },
       "weight": 1,
-      "id": 1699,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1700, "name": "Southwest Green",
+      "exits": { "south": 1712, "west": 1699, "east": 1701, "north": 1690 },
       "environment": -1,
-      "exits": {
-        "south": 1712,
-        "west": 1699,
-        "east": 1701,
-        "north": 1690
-      },
       "weight": 1,
-      "id": 1700,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1701, "name": "Southwest Green",
+      "exits": { "south": 1711, "west": 1700, "east": 1702, "north": 1691 },
       "environment": -1,
-      "exits": {
-        "south": 1711,
-        "west": 1700,
-        "east": 1702,
-        "north": 1691
-      },
       "weight": 1,
-      "id": 1701,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southeast Green",
+      "id": 1702, "name": "Southeast Green",
+      "exits": { "south": 1714, "west": 1701, "east": 1707, "north": 1692 },
       "environment": -1,
-      "exits": {
-        "south": 1714,
-        "west": 1701,
-        "east": 1707,
-        "north": 1692
-      },
       "weight": 1,
-      "id": 1702,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1703, "name": "Northeast Green",
+      "exits": { "south": 1692, "west": 1704, "east": 1705, "north": 1696 },
       "environment": -1,
-      "exits": {
-        "south": 1692,
-        "west": 1704,
-        "east": 1705,
-        "north": 1696
-      },
       "weight": 1,
-      "id": 1703,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northwest Green",
+      "id": 1704, "name": "Northwest Green",
+      "exits": { "south": 1691, "west": 1694, "east": 1703, "north": 1695 },
       "environment": -1,
-      "exits": {
-        "south": 1691,
-        "west": 1694,
-        "east": 1703,
-        "north": 1695
-      },
       "weight": 1,
-      "id": 1704,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1705, "name": "Northeast Green",
+      "exits": { "south": 1706, "west": 1703, "east": 1710, "north": 1697 },
       "environment": -1,
-      "exits": {
-        "south": 1706,
-        "west": 1703,
-        "east": 1710,
-        "north": 1697
-      },
       "weight": 1,
-      "id": 1705,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1706, "name": "Northeast Green",
+      "exits": { "south": 1707, "west": 1692, "east": 1709, "north": 1705 },
       "environment": -1,
-      "exits": {
-        "south": 1707,
-        "west": 1692,
-        "east": 1709,
-        "north": 1705
-      },
       "weight": 1,
-      "id": 1706,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Ruins in the Southeast Green",
+      "id": 1707, "name": "Ruins in the Southeast Green",
+      "exits": { "south": 1715, "west": 1702, "east": 1708, "north": 1706 },
       "environment": -1,
-      "exits": {
-        "south": 1715,
-        "west": 1702,
-        "east": 1708,
-        "north": 1706
-      },
       "weight": 1,
-      "id": 1707,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Ruins in the Southeast Green",
+      "id": 1708, "name": "Ruins in the Southeast Green",
+      "exits": { "west": 1707, "south": 1716, "north": 1709 },
       "environment": -1,
-      "exits": {
-        "west": 1707,
-        "south": 1716,
-        "north": 1709
-      },
       "weight": 1,
-      "id": 1708,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeastern Green",
+      "id": 1709, "name": "Northeastern Green",
+      "exits": { "west": 1706, "south": 1708, "north": 1710 },
       "environment": -1,
-      "exits": {
-        "west": 1706,
-        "south": 1708,
-        "north": 1710
-      },
       "weight": 1,
-      "id": 1709,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Northeast Green",
+      "id": 1710, "name": "Northeast Green",
+      "exits": { "south": 1709, "west": 1705, "east": 1722, "north": 1698 },
       "environment": -1,
-      "exits": {
-        "south": 1709,
-        "west": 1705,
-        "east": 1722,
-        "north": 1698
-      },
       "weight": 1,
-      "id": 1710,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1711, "name": "Southwest Green",
+      "exits": { "south": 1717, "west": 1712, "east": 1714, "north": 1701 },
       "environment": -1,
-      "exits": {
-        "south": 1717,
-        "west": 1712,
-        "east": 1714,
-        "north": 1701
-      },
       "weight": 1,
-      "id": 1711,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1712, "name": "Southwest Green",
+      "exits": { "south": 1718, "west": 1713, "east": 1711, "north": 1700 },
       "environment": -1,
-      "exits": {
-        "south": 1718,
-        "west": 1713,
-        "east": 1711,
-        "north": 1700
-      },
       "weight": 1,
-      "id": 1712,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1713, "name": "Southwest Green",
+      "exits": { "south": 1719, "east": 1712, "north": 1699 },
       "environment": -1,
-      "exits": {
-        "south": 1719,
-        "east": 1712,
-        "north": 1699
-      },
       "weight": 1,
-      "id": 1713,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southeast Green",
+      "id": 1714, "name": "Southeast Green",
+      "exits": { "west": 1711, "east": 1715, "north": 1702 },
       "environment": -1,
-      "exits": {
-        "west": 1711,
-        "east": 1715,
-        "north": 1702
-      },
       "weight": 1,
-      "id": 1714,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southeast Green",
+      "id": 1715, "name": "Southeast Green",
+      "exits": { "west": 1714, "east": 1716, "north": 1707 },
       "environment": -1,
-      "exits": {
-        "west": 1714,
-        "east": 1716,
-        "north": 1707
-      },
       "weight": 1,
-      "id": 1715,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southeast Green",
+      "id": 1716, "name": "Southeast Green",
+      "exits": { "west": 1715, "north": 1708 },
       "environment": -1,
-      "exits": {
-        "west": 1715,
-        "north": 1708
-      },
       "weight": 1,
-      "id": 1716,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Southwest Green",
+      "id": 1717, "name": "Southwest Green",
+      "exits": { "west": 1718, "north": 1711 },
       "environment": -1,
-      "exits": {
-        "west": 1718,
-        "north": 1711
-      },
       "weight": 1,
-      "id": 1717,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Dark Southwest Green",
+      "id": 1718, "name": "Dark Southwest Green",
+      "exits": { "south": 1721, "west": 1719, "east": 1717, "north": 1712 },
       "environment": -1,
-      "exits": {
-        "south": 1721,
-        "west": 1719,
-        "east": 1717,
-        "north": 1712
-      },
       "weight": 1,
-      "id": 1718,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Dark Southwest Green",
+      "id": 1719, "name": "Dark Southwest Green",
+      "exits": { "south": 1720, "east": 1718, "north": 1713 },
       "environment": -1,
-      "exits": {
-        "south": 1720,
-        "east": 1718,
-        "north": 1713
-      },
       "weight": 1,
-      "id": 1719,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Dark Southwest Green",
+      "id": 1720, "name": "Dark Southwest Green",
+      "exits": { "east": 1721, "north": 1719 },
       "environment": -1,
-      "exits": {
-        "east": 1721,
-        "north": 1719
-      },
       "weight": 1,
-      "id": 1720,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Dark Southwest Green",
+      "id": 1721, "name": "Dark Southwest Green",
+      "exits": { "west": 1720, "north": 1718 },
       "environment": -1,
-      "exits": {
-        "west": 1720,
-        "north": 1718
-      },
       "weight": 1,
-      "id": 1721,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "The Herb Exchange",
+      "id": 1722, "name": "The Herb Exchange",
+      "exits": { "west": 1710 },
       "environment": -1,
-      "exits": {
-        "west": 1710
-      },
       "weight": 1,
-      "id": 1722,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Inside the Anthill",
+      "id": 1723, "name": "Inside the Anthill",
+      "exits": { "up": 1806, "down": 1744, "north": 1740 },
       "environment": -1,
-      "exits": {
-        "up": 1806,
-        "down": 1744,
-        "north": 1740
-      },
       "weight": 1,
-      "id": 1723,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
+      "id": 1724, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "northwest": 990, "southeast": 1729 },
       "environment": -1,
-      "exits": {
-        "northwest": 990,
-        "southeast": 1729
-      },
       "weight": 1,
-      "id": 1724,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
+      "id": 1725, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "southwest": 1728, "northeast": 990 },
       "environment": -1,
-      "exits": {
-        "southwest": 1728,
-        "northeast": 990
-      },
       "weight": 1,
-      "id": 1725,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Oak Treehouse Rope Bridge",
+      "id": 1726, "name": "Oak Treehouse Rope Bridge",
+      "exits": { "southwest": 990, "northeast": 1727 },
       "environment": -1,
-      "exits": {
-        "southwest": 990,
-        "northeast": 1727
-      },
       "weight": 1,
-      "id": 1726,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Living Quarters in the Oak",
+      "id": 1727, "name": "Living Quarters in the Oak",
+      "exits": { "southwest": 1726 },
       "environment": -1,
-      "exits": {
-        "southwest": 1726
-      },
       "weight": 1,
-      "id": 1727,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Living Quarters in the Oak",
+      "id": 1728, "name": "Living Quarters in the Oak",
+      "exits": { "northeast": 1725 },
       "environment": -1,
-      "exits": {
-        "northeast": 1725
-      },
       "weight": 1,
-      "id": 1728,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Oak Treehouse Gazebo",
+      "id": 1729, "name": "Oak Treehouse Gazebo",
+      "exits": { "northwest": 1724, "east": 1730 },
       "environment": -1,
-      "exits": {
-        "northwest": 1724,
-        "east": 1730
-      },
       "weight": 1,
-      "id": 1729,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Long Rope Bridge",
+      "id": 1730, "name": "Long Rope Bridge",
+      "exits": { "east": 1731, "west": 1729 },
       "environment": -1,
-      "exits": {
-        "east": 1731,
-        "west": 1729
-      },
       "weight": 1,
-      "id": 1730,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "The rope bridge sways underfoot, but you maintain your balance.",
+      "id": 1731, "name": "The rope bridge sways underfoot, but you maintain your balance.",
+      "exits": { "west": 1730, "northeast": 1732, "east": 1733, "south": 1734 },
       "environment": -1,
-      "exits": {
-        "west": 1730,
-        "northeast": 1732,
-        "east": 1733,
-        "south": 1734
-      },
       "weight": 1,
-      "id": 1731,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "You push open the door and proceed northeast into the large room.",
+      "id": 1732, "name": "You push open the door and proceed northeast into the large room.",
+      "exits": { "southwest": 1731 },
       "environment": -1,
-      "exits": {
-        "southwest": 1731
-      },
       "weight": 1,
-      "id": 1732,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "You push open the door to the private quarters.",
+      "id": 1733, "name": "You push open the door to the private quarters.",
+      "exits": { "west": 1731 },
       "environment": -1,
-      "exits": {
-        "west": 1731
-      },
       "weight": 1,
-      "id": 1733,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Gingerly, you step out onto the taunt rope bridge.",
+      "id": 1734, "name": "Gingerly, you step out onto the taunt rope bridge.",
+      "exits": { "south": 1735, "north": 1731 },
       "environment": -1,
-      "exits": {
-        "south": 1735,
-        "north": 1731
-      },
       "weight": 1,
-      "id": 1734,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "You scurry across the swinging rope bridge.",
+      "id": 1735, "name": "You scurry across the swinging rope bridge.",
+      "exits": { "southeast": 1736, "north": 1734 },
       "environment": -1,
-      "exits": {
-        "southeast": 1736,
-        "north": 1734
-      },
       "weight": 1,
-      "id": 1735,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Tel'Quesir Throne Room",
+      "id": 1736, "name": "Tel'Quesir Throne Room",
+      "exits": { "northeast": 1738, "northwest": 1735, "southeast": 1737 },
       "environment": -1,
-      "exits": {
-        "northeast": 1738,
-        "northwest": 1735,
-        "southeast": 1737
-      },
       "weight": 1,
-      "id": 1736,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "White Chapel",
+      "id": 1737, "name": "White Chapel",
+      "exits": { "northwest": 1736, "north": 1738 },
       "environment": -1,
-      "exits": {
-        "northwest": 1736,
-        "north": 1738
-      },
       "weight": 1,
-      "id": 1737,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Hall of Ministers",
+      "id": 1738, "name": "Hall of Ministers",
+      "exits": { "southwest": 1736, "south": 1737 },
       "environment": -1,
-      "exits": {
-        "southwest": 1736,
-        "south": 1737
-      },
       "weight": 1,
-      "id": 1738,
-      "area": {
-        "id": 33
-      }
+      "area": {"id": 33}
     },
     {
-      "name": "Landak's Hut:",
+      "id": 1739, "name": "Landak's Hut:",
+      "exits": { "west": 995 },
       "environment": -1,
-      "exits": {
-        "west": 995
-      },
       "weight": 1,
-      "id": 1739,
-      "area": {
-        "id": 15
-      }
+      "area": {"id": 15}
     },
     {
-      "name": "Inside the Anthill",
+      "id": 1740, "name": "Inside the Anthill",
+      "exits": { "southwest": 1741, "southeast": 1743, "south": 1723 },
       "environment": -1,
-      "exits": {
-        "southwest": 1741,
-        "southeast": 1743,
-        "south": 1723
-      },
       "weight": 1,
-      "id": 1740,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Inside the Anthill",
+      "id": 1741, "name": "Inside the Anthill",
+      "exits": { "southeast": 1742, "northeast": 1740 },
       "environment": -1,
-      "exits": {
-        "southeast": 1742,
-        "northeast": 1740
-      },
       "weight": 1,
-      "id": 1741,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Inside the Anthill",
+      "id": 1742, "name": "Inside the Anthill",
+      "exits": { "northwest": 1741, "northeast": 1743 },
       "environment": -1,
-      "exits": {
-        "northwest": 1741,
-        "northeast": 1743
-      },
       "weight": 1,
-      "id": 1742,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Inside the Anthill",
+      "id": 1743, "name": "Inside the Anthill",
+      "exits": { "northwest": 1740, "southwest": 1742 },
       "environment": -1,
-      "exits": {
-        "northwest": 1740,
-        "southwest": 1742
-      },
       "weight": 1,
-      "id": 1743,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1744, "name": "In the Heart of the Anthill",
+      "exits": { "southeast": 1751, "up": 1723, "southwest": 1750, "northeast": 1745, "down": 1754, "northwest": 1747 },
       "environment": -1,
-      "exits": {
-        "southeast": 1751,
-        "up": 1723,
-        "southwest": 1750,
-        "northeast": 1745,
-        "down": 1754,
-        "northwest": 1747
-      },
       "weight": 1,
-      "id": 1744,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1745, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1744, "south": 1746 },
       "environment": -1,
-      "exits": {
-        "southwest": 1744,
-        "south": 1746
-      },
       "weight": 1,
-      "id": 1745,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1746, "name": "In the Heart of the Anthill",
+      "exits": { "north": 1745 },
       "environment": -1,
-      "exits": {
-        "north": 1745
-      },
       "weight": 1,
-      "id": 1746,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1747, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1749, "northeast": 1748, "southeast": 1744 },
       "environment": -1,
-      "exits": {
-        "southwest": 1749,
-        "northeast": 1748,
-        "southeast": 1744
-      },
       "weight": 1,
-      "id": 1747,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1748, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1747 },
       "environment": -1,
-      "exits": {
-        "southwest": 1747
-      },
       "weight": 1,
-      "id": 1748,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1749, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1747 },
       "environment": -1,
-      "exits": {
-        "northeast": 1747
-      },
       "weight": 1,
-      "id": 1749,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1750, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1744 },
       "environment": -1,
-      "exits": {
-        "northeast": 1744
-      },
       "weight": 1,
-      "id": 1750,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1751, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1753, "northeast": 1752, "northwest": 1744 },
       "environment": -1,
-      "exits": {
-        "southwest": 1753,
-        "northeast": 1752,
-        "northwest": 1744
-      },
       "weight": 1,
-      "id": 1751,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1752, "name": "In the Heart of the Anthill",
+      "exits": { "southwest": 1751 },
       "environment": -1,
-      "exits": {
-        "southwest": 1751
-      },
       "weight": 1,
-      "id": 1752,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "In the Heart of the Anthill",
+      "id": 1753, "name": "In the Heart of the Anthill",
+      "exits": { "northeast": 1751 },
       "environment": -1,
-      "exits": {
-        "northeast": 1751
-      },
       "weight": 1,
-      "id": 1753,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1754, "name": "At the Base of the Anthill",
+      "exits": { "up": 1744, "east": 1758, "south": 1755 },
       "environment": -1,
-      "exits": {
-        "up": 1744,
-        "east": 1758,
-        "south": 1755
-      },
       "weight": 1,
-      "id": 1754,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1755, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1756, "north": 1754 },
       "environment": -1,
-      "exits": {
-        "southeast": 1756,
-        "north": 1754
-      },
       "weight": 1,
-      "id": 1755,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1756, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1755, "southwest": 1757 },
       "environment": -1,
-      "exits": {
-        "northwest": 1755,
-        "southwest": 1757
-      },
       "weight": 1,
-      "id": 1756,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1757, "name": "At the Base of the Anthill",
+      "exits": { "northeast": 1756 },
       "environment": -1,
-      "exits": {
-        "northeast": 1756
-      },
       "weight": 1,
-      "id": 1757,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1758, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1763, "northeast": 1759, "northwest": 1762, "west": 1754 },
       "environment": -1,
-      "exits": {
-        "southeast": 1763,
-        "northeast": 1759,
-        "northwest": 1762,
-        "west": 1754
-      },
       "weight": 1,
-      "id": 1758,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1759, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1760, "southwest": 1758 },
       "environment": -1,
-      "exits": {
-        "northwest": 1760,
-        "southwest": 1758
-      },
       "weight": 1,
-      "id": 1759,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1760, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1762, "northwest": 1761, "southeast": 1759 },
       "environment": -1,
-      "exits": {
-        "southwest": 1762,
-        "northwest": 1761,
-        "southeast": 1759
-      },
       "weight": 1,
-      "id": 1760,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1761, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1760 },
       "environment": -1,
-      "exits": {
-        "southeast": 1760
-      },
       "weight": 1,
-      "id": 1761,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1762, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1765, "northeast": 1760, "southeast": 1758 },
       "environment": -1,
-      "exits": {
-        "southwest": 1765,
-        "northeast": 1760,
-        "southeast": 1758
-      },
       "weight": 1,
-      "id": 1762,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1763, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1758, "northeast": 1764 },
       "environment": -1,
-      "exits": {
-        "northwest": 1758,
-        "northeast": 1764
-      },
       "weight": 1,
-      "id": 1763,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1764, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1763 },
       "environment": -1,
-      "exits": {
-        "southwest": 1763
-      },
       "weight": 1,
-      "id": 1764,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1765, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1766, "northeast": 1762 },
       "environment": -1,
-      "exits": {
-        "northwest": 1766,
-        "northeast": 1762
-      },
       "weight": 1,
-      "id": 1765,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1766, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1767, "northeast": 1770, "southeast": 1765 },
       "environment": -1,
-      "exits": {
-        "southwest": 1767,
-        "northeast": 1770,
-        "southeast": 1765
-      },
       "weight": 1,
-      "id": 1766,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1767, "name": "At the Base of the Anthill",
+      "exits": { "southeast": 1768, "northeast": 1766 },
       "environment": -1,
-      "exits": {
-        "southeast": 1768,
-        "northeast": 1766
-      },
       "weight": 1,
-      "id": 1767,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1768, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1767, "southeast": 1769 },
       "environment": -1,
-      "exits": {
-        "northwest": 1767,
-        "southeast": 1769
-      },
       "weight": 1,
-      "id": 1768,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1769, "name": "At the Base of the Anthill",
+      "exits": { "northwest": 1768 },
       "environment": -1,
-      "exits": {
-        "northwest": 1768
-      },
       "weight": 1,
-      "id": 1769,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the Base of the Anthill",
+      "id": 1770, "name": "At the Base of the Anthill",
+      "exits": { "southwest": 1766 },
       "environment": -1,
-      "exits": {
-        "southwest": 1766
-      },
       "weight": 1,
-      "id": 1770,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1771, "name": "Beneath the Anthill",
+      "exits": { "south": 1798, "west": 1772, "east": 1782, "north": 1797 },
       "environment": -1,
-      "exits": {
-        "south": 1798,
-        "west": 1772,
-        "east": 1782,
-        "north": 1797
-      },
       "weight": 1,
-      "id": 1771,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1772, "name": "Beneath the Anthill",
+      "exits": { "northwest": 1773, "east": 1771 },
       "environment": -1,
-      "exits": {
-        "northwest": 1773,
-        "east": 1771
-      },
       "weight": 1,
-      "id": 1772,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1773, "name": "Beneath the Anthill",
+      "exits": { "east": 1774, "southeast": 1772, "south": 1791 },
       "environment": -1,
-      "exits": {
-        "east": 1774,
-        "southeast": 1772,
-        "south": 1791
-      },
       "weight": 1,
-      "id": 1773,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1774, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1775, "west": 1773, "north": 1783 },
       "environment": -1,
-      "exits": {
-        "northeast": 1775,
-        "west": 1773,
-        "north": 1783
-      },
       "weight": 1,
-      "id": 1774,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1775, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1774, "east": 1776 },
       "environment": -1,
-      "exits": {
-        "southwest": 1774,
-        "east": 1776
-      },
       "weight": 1,
-      "id": 1775,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1776, "name": "Beneath the Anthill",
+      "exits": { "west": 1775, "south": 1777 },
       "environment": -1,
-      "exits": {
-        "west": 1775,
-        "south": 1777
-      },
       "weight": 1,
-      "id": 1776,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1777, "name": "Beneath the Anthill",
+      "exits": { "south": 1782, "west": 1797, "northeast": 1778, "east": 1799, "north": 1776 },
       "environment": -1,
-      "exits": {
-        "south": 1782,
-        "west": 1797,
-        "northeast": 1778,
-        "east": 1799,
-        "north": 1776
-      },
       "weight": 1,
-      "id": 1777,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1778, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1777, "east": 1779 },
       "environment": -1,
-      "exits": {
-        "southwest": 1777,
-        "east": 1779
-      },
       "weight": 1,
-      "id": 1778,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1779, "name": "Beneath the Anthill",
+      "exits": { "west": 1778, "south": 1780 },
       "environment": -1,
-      "exits": {
-        "west": 1778,
-        "south": 1780
-      },
       "weight": 1,
-      "id": 1779,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1780, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1781, "south": 1803, "north": 1779 },
       "environment": -1,
-      "exits": {
-        "southwest": 1781,
-        "south": 1803,
-        "north": 1779
-      },
       "weight": 1,
-      "id": 1780,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1781, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1780, "west": 1782, "south": 1800 },
       "environment": -1,
-      "exits": {
-        "northeast": 1780,
-        "west": 1782,
-        "south": 1800
-      },
       "weight": 1,
-      "id": 1781,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1782, "name": "Beneath the Anthill",
+      "exits": { "west": 1771, "east": 1781, "north": 1777 },
       "environment": -1,
-      "exits": {
-        "west": 1771,
-        "east": 1781,
-        "north": 1777
-      },
       "weight": 1,
-      "id": 1782,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1783, "name": "Beneath the Anthill",
+      "exits": { "west": 1784, "south": 1774 },
       "environment": -1,
-      "exits": {
-        "west": 1784,
-        "south": 1774
-      },
       "weight": 1,
-      "id": 1783,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1784, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1785, "east": 1783 },
       "environment": -1,
-      "exits": {
-        "southwest": 1785,
-        "east": 1783
-      },
       "weight": 1,
-      "id": 1784,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1785, "name": "Beneath the Anthill",
+      "exits": { "west": 1786, "northeast": 1784 },
       "environment": -1,
-      "exits": {
-        "west": 1786,
-        "northeast": 1784
-      },
       "weight": 1,
-      "id": 1785,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1786, "name": "Beneath the Anthill",
+      "exits": { "east": 1785, "south": 1787 },
       "environment": -1,
-      "exits": {
-        "east": 1785,
-        "south": 1787
-      },
       "weight": 1,
-      "id": 1786,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1787, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1788, "north": 1786 },
       "environment": -1,
-      "exits": {
-        "southwest": 1788,
-        "north": 1786
-      },
       "weight": 1,
-      "id": 1787,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Near the Queen's Lair",
+      "id": 1788, "name": "Near the Queen's Lair",
+      "exits": { "northeast": 1787, "north": 1789 },
       "environment": -1,
-      "exits": {
-        "northeast": 1787,
-        "north": 1789
-      },
       "weight": 1,
-      "id": 1788,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Near the Queen's Lair",
+      "id": 1789, "name": "Near the Queen's Lair",
+      "exits": { "south": 1788, "north": 1790 },
       "environment": -1,
-      "exits": {
-        "south": 1788,
-        "north": 1790
-      },
       "weight": 1,
-      "id": 1789,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "The Ant Lair",
+      "id": 1790, "name": "The Ant Lair",
+      "exits": { "south": 1789 },
       "environment": -1,
-      "exits": {
-        "south": 1789
-      },
       "weight": 1,
-      "id": 1790,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1791, "name": "Beneath the Anthill",
+      "exits": { "south": 1792, "southeast": 1796, "north": 1773 },
       "environment": -1,
-      "exits": {
-        "south": 1792,
-        "southeast": 1796,
-        "north": 1773
-      },
       "weight": 1,
-      "id": 1791,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1792, "name": "Beneath the Anthill",
+      "exits": { "west": 1793, "east": 1796, "north": 1791 },
       "environment": -1,
-      "exits": {
-        "west": 1793,
-        "east": 1796,
-        "north": 1791
-      },
       "weight": 1,
-      "id": 1792,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1793, "name": "Beneath the Anthill",
+      "exits": { "east": 1792, "north": 1794 },
       "environment": -1,
-      "exits": {
-        "east": 1792,
-        "north": 1794
-      },
       "weight": 1,
-      "id": 1793,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1794, "name": "Beneath the Anthill",
+      "exits": { "southwest": 1795, "south": 1793 },
       "environment": -1,
-      "exits": {
-        "southwest": 1795,
-        "south": 1793
-      },
       "weight": 1,
-      "id": 1794,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1795, "name": "Beneath the Anthill",
+      "exits": { "northeast": 1794 },
       "environment": -1,
-      "exits": {
-        "northeast": 1794
-      },
       "weight": 1,
-      "id": 1795,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1796, "name": "Beneath the Anthill",
+      "exits": { "northwest": 1791, "west": 1792 },
       "environment": -1,
-      "exits": {
-        "northwest": 1791,
-        "west": 1792
-      },
       "weight": 1,
-      "id": 1796,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1797, "name": "Beneath the Anthill",
+      "exits": { "east": 1777, "south": 1771 },
       "environment": -1,
-      "exits": {
-        "east": 1777,
-        "south": 1771
-      },
       "weight": 1,
-      "id": 1797,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1798, "name": "Beneath the Anthill",
+      "exits": { "north": 1771 },
       "environment": -1,
-      "exits": {
-        "north": 1771
-      },
       "weight": 1,
-      "id": 1798,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1799, "name": "Beneath the Anthill",
+      "exits": { "west": 1777 },
       "environment": -1,
-      "exits": {
-        "west": 1777
-      },
       "weight": 1,
-      "id": 1799,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1800, "name": "Beneath the Anthill",
+      "exits": { "west": 1801, "east": 1802, "north": 1781 },
       "environment": -1,
-      "exits": {
-        "west": 1801,
-        "east": 1802,
-        "north": 1781
-      },
       "weight": 1,
-      "id": 1800,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1801, "name": "Beneath the Anthill",
+      "exits": { "east": 1800 },
       "environment": -1,
-      "exits": {
-        "east": 1800
-      },
       "weight": 1,
-      "id": 1801,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1802, "name": "Beneath the Anthill",
+      "exits": { "west": 1800, "north": 1803 },
       "environment": -1,
-      "exits": {
-        "west": 1800,
-        "north": 1803
-      },
       "weight": 1,
-      "id": 1802,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1803, "name": "Beneath the Anthill",
+      "exits": { "south": 1802, "east": 1804, "north": 1780 },
       "environment": -1,
-      "exits": {
-        "south": 1802,
-        "east": 1804,
-        "north": 1780
-      },
       "weight": 1,
-      "id": 1803,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1804, "name": "Beneath the Anthill",
+      "exits": { "west": 1803, "north": 1805 },
       "environment": -1,
-      "exits": {
-        "west": 1803,
-        "north": 1805
-      },
       "weight": 1,
-      "id": 1804,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Beneath the Anthill",
+      "id": 1805, "name": "Beneath the Anthill",
+      "exits": { "south": 1804 },
       "environment": -1,
-      "exits": {
-        "south": 1804
-      },
       "weight": 1,
-      "id": 1805,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "At the top of the anthill.",
+      "id": 1806, "name": "At the top of the anthill.",
       "environment": -1,
-      "id": 1806,
       "weight": 1,
-      "area": {
-        "id": 34
-      }
+      "area": {"id": 34}
     },
     {
-      "name": "Moist cavern",
+      "id": 1807, "name": "Moist cavern",
+      "exits": { "down": 1809, "up": 1808 },
       "environment": -1,
-      "exits": {
-        "down": 1809,
-        "up": 1808
-      },
       "weight": 1,
-      "id": 1807,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "Crack in the mountainside",
+      "id": 1808, "name": "Crack in the mountainside",
+      "exits": { "down": 1807 },
       "environment": -1,
-      "exits": {
-        "down": 1807
-      },
       "weight": 1,
-      "id": 1808,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "Giant cavern",
+      "id": 1809, "name": "Giant cavern",
+      "exits": { "up": 1807, "west": 1810 },
       "environment": -1,
-      "exits": {
-        "up": 1807,
-        "west": 1810
-      },
       "weight": 1,
-      "id": 1809,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "Bright niche",
+      "id": 1810, "name": "Bright niche",
+      "exits": { "east": 1809 },
       "environment": -1,
-      "exits": {
-        "east": 1809
-      },
       "weight": 1,
-      "id": 1810,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "The ore lift",
+      "id": 1811, "name": "The ore lift",
+      "exits": { "south": 1812 },
       "environment": -1,
-      "exits": {
-        "south": 1812
-      },
       "weight": 1,
-      "id": 1811,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "The Crimsonaxe mine",
+      "id": 1812, "name": "The Crimsonaxe mine",
+      "exits": { "west": 1813, "south": 1815, "north": 1811 },
       "environment": -1,
-      "exits": {
-        "west": 1813,
-        "south": 1815,
-        "north": 1811
-      },
       "weight": 1,
-      "id": 1812,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A guard point",
+      "id": 1813, "name": "A guard point",
+      "exits": { "south": 1814, "east": 1812, "north": 1823 },
       "environment": -1,
-      "exits": {
-        "south": 1814,
-        "east": 1812,
-        "north": 1823
-      },
       "weight": 1,
-      "id": 1813,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "The immense stone slab moves suprisingly easily.",
+      "id": 1814, "name": "The immense stone slab moves suprisingly easily.",
+      "exits": { "north": 1813 },
       "environment": -1,
-      "exits": {
-        "north": 1813
-      },
       "weight": 1,
-      "id": 1814,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "The Crimsonaxe mine",
+      "id": 1815, "name": "The Crimsonaxe mine",
+      "exits": { "south": 1816, "east": 1821, "north": 1812 },
       "environment": -1,
-      "exits": {
-        "south": 1816,
-        "east": 1821,
-        "north": 1812
-      },
       "weight": 1,
-      "id": 1815,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A bend in the tunnel.",
+      "id": 1816, "name": "A bend in the tunnel.",
+      "exits": { "southeast": 1817, "north": 1815 },
       "environment": -1,
-      "exits": {
-        "southeast": 1817,
-        "north": 1815
-      },
       "weight": 1,
-      "id": 1816,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A mine shaft.",
+      "id": 1817, "name": "A mine shaft.",
+      "exits": { "northwest": 1816, "east": 1818, "up": 1820 },
       "environment": -1,
-      "exits": {
-        "northwest": 1816,
-        "east": 1818,
-        "up": 1820
-      },
       "weight": 1,
-      "id": 1817,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A guard house.",
+      "id": 1818, "name": "A guard house.",
+      "exits": { "up": 1819, "west": 1817 },
       "environment": -1,
-      "exits": {
-        "up": 1819,
-        "west": 1817
-      },
       "weight": 1,
-      "id": 1818,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A sentry room",
+      "id": 1819, "name": "A sentry room",
+      "exits": { "down": 1818 },
       "environment": -1,
-      "exits": {
-        "down": 1818
-      },
       "weight": 1,
-      "id": 1819,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A darkened entrance.",
+      "id": 1820, "name": "A darkened entrance.",
+      "exits": { "down": 1817 },
       "environment": -1,
-      "exits": {
-        "down": 1817
-      },
       "weight": 1,
-      "id": 1820,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "Mine catering",
+      "id": 1821, "name": "Mine catering",
+      "exits": { "west": 1815, "north": 1822 },
       "environment": -1,
-      "exits": {
-        "west": 1815,
-        "north": 1822
-      },
       "weight": 1,
-      "id": 1821,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "A smelly crevice.",
+      "id": 1822, "name": "A smelly crevice.",
+      "exits": { "south": 1821 },
       "environment": -1,
-      "exits": {
-        "south": 1821
-      },
       "weight": 1,
-      "id": 1822,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "The immense stone slab moves suprisingly easily.",
+      "id": 1823, "name": "The immense stone slab moves suprisingly easily.",
+      "exits": { "south": 1813 },
       "environment": -1,
-      "exits": {
-        "south": 1813
-      },
       "weight": 1,
-      "id": 1823,
-      "area": {
-        "id": 35
-      }
+      "area": {"id": 35}
     },
     {
-      "name": "You are just inside the entrace to a large cave",
+      "id": 1824, "name": "You are just inside the entrace to a large cave",
+      "exits": { "east": 1825 },
       "environment": -1,
-      "exits": {
-        "east": 1825
-      },
       "weight": 1,
-      "id": 1824,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A wide tunnel",
+      "id": 1825, "name": "A wide tunnel",
+      "exits": { "west": 1824, "south": 1826, "north": 1827 },
       "environment": -1,
-      "exits": {
-        "west": 1824,
-        "south": 1826,
-        "north": 1827
-      },
       "weight": 1,
-      "id": 1825,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A den",
+      "id": 1826, "name": "A den",
+      "exits": { "north": 1825 },
       "environment": -1,
-      "exits": {
-        "north": 1825
-      },
       "weight": 1,
-      "id": 1826,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A tunnel",
+      "id": 1827, "name": "A tunnel",
+      "exits": { "south": 1825, "north": 1828 },
       "environment": -1,
-      "exits": {
-        "south": 1825,
-        "north": 1828
-      },
       "weight": 1,
-      "id": 1827,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A bend in the tunnel",
+      "id": 1828, "name": "A bend in the tunnel",
+      "exits": { "east": 1829, "south": 1827 },
       "environment": -1,
-      "exits": {
-        "east": 1829,
-        "south": 1827
-      },
       "weight": 1,
-      "id": 1828,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A tunnel",
+      "id": 1829, "name": "A tunnel",
+      "exits": { "east": 1830, "west": 1828 },
       "environment": -1,
-      "exits": {
-        "east": 1830,
-        "west": 1828
-      },
       "weight": 1,
-      "id": 1829,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "T-intersection",
+      "id": 1830, "name": "T-intersection",
+      "exits": { "west": 1829, "south": 1831, "north": 1833 },
       "environment": -1,
-      "exits": {
-        "west": 1829,
-        "south": 1831,
-        "north": 1833
-      },
       "weight": 1,
-      "id": 1830,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "The widening tunnel",
+      "id": 1831, "name": "The widening tunnel",
+      "exits": { "east": 1832, "north": 1830 },
       "environment": -1,
-      "exits": {
-        "east": 1832,
-        "north": 1830
-      },
       "weight": 1,
-      "id": 1831,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A large chamber",
+      "id": 1832, "name": "A large chamber",
+      "exits": { "west": 1831 },
       "environment": -1,
-      "exits": {
-        "west": 1831
-      },
       "weight": 1,
-      "id": 1832,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "A small chamber",
+      "id": 1833, "name": "A small chamber",
+      "exits": { "south": 1830 },
       "environment": -1,
-      "exits": {
-        "south": 1830
-      },
       "weight": 1,
-      "id": 1833,
-      "area": {
-        "id": 36
-      }
+      "area": {"id": 36}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1834, "name": "Chikurin Forest Path",
+      "exits": { "northeast": 1858, "northwest": 1835, "north": 1856 },
       "environment": -1,
-      "exits": {
-        "northeast": 1858,
-        "northwest": 1835,
-        "north": 1856
-      },
       "weight": 1,
-      "id": 1834,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1835, "name": "Bamboo Forest",
+      "exits": { "east": 1856, "northeast": 1857, "southeast": 1834, "north": 1836 },
       "environment": -1,
-      "exits": {
-        "east": 1856,
-        "northeast": 1857,
-        "southeast": 1834,
-        "north": 1836
-      },
       "weight": 1,
-      "id": 1835,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1836, "name": "Bamboo Forest",
+      "exits": { "northwest": 1837, "south": 1835, "northeast": 1862, "east": 1857, "north": 1855 },
       "environment": -1,
-      "exits": {
-        "northwest": 1837,
-        "south": 1835,
-        "northeast": 1862,
-        "east": 1857,
-        "north": 1855
-      },
       "weight": 1,
-      "id": 1836,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1837, "name": "Bamboo Forest",
+      "exits": { "east": 1855, "northeast": 1851, "southeast": 1836, "north": 1838 },
       "environment": -1,
-      "exits": {
-        "east": 1855,
-        "northeast": 1851,
-        "southeast": 1836,
-        "north": 1838
-      },
       "weight": 1,
-      "id": 1837,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Calm Clearing in the Bamboo Forest",
+      "id": 1838, "name": "Calm Clearing in the Bamboo Forest",
+      "exits": { "southeast": 1855, "south": 1837, "northeast": 1850, "east": 1851, "north": 1839 },
       "environment": -1,
-      "exits": {
-        "southeast": 1855,
-        "south": 1837,
-        "northeast": 1850,
-        "east": 1851,
-        "north": 1839
-      },
       "weight": 1,
-      "id": 1838,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1839, "name": "Bamboo Forest",
+      "exits": { "east": 1850, "northeast": 1840, "southeast": 1851, "south": 1838 },
       "environment": -1,
-      "exits": {
-        "east": 1850,
-        "northeast": 1840,
-        "southeast": 1851,
-        "south": 1838
-      },
       "weight": 1,
-      "id": 1839,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest, Near a Pond",
+      "id": 1840, "name": "Bamboo Forest, Near a Pond",
+      "exits": { "southeast": 1849, "south": 1850, "southwest": 1839, "northeast": 1842, "east": 1846, "north": 1841 },
       "environment": -1,
-      "exits": {
-        "southeast": 1849,
-        "south": 1850,
-        "southwest": 1839,
-        "northeast": 1842,
-        "east": 1846,
-        "north": 1841
-      },
       "weight": 1,
-      "id": 1840,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1841, "name": "Bamboo Forest",
+      "exits": { "east": 1842, "southeast": 1846, "south": 1840 },
       "environment": -1,
-      "exits": {
-        "east": 1842,
-        "southeast": 1846,
-        "south": 1840
-      },
       "weight": 1,
-      "id": 1841,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1842, "name": "Chikurin Forest Path",
+      "exits": { "south": 1846, "west": 1841, "east": 1845, "north": 1843 },
       "environment": -1,
-      "exits": {
-        "south": 1846,
-        "west": 1841,
-        "east": 1845,
-        "north": 1843
-      },
       "weight": 1,
-      "id": 1842,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Path, south of Semai Pass",
+      "id": 1843, "name": "Chikurin Path, south of Semai Pass",
+      "exits": { "south": 1842, "north": 1844 },
       "environment": -1,
-      "exits": {
-        "south": 1842,
-        "north": 1844
-      },
       "weight": 1,
-      "id": 1843,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Heading north, you enter the narrow Semai Pass.",
+      "id": 1844, "name": "Heading north, you enter the narrow Semai Pass.",
+      "exits": { "south": 1843 },
       "environment": -1,
-      "exits": {
-        "south": 1843
-      },
       "weight": 1,
-      "id": 1844,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1845, "name": "Bamboo Forest",
+      "exits": { "southwest": 1846, "west": 1842, "south": 1848 },
       "environment": -1,
-      "exits": {
-        "southwest": 1846,
-        "west": 1842,
-        "south": 1848
-      },
       "weight": 1,
-      "id": 1845,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1846, "name": "Chikurin Forest Path",
+      "exits": { "southeast": 1847, "west": 1840, "northwest": 1841, "south": 1849, "southwest": 1850, "northeast": 1845, "east": 1848, "north": 1842 },
       "environment": -1,
-      "exits": {
-        "southeast": 1847,
-        "west": 1840,
-        "northwest": 1841,
-        "south": 1849,
-        "southwest": 1850,
-        "northeast": 1845,
-        "east": 1848,
-        "north": 1842
-      },
       "weight": 1,
-      "id": 1846,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1847, "name": "Bamboo Forest",
+      "exits": { "northwest": 1846, "south": 1853, "west": 1849, "east": 1852, "north": 1848 },
       "environment": -1,
-      "exits": {
-        "northwest": 1846,
-        "south": 1853,
-        "west": 1849,
-        "east": 1852,
-        "north": 1848
-      },
       "weight": 1,
-      "id": 1847,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1848, "name": "Bamboo Forest",
+      "exits": { "northwest": 1842, "south": 1847, "southwest": 1849, "west": 1846, "southeast": 1852, "north": 1845 },
       "environment": -1,
-      "exits": {
-        "northwest": 1842,
-        "south": 1847,
-        "southwest": 1849,
-        "west": 1846,
-        "southeast": 1852,
-        "north": 1845
-      },
       "weight": 1,
-      "id": 1848,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1849, "name": "Chikurin Forest Path",
+      "exits": { "southeast": 1853, "south": 1854, "southwest": 1851, "west": 1850, "north": 1846 },
       "environment": -1,
-      "exits": {
-        "southeast": 1853,
-        "south": 1854,
-        "southwest": 1851,
-        "west": 1850,
-        "north": 1846
-      },
       "weight": 1,
-      "id": 1849,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1850, "name": "Bamboo Forest",
+      "exits": { "west": 1839, "south": 1851, "southwest": 1838, "northeast": 1846, "east": 1849, "north": 1840 },
       "environment": -1,
-      "exits": {
-        "west": 1839,
-        "south": 1851,
-        "southwest": 1838,
-        "northeast": 1846,
-        "east": 1849,
-        "north": 1840
-      },
       "weight": 1,
-      "id": 1850,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1851, "name": "Bamboo Forest",
+      "exits": { "southeast": 1862, "west": 1838, "northwest": 1839, "south": 1855, "southwest": 1837, "northeast": 1849, "east": 1854, "north": 1850 },
       "environment": -1,
-      "exits": {
-        "southeast": 1862,
-        "west": 1838,
-        "northwest": 1839,
-        "south": 1855,
-        "southwest": 1837,
-        "northeast": 1849,
-        "east": 1854,
-        "north": 1850
-      },
       "weight": 1,
-      "id": 1851,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest, North of a Monastery",
+      "id": 1852, "name": "Bamboo Forest, North of a Monastery",
+      "exits": { "northwest": 1848, "west": 1847 },
       "environment": -1,
-      "exits": {
-        "northwest": 1848,
-        "west": 1847
-      },
       "weight": 1,
-      "id": 1852,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest, West of a Monastery",
+      "id": 1853, "name": "Bamboo Forest, West of a Monastery",
+      "exits": { "northwest": 1849, "south": 1860, "southwest": 1862, "west": 1854, "north": 1847 },
       "environment": -1,
-      "exits": {
-        "northwest": 1849,
-        "south": 1860,
-        "southwest": 1862,
-        "west": 1854,
-        "north": 1847
-      },
       "weight": 1,
-      "id": 1853,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1854, "name": "Chikurin Forest Path",
+      "exits": { "south": 1862, "southwest": 1855, "west": 1851, "east": 1853, "north": 1849 },
       "environment": -1,
-      "exits": {
-        "south": 1862,
-        "southwest": 1855,
-        "west": 1851,
-        "east": 1853,
-        "north": 1849
-      },
       "weight": 1,
-      "id": 1854,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1855, "name": "Bamboo Forest",
+      "exits": { "southeast": 1857, "northwest": 1838, "south": 1836, "west": 1837, "northeast": 1854, "east": 1862, "north": 1851 },
       "environment": -1,
-      "exits": {
-        "southeast": 1857,
-        "northwest": 1838,
-        "south": 1836,
-        "west": 1837,
-        "northeast": 1854,
-        "east": 1862,
-        "north": 1851
-      },
       "weight": 1,
-      "id": 1855,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1856, "name": "Chikurin Forest Path",
+      "exits": { "south": 1834, "west": 1835, "east": 1858, "north": 1857 },
       "environment": -1,
-      "exits": {
-        "south": 1834,
-        "west": 1835,
-        "east": 1858,
-        "north": 1857
-      },
       "weight": 1,
-      "id": 1856,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1857, "name": "Chikurin Forest Path",
+      "exits": { "north": 1862 },
       "environment": -1,
-      "exits": {
-        "north": 1862
-      },
       "weight": 1,
-      "id": 1857,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1858, "name": "Bamboo Forest",
+      "exits": { "southwest": 1834, "west": 1856, "northwest": 1857, "north": 1859 },
       "environment": -1,
-      "exits": {
-        "southwest": 1834,
-        "west": 1856,
-        "northwest": 1857,
-        "north": 1859
-      },
       "weight": 1,
-      "id": 1858,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1859, "name": "Bamboo Forest",
+      "exits": { "west": 1857, "south": 1858, "northwest": 1862, "north": 1860 },
       "environment": -1,
-      "exits": {
-        "west": 1857,
-        "south": 1858,
-        "northwest": 1862,
-        "north": 1860
-      },
       "weight": 1,
-      "id": 1859,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest",
+      "id": 1860, "name": "Bamboo Forest",
+      "exits": { "south": 1859, "southwest": 1857, "west": 1862, "east": 1861, "north": 1853 },
       "environment": -1,
-      "exits": {
-        "south": 1859,
-        "southwest": 1857,
-        "west": 1862,
-        "east": 1861,
-        "north": 1853
-      },
       "weight": 1,
-      "id": 1860,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Bamboo Forest, South of a Monastery",
+      "id": 1861, "name": "Bamboo Forest, South of a Monastery",
+      "exits": { "southwest": 1859, "west": 1860, "north": 1863 },
       "environment": -1,
-      "exits": {
-        "southwest": 1859,
-        "west": 1860,
-        "north": 1863
-      },
       "weight": 1,
-      "id": 1861,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "Chikurin Forest Path",
+      "id": 1862, "name": "Chikurin Forest Path",
+      "exits": { "south": 1857 },
       "environment": -1,
-      "exits": {
-        "south": 1857
-      },
       "weight": 1,
-      "id": 1862,
-      "area": {
-        "id": 37
-      }
+      "area": {"id": 37}
     },
     {
-      "name": "You cross the sharply arching bridge.",
+      "id": 1863, "name": "You cross the sharply arching bridge.",
+      "exits": { "south": 1861, "north": 1864 },
       "environment": -1,
-      "exits": {
-        "south": 1861,
-        "north": 1864
-      },
       "weight": 1,
-      "id": 1863,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
+      "id": 1864, "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
+      "exits": { "south": 1863, "north": 1865 },
       "environment": -1,
-      "exits": {
-        "south": 1863,
-        "north": 1865
-      },
       "weight": 1,
-      "id": 1864,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "You step down into the sandy courtyard.",
+      "id": 1865, "name": "You step down into the sandy courtyard.",
+      "exits": { "south": 1864, "north": 1866 },
       "environment": -1,
-      "exits": {
-        "south": 1864,
-        "north": 1866
-      },
       "weight": 1,
-      "id": 1865,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "Northwest Training Yard",
+      "id": 1866, "name": "Northwest Training Yard",
+      "exits": { "south": 1865, "north": 1867 },
       "environment": -1,
-      "exits": {
-        "south": 1865,
-        "north": 1867
-      },
       "weight": 1,
-      "id": 1866,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "You step up onto the boardwalk that rings the practice yard.",
+      "id": 1867, "name": "You step up onto the boardwalk that rings the practice yard.",
+      "exits": { "south": 1866, "north": 1868 },
       "environment": -1,
-      "exits": {
-        "south": 1866,
-        "north": 1868
-      },
       "weight": 1,
-      "id": 1867,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "You slide back the fusumi with a flick of your hand.",
+      "id": 1868, "name": "You slide back the fusumi with a flick of your hand.",
+      "exits": { "south": 1867 },
       "environment": -1,
-      "exits": {
-        "south": 1867
-      },
       "weight": 1,
-      "id": 1868,
-      "area": {
-        "id": 38
-      }
+      "area": {"id": 38}
     },
     {
-      "name": "down the waterfall.",
+      "id": 1869, "name": "down the waterfall.",
+      "exits": { "down": 1339 },
       "environment": -1,
-      "exits": {
-        "down": 1339
-      },
       "weight": 1,
-      "id": 1869,
-      "area": {
-        "id": 26
-      }
+      "area": {"id": 26}
     },
     {
-      "name": "Armoury",
+      "id": 1870, "name": "Armoury",
+      "exits": { "south": 1086 },
       "environment": -1,
-      "exits": {
-        "south": 1086
-      },
       "weight": 1,
-      "id": 1870,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     },
     {
-      "name": "Stables",
+      "id": 1871, "name": "Stables",
+      "exits": { "north": 1086 },
       "environment": -1,
-      "exits": {
-        "north": 1086
-      },
       "weight": 1,
-      "id": 1871,
-      "area": {
-        "id": 19
-      }
+      "area": {"id": 19}
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/nature-preserve.json
+++ b/maps/nature-preserve.json
@@ -4,588 +4,296 @@
   },
   "rooms": [
     {
-      "name": "Bridge",
-      "exits": {
-        "west": 433
-      },
-      "id": 432
-    },
-    {
-      "name": "Waterfall",
-      "exits": {
-        "east": 432
-      },
-      "id": 433
+      "id": 432, "name": "Bridge",
+      "exits": { "west": 433 }
     },
-    {
-      "name": "",
-      "exits": {
-        "north": 435
-      },
-      "id": 434
+    {
+      "id": 433, "name": "Waterfall",
+      "exits": { "east": 432 }
+    },
+    {
+      "id": 434, "name": "",
+      "exits": { "north": 435 }
+    },
+    {
+      "id": 435, "name": "Canopy Trail",
+      "exits": { "west": 436, "south": 434 }
+    },
+    {
+      "id": 436, "name": "Canopy Trail",
+      "exits": { "east": 435, "west": 437 }
+    },
+    {
+      "id": 437, "name": "Canopy Trail",
+      "exits": { "east": 436, "west": 438 }
+    },
+    {
+      "id": 438, "name": "Canopy Trail",
+      "exits": { "west": 439, "east": 437, "south": 440 }
+    },
+    {
+      "id": 439, "name": "Canopy Trail",
+      "exits": { "east": 438, "west": 445 }
+    },
+    {
+      "id": 440, "name": "Nature Preserve",
+      "exits": { "south": 441, "north": 438 }
+    },
+    {
+      "id": 441, "name": "Tropical Forest",
+      "exits": { "south": 442, "north": 440 }
+    },
+    {
+      "id": 442, "name": "Nature Preserve",
+      "exits": { "west": 443, "east": 444, "north": 441 }
+    },
+    {
+      "id": 443, "name": "Bird Sanctuary",
+      "exits": { "east": 442 }
+    },
+    {
+      "id": 444, "name": "Nature Preserve",
+      "exits": { "west": 442 }
+    },
+    {
+      "id": 445, "name": "Canopy Trail",
+      "exits": { "west": 496, "east": 439, "north": 446 }
+    },
+    {
+      "id": 446, "name": "Entrance to Queen's Meadow",
+      "exits": { "south": 445, "north": 447 }
+    },
+    {
+      "id": 447, "name": "Queen's Meadow",
+      "exits": { "south": 446, "north": 448 }
+    },
+    {
+      "id": 448, "name": "Queen's Meadow",
+      "exits": { "south": 447, "north": 449 }
+    },
+    {
+      "id": 449, "name": "Queen's Meadow",
+      "exits": { "west": 450, "south": 448, "north": 494 }
+    },
+    {
+      "id": 450, "name": "Nature Preserve",
+      "exits": { "east": 449, "west": 451 }
+    },
+    {
+      "id": 451, "name": "Nature Preserve",
+      "exits": { "east": 450, "west": 452 }
+    },
+    {
+      "id": 452, "name": "Nature Preserve",
+      "exits": { "east": 451, "west": 453 }
+    },
+    {
+      "id": 453, "name": "Nature Preserve",
+      "exits": { "south": 455, "east": 452, "north": 454 }
+    },
+    {
+      "id": 454, "name": "Nature Preserve",
+      "exits": { "south": 453 }
+    },
+    {
+      "id": 455, "name": "Nature Preserve",
+      "exits": { "south": 456, "north": 453 }
+    },
+    {
+      "id": 456, "name": "Nature Preserve",
+      "exits": { "west": 457, "north": 455 }
+    },
+    {
+      "id": 457, "name": "Nature Preserve",
+      "exits": { "east": 456, "west": 458 }
+    },
+    {
+      "id": 458, "name": "Nature Preserve",
+      "exits": { "east": 457, "north": 459 }
+    },
+    {
+      "id": 459, "name": "Nature Preserve",
+      "exits": { "south": 458, "north": 460 }
+    },
+    {
+      "id": 460, "name": "Nature Preserve",
+      "exits": { "west": 495, "south": 459, "north": 461 }
+    },
+    {
+      "id": 461, "name": "Nature Preserve",
+      "exits": { "west": 463, "east": 462, "south": 460 }
+    },
+    {
+      "id": 462, "name": "Nature Preserve",
+      "exits": { "west": 461, "north": 464 }
+    },
+    {
+      "id": 463, "name": "Sink Hole",
+      "exits": { "east": 461 }
+    },
+    {
+      "id": 464, "name": "Nature Preserve",
+      "exits": { "west": 486, "east": 465, "south": 462 }
+    },
+    {
+      "id": 465, "name": "Nature Preserve",
+      "exits": { "west": 464, "north": 466 }
+    },
+    {
+      "id": 466, "name": "Nature Preserve",
+      "exits": { "east": 467, "south": 465 }
+    },
+    {
+      "id": 467, "name": "Nature Preserve",
+      "exits": { "east": 468, "west": 466 }
+    },
+    {
+      "id": 468, "name": "Nature Preserve",
+      "exits": { "east": 469, "west": 467 }
+    },
+    {
+      "id": 469, "name": "Nature Preserve",
+      "exits": { "east": 470, "west": 468 }
+    },
+    {
+      "id": 470, "name": "Queen's Meadow",
+      "exits": { "west": 469, "south": 493, "north": 471 }
+    },
+    {
+      "id": 471, "name": "Tropical Landscape",
+      "exits": { "south": 470, "north": 472 }
+    },
+    {
+      "id": 472, "name": "Nature Preserve",
+      "exits": { "south": 471, "north": 473 }
+    },
+    {
+      "id": 473, "name": "Nature Preserve",
+      "exits": { "west": 476, "east": 474, "south": 472 }
+    },
+    {
+      "id": 474, "name": "Nature Preserve",
+      "exits": { "east": 475, "west": 473 }
+    },
+    {
+      "id": 475, "name": "Nature Preserve",
+      "exits": { "west": 474 }
+    },
+    {
+      "id": 476, "name": "Nature Preserve",
+      "exits": { "northwest": 477, "east": 473 }
+    },
+    {
+      "id": 477, "name": "Nature Preserve",
+      "exits": { "southwest": 478, "southeast": 476, "north": 490 }
+    },
+    {
+      "id": 478, "name": "Nature Preserve",
+      "exits": { "west": 479, "northeast": 477 }
+    },
+    {
+      "id": 479, "name": "Nature Preserve",
+      "exits": { "west": 480, "east": 478, "south": 487 }
     },
     {
-      "name": "Canopy Trail",
-      "exits": {
-        "west": 436,
-        "south": 434
-      },
-      "id": 435
+      "id": 480, "name": "Nature Preserve",
+      "exits": { "east": 479, "west": 481 }
     },
     {
-      "name": "Canopy Trail",
-      "exits": {
-        "east": 435,
-        "west": 437
-      },
-      "id": 436
+      "id": 481, "name": "Nature Preserve",
+      "exits": { "east": 480, "south": 482 }
     },
     {
-      "name": "Canopy Trail",
-      "exits": {
-        "east": 436,
-        "west": 438
-      },
-      "id": 437
+      "id": 482, "name": "Nature Preserve",
+      "exits": { "west": 483, "south": 484, "north": 481 }
     },
     {
-      "name": "Canopy Trail",
-      "exits": {
-        "west": 439,
-        "east": 437,
-        "south": 440
-      },
-      "id": 438
+      "id": 483, "name": "Nature Preserve",
+      "exits": { "east": 482 }
     },
-    {
-      "name": "Canopy Trail",
-      "exits": {
-        "east": 438,
-        "west": 445
-      },
-      "id": 439
+    {
+      "id": 484, "name": "Nature Preserve",
+      "exits": { "south": 485, "north": 482 }
+    },
+    {
+      "id": 485, "name": "Nature Preserve",
+      "exits": { "south": 486, "north": 484 }
+    },
+    {
+      "id": 486, "name": "Nature Preserve",
+      "exits": { "east": 464, "north": 485 }
+    },
+    {
+      "id": 487, "name": "Nature Preserve",
+      "exits": { "south": 488, "north": 479 }
+    },
+    {
+      "id": 488, "name": "Nature Preserve",
+      "exits": { "east": 489, "north": 487 }
+    },
+    {
+      "id": 489, "name": "Nature Preserve",
+      "exits": { "west": 488 }
+    },
+    {
+      "id": 490, "name": "Nature Preserve",
+      "exits": { "south": 477, "north": 491 }
+    },
+    {
+      "id": 491, "name": "Nature Preserve",
+      "exits": { "east": 492, "south": 490 }
     },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 441,
-        "north": 438
-      },
-      "id": 440
+    {
+      "id": 492, "name": "A Hollowed Tree",
+      "exits": { "west": 491 }
+    },
+    {
+      "id": 493, "name": "Queen's Meadow",
+      "exits": { "south": 494, "north": 470 }
+    },
+    {
+      "id": 494, "name": "Queen's Meadow",
+      "exits": { "south": 449, "north": 493 }
+    },
+    {
+      "id": 495, "name": "Nature Preserve",
+      "exits": { "east": 460 }
+    },
+    {
+      "id": 496, "name": "Canopy Trail",
+      "exits": { "east": 445, "west": 497 }
     },
-    {
-      "name": "Tropical Forest",
-      "exits": {
-        "south": 442,
-        "north": 440
-      },
-      "id": 441
+    {
+      "id": 497, "name": "Canopy Trail",
+      "exits": { "west": 498, "east": 496, "south": 501 }
     },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 443,
-        "east": 444,
-        "north": 441
-      },
-      "id": 442
-    },
-    {
-      "name": "Bird Sanctuary",
-      "exits": {
-        "east": 442
-      },
-      "id": 443
+    {
+      "id": 498, "name": "Canopy Trail",
+      "exits": { "east": 497, "north": 499 }
     },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 442
-      },
-      "id": 444
+    {
+      "id": 499, "name": "Nature Preserve",
+      "exits": { "east": 500, "south": 498 }
     },
     {
-      "name": "Canopy Trail",
-      "exits": {
-        "west": 496,
-        "east": 439,
-        "north": 446
-      },
-      "id": 445
+      "id": 500, "name": "Dragon's Den",
+      "exits": { "west": 499 }
     },
-    {
-      "name": "Entrance to Queen's Meadow",
-      "exits": {
-        "south": 445,
-        "north": 447
-      },
-      "id": 446
+    {
+      "id": 501, "name": "Nature Preserve",
+      "exits": { "south": 502, "north": 497 }
     },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "south": 446,
-        "north": 448
-      },
-      "id": 447
+    {
+      "id": 502, "name": "Nature Preserve",
+      "exits": { "west": 504, "east": 503, "north": 501 }
     },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "south": 447,
-        "north": 449
-      },
-      "id": 448
+    {
+      "id": 503, "name": "Nature Preserve",
+      "exits": { "west": 502 }
     },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "west": 450,
-        "south": 448,
-        "north": 494
-      },
-      "id": 449
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 449,
-        "west": 451
-      },
-      "id": 450
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 450,
-        "west": 452
-      },
-      "id": 451
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 451,
-        "west": 453
-      },
-      "id": 452
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 455,
-        "east": 452,
-        "north": 454
-      },
-      "id": 453
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 453
-      },
-      "id": 454
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 456,
-        "north": 453
-      },
-      "id": 455
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 457,
-        "north": 455
-      },
-      "id": 456
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 456,
-        "west": 458
-      },
-      "id": 457
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 457,
-        "north": 459
-      },
-      "id": 458
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 458,
-        "north": 460
-      },
-      "id": 459
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 495,
-        "south": 459,
-        "north": 461
-      },
-      "id": 460
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 463,
-        "east": 462,
-        "south": 460
-      },
-      "id": 461
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 461,
-        "north": 464
-      },
-      "id": 462
-    },
-    {
-      "name": "Sink Hole",
-      "exits": {
-        "east": 461
-      },
-      "id": 463
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 486,
-        "east": 465,
-        "south": 462
-      },
-      "id": 464
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 464,
-        "north": 466
-      },
-      "id": 465
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 467,
-        "south": 465
-      },
-      "id": 466
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 468,
-        "west": 466
-      },
-      "id": 467
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 469,
-        "west": 467
-      },
-      "id": 468
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 470,
-        "west": 468
-      },
-      "id": 469
-    },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "west": 469,
-        "south": 493,
-        "north": 471
-      },
-      "id": 470
-    },
-    {
-      "name": "Tropical Landscape",
-      "exits": {
-        "south": 470,
-        "north": 472
-      },
-      "id": 471
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 471,
-        "north": 473
-      },
-      "id": 472
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 476,
-        "east": 474,
-        "south": 472
-      },
-      "id": 473
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 475,
-        "west": 473
-      },
-      "id": 474
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 474
-      },
-      "id": 475
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "northwest": 477,
-        "east": 473
-      },
-      "id": 476
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "southwest": 478,
-        "southeast": 476,
-        "north": 490
-      },
-      "id": 477
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 479,
-        "northeast": 477
-      },
-      "id": 478
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 480,
-        "east": 478,
-        "south": 487
-      },
-      "id": 479
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 479,
-        "west": 481
-      },
-      "id": 480
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 480,
-        "south": 482
-      },
-      "id": 481
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 483,
-        "south": 484,
-        "north": 481
-      },
-      "id": 482
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 482
-      },
-      "id": 483
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 485,
-        "north": 482
-      },
-      "id": 484
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 486,
-        "north": 484
-      },
-      "id": 485
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 464,
-        "north": 485
-      },
-      "id": 486
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 488,
-        "north": 479
-      },
-      "id": 487
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 489,
-        "north": 487
-      },
-      "id": 488
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 488
-      },
-      "id": 489
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 477,
-        "north": 491
-      },
-      "id": 490
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 492,
-        "south": 490
-      },
-      "id": 491
-    },
-    {
-      "name": "A Hollowed Tree",
-      "exits": {
-        "west": 491
-      },
-      "id": 492
-    },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "south": 494,
-        "north": 470
-      },
-      "id": 493
-    },
-    {
-      "name": "Queen's Meadow",
-      "exits": {
-        "south": 449,
-        "north": 493
-      },
-      "id": 494
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 460
-      },
-      "id": 495
-    },
-    {
-      "name": "Canopy Trail",
-      "exits": {
-        "east": 445,
-        "west": 497
-      },
-      "id": 496
-    },
-    {
-      "name": "Canopy Trail",
-      "exits": {
-        "west": 498,
-        "east": 496,
-        "south": 501
-      },
-      "id": 497
-    },
-    {
-      "name": "Canopy Trail",
-      "exits": {
-        "east": 497,
-        "north": 499
-      },
-      "id": 498
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 500,
-        "south": 498
-      },
-      "id": 499
-    },
-    {
-      "name": "Dragon's Den",
-      "exits": {
-        "west": 499
-      },
-      "id": 500
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "south": 502,
-        "north": 497
-      },
-      "id": 501
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 504,
-        "east": 503,
-        "north": 501
-      },
-      "id": 502
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "west": 502
-      },
-      "id": 503
-    },
-    {
-      "name": "Nature Preserve",
-      "exits": {
-        "east": 502
-      },
-      "id": 504
+    {
+      "id": 504, "name": "Nature Preserve",
+      "exits": { "east": 502 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/promenade-des-trafficants.json
+++ b/maps/promenade-des-trafficants.json
@@ -4,131 +4,68 @@
   },
   "rooms": [
     {
-      "name": "Promenade des Trafficants",
-      "exits": {
-        "south": 1147,
-        "north": 1170
-      },
-      "id": 1169
+      "id": 1169, "name": "Promenade des Trafficants",
+      "exits": { "south": 1147, "north": 1170 }
     },
     {
-      "name": "The Promenade's gate",
-      "exits": {
-        "south": 1169,
-        "north": 1171
-      },
-      "id": 1170
+      "id": 1170, "name": "The Promenade's gate",
+      "exits": { "south": 1169, "north": 1171 }
     },
     {
-      "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
-      "exits": {
-        "south": 1170,
-        "east": 1184,
-        "north": 1172
-      },
-      "id": 1171
+      "id": 1171, "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
+      "exits": { "south": 1170, "east": 1184, "north": 1172 }
     },
     {
-      "name": "Moonlit Promenade",
-      "exits": {
-        "west": 1173,
-        "south": 1171,
-        "north": 1174
-      },
-      "id": 1172
+      "id": 1172, "name": "Moonlit Promenade",
+      "exits": { "west": 1173, "south": 1171, "north": 1174 }
     },
     {
-      "name": "Mekalar's Outdoor Gear",
-      "exits": {
-        "east": 1172
-      },
-      "id": 1173
+      "id": 1173, "name": "Mekalar's Outdoor Gear",
+      "exits": { "east": 1172 }
     },
     {
-      "name": "Moonlit Promenade",
-      "exits": {
-        "south": 1172,
-        "east": 1183,
-        "north": 1175
-      },
-      "id": 1174
+      "id": 1174, "name": "Moonlit Promenade",
+      "exits": { "south": 1172, "east": 1183, "north": 1175 }
     },
     {
-      "name": "Middle of the moonlit Promenade",
-      "exits": {
-        "south": 1174,
-        "north": 1176
-      },
-      "id": 1175
+      "id": 1175, "name": "Middle of the moonlit Promenade",
+      "exits": { "south": 1174, "north": 1176 }
     },
     {
-      "name": "Moonlit Promenade",
-      "exits": {
-        "south": 1175,
-        "north": 1177
-      },
-      "id": 1176
+      "id": 1176, "name": "Moonlit Promenade",
+      "exits": { "south": 1175, "north": 1177 }
     },
     {
-      "name": "Moonlit Promenade",
-      "exits": {
-        "west": 1182,
-        "south": 1176,
-        "north": 1178
-      },
-      "id": 1177
+      "id": 1177, "name": "Moonlit Promenade",
+      "exits": { "west": 1182, "south": 1176, "north": 1178 }
     },
     {
-      "name": "Moonlit Promenade",
-      "exits": {
-        "south": 1177,
-        "north": 1179
-      },
-      "id": 1178
+      "id": 1178, "name": "Moonlit Promenade",
+      "exits": { "south": 1177, "north": 1179 }
     },
     {
-      "name": "Northern end of the moonlit Promenade",
-      "exits": {
-        "west": 1181,
-        "south": 1178,
-        "north": 1180
-      },
-      "id": 1179
+      "id": 1179, "name": "Northern end of the moonlit Promenade",
+      "exits": { "west": 1181, "south": 1178, "north": 1180 }
     },
     {
-      "name": "Enchanter's Store",
-      "exits": {
-        "south": 1179
-      },
-      "id": 1180
+      "id": 1180, "name": "Enchanter's Store",
+      "exits": { "south": 1179 }
     },
     {
-      "name": "Gere's Petshop",
-      "exits": {
-        "east": 1179
-      },
-      "id": 1181
+      "id": 1181, "name": "Gere's Petshop",
+      "exits": { "east": 1179 }
     },
     {
-      "name": "Carpenter's shop",
-      "exits": {
-        "east": 1177
-      },
-      "id": 1182
+      "id": 1182, "name": "Carpenter's shop",
+      "exits": { "east": 1177 }
     },
     {
-      "name": "Roget's Furrier",
-      "exits": {
-        "west": 1174
-      },
-      "id": 1183
+      "id": 1183, "name": "Roget's Furrier",
+      "exits": { "west": 1174 }
     },
     {
-      "name": "Volshev's Advertising Agency",
-      "exits": {
-        "west": 1171
-      },
-      "id": 1184
+      "id": 1184, "name": "Volshev's Advertising Agency",
+      "exits": { "west": 1171 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/pylus.json
+++ b/maps/pylus.json
@@ -4,794 +4,400 @@
   },
   "rooms": [
     {
-      "name": "End of Pylus road",
-      "exits": {
-        "south": 1206
-      },
-      "id": 1205
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "south": 1207,
-        "north": 1205
-      },
-      "id": 1206
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "south": 1208,
-        "east": 1212,
-        "north": 1206
-      },
-      "id": 1207
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "west": 1209,
-        "south": 1213,
-        "north": 1207
-      },
-      "id": 1208
-    },
-    {
-      "name": "Freemason's",
-      "exits": {
-        "south": 1210,
-        "east": 1208,
-        "north": 1211
-      },
-      "id": 1209
-    },
-    {
-      "name": "Apprentice's",
-      "exits": {
-        "north": 1209
-      },
-      "id": 1210
-    },
-    {
-      "name": "Master stonemason's",
-      "exits": {
-        "south": 1209
-      },
-      "id": 1211
-    },
-    {
-      "name": "Mausoleum entrance",
-      "exits": {
-        "west": 1207
-      },
-      "id": 1212
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "south": 1214,
-        "north": 1208
-      },
-      "id": 1213
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "south": 1215,
-        "west": 1218,
-        "east": 1219,
-        "north": 1213
-      },
-      "id": 1214
-    },
-    {
-      "name": "Pylus road",
-      "exits": {
-        "southwest": 1216,
-        "east": 1222,
-        "southeast": 1217,
-        "north": 1214
-      },
-      "id": 1215
-    },
-    {
-      "name": "Porch",
-      "exits": {
-        "northeast": 1215
-      },
-      "id": 1216
-    },
-    {
-      "name": "Sanity's Requiem",
-      "exits": {
-        "northwest": 1215
-      },
-      "id": 1217
-    },
-    {
-      "name": "Hall of Bacchus",
-      "exits": {
-        "east": 1214
-      },
-      "id": 1218
-    },
-    {
-      "name": "Triage",
-      "exits": {
-        "west": 1214,
-        "north": 1220
-      },
-      "id": 1219
-    },
-    {
-      "name": "Waiting room",
-      "exits": {
-        "east": 1221,
-        "south": 1219
-      },
-      "id": 1220
-    },
-    {
-      "name": "Operating room",
-      "exits": {
-        "west": 1220
-      },
-      "id": 1221
-    },
-    {
-      "name": "Pylus road checkpoint",
-      "exits": {
-        "east": 1289,
-        "west": 1215
-      },
-      "id": 1222
-    },
-    {
-      "name": "Iola square",
-      "exits": {
-        "west": 1289,
-        "south": 1227,
-        "north": 1225
-      },
-      "id": 1224
-    },
-    {
-      "name": "Iola way",
-      "exits": {
-        "west": 1363,
-        "south": 1224,
-        "north": 1226
-      },
-      "id": 1225
-    },
-    {
-      "name": "Iola way",
-      "exits": {
-        "south": 1225,
-        "north": 1248
-      },
-      "id": 1226
-    },
-    {
-      "name": "Iola way",
-      "exits": {
-        "south": 1228,
-        "west": 1247,
-        "east": 1246,
-        "north": 1224
-      },
-      "id": 1227
-    },
-    {
-      "name": "Iola way",
-      "exits": {
-        "south": 1229,
-        "west": 1244,
-        "east": 1243,
-        "north": 1227
-      },
-      "id": 1228
-    },
-    {
-      "name": "Iola bridge",
-      "exits": {
-        "southwest": 1230,
-        "east": 1231,
-        "north": 1228
-      },
-      "id": 1229
-    },
-    {
-      "name": "Large field",
-      "exits": {
-        "west": 1239,
-        "northeast": 1229
-      },
-      "id": 1230
-    },
-    {
-      "name": "Polema street",
-      "exits": {
-        "west": 1229,
-        "east": 1233,
-        "south": 1232
-      },
-      "id": 1231
-    },
-    {
-      "name": "Gay house",
-      "exits": {
-        "north": 1231
-      },
-      "id": 1232
-    },
-    {
-      "name": "Polema street",
-      "exits": {
-        "south": 1234,
-        "west": 1231,
-        "east": 1235,
-        "north": 1238
-      },
-      "id": 1233
+      "id": 1205, "name": "End of Pylus road",
+      "exits": { "south": 1206 }
     },
     {
-      "name": "Short house",
-      "exits": {
-        "north": 1233
-      },
-      "id": 1234
+      "id": 1206, "name": "Pylus road",
+      "exits": { "south": 1207, "north": 1205 }
     },
     {
-      "name": "Polema street",
-      "exits": {
-        "west": 1233,
-        "east": 1237,
-        "north": 1236
-      },
-      "id": 1235
+      "id": 1207, "name": "Pylus road",
+      "exits": { "south": 1208, "east": 1212, "north": 1206 }
     },
     {
-      "name": "Bright house",
-      "exits": {
-        "south": 1235
-      },
-      "id": 1236
+      "id": 1208, "name": "Pylus road",
+      "exits": { "west": 1209, "south": 1213, "north": 1207 }
     },
     {
-      "name": "Foyer",
-      "exits": {
-        "west": 1235
-      },
-      "id": 1237
+      "id": 1209, "name": "Freemason's",
+      "exits": { "south": 1210, "east": 1208, "north": 1211 }
     },
     {
-      "name": "Tall house",
-      "exits": {
-        "south": 1233
-      },
-      "id": 1238
-    },
+      "id": 1210, "name": "Apprentice's",
+      "exits": { "north": 1209 }
+    },
+    {
+      "id": 1211, "name": "Master stonemason's",
+      "exits": { "south": 1209 }
+    },
+    {
+      "id": 1212, "name": "Mausoleum entrance",
+      "exits": { "west": 1207 }
+    },
+    {
+      "id": 1213, "name": "Pylus road",
+      "exits": { "south": 1214, "north": 1208 }
+    },
+    {
+      "id": 1214, "name": "Pylus road",
+      "exits": { "south": 1215, "west": 1218, "east": 1219, "north": 1213 }
+    },
+    {
+      "id": 1215, "name": "Pylus road",
+      "exits": { "southwest": 1216, "east": 1222, "southeast": 1217, "north": 1214 }
+    },
+    {
+      "id": 1216, "name": "Porch",
+      "exits": { "northeast": 1215 }
+    },
+    {
+      "id": 1217, "name": "Sanity's Requiem",
+      "exits": { "northwest": 1215 }
+    },
+    {
+      "id": 1218, "name": "Hall of Bacchus",
+      "exits": { "east": 1214 }
+    },
+    {
+      "id": 1219, "name": "Triage",
+      "exits": { "west": 1214, "north": 1220 }
+    },
+    {
+      "id": 1220, "name": "Waiting room",
+      "exits": { "east": 1221, "south": 1219 }
+    },
+    {
+      "id": 1221, "name": "Operating room",
+      "exits": { "west": 1220 }
+    },
+    {
+      "id": 1222, "name": "Pylus road checkpoint",
+      "exits": { "east": 1289, "west": 1215 }
+    },
+    {
+      "id": 1224, "name": "Iola square",
+      "exits": { "west": 1289, "south": 1227, "north": 1225 }
+    },
+    {
+      "id": 1225, "name": "Iola way",
+      "exits": { "west": 1363, "south": 1224, "north": 1226 }
+    },
+    {
+      "id": 1226, "name": "Iola way",
+      "exits": { "south": 1225, "north": 1248 }
+    },
+    {
+      "id": 1227, "name": "Iola way",
+      "exits": { "south": 1228, "west": 1247, "east": 1246, "north": 1224 }
+    },
+    {
+      "id": 1228, "name": "Iola way",
+      "exits": { "south": 1229, "west": 1244, "east": 1243, "north": 1227 }
+    },
+    {
+      "id": 1229, "name": "Iola bridge",
+      "exits": { "southwest": 1230, "east": 1231, "north": 1228 }
+    },
+    {
+      "id": 1230, "name": "Large field",
+      "exits": { "west": 1239, "northeast": 1229 }
+    },
+    {
+      "id": 1231, "name": "Polema street",
+      "exits": { "west": 1229, "east": 1233, "south": 1232 }
+    },
+    {
+      "id": 1232, "name": "Gay house",
+      "exits": { "north": 1231 }
+    },
+    {
+      "id": 1233, "name": "Polema street",
+      "exits": { "south": 1234, "west": 1231, "east": 1235, "north": 1238 }
+    },
+    {
+      "id": 1234, "name": "Short house",
+      "exits": { "north": 1233 }
+    },
+    {
+      "id": 1235, "name": "Polema street",
+      "exits": { "west": 1233, "east": 1237, "north": 1236 }
+    },
+    {
+      "id": 1236, "name": "Bright house",
+      "exits": { "south": 1235 }
+    },
+    {
+      "id": 1237, "name": "Foyer",
+      "exits": { "west": 1235 }
+    },
+    {
+      "id": 1238, "name": "Tall house",
+      "exits": { "south": 1233 }
+    },
+    {
+      "id": 1239, "name": "Gymnasium foyer",
+      "exits": { "west": 1240, "east": 1230, "south": 1241 }
+    },
+    {
+      "id": 1240, "name": "Changing room",
+      "exits": { "east": 1239 }
+    },
+    {
+      "id": 1241, "name": "Gymnasium hallway",
+      "exits": { "south": 1242, "north": 1239 }
+    },
+    {
+      "id": 1242, "name": "Natatorium",
+      "exits": { "north": 1241 }
+    },
+    {
+      "id": 1243, "name": "Vegetable seller's",
+      "exits": { "west": 1228 }
+    },
+    {
+      "id": 1244, "name": "Herbarium",
+      "exits": { "east": 1228, "south": 1245 }
+    },
+    {
+      "id": 1245, "name": "Herb garden",
+      "exits": { "north": 1244 }
+    },
+    {
+      "id": 1246, "name": "Butcher shop",
+      "exits": { "west": 1227 }
+    },
+    {
+      "id": 1247, "name": "Guild/Shop Space for rent",
+      "exits": { "east": 1227 }
+    },
+    {
+      "id": 1248, "name": "Iola way",
+      "exits": { "west": 1249, "east": 1252, "south": 1226 }
+    },
+    {
+      "id": 1249, "name": "Garden entry",
+      "exits": { "east": 1248, "north": 1250 }
+    },
+    {
+      "id": 1250, "name": "Garden clearing",
+      "exits": { "west": 1251, "south": 1249 }
+    },
+    {
+      "id": 1251, "name": "Entry to akademos",
+      "exits": { "east": 1250, "west": 1374 }
+    },
+    {
+      "id": 1252, "name": "Ithsma street",
+      "exits": { "east": 1253, "west": 1248 }
+    },
+    {
+      "id": 1253, "name": "Ithsma street",
+      "exits": { "west": 1252, "east": 1255, "south": 1254 }
+    },
+    {
+      "id": 1254, "name": "Short path",
+      "exits": { "south": 1375, "north": 1253 }
+    },
+    {
+      "id": 1255, "name": "Ithsma street",
+      "exits": { "west": 1253, "east": 1389, "north": 1256 }
+    },
+    {
+      "id": 1256, "name": "Before the Palace",
+      "exits": { "south": 1255, "north": 1257 }
+    },
+    {
+      "id": 1257, "name": "Threshold to the Grand Rotunda",
+      "exits": { "south": 1256, "north": 1258 }
+    },
+    {
+      "id": 1258, "name": "Grand Rotunda",
+      "exits": { "west": 1259, "east": 1362, "south": 1257 }
+    },
+    {
+      "id": 1259, "name": "Administrative hallway",
+      "exits": { "west": 1261, "east": 1258, "north": 1260 }
+    },
+    {
+      "id": 1260, "name": "Office of the Magistrate",
+      "exits": { "south": 1259 }
+    },
+    {
+      "id": 1261, "name": "Administrative hallway",
+      "exits": { "west": 1262, "east": 1259, "south": 1391 }
+    },
+    {
+      "id": 1262, "name": "Royal Throne Room",
+      "exits": { "east": 1261 }
+    },
+    {
+      "id": 1289, "name": "Gate of Triumph",
+      "exits": { "south": 1290, "west": 1222, "east": 1224, "north": 1291 }
+    },
+    {
+      "id": 1290, "name": "Southern niche",
+      "exits": { "north": 1289 }
+    },
+    {
+      "id": 1291, "name": "Northern niche",
+      "exits": { "south": 1289 }
+    },
+    {
+      "id": 1362, "name": "Guard Post",
+      "exits": { "west": 1258, "east": 1392, "north": 1395 }
+    },
+    {
+      "id": 1363, "name": "Doorway",
+      "exits": { "east": 1225, "west": 1364 }
+    },
+    {
+      "id": 1364, "name": "Statued hallway",
+      "exits": { "east": 1363, "west": 1365 }
+    },
+    {
+      "id": 1365, "name": "Hallway",
+      "exits": { "west": 1366, "east": 1364, "north": 1367 }
+    },
+    {
+      "id": 1366, "name": "Captain's office",
+      "exits": { "east": 1365 }
+    },
     {
-      "name": "Gymnasium foyer",
-      "exits": {
-        "west": 1240,
-        "east": 1230,
-        "south": 1241
-      },
-      "id": 1239
+      "id": 1367, "name": "Courtyard",
+      "exits": { "south": 1365, "north": 1368 }
     },
     {
-      "name": "Changing room",
-      "exits": {
-        "east": 1239
-      },
-      "id": 1240
-    },
-    {
-      "name": "Gymnasium hallway",
-      "exits": {
-        "south": 1242,
-        "north": 1239
-      },
-      "id": 1241
-    },
-    {
-      "name": "Natatorium",
-      "exits": {
-        "north": 1241
-      },
-      "id": 1242
-    },
-    {
-      "name": "Vegetable seller's",
-      "exits": {
-        "west": 1228
-      },
-      "id": 1243
-    },
-    {
-      "name": "Herbarium",
-      "exits": {
-        "east": 1228,
-        "south": 1245
-      },
-      "id": 1244
-    },
-    {
-      "name": "Herb garden",
-      "exits": {
-        "north": 1244
-      },
-      "id": 1245
+      "id": 1368, "name": "Courtyard",
+      "exits": { "south": 1367, "north": 1369 }
     },
-    {
-      "name": "Butcher shop",
-      "exits": {
-        "west": 1227
-      },
-      "id": 1246
-    },
     {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "east": 1227
-      },
-      "id": 1247
-    },
-    {
-      "name": "Iola way",
-      "exits": {
-        "west": 1249,
-        "east": 1252,
-        "south": 1226
-      },
-      "id": 1248
-    },
+      "id": 1369, "name": "Hallway",
+      "exits": { "up": 1373, "west": 1370, "east": 1371, "south": 1368 }
+    },
+    {
+      "id": 1370, "name": "West wing",
+      "exits": { "east": 1369 }
+    },
+    {
+      "id": 1371, "name": "East wing",
+      "exits": { "west": 1369, "south": 1372 }
+    },
+    {
+      "id": 1372, "name": "East wing hallway",
+      "exits": { "north": 1371 }
+    },
+    {
+      "id": 1373, "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
+      "exits": { "down": 1369 }
+    },
+    {
+      "id": 1374, "name": "Akademos",
+      "exits": { "east": 1251 }
+    },
+    {
+      "id": 1375, "name": "Temple entry",
+      "exits": { "south": 1376, "north": 1254 }
+    },
     {
-      "name": "Garden entry",
-      "exits": {
-        "east": 1248,
-        "north": 1250
-      },
-      "id": 1249
-    },
-    {
-      "name": "Garden clearing",
-      "exits": {
-        "west": 1251,
-        "south": 1249
-      },
-      "id": 1250
-    },
+      "id": 1376, "name": "Temple rotunda",
+      "exits": { "south": 1377, "west": 1381, "east": 1384, "north": 1375 }
+    },
     {
-      "name": "Entry to akademos",
-      "exits": {
-        "east": 1250,
-        "west": 1374
-      },
-      "id": 1251
-    },
-    {
-      "name": "Ithsma street",
-      "exits": {
-        "east": 1253,
-        "west": 1248
-      },
-      "id": 1252
-    },
-    {
-      "name": "Ithsma street",
-      "exits": {
-        "west": 1252,
-        "east": 1255,
-        "south": 1254
-      },
-      "id": 1253
+      "id": 1377, "name": "Temple hallway",
+      "exits": { "south": 1378, "north": 1376 }
     },
-    {
-      "name": "Short path",
-      "exits": {
-        "south": 1375,
-        "north": 1253
-      },
-      "id": 1254
-    },
-    {
-      "name": "Ithsma street",
-      "exits": {
-        "west": 1253,
-        "east": 1389,
-        "north": 1256
-      },
-      "id": 1255
-    },
-    {
-      "name": "Before the Palace",
-      "exits": {
-        "south": 1255,
-        "north": 1257
-      },
-      "id": 1256
-    },
-    {
-      "name": "Threshold to the Grand Rotunda",
-      "exits": {
-        "south": 1256,
-        "north": 1258
-      },
-      "id": 1257
-    },
-    {
-      "name": "Grand Rotunda",
-      "exits": {
-        "west": 1259,
-        "east": 1362,
-        "south": 1257
-      },
-      "id": 1258
-    },
-    {
-      "name": "Administrative hallway",
-      "exits": {
-        "west": 1261,
-        "east": 1258,
-        "north": 1260
-      },
-      "id": 1259
-    },
-    {
-      "name": "Office of the Magistrate",
-      "exits": {
-        "south": 1259
-      },
-      "id": 1260
-    },
-    {
-      "name": "Administrative hallway",
-      "exits": {
-        "west": 1262,
-        "east": 1259,
-        "south": 1391
-      },
-      "id": 1261
-    },
-    {
-      "name": "Royal Throne Room",
-      "exits": {
-        "east": 1261
-      },
-      "id": 1262
-    },
-    {
-      "name": "Gate of Triumph",
-      "exits": {
-        "south": 1290,
-        "west": 1222,
-        "east": 1224,
-        "north": 1291
-      },
-      "id": 1289
-    },
-    {
-      "name": "Southern niche",
-      "exits": {
-        "north": 1289
-      },
-      "id": 1290
-    },
-    {
-      "name": "Northern niche",
-      "exits": {
-        "south": 1289
-      },
-      "id": 1291
-    },
-    {
-      "name": "Guard Post",
-      "exits": {
-        "west": 1258,
-        "east": 1392,
-        "north": 1395
-      },
-      "id": 1362
-    },
-    {
-      "name": "Doorway",
-      "exits": {
-        "east": 1225,
-        "west": 1364
-      },
-      "id": 1363
-    },
-    {
-      "name": "Statued hallway",
-      "exits": {
-        "east": 1363,
-        "west": 1365
-      },
-      "id": 1364
-    },
-    {
-      "name": "Hallway",
-      "exits": {
-        "west": 1366,
-        "east": 1364,
-        "north": 1367
-      },
-      "id": 1365
-    },
-    {
-      "name": "Captain's office",
-      "exits": {
-        "east": 1365
-      },
-      "id": 1366
-    },
-    {
-      "name": "Courtyard",
-      "exits": {
-        "south": 1365,
-        "north": 1368
-      },
-      "id": 1367
-    },
-    {
-      "name": "Courtyard",
-      "exits": {
-        "south": 1367,
-        "north": 1369
-      },
-      "id": 1368
-    },
-    {
-      "name": "Hallway",
-      "exits": {
-        "up": 1373,
-        "west": 1370,
-        "east": 1371,
-        "south": 1368
-      },
-      "id": 1369
-    },
-    {
-      "name": "West wing",
-      "exits": {
-        "east": 1369
-      },
-      "id": 1370
-    },
-    {
-      "name": "East wing",
-      "exits": {
-        "west": 1369,
-        "south": 1372
-      },
-      "id": 1371
-    },
-    {
-      "name": "East wing hallway",
-      "exits": {
-        "north": 1371
-      },
-      "id": 1372
-    },
-    {
-      "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
-      "exits": {
-        "down": 1369
-      },
-      "id": 1373
-    },
-    {
-      "name": "Akademos",
-      "exits": {
-        "east": 1251
-      },
-      "id": 1374
-    },
-    {
-      "name": "Temple entry",
-      "exits": {
-        "south": 1376,
-        "north": 1254
-      },
-      "id": 1375
-    },
-    {
-      "name": "Temple rotunda",
-      "exits": {
-        "south": 1377,
-        "west": 1381,
-        "east": 1384,
-        "north": 1375
-      },
-      "id": 1376
-    },
-    {
-      "name": "Temple hallway",
-      "exits": {
-        "south": 1378,
-        "north": 1376
-      },
-      "id": 1377
-    },
     {
-      "name": "End of temple hallway",
-      "exits": {
-        "west": 1380,
-        "east": 1379,
-        "north": 1377
-      },
-      "id": 1378
+      "id": 1378, "name": "End of temple hallway",
+      "exits": { "west": 1380, "east": 1379, "north": 1377 }
     },
     {
-      "name": "Folio depository",
-      "exits": {
-        "west": 1378
-      },
-      "id": 1379
-    },
+      "id": 1379, "name": "Folio depository",
+      "exits": { "west": 1378 }
+    },
     {
-      "name": "Reliquary",
-      "exits": {
-        "east": 1378
-      },
-      "id": 1380
-    },
+      "id": 1380, "name": "Reliquary",
+      "exits": { "east": 1378 }
+    },
     {
-      "name": "Hall of Peace",
-      "exits": {
-        "east": 1376,
-        "west": 1382
-      },
-      "id": 1381
+      "id": 1381, "name": "Hall of Peace",
+      "exits": { "east": 1376, "west": 1382 }
     },
     {
-      "name": "Hall of Peace",
-      "exits": {
-        "west": 1383,
-        "east": 1381,
-        "south": 1387
-      },
-      "id": 1382
+      "id": 1382, "name": "Hall of Peace",
+      "exits": { "west": 1383, "east": 1381, "south": 1387 }
     },
     {
-      "name": "Rotunda of Peace",
-      "exits": {
-        "east": 1382
-      },
-      "id": 1383
-    },
+      "id": 1383, "name": "Rotunda of Peace",
+      "exits": { "east": 1382 }
+    },
     {
-      "name": "Hall of War",
-      "exits": {
-        "west": 1376,
-        "east": 1385,
-        "south": 1388
-      },
-      "id": 1384
+      "id": 1384, "name": "Hall of War",
+      "exits": { "west": 1376, "east": 1385, "south": 1388 }
     },
     {
-      "name": "Hall of War",
-      "exits": {
-        "east": 1386,
-        "west": 1384
-      },
-      "id": 1385
+      "id": 1385, "name": "Hall of War",
+      "exits": { "east": 1386, "west": 1384 }
     },
     {
-      "name": "Rotunda of War",
-      "exits": {
-        "west": 1385
-      },
-      "id": 1386
+      "id": 1386, "name": "Rotunda of War",
+      "exits": { "west": 1385 }
     },
     {
-      "name": "Chapel of Peace",
-      "exits": {
-        "north": 1382
-      },
-      "id": 1387
+      "id": 1387, "name": "Chapel of Peace",
+      "exits": { "north": 1382 }
     },
     {
-      "name": "Chapel of War",
-      "exits": {
-        "north": 1384
-      },
-      "id": 1388
+      "id": 1388, "name": "Chapel of War",
+      "exits": { "north": 1384 }
     },
     {
-      "name": "Ithsma street",
-      "exits": {
-        "east": 1390,
-        "west": 1255
-      },
-      "id": 1389
+      "id": 1389, "name": "Ithsma street",
+      "exits": { "east": 1390, "west": 1255 }
     },
     {
-      "name": "End of Ithsma street",
-      "exits": {
-        "west": 1389
-      },
-      "id": 1390
+      "id": 1390, "name": "End of Ithsma street",
+      "exits": { "west": 1389 }
     },
     {
-      "name": "Office of the Secretary",
-      "exits": {
-        "north": 1261
-      },
-      "id": 1391
+      "id": 1391, "name": "Office of the Secretary",
+      "exits": { "north": 1261 }
     },
     {
-      "name": "Formal gardens",
-      "exits": {
-        "west": 1362,
-        "east": 1393,
-        "south": 1394
-      },
-      "id": 1392
+      "id": 1392, "name": "Formal gardens",
+      "exits": { "west": 1362, "east": 1393, "south": 1394 }
     },
     {
-      "name": "A private corner in the garden",
-      "exits": {
-        "west": 1392
-      },
-      "id": 1393
+      "id": 1393, "name": "A private corner in the garden",
+      "exits": { "west": 1392 }
     },
     {
-      "name": "A private corner in the garden",
-      "exits": {
-        "north": 1392
-      },
-      "id": 1394
+      "id": 1394, "name": "A private corner in the garden",
+      "exits": { "north": 1392 }
     },
     {
-      "name": "Residential hallway",
-      "exits": {
-        "east": 1396,
-        "south": 1362
-      },
-      "id": 1395
+      "id": 1395, "name": "Residential hallway",
+      "exits": { "east": 1396, "south": 1362 }
     },
     {
-      "name": "Residential hallway",
-      "exits": {
-        "west": 1395,
-        "east": 1397,
-        "north": 1398
-      },
-      "id": 1396
+      "id": 1396, "name": "Residential hallway",
+      "exits": { "west": 1395, "east": 1397, "north": 1398 }
     },
     {
-      "name": "The harem",
-      "exits": {
-        "west": 1396,
-        "north": 1400
-      },
-      "id": 1397
+      "id": 1397, "name": "The harem",
+      "exits": { "west": 1396, "north": 1400 }
     },
     {
-      "name": "The Royal Chambers",
-      "exits": {
-        "west": 1399,
-        "south": 1396
-      },
-      "id": 1398
+      "id": 1398, "name": "The Royal Chambers",
+      "exits": { "west": 1399, "south": 1396 }
     },
     {
-      "name": "The royal dressing room",
-      "exits": {
-        "east": 1398
-      },
-      "id": 1399
+      "id": 1399, "name": "The royal dressing room",
+      "exits": { "east": 1398 }
     },
     {
-      "name": "The Consort's chambers",
-      "exits": {
-        "south": 1397
-      },
-      "id": 1400
+      "id": 1400, "name": "The Consort's chambers",
+      "exits": { "south": 1397 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/vesla.json
+++ b/maps/vesla.json
@@ -4,2332 +4,1132 @@
   },
   "rooms": [
     {
-      "name": "The Gate to the Wilderness",
-      "exits": {
-        "west": 116
-      },
-      "id": 115
-    },
-    {
-      "name": "Intersection of Park Street and Caravan Road",
-      "exits": {
-        "south": 233,
-        "west": 117,
-        "east": 115,
-        "north": 172
-      },
-      "id": 116
-    },
-    {
-      "name": "Intersection of Park Street and Via Sacra",
-      "exits": {
-        "south": 220,
-        "west": 118,
-        "east": 116,
-        "north": 226
-      },
-      "id": 117
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "south": 221,
-        "west": 119,
-        "east": 117,
-        "north": 227
-      },
-      "id": 118
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "south": 222,
-        "west": 120,
-        "east": 118,
-        "north": 230
-      },
-      "id": 119
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "west": 121,
-        "east": 119,
-        "south": 223
-      },
-      "id": 120
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "south": 224,
-        "west": 122,
-        "east": 120,
-        "north": 425
-      },
-      "id": 121
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "south": 225,
-        "west": 123,
-        "east": 121,
-        "north": 410
-      },
-      "id": 122
-    },
-    {
-      "name": "A shaded walk",
-      "exits": {
-        "west": 124,
-        "east": 122,
-        "north": 411
-      },
-      "id": 123
-    },
-    {
-      "name": "A break in the coverage",
-      "exits": {
-        "west": 125,
-        "east": 123,
-        "north": 412
-      },
-      "id": 124
-    },
-    {
-      "name": "A busy intersection",
-      "exits": {
-        "south": 159,
-        "west": 126,
-        "east": 124,
-        "north": 160
-      },
-      "id": 125
-    },
-    {
-      "name": "The end of the park street",
-      "exits": {
-        "south": 880,
-        "west": 127,
-        "east": 125,
-        "north": 879
-      },
-      "id": 126
-    },
-    {
-      "name": "Entrance to the Old City.",
-      "exits": {
-        "west": 128,
-        "east": 126,
-        "north": 878
-      },
-      "id": 127
-    },
-    {
-      "name": "Westroad, The Entrance to the Old City.",
-      "exits": {
-        "west": 129,
-        "east": 127,
-        "north": 881
-      },
-      "id": 128
-    },
-    {
-      "name": "Westroad",
-      "exits": {
-        "west": 130,
-        "east": 128,
-        "south": 419
-      },
-      "id": 129
-    },
-    {
-      "name": "Westroad",
-      "exits": {
-        "west": 131,
-        "east": 129,
-        "south": 420
-      },
-      "id": 130
-    },
-    {
-      "name": "Westroad",
-      "exits": {
-        "west": 132,
-        "east": 130,
-        "north": 858
-      },
-      "id": 131
-    },
-    {
-      "name": "Westroad",
-      "exits": {
-        "west": 133,
-        "east": 131,
-        "south": 421
-      },
-      "id": 132
-    },
-    {
-      "name": "The corner of Westroad and Basalt Avenue",
-      "exits": {
-        "west": 134,
-        "east": 132,
-        "south": 135
-      },
-      "id": 133
-    },
-    {
-      "name": "Western Gate of Vesla",
-      "exits": {
-        "east": 133
-      },
-      "id": 134
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 136,
-        "north": 133
-      },
-      "id": 135
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 137,
-        "north": 135
-      },
-      "id": 136
-    },
-    {
-      "name": "Intersection of Basalt Avenue and Rapier Way",
-      "exits": {
-        "south": 138,
-        "east": 193,
-        "north": 136
-      },
-      "id": 137
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 139,
-        "west": 856,
-        "east": 855,
-        "north": 137
-      },
-      "id": 138
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 140,
-        "west": 853,
-        "east": 854,
-        "north": 138
-      },
-      "id": 139
-    },
-    {
-      "name": "Intersection of Basalt Avenue and Street of the Bells",
-      "exits": {
-        "south": 141,
-        "east": 204,
-        "north": 139
-      },
-      "id": 140
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 142,
-        "north": 140
-      },
-      "id": 141
-    },
-    {
-      "name": "Basalt Avenue",
-      "exits": {
-        "south": 143,
-        "east": 850,
-        "north": 141
-      },
-      "id": 142
-    },
-    {
-      "name": "Corner of Basalt Avenue and West River Street",
-      "exits": {
-        "east": 144,
-        "north": 142
-      },
-      "id": 143
-    },
-    {
-      "name": "West River Street",
-      "exits": {
-        "west": 143,
-        "east": 145,
-        "south": 847
-      },
-      "id": 144
-    },
-    {
-      "name": "West River Street",
-      "exits": {
-        "east": 146,
-        "west": 144
-      },
-      "id": 145
-    },
-    {
-      "name": "West River Street",
-      "exits": {
-        "south": 845,
-        "west": 145,
-        "east": 147,
-        "north": 842
-      },
-      "id": 146
-    },
-    {
-      "name": "West River Street",
-      "exits": {
-        "south": 846,
-        "west": 146,
-        "east": 148,
-        "north": 841
-      },
-      "id": 147
-    },
-    {
-      "name": "West River Street",
-      "exits": {
-        "west": 147,
-        "east": 149,
-        "north": 840
-      },
-      "id": 148
-    },
-    {
-      "name": "West River street",
-      "exits": {
-        "east": 150,
-        "west": 148
-      },
-      "id": 149
-    },
-    {
-      "name": "West River street",
-      "exits": {
-        "east": 151,
-        "west": 149
-      },
-      "id": 150
-    },
-    {
-      "name": "River Street and South Main",
-      "exits": {
-        "south": 816,
-        "west": 150,
-        "east": 205,
-        "north": 152
-      },
-      "id": 151
-    },
-    {
-      "name": "South Main street",
-      "exits": {
-        "south": 151,
-        "west": 819,
-        "east": 817,
-        "north": 153
-      },
-      "id": 152
-    },
-    {
-      "name": "South Main Street",
-      "exits": {
-        "west": 820,
-        "south": 152,
-        "north": 154
-      },
-      "id": 153
-    },
-    {
-      "name": "South Main Street",
-      "exits": {
-        "south": 153,
-        "east": 821,
-        "north": 155
-      },
-      "id": 154
-    },
-    {
-      "name": "South Main Street",
-      "exits": {
-        "south": 154,
-        "west": 423,
-        "east": 422,
-        "north": 156
-      },
-      "id": 155
-    },
-    {
-      "name": "South Main Street",
-      "exits": {
-        "south": 155,
-        "west": 822,
-        "east": 424,
-        "north": 157
-      },
-      "id": 156
-    },
-    {
-      "name": "South Main Street",
-      "exits": {
-        "south": 156,
-        "west": 823,
-        "east": 830,
-        "north": 158
-      },
-      "id": 157
-    },
-    {
-      "name": "South Main street",
-      "exits": {
-        "west": 824,
-        "south": 157,
-        "north": 159
-      },
-      "id": 158
-    },
-    {
-      "name": "South Main street",
-      "exits": {
-        "south": 158,
-        "north": 125
-      },
-      "id": 159
-    },
-    {
-      "name": "Northern Main",
-      "exits": {
-        "south": 125,
-        "east": 412,
-        "north": 161
-      },
-      "id": 160
-    },
-    {
-      "name": "Northern Main Street",
-      "exits": {
-        "south": 160,
-        "east": 808,
-        "north": 162
-      },
-      "id": 161
-    },
-    {
-      "name": "Northern Main street",
-      "exits": {
-        "south": 161,
-        "east": 810,
-        "north": 163
-      },
-      "id": 162
-    },
-    {
-      "name": "Northern Main Street",
-      "exits": {
-        "south": 162,
-        "east": 811,
-        "north": 164
-      },
-      "id": 163
-    },
-    {
-      "name": "Northern Main street",
-      "exits": {
-        "south": 163,
-        "east": 812,
-        "north": 165
-      },
-      "id": 164
-    },
-    {
-      "name": "Northern Main street",
-      "exits": {
-        "south": 164,
-        "north": 166
-      },
-      "id": 165
-    },
-    {
-      "name": "Intersection of North Main and Scholar's Way",
-      "exits": {
-        "south": 165,
-        "east": 192,
-        "north": 167
-      },
-      "id": 166
-    },
-    {
-      "name": "Northern Main street",
-      "exits": {
-        "south": 166,
-        "north": 168
-      },
-      "id": 167
-    },
-    {
-      "name": "Intersection of North Main and Wall Street",
-      "exits": {
-        "south": 167,
-        "west": 793,
-        "east": 170,
-        "north": 169
-      },
-      "id": 168
-    },
-    {
-      "name": "Northern Gate",
-      "exits": {
-        "south": 168,
-        "northeast": 753
-      },
-      "id": 169
-    },
-    {
-      "name": "Western End of Wall Street",
-      "exits": {
-        "east": 171,
-        "west": 168
-      },
-      "id": 170
-    },
-    {
-      "name": "Wall Street",
-      "exits": {
-        "west": 170
-      },
-      "id": 171
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 116,
-        "west": 226,
-        "east": 735,
-        "north": 173
-      },
-      "id": 172
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 172,
-        "west": 232,
-        "east": 736,
-        "north": 174
-      },
-      "id": 173
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 173,
-        "north": 175
-      },
-      "id": 174
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 174,
-        "north": 176
-      },
-      "id": 175
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 175,
-        "north": 177
-      },
-      "id": 176
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 176,
-        "north": 178
-      },
-      "id": 177
-    },
-    {
-      "name": "Intersection of Scholar's Way and Caravan Road",
-      "exits": {
-        "west": 185,
-        "south": 177,
-        "north": 179
-      },
-      "id": 178
-    },
-    {
-      "name": "Caravan Road",
-      "exits": {
-        "south": 178,
-        "north": 180
-      },
-      "id": 179
-    },
-    {
-      "name": "Intersection of Caravan Road and Wall Street",
-      "exits": {
-        "west": 181,
-        "south": 179
-      },
-      "id": 180
-    },
-    {
-      "name": "Eastern End of Wall Street",
-      "exits": {
-        "east": 180,
-        "west": 182
-      },
-      "id": 181
-    },
-    {
-      "name": "Wall Street",
-      "exits": {
-        "east": 181,
-        "west": 183
-      },
-      "id": 182
-    },
-    {
-      "name": "Wall Street",
-      "exits": {
-        "east": 182,
-        "west": 184
-      },
-      "id": 183
-    },
-    {
-      "name": "Wall Street",
-      "exits": {
-        "east": 183
-      },
-      "id": 184
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "east": 178,
-        "west": 186
-      },
-      "id": 185
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "east": 185,
-        "west": 187
-      },
-      "id": 186
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "west": 188,
-        "east": 186,
-        "north": 737
-      },
-      "id": 187
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "west": 189,
-        "east": 187,
-        "north": 738
-      },
-      "id": 188
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "west": 190,
-        "east": 188,
-        "south": 739
-      },
-      "id": 189
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "south": 740,
-        "west": 191,
-        "east": 189,
-        "north": 741
-      },
-      "id": 190
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "south": 742,
-        "west": 192,
-        "east": 190,
-        "north": 743
-      },
-      "id": 191
-    },
-    {
-      "name": "Scholar's Way",
-      "exits": {
-        "west": 166,
-        "east": 191,
-        "south": 744
-      },
-      "id": 192
-    },
-    {
-      "name": "Rapier Way",
-      "exits": {
-        "east": 194,
-        "west": 137
-      },
-      "id": 193
-    },
-    {
-      "name": "Rapier Way",
-      "exits": {
-        "east": 195,
-        "west": 193
-      },
-      "id": 194
-    },
-    {
-      "name": "Rapier Way",
-      "exits": {
-        "east": 196,
-        "west": 194
-      },
-      "id": 195
-    },
-    {
-      "name": "Rapier Way",
-      "exits": {
-        "east": 197,
-        "west": 195
-      },
-      "id": 196
-    },
-    {
-      "name": "Intersection of Rapier Way and Zand Boulevard",
-      "exits": {
-        "west": 196,
-        "south": 198
-      },
-      "id": 197
-    },
-    {
-      "name": "Zand Boulevard",
-      "exits": {
-        "south": 199,
-        "east": 857,
-        "north": 197
-      },
-      "id": 198
-    },
-    {
-      "name": "Zand Boulevard",
-      "exits": {
-        "south": 200,
-        "east": 962,
-        "north": 198
-      },
-      "id": 199
-    },
-    {
-      "name": "Intersection of Street of the Bells and Zand Boulevard",
-      "exits": {
-        "west": 201,
-        "north": 199
-      },
-      "id": 200
-    },
-    {
-      "name": "Street of the Bells",
-      "exits": {
-        "south": 843,
-        "west": 202,
-        "east": 200,
-        "north": 931
-      },
-      "id": 201
-    },
-    {
-      "name": "Street of the Bells",
-      "exits": {
-        "west": 203,
-        "east": 201,
-        "south": 844
-      },
-      "id": 202
-    },
-    {
-      "name": "Street of the Bells",
-      "exits": {
-        "east": 202,
-        "west": 204
-      },
-      "id": 203
-    },
-    {
-      "name": "Street of the Bells",
-      "exits": {
-        "east": 203,
-        "west": 140
-      },
-      "id": 204
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "east": 206,
-        "west": 151
-      },
-      "id": 205
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "west": 205,
-        "east": 207,
-        "north": 397
-      },
-      "id": 206
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "east": 208,
-        "west": 206
-      },
-      "id": 207
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "west": 207,
-        "east": 209,
-        "north": 396
-      },
-      "id": 208
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "west": 208,
-        "east": 210,
-        "north": 395
-      },
-      "id": 209
-    },
-    {
-      "name": "East River Street",
-      "exits": {
-        "west": 209,
-        "east": 211,
-        "north": 394
-      },
-      "id": 210
-    },
-    {
-      "name": "End of East River Street",
-      "exits": {
-        "east": 212,
-        "west": 210
-      },
-      "id": 211
-    },
-    {
-      "name": "Intersection of Via Sacra and River Street",
-      "exits": {
-        "west": 211,
-        "north": 213
-      },
-      "id": 212
-    },
-    {
-      "name": "South End of Via Sacra",
-      "exits": {
-        "south": 212,
-        "east": 399,
-        "north": 214
-      },
-      "id": 213
-    },
-    {
-      "name": "Southern Via Sacra",
-      "exits": {
-        "south": 213,
-        "west": 400,
-        "east": 401,
-        "north": 215
-      },
-      "id": 214
-    },
-    {
-      "name": "Via Sacra",
-      "exits": {
-        "south": 214,
-        "north": 216
-      },
-      "id": 215
-    },
-    {
-      "name": "Via Sacra",
-      "exits": {
-        "south": 215,
-        "west": 402,
-        "east": 403,
-        "north": 217
-      },
-      "id": 216
-    },
-    {
-      "name": "Via Sacra",
-      "exits": {
-        "west": 408,
-        "south": 216,
-        "north": 218
-      },
-      "id": 217
-    },
-    {
-      "name": "Via Sacra",
-      "exits": {
-        "south": 217,
-        "north": 219
-      },
-      "id": 218
-    },
-    {
-      "name": "Via Sacra",
-      "exits": {
-        "west": 409,
-        "south": 218,
-        "north": 220
-      },
-      "id": 219
-    },
-    {
-      "name": "Northern End of Via Sacra",
-      "exits": {
-        "south": 219,
-        "west": 221,
-        "east": 233,
-        "north": 117
-      },
-      "id": 220
-    },
-    {
-      "name": "General Store",
-      "exits": {
-        "west": 222,
-        "east": 220,
-        "north": 118
-      },
-      "id": 221
-    },
-    {
-      "name": "Comfortably Numb",
-      "exits": {
-        "west": 223,
-        "east": 221,
-        "north": 119
-      },
-      "id": 222
-    },
-    {
-      "name": "Medieval Mounts",
-      "exits": {
-        "west": 224,
-        "east": 222,
-        "north": 120
-      },
-      "id": 223
-    },
-    {
-      "name": "Big Hole Banking",
-      "exits": {
-        "west": 225,
-        "east": 223,
-        "north": 121
-      },
-      "id": 224
-    },
-    {
-      "name": "Brimstone",
-      "exits": {
-        "east": 224,
-        "north": 122
-      },
-      "id": 225
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 117,
-        "west": 227,
-        "east": 172,
-        "north": 232
-      },
-      "id": 226
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 118,
-        "west": 230,
-        "east": 226,
-        "north": 228
-      },
-      "id": 227
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 227,
-        "west": 231,
-        "east": 232,
-        "north": 229
-      },
-      "id": 228
-    },
-    {
-      "name": "Sanctuary",
-      "exits": {
-        "up": 893,
-        "south": 228
-      },
-      "id": 229
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 119,
-        "west": 815,
-        "east": 227,
-        "north": 231
-      },
-      "id": 230
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 230,
-        "west": 796,
-        "east": 228,
-        "north": 426
-      },
-      "id": 231
-    },
-    {
-      "name": "A peaceful park",
-      "exits": {
-        "south": 226,
-        "west": 228,
-        "east": 173,
-        "north": 234
-      },
-      "id": 232
-    },
-    {
-      "name": "The Shadowed Anvil",
-      "exits": {
-        "west": 220,
-        "north": 116
-      },
-      "id": 233
-    },
-    {
-      "name": "Andre's Clothing",
-      "exits": {
-        "south": 232
-      },
-      "id": 234
-    },
-    {
-      "name": "Smoke House",
-      "exits": {
-        "south": 210
-      },
-      "id": 394
-    },
-    {
-      "name": "The Lathe",
-      "exits": {
-        "south": 209
-      },
-      "id": 395
-    },
-    {
-      "name": "Antique Shop",
-      "exits": {
-        "south": 208
-      },
-      "id": 396
-    },
-    {
-      "name": "Mage's House",
-      "exits": {
-        "east": 398,
-        "south": 206
-      },
-      "id": 397
-    },
-    {
-      "name": "Mage's Apprentice House",
-      "exits": {
-        "west": 397
-      },
-      "id": 398
-    },
-    {
-      "name": "Retired Warrior's House",
-      "exits": {
-        "up": 734,
-        "west": 213
-      },
-      "id": 399
-    },
-    {
-      "name": "Bell maker's shop",
-      "exits": {
-        "east": 214
-      },
-      "id": 400
-    },
-    {
-      "name": "Candle Shop",
-      "exits": {
-        "west": 214
-      },
-      "id": 401
-    },
-    {
-      "name": "Do-it-Yourself Distiller",
-      "exits": {
-        "east": 216
-      },
-      "id": 402
-    },
-    {
-      "name": "Entrance to a temple",
-      "exits": {
-        "east": 404,
-        "west": 216
-      },
-      "id": 403
-    },
-    {
-      "name": "Temple of Amaterasu",
-      "exits": {
-        "east": 405,
-        "west": 403
-      },
-      "id": 404
-    },
-    {
-      "name": "Temple of Amaterasu",
-      "exits": {
-        "west": 404,
-        "south": 407,
-        "north": 406
-      },
-      "id": 405
-    },
-    {
-      "name": "Candle Room",
-      "exits": {
-        "south": 405
-      },
-      "id": 406
-    },
-    {
-      "name": "Quiet Room",
-      "exits": {
-        "north": 405
-      },
-      "id": 407
-    },
-    {
-      "name": "MD Banking",
-      "exits": {
-        "east": 217
-      },
-      "id": 408
-    },
-    {
-      "name": "Bounty Room",
-      "exits": {
-        "east": 219
-      },
-      "id": 409
-    },
-    {
-      "name": "A dingy alleyway",
-      "exits": {
-        "west": 411,
-        "south": 122,
-        "north": 792
-      },
-      "id": 410
-    },
-    {
-      "name": "Vesla Times Press Office",
-      "exits": {
-        "east": 410,
-        "south": 123
-      },
-      "id": 411
-    },
-    {
-      "name": "Smithy",
-      "exits": {
-        "west": 160,
-        "south": 124
-      },
-      "id": 412
-    },
-    {
-      "name": "A dark alleyway",
-      "exits": {
-        "north": 129
-      },
-      "id": 419
-    },
-    {
-      "name": "The Old Temple",
-      "exits": {
-        "north": 130
-      },
-      "id": 420
-    },
-    {
-      "name": "Mage's Guild",
-      "exits": {
-        "north": 132
-      },
-      "id": 421
-    },
-    {
-      "name": "Mercantile Guild Office",
-      "exits": {
-        "east": 837,
-        "west": 155
-      },
-      "id": 422
-    },
-    {
-      "name": "Glassblower",
-      "exits": {
-        "east": 155
-      },
-      "id": 423
-    },
-    {
-      "name": "Fighter's Guild",
-      "exits": {
-        "west": 156
-      },
-      "id": 424
-    },
-    {
-      "name": "Omar's Oils II",
-      "exits": {
-        "south": 121
-      },
-      "id": 425
-    },
-    {
-      "name": "Deora's Outfitters",
-      "exits": {
-        "south": 231
-      },
-      "id": 426
-    },
-    {
-      "name": "Weapon Master's Bedroom",
-      "exits": {
-        "down": 399
-      },
-      "id": 734
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "west": 172
-      },
-      "id": 735
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "west": 173
-      },
-      "id": 736
-    },
-    {
-      "name": "Chamber of Commerce",
-      "exits": {
-        "south": 187
-      },
-      "id": 737
-    },
-    {
-      "name": "Alley",
-      "exits": {
-        "south": 188
-      },
-      "id": 738
-    },
-    {
-      "name": "The School of Guild Skills",
-      "exits": {
-        "north": 189
-      },
-      "id": 739
-    },
-    {
-      "name": "Stationery Store",
-      "exits": {
-        "north": 190
-      },
-      "id": 740
-    },
-    {
-      "name": "Dormitory Hallway",
-      "exits": {
-        "up": 748,
-        "south": 190,
-        "east": 747,
-        "north": 745
-      },
-      "id": 741
-    },
-    {
-      "name": "Magoo's Bookstore",
-      "exits": {
-        "north": 191
-      },
-      "id": 742
-    },
-    {
-      "name": "Frenchie's Cafe",
-      "exits": {
-        "south": 191
-      },
-      "id": 743
-    },
-    {
-      "name": "An empty lot.",
-      "exits": {
-        "north": 192
-      },
-      "id": 744
-    },
-    {
-      "name": "Dormitory Kitchen",
-      "exits": {
-        "east": 746,
-        "south": 741
-      },
-      "id": 745
-    },
-    {
-      "name": "Store Room",
-      "exits": {
-        "west": 745
-      },
-      "id": 746
-    },
-    {
-      "name": "Dormitory Administrator's Room",
-      "exits": {
-        "west": 741
-      },
-      "id": 747
-    },
-    {
-      "name": "Dormitory Hallway",
-      "exits": {
-        "west": 751,
-        "down": 741,
-        "south": 752,
-        "east": 750,
-        "north": 749
-      },
-      "id": 748
-    },
-    {
-      "name": "Dormer",
-      "exits": {
-        "south": 748
-      },
-      "id": 749
-    },
-    {
-      "name": "Dormer",
-      "exits": {
-        "west": 748
-      },
-      "id": 750
-    },
-    {
-      "name": "Dormer",
-      "exits": {
-        "east": 748
-      },
-      "id": 751
-    },
-    {
-      "name": "Dormer",
-      "exits": {
-        "north": 748
-      },
-      "id": 752
-    },
-    {
-      "name": "The drawbridge",
-      "exits": {
-        "southwest": 169,
-        "north": 754
-      },
-      "id": 753
-    },
-    {
-      "name": "Between the towers",
-      "exits": {
-        "south": 753,
-        "north": 755
-      },
-      "id": 754
-    },
-    {
-      "name": "Between the towers",
-      "exits": {
-        "south": 754,
-        "north": 756
-      },
-      "id": 755
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "south": 755,
-        "north": 757
-      },
-      "id": 756
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "south": 756,
-        "northeast": 765,
-        "east": 758,
-        "north": 766
-      },
-      "id": 757
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "west": 757,
-        "south": 759,
-        "northwest": 766,
-        "north": 765
-      },
-      "id": 758
-    },
-    {
-      "name": "Eastern guard room",
-      "exits": {
-        "northeast": 760,
-        "north": 758
-      },
-      "id": 759
-    },
-    {
-      "name": "Lower eastern stairwell",
-      "exits": {
-        "southwest": 759,
-        "up": 761
-      },
-      "id": 760
-    },
-    {
-      "name": "Middle eastern stairwell",
-      "exits": {
-        "southwest": 762,
-        "down": 760,
-        "up": 763
-      },
-      "id": 761
-    },
-    {
-      "name": "Eastern guard quarters",
-      "exits": {
-        "northeast": 761
-      },
-      "id": 762
-    },
-    {
-      "name": "Upper eastern stairwell",
-      "exits": {
-        "southwest": 764,
-        "down": 761
-      },
-      "id": 763
-    },
-    {
-      "name": "Eastern tower observatory",
-      "exits": {
-        "northeast": 763
-      },
-      "id": 764
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "west": 766,
-        "northwest": 767,
-        "south": 758,
-        "southwest": 757,
-        "northeast": 769,
-        "east": 770,
-        "north": 768
-      },
-      "id": 765
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "southeast": 758,
-        "south": 757,
-        "northeast": 768,
-        "east": 765,
-        "north": 767
-      },
-      "id": 766
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "east": 768,
-        "southeast": 765,
-        "south": 766
-      },
-      "id": 767
-    },
-    {
-      "name": "The inner ward",
-      "exits": {
-        "southwest": 766,
-        "west": 767,
-        "east": 769,
-        "south": 765
-      },
-      "id": 768
-    },
-    {
-      "name": "The well",
-      "exits": {
-        "southwest": 765,
-        "east": 771,
-        "west": 768
-      },
-      "id": 769
-    },
-    {
-      "name": "Castle stables",
-      "exits": {
-        "south": 790,
-        "west": 765,
-        "east": 773,
-        "north": 791
-      },
-      "id": 770
-    },
-    {
-      "name": "The blacksmith",
-      "exits": {
-        "east": 772,
-        "west": 769
-      },
-      "id": 771
-    },
-    {
-      "name": "The storage room",
-      "exits": {
-        "west": 771
-      },
-      "id": 772
-    },
-    {
-      "name": "Castle stables",
-      "exits": {
-        "south": 789,
-        "west": 770,
-        "east": 774,
-        "north": 788
-      },
-      "id": 773
-    },
-    {
-      "name": "Castle stables",
-      "exits": {
-        "south": 787,
-        "west": 773,
-        "east": 775,
-        "north": 786
-      },
-      "id": 774
-    },
-    {
-      "name": "Castle stables",
-      "exits": {
-        "south": 784,
-        "west": 774,
-        "east": 776,
-        "north": 785
-      },
-      "id": 775
-    },
-    {
-      "name": "Castle stables",
-      "exits": {
-        "south": 782,
-        "west": 775,
-        "east": 777,
-        "north": 781
-      },
-      "id": 776
-    },
-    {
-      "name": "Small paddock",
-      "exits": {
-        "southeast": 779,
-        "south": 783,
-        "west": 776,
-        "east": 778,
-        "north": 780
-      },
-      "id": 777
-    },
-    {
-      "name": "Small paddock",
-      "exits": {
-        "southwest": 783,
-        "west": 777,
-        "northwest": 780,
-        "south": 779
-      },
-      "id": 778
-    },
-    {
-      "name": "Small paddock",
-      "exits": {
-        "west": 783,
-        "northwest": 777,
-        "north": 778
-      },
-      "id": 779
-    },
-    {
-      "name": "Wash area",
-      "exits": {
-        "southeast": 778,
-        "south": 777
-      },
-      "id": 780
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "south": 776
-      },
-      "id": 781
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "north": 776
-      },
-      "id": 782
-    },
-    {
-      "name": "Small paddock",
-      "exits": {
-        "northeast": 778,
-        "east": 779,
-        "north": 777
-      },
-      "id": 783
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "north": 775
-      },
-      "id": 784
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "south": 775
-      },
-      "id": 785
-    },
-    {
-      "name": "Tack room",
-      "exits": {
-        "south": 774
-      },
-      "id": 786
-    },
-    {
-      "name": "Feed room",
-      "exits": {
-        "north": 774
-      },
-      "id": 787
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "south": 773
-      },
-      "id": 788
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "north": 773
-      },
-      "id": 789
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "north": 770
-      },
-      "id": 790
-    },
-    {
-      "name": "You swing open the wooden door and enter the stall.",
-      "exits": {
-        "south": 770
-      },
-      "id": 791
-    },
-    {
-      "name": "A dingy alleyway",
-      "exits": {
-        "south": 410,
-        "east": 795,
-        "north": 794
-      },
-      "id": 792
-    },
-    {
-      "name": "Effortlessly, you scale the brick wall and drop into a garden on the opposite",
-      "exits": {
-        "east": 168
-      },
-      "id": 793
-    },
-    {
-      "name": "A small building.",
-      "exits": {
-        "south": 792
-      },
-      "id": 794
-    },
-    {
-      "name": "A dingy alleyway",
-      "exits": {
-        "south": 813,
-        "west": 792,
-        "east": 796,
-        "north": 797
-      },
-      "id": 795
-    },
-    {
-      "name": "An alley",
-      "exits": {
-        "south": 814,
-        "west": 795,
-        "east": 231,
-        "north": 961
-      },
-      "id": 796
-    },
-    {
-      "name": "A dingy alley",
-      "exits": {
-        "south": 795,
-        "north": 798
-      },
-      "id": 797
-    },
-    {
-      "name": "A Dingy Alley",
-      "exits": {
-        "south": 797,
-        "north": 799
-      },
-      "id": 798
-    },
-    {
-      "name": "Stink Alley Way",
-      "exits": {
-        "west": 802,
-        "east": 800,
-        "south": 798
-      },
-      "id": 799
-    },
-    {
-      "name": "Stink Alley Way",
-      "exits": {
-        "west": 799,
-        "east": 801,
-        "north": 806
-      },
-      "id": 800
-    },
-    {
-      "name": "Stink Alley Way",
-      "exits": {
-        "west": 800
-      },
-      "id": 801
-    },
-    {
-      "name": "Stink Alley Way",
-      "exits": {
-        "south": 805,
-        "west": 803,
-        "east": 799,
-        "north": 807
-      },
-      "id": 802
-    },
-    {
-      "name": "Stink Alley Way",
-      "exits": {
-        "east": 802,
-        "south": 804
-      },
-      "id": 803
-    },
-    {
-      "name": "Fish Mongery",
-      "exits": {
-        "north": 803
-      },
-      "id": 804
-    },
-    {
-      "name": "Crazy Habib's Fertilizer",
-      "exits": {
-        "north": 802
-      },
-      "id": 805
-    },
-    {
-      "name": "Barber Shop",
-      "exits": {
-        "south": 800
-      },
-      "id": 806
-    },
-    {
-      "name": "Pornographers Den",
-      "exits": {
-        "south": 802
-      },
-      "id": 807
-    },
-    {
-      "name": "Livery",
-      "exits": {
-        "up": 809,
-        "west": 161
-      },
-      "id": 808
-    },
-    {
-      "name": "Hayloft",
-      "exits": {
-        "down": 808
-      },
-      "id": 809
-    },
-    {
-      "name": "Tailor's Shop",
-      "exits": {
-        "west": 162
-      },
-      "id": 810
-    },
-    {
-      "name": "Hardware Store",
-      "exits": {
-        "west": 163
-      },
-      "id": 811
-    },
-    {
-      "name": "Haseltine Engravers",
-      "exits": {
-        "west": 164
-      },
-      "id": 812
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "north": 795
-      },
-      "id": 813
-    },
-    {
-      "name": "Flea Market",
-      "exits": {
-        "north": 796
-      },
-      "id": 814
-    },
-    {
-      "name": "The Back Room",
-      "exits": {
-        "east": 230,
-        "north": 814
-      },
-      "id": 815
-    },
-    {
-      "name": "Castle Bridge",
-      "exits": {
-        "north": 151
-      },
-      "id": 816
-    },
-    {
-      "name": "Manor House",
-      "exits": {
-        "up": 818,
-        "west": 152
-      },
-      "id": 817
-    },
-    {
-      "name": "Manor House",
-      "exits": {
-        "down": 817
-      },
-      "id": 818
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "east": 152
-      },
-      "id": 819
-    },
-    {
-      "name": "Cleric Guild",
-      "exits": {
-        "west": 839,
-        "east": 153,
-        "north": 838
-      },
-      "id": 820
-    },
-    {
-      "name": "Hall of the builders guild",
-      "exits": {
-        "west": 154
-      },
-      "id": 821
-    },
-    {
-      "name": "City Hall",
-      "exits": {
-        "east": 156,
-        "up": 831
-      },
-      "id": 822
-    },
-    {
-      "name": "Tea Shop",
-      "exits": {
-        "east": 157
-      },
-      "id": 823
-    },
-    {
-      "name": "Whore House",
-      "exits": {
-        "east": 158,
-        "up": 825
-      },
-      "id": 824
-    },
-    {
-      "name": "Second floor of whore house.",
-      "exits": {
-        "south": 828,
-        "west": 826,
-        "up": 829,
-        "down": 824,
-        "north": 827
-      },
-      "id": 825
-    },
-    {
-      "name": "Viking's room",
-      "exits": {
-        "east": 825
-      },
-      "id": 826
-    },
-    {
-      "name": "Sandra's room",
-      "exits": {
-        "south": 825
-      },
-      "id": 827
-    },
-    {
-      "name": "Kathy's room",
-      "exits": {
-        "north": 825
-      },
-      "id": 828
-    },
-    {
-      "name": "Robert's room",
-      "exits": {
-        "down": 825
-      },
-      "id": 829
-    },
-    {
-      "name": "Baker's Shop",
-      "exits": {
-        "west": 157
-      },
-      "id": 830
-    },
-    {
-      "name": "First Floor",
-      "exits": {
-        "up": 833,
-        "down": 822,
-        "west": 832
-      },
-      "id": 831
-    },
-    {
-      "name": "Chamber of Commerce",
-      "exits": {
-        "east": 831
-      },
-      "id": 832
-    },
-    {
-      "name": "Second Floor",
-      "exits": {
-        "up": 835,
-        "down": 831,
-        "west": 834
-      },
-      "id": 833
-    },
-    {
-      "name": "Magistrate",
-      "exits": {
-        "east": 833
-      },
-      "id": 834
-    },
-    {
-      "name": "City Archives",
-      "exits": {
-        "down": 833,
-        "west": 836
-      },
-      "id": 835
-    },
-    {
-      "name": "Inner Sanctum",
-      "exits": {
-        "east": 835
-      },
-      "id": 836
-    },
-    {
-      "name": "Open Air Market:",
-      "exits": {
-        "west": 422
-      },
-      "id": 837
-    },
-    {
-      "name": "Chapel of War",
-      "exits": {
-        "south": 820
-      },
-      "id": 838
-    },
-    {
-      "name": "Reconciliation Chapel",
-      "exits": {
-        "east": 820
-      },
-      "id": 839
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "west": 841,
-        "south": 148
-      },
-      "id": 840
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "south": 147,
-        "west": 842,
-        "east": 840,
-        "north": 843
-      },
-      "id": 841
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "south": 146,
-        "east": 841,
-        "north": 844
-      },
-      "id": 842
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "west": 844,
-        "south": 841,
-        "north": 201
-      },
-      "id": 843
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "south": 842,
-        "east": 843,
-        "north": 202
-      },
-      "id": 844
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "east": 846,
-        "north": 146
-      },
-      "id": 845
-    },
-    {
-      "name": "Burned Area",
-      "exits": {
-        "west": 845,
-        "north": 147
-      },
-      "id": 846
-    },
-    {
-      "name": "Old City Offices",
-      "exits": {
-        "west": 849,
-        "east": 848,
-        "north": 144
-      },
-      "id": 847
-    },
-    {
-      "name": "Old Office",
-      "exits": {
-        "west": 847
-      },
-      "id": 848
-    },
-    {
-      "name": "Old Office",
-      "exits": {
-        "east": 847
-      },
-      "id": 849
-    },
-    {
-      "name": "Howling Wolf Inn",
-      "exits": {
-        "west": 142,
-        "east": 852,
-        "north": 851
-      },
-      "id": 850
-    },
-    {
-      "name": "Howling Wolf Inn",
-      "exits": {
-        "south": 850
-      },
-      "id": 851
-    },
-    {
-      "name": "Howling Wolf Inn",
-      "exits": {
-        "west": 850
-      },
-      "id": 852
-    },
-    {
-      "name": "Abandoned Building",
-      "exits": {
-        "east": 139
-      },
-      "id": 853
-    },
-    {
-      "name": "Spice Merchant",
-      "exits": {
-        "west": 139
-      },
-      "id": 854
-    },
-    {
-      "name": "Abandoned Building",
-      "exits": {
-        "west": 138
-      },
-      "id": 855
-    },
-    {
-      "name": "Carvings Shop",
-      "exits": {
-        "east": 138
-      },
-      "id": 856
-    },
-    {
-      "name": "Abandoned Warehouse",
-      "exits": {
-        "west": 198
-      },
-      "id": 857
-    },
-    {
-      "name": "In Rohan's bedroom",
-      "exits": {
-        "down": 869,
-        "up": 871
-      },
-      "id": 870
-    },
-    {
-      "name": "In Gwyneth's bedroom",
-      "exits": {
-        "down": 873,
-        "up": 872
-      },
-      "id": 871
-    },
-    {
-      "name": "In Vella's bedroom",
-      "exits": {
-        "down": 871
-      },
-      "id": 872
-    },
-    {
-      "name": "<> Aladrin escapes reality and falls into Moral Decay. <>",
-      "exits": {
-        "down": 874,
-        "up": 871
-      },
-      "id": 873
-    },
-    {
-      "name": "Bottom floor of the silo",
-      "exits": {
-        "up": 873
-      },
-      "id": 874
-    },
-    {
-      "name": "Guild/Shop Space for rent",
-      "exits": {
-        "south": 127
-      },
-      "id": 878
-    },
-    {
-      "name": "Vesla Post Office",
-      "exits": {
-        "south": 126
-      },
-      "id": 879
-    },
-    {
-      "name": "Old Adventurer's Guild",
-      "exits": {
-        "north": 126
-      },
-      "id": 880
-    },
-    {
-      "name": "The Players' lounge",
-      "exits": {
-        "down": 229
-      },
-      "id": 893
-    },
-    {
-      "name": "Rising Phoenix",
-      "exits": {
-        "south": 796
-      },
-      "id": 961
-    },
-    {
-      "name": "Abandoned Store",
-      "exits": {
-        "west": 199
-      },
-      "id": 962
+      "id": 115, "name": "The Gate to the Wilderness",
+      "exits": { "west": 116 }
+    },
+    {
+      "id": 116, "name": "Intersection of Park Street and Caravan Road",
+      "exits": { "south": 233, "west": 117, "east": 115, "north": 172 }
+    },
+    {
+      "id": 117, "name": "Intersection of Park Street and Via Sacra",
+      "exits": { "south": 220, "west": 118, "east": 116, "north": 226 }
+    },
+    {
+      "id": 118, "name": "A shaded walk",
+      "exits": { "south": 221, "west": 119, "east": 117, "north": 227 }
+    },
+    {
+      "id": 119, "name": "A shaded walk",
+      "exits": { "south": 222, "west": 120, "east": 118, "north": 230 }
+    },
+    {
+      "id": 120, "name": "A shaded walk",
+      "exits": { "west": 121, "east": 119, "south": 223 }
+    },
+    {
+      "id": 121, "name": "A shaded walk",
+      "exits": { "south": 224, "west": 122, "east": 120, "north": 425 }
+    },
+    {
+      "id": 122, "name": "A shaded walk",
+      "exits": { "south": 225, "west": 123, "east": 121, "north": 410 }
+    },
+    {
+      "id": 123, "name": "A shaded walk",
+      "exits": { "west": 124, "east": 122, "north": 411 }
+    },
+    {
+      "id": 124, "name": "A break in the coverage",
+      "exits": { "west": 125, "east": 123, "north": 412 }
+    },
+    {
+      "id": 125, "name": "A busy intersection",
+      "exits": { "south": 159, "west": 126, "east": 124, "north": 160 }
+    },
+    {
+      "id": 126, "name": "The end of the park street",
+      "exits": { "south": 880, "west": 127, "east": 125, "north": 879 }
+    },
+    {
+      "id": 127, "name": "Entrance to the Old City.",
+      "exits": { "west": 128, "east": 126, "north": 878 }
+    },
+    {
+      "id": 128, "name": "Westroad, The Entrance to the Old City.",
+      "exits": { "west": 129, "east": 127, "north": 881 }
+    },
+    {
+      "id": 129, "name": "Westroad",
+      "exits": { "west": 130, "east": 128, "south": 419 }
+    },
+    {
+      "id": 130, "name": "Westroad",
+      "exits": { "west": 131, "east": 129, "south": 420 }
+    },
+    {
+      "id": 131, "name": "Westroad",
+      "exits": { "west": 132, "east": 130, "north": 858 }
+    },
+    {
+      "id": 132, "name": "Westroad",
+      "exits": { "west": 133, "east": 131, "south": 421 }
+    },
+    {
+      "id": 133, "name": "The corner of Westroad and Basalt Avenue",
+      "exits": { "west": 134, "east": 132, "south": 135 }
+    },
+    {
+      "id": 134, "name": "Western Gate of Vesla",
+      "exits": { "east": 133 }
+    },
+    {
+      "id": 135, "name": "Basalt Avenue",
+      "exits": { "south": 136, "north": 133 }
+    },
+    {
+      "id": 136, "name": "Basalt Avenue",
+      "exits": { "south": 137, "north": 135 }
+    },
+    {
+      "id": 137, "name": "Intersection of Basalt Avenue and Rapier Way",
+      "exits": { "south": 138, "east": 193, "north": 136 }
+    },
+    {
+      "id": 138, "name": "Basalt Avenue",
+      "exits": { "south": 139, "west": 856, "east": 855, "north": 137 }
+    },
+    {
+      "id": 139, "name": "Basalt Avenue",
+      "exits": { "south": 140, "west": 853, "east": 854, "north": 138 }
+    },
+    {
+      "id": 140, "name": "Intersection of Basalt Avenue and Street of the Bells",
+      "exits": { "south": 141, "east": 204, "north": 139 }
+    },
+    {
+      "id": 141, "name": "Basalt Avenue",
+      "exits": { "south": 142, "north": 140 }
+    },
+    {
+      "id": 142, "name": "Basalt Avenue",
+      "exits": { "south": 143, "east": 850, "north": 141 }
+    },
+    {
+      "id": 143, "name": "Corner of Basalt Avenue and West River Street",
+      "exits": { "east": 144, "north": 142 }
+    },
+    {
+      "id": 144, "name": "West River Street",
+      "exits": { "west": 143, "east": 145, "south": 847 }
+    },
+    {
+      "id": 145, "name": "West River Street",
+      "exits": { "east": 146, "west": 144 }
+    },
+    {
+      "id": 146, "name": "West River Street",
+      "exits": { "south": 845, "west": 145, "east": 147, "north": 842 }
+    },
+    {
+      "id": 147, "name": "West River Street",
+      "exits": { "south": 846, "west": 146, "east": 148, "north": 841 }
+    },
+    {
+      "id": 148, "name": "West River Street",
+      "exits": { "west": 147, "east": 149, "north": 840 }
+    },
+    {
+      "id": 149, "name": "West River street",
+      "exits": { "east": 150, "west": 148 }
+    },
+    {
+      "id": 150, "name": "West River street",
+      "exits": { "east": 151, "west": 149 }
+    },
+    {
+      "id": 151, "name": "River Street and South Main",
+      "exits": { "south": 816, "west": 150, "east": 205, "north": 152 }
+    },
+    {
+      "id": 152, "name": "South Main street",
+      "exits": { "south": 151, "west": 819, "east": 817, "north": 153 }
+    },
+    {
+      "id": 153, "name": "South Main Street",
+      "exits": { "west": 820, "south": 152, "north": 154 }
+    },
+    {
+      "id": 154, "name": "South Main Street",
+      "exits": { "south": 153, "east": 821, "north": 155 }
+    },
+    {
+      "id": 155, "name": "South Main Street",
+      "exits": { "south": 154, "west": 423, "east": 422, "north": 156 }
+    },
+    {
+      "id": 156, "name": "South Main Street",
+      "exits": { "south": 155, "west": 822, "east": 424, "north": 157 }
+    },
+    {
+      "id": 157, "name": "South Main Street",
+      "exits": { "south": 156, "west": 823, "east": 830, "north": 158 }
+    },
+    {
+      "id": 158, "name": "South Main street",
+      "exits": { "west": 824, "south": 157, "north": 159 }
+    },
+    {
+      "id": 159, "name": "South Main street",
+      "exits": { "south": 158, "north": 125 }
+    },
+    {
+      "id": 160, "name": "Northern Main",
+      "exits": { "south": 125, "east": 412, "north": 161 }
+    },
+    {
+      "id": 161, "name": "Northern Main Street",
+      "exits": { "south": 160, "east": 808, "north": 162 }
+    },
+    {
+      "id": 162, "name": "Northern Main street",
+      "exits": { "south": 161, "east": 810, "north": 163 }
+    },
+    {
+      "id": 163, "name": "Northern Main Street",
+      "exits": { "south": 162, "east": 811, "north": 164 }
+    },
+    {
+      "id": 164, "name": "Northern Main street",
+      "exits": { "south": 163, "east": 812, "north": 165 }
+    },
+    {
+      "id": 165, "name": "Northern Main street",
+      "exits": { "south": 164, "north": 166 }
+    },
+    {
+      "id": 166, "name": "Intersection of North Main and Scholar's Way",
+      "exits": { "south": 165, "east": 192, "north": 167 }
+    },
+    {
+      "id": 167, "name": "Northern Main street",
+      "exits": { "south": 166, "north": 168 }
+    },
+    {
+      "id": 168, "name": "Intersection of North Main and Wall Street",
+      "exits": { "south": 167, "west": 793, "east": 170, "north": 169 }
+    },
+    {
+      "id": 169, "name": "Northern Gate",
+      "exits": { "south": 168, "northeast": 753 }
+    },
+    {
+      "id": 170, "name": "Western End of Wall Street",
+      "exits": { "east": 171, "west": 168 }
+    },
+    {
+      "id": 171, "name": "Wall Street",
+      "exits": { "west": 170 }
+    },
+    {
+      "id": 172, "name": "Caravan Road",
+      "exits": { "south": 116, "west": 226, "east": 735, "north": 173 }
+    },
+    {
+      "id": 173, "name": "Caravan Road",
+      "exits": { "south": 172, "west": 232, "east": 736, "north": 174 }
+    },
+    {
+      "id": 174, "name": "Caravan Road",
+      "exits": { "south": 173, "north": 175 }
+    },
+    {
+      "id": 175, "name": "Caravan Road",
+      "exits": { "south": 174, "north": 176 }
+    },
+    {
+      "id": 176, "name": "Caravan Road",
+      "exits": { "south": 175, "north": 177 }
+    },
+    {
+      "id": 177, "name": "Caravan Road",
+      "exits": { "south": 176, "north": 178 }
+    },
+    {
+      "id": 178, "name": "Intersection of Scholar's Way and Caravan Road",
+      "exits": { "west": 185, "south": 177, "north": 179 }
+    },
+    {
+      "id": 179, "name": "Caravan Road",
+      "exits": { "south": 178, "north": 180 }
+    },
+    {
+      "id": 180, "name": "Intersection of Caravan Road and Wall Street",
+      "exits": { "west": 181, "south": 179 }
+    },
+    {
+      "id": 181, "name": "Eastern End of Wall Street",
+      "exits": { "east": 180, "west": 182 }
+    },
+    {
+      "id": 182, "name": "Wall Street",
+      "exits": { "east": 181, "west": 183 }
+    },
+    {
+      "id": 183, "name": "Wall Street",
+      "exits": { "east": 182, "west": 184 }
+    },
+    {
+      "id": 184, "name": "Wall Street",
+      "exits": { "east": 183 }
+    },
+    {
+      "id": 185, "name": "Scholar's Way",
+      "exits": { "east": 178, "west": 186 }
+    },
+    {
+      "id": 186, "name": "Scholar's Way",
+      "exits": { "east": 185, "west": 187 }
+    },
+    {
+      "id": 187, "name": "Scholar's Way",
+      "exits": { "west": 188, "east": 186, "north": 737 }
+    },
+    {
+      "id": 188, "name": "Scholar's Way",
+      "exits": { "west": 189, "east": 187, "north": 738 }
+    },
+    {
+      "id": 189, "name": "Scholar's Way",
+      "exits": { "west": 190, "east": 188, "south": 739 }
+    },
+    {
+      "id": 190, "name": "Scholar's Way",
+      "exits": { "south": 740, "west": 191, "east": 189, "north": 741 }
+    },
+    {
+      "id": 191, "name": "Scholar's Way",
+      "exits": { "south": 742, "west": 192, "east": 190, "north": 743 }
+    },
+    {
+      "id": 192, "name": "Scholar's Way",
+      "exits": { "west": 166, "east": 191, "south": 744 }
+    },
+    {
+      "id": 193, "name": "Rapier Way",
+      "exits": { "east": 194, "west": 137 }
+    },
+    {
+      "id": 194, "name": "Rapier Way",
+      "exits": { "east": 195, "west": 193 }
+    },
+    {
+      "id": 195, "name": "Rapier Way",
+      "exits": { "east": 196, "west": 194 }
+    },
+    {
+      "id": 196, "name": "Rapier Way",
+      "exits": { "east": 197, "west": 195 }
+    },
+    {
+      "id": 197, "name": "Intersection of Rapier Way and Zand Boulevard",
+      "exits": { "west": 196, "south": 198 }
+    },
+    {
+      "id": 198, "name": "Zand Boulevard",
+      "exits": { "south": 199, "east": 857, "north": 197 }
+    },
+    {
+      "id": 199, "name": "Zand Boulevard",
+      "exits": { "south": 200, "east": 962, "north": 198 }
+    },
+    {
+      "id": 200, "name": "Intersection of Street of the Bells and Zand Boulevard",
+      "exits": { "west": 201, "north": 199 }
+    },
+    {
+      "id": 201, "name": "Street of the Bells",
+      "exits": { "south": 843, "west": 202, "east": 200, "north": 931 }
+    },
+    {
+      "id": 202, "name": "Street of the Bells",
+      "exits": { "west": 203, "east": 201, "south": 844 }
+    },
+    {
+      "id": 203, "name": "Street of the Bells",
+      "exits": { "east": 202, "west": 204 }
+    },
+    {
+      "id": 204, "name": "Street of the Bells",
+      "exits": { "east": 203, "west": 140 }
+    },
+    {
+      "id": 205, "name": "East River Street",
+      "exits": { "east": 206, "west": 151 }
+    },
+    {
+      "id": 206, "name": "East River Street",
+      "exits": { "west": 205, "east": 207, "north": 397 }
+    },
+    {
+      "id": 207, "name": "East River Street",
+      "exits": { "east": 208, "west": 206 }
+    },
+    {
+      "id": 208, "name": "East River Street",
+      "exits": { "west": 207, "east": 209, "north": 396 }
+    },
+    {
+      "id": 209, "name": "East River Street",
+      "exits": { "west": 208, "east": 210, "north": 395 }
+    },
+    {
+      "id": 210, "name": "East River Street",
+      "exits": { "west": 209, "east": 211, "north": 394 }
+    },
+    {
+      "id": 211, "name": "End of East River Street",
+      "exits": { "east": 212, "west": 210 }
+    },
+    {
+      "id": 212, "name": "Intersection of Via Sacra and River Street",
+      "exits": { "west": 211, "north": 213 }
+    },
+    {
+      "id": 213, "name": "South End of Via Sacra",
+      "exits": { "south": 212, "east": 399, "north": 214 }
+    },
+    {
+      "id": 214, "name": "Southern Via Sacra",
+      "exits": { "south": 213, "west": 400, "east": 401, "north": 215 }
+    },
+    {
+      "id": 215, "name": "Via Sacra",
+      "exits": { "south": 214, "north": 216 }
+    },
+    {
+      "id": 216, "name": "Via Sacra",
+      "exits": { "south": 215, "west": 402, "east": 403, "north": 217 }
+    },
+    {
+      "id": 217, "name": "Via Sacra",
+      "exits": { "west": 408, "south": 216, "north": 218 }
+    },
+    {
+      "id": 218, "name": "Via Sacra",
+      "exits": { "south": 217, "north": 219 }
+    },
+    {
+      "id": 219, "name": "Via Sacra",
+      "exits": { "west": 409, "south": 218, "north": 220 }
+    },
+    {
+      "id": 220, "name": "Northern End of Via Sacra",
+      "exits": { "south": 219, "west": 221, "east": 233, "north": 117 }
+    },
+    {
+      "id": 221, "name": "General Store",
+      "exits": { "west": 222, "east": 220, "north": 118 }
+    },
+    {
+      "id": 222, "name": "Comfortably Numb",
+      "exits": { "west": 223, "east": 221, "north": 119 }
+    },
+    {
+      "id": 223, "name": "Medieval Mounts",
+      "exits": { "west": 224, "east": 222, "north": 120 }
+    },
+    {
+      "id": 224, "name": "Big Hole Banking",
+      "exits": { "west": 225, "east": 223, "north": 121 }
+    },
+    {
+      "id": 225, "name": "Brimstone",
+      "exits": { "east": 224, "north": 122 }
+    },
+    {
+      "id": 226, "name": "A peaceful park",
+      "exits": { "south": 117, "west": 227, "east": 172, "north": 232 }
+    },
+    {
+      "id": 227, "name": "A peaceful park",
+      "exits": { "south": 118, "west": 230, "east": 226, "north": 228 }
+    },
+    {
+      "id": 228, "name": "A peaceful park",
+      "exits": { "south": 227, "west": 231, "east": 232, "north": 229 }
+    },
+    {
+      "id": 229, "name": "Sanctuary",
+      "exits": { "up": 893, "south": 228 }
+    },
+    {
+      "id": 230, "name": "A peaceful park",
+      "exits": { "south": 119, "west": 815, "east": 227, "north": 231 }
+    },
+    {
+      "id": 231, "name": "A peaceful park",
+      "exits": { "south": 230, "west": 796, "east": 228, "north": 426 }
+    },
+    {
+      "id": 232, "name": "A peaceful park",
+      "exits": { "south": 226, "west": 228, "east": 173, "north": 234 }
+    },
+    {
+      "id": 233, "name": "The Shadowed Anvil",
+      "exits": { "west": 220, "north": 116 }
+    },
+    {
+      "id": 234, "name": "Andre's Clothing",
+      "exits": { "south": 232 }
+    },
+    {
+      "id": 394, "name": "Smoke House",
+      "exits": { "south": 210 }
+    },
+    {
+      "id": 395, "name": "The Lathe",
+      "exits": { "south": 209 }
+    },
+    {
+      "id": 396, "name": "Antique Shop",
+      "exits": { "south": 208 }
+    },
+    {
+      "id": 397, "name": "Mage's House",
+      "exits": { "east": 398, "south": 206 }
+    },
+    {
+      "id": 398, "name": "Mage's Apprentice House",
+      "exits": { "west": 397 }
+    },
+    {
+      "id": 399, "name": "Retired Warrior's House",
+      "exits": { "up": 734, "west": 213 }
+    },
+    {
+      "id": 400, "name": "Bell maker's shop",
+      "exits": { "east": 214 }
+    },
+    {
+      "id": 401, "name": "Candle Shop",
+      "exits": { "west": 214 }
+    },
+    {
+      "id": 402, "name": "Do-it-Yourself Distiller",
+      "exits": { "east": 216 }
+    },
+    {
+      "id": 403, "name": "Entrance to a temple",
+      "exits": { "east": 404, "west": 216 }
+    },
+    {
+      "id": 404, "name": "Temple of Amaterasu",
+      "exits": { "east": 405, "west": 403 }
+    },
+    {
+      "id": 405, "name": "Temple of Amaterasu",
+      "exits": { "west": 404, "south": 407, "north": 406 }
+    },
+    {
+      "id": 406, "name": "Candle Room",
+      "exits": { "south": 405 }
+    },
+    {
+      "id": 407, "name": "Quiet Room",
+      "exits": { "north": 405 }
+    },
+    {
+      "id": 408, "name": "MD Banking",
+      "exits": { "east": 217 }
+    },
+    {
+      "id": 409, "name": "Bounty Room",
+      "exits": { "east": 219 }
+    },
+    {
+      "id": 410, "name": "A dingy alleyway",
+      "exits": { "west": 411, "south": 122, "north": 792 }
+    },
+    {
+      "id": 411, "name": "Vesla Times Press Office",
+      "exits": { "east": 410, "south": 123 }
+    },
+    {
+      "id": 412, "name": "Smithy",
+      "exits": { "west": 160, "south": 124 }
+    },
+    {
+      "id": 419, "name": "A dark alleyway",
+      "exits": { "north": 129 }
+    },
+    {
+      "id": 420, "name": "The Old Temple",
+      "exits": { "north": 130 }
+    },
+    {
+      "id": 421, "name": "Mage's Guild",
+      "exits": { "north": 132 }
+    },
+    {
+      "id": 422, "name": "Mercantile Guild Office",
+      "exits": { "east": 837, "west": 155 }
+    },
+    {
+      "id": 423, "name": "Glassblower",
+      "exits": { "east": 155 }
+    },
+    {
+      "id": 424, "name": "Fighter's Guild",
+      "exits": { "west": 156 }
+    },
+    {
+      "id": 425, "name": "Omar's Oils II",
+      "exits": { "south": 121 }
+    },
+    {
+      "id": 426, "name": "Deora's Outfitters",
+      "exits": { "south": 231 }
+    },
+    {
+      "id": 734, "name": "Weapon Master's Bedroom",
+      "exits": { "down": 399 }
+    },
+    {
+      "id": 735, "name": "Guild/Shop Space for rent",
+      "exits": { "west": 172 }
+    },
+    {
+      "id": 736, "name": "Guild/Shop Space for rent",
+      "exits": { "west": 173 }
+    },
+    {
+      "id": 737, "name": "Chamber of Commerce",
+      "exits": { "south": 187 }
+    },
+    {
+      "id": 738, "name": "Alley",
+      "exits": { "south": 188 }
+    },
+    {
+      "id": 739, "name": "The School of Guild Skills",
+      "exits": { "north": 189 }
+    },
+    {
+      "id": 740, "name": "Stationery Store",
+      "exits": { "north": 190 }
+    },
+    {
+      "id": 741, "name": "Dormitory Hallway",
+      "exits": { "up": 748, "south": 190, "east": 747, "north": 745 }
+    },
+    {
+      "id": 742, "name": "Magoo's Bookstore",
+      "exits": { "north": 191 }
+    },
+    {
+      "id": 743, "name": "Frenchie's Cafe",
+      "exits": { "south": 191 }
+    },
+    {
+      "id": 744, "name": "An empty lot.",
+      "exits": { "north": 192 }
+    },
+    {
+      "id": 745, "name": "Dormitory Kitchen",
+      "exits": { "east": 746, "south": 741 }
+    },
+    {
+      "id": 746, "name": "Store Room",
+      "exits": { "west": 745 }
+    },
+    {
+      "id": 747, "name": "Dormitory Administrator's Room",
+      "exits": { "west": 741 }
+    },
+    {
+      "id": 748, "name": "Dormitory Hallway",
+      "exits": { "west": 751, "down": 741, "south": 752, "east": 750, "north": 749 }
+    },
+    {
+      "id": 749, "name": "Dormer",
+      "exits": { "south": 748 }
+    },
+    {
+      "id": 750, "name": "Dormer",
+      "exits": { "west": 748 }
+    },
+    {
+      "id": 751, "name": "Dormer",
+      "exits": { "east": 748 }
+    },
+    {
+      "id": 752, "name": "Dormer",
+      "exits": { "north": 748 }
+    },
+    {
+      "id": 753, "name": "The drawbridge",
+      "exits": { "southwest": 169, "north": 754 }
+    },
+    {
+      "id": 754, "name": "Between the towers",
+      "exits": { "south": 753, "north": 755 }
+    },
+    {
+      "id": 755, "name": "Between the towers",
+      "exits": { "south": 754, "north": 756 }
+    },
+    {
+      "id": 756, "name": "The inner ward",
+      "exits": { "south": 755, "north": 757 }
+    },
+    {
+      "id": 757, "name": "The inner ward",
+      "exits": { "south": 756, "northeast": 765, "east": 758, "north": 766 }
+    },
+    {
+      "id": 758, "name": "The inner ward",
+      "exits": { "west": 757, "south": 759, "northwest": 766, "north": 765 }
+    },
+    {
+      "id": 759, "name": "Eastern guard room",
+      "exits": { "northeast": 760, "north": 758 }
+    },
+    {
+      "id": 760, "name": "Lower eastern stairwell",
+      "exits": { "southwest": 759, "up": 761 }
+    },
+    {
+      "id": 761, "name": "Middle eastern stairwell",
+      "exits": { "southwest": 762, "down": 760, "up": 763 }
+    },
+    {
+      "id": 762, "name": "Eastern guard quarters",
+      "exits": { "northeast": 761 }
+    },
+    {
+      "id": 763, "name": "Upper eastern stairwell",
+      "exits": { "southwest": 764, "down": 761 }
+    },
+    {
+      "id": 764, "name": "Eastern tower observatory",
+      "exits": { "northeast": 763 }
+    },
+    {
+      "id": 765, "name": "The inner ward",
+      "exits": { "west": 766, "northwest": 767, "south": 758, "southwest": 757, "northeast": 769, "east": 770, "north": 768 }
+    },
+    {
+      "id": 766, "name": "The inner ward",
+      "exits": { "southeast": 758, "south": 757, "northeast": 768, "east": 765, "north": 767 }
+    },
+    {
+      "id": 767, "name": "The inner ward",
+      "exits": { "east": 768, "southeast": 765, "south": 766 }
+    },
+    {
+      "id": 768, "name": "The inner ward",
+      "exits": { "southwest": 766, "west": 767, "east": 769, "south": 765 }
+    },
+    {
+      "id": 769, "name": "The well",
+      "exits": { "southwest": 765, "east": 771, "west": 768 }
+    },
+    {
+      "id": 770, "name": "Castle stables",
+      "exits": { "south": 790, "west": 765, "east": 773, "north": 791 }
+    },
+    {
+      "id": 771, "name": "The blacksmith",
+      "exits": { "east": 772, "west": 769 }
+    },
+    {
+      "id": 772, "name": "The storage room",
+      "exits": { "west": 771 }
+    },
+    {
+      "id": 773, "name": "Castle stables",
+      "exits": { "south": 789, "west": 770, "east": 774, "north": 788 }
+    },
+    {
+      "id": 774, "name": "Castle stables",
+      "exits": { "south": 787, "west": 773, "east": 775, "north": 786 }
+    },
+    {
+      "id": 775, "name": "Castle stables",
+      "exits": { "south": 784, "west": 774, "east": 776, "north": 785 }
+    },
+    {
+      "id": 776, "name": "Castle stables",
+      "exits": { "south": 782, "west": 775, "east": 777, "north": 781 }
+    },
+    {
+      "id": 777, "name": "Small paddock",
+      "exits": { "southeast": 779, "south": 783, "west": 776, "east": 778, "north": 780 }
+    },
+    {
+      "id": 778, "name": "Small paddock",
+      "exits": { "southwest": 783, "west": 777, "northwest": 780, "south": 779 }
+    },
+    {
+      "id": 779, "name": "Small paddock",
+      "exits": { "west": 783, "northwest": 777, "north": 778 }
+    },
+    {
+      "id": 780, "name": "Wash area",
+      "exits": { "southeast": 778, "south": 777 }
+    },
+    {
+      "id": 781, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 776 }
+    },
+    {
+      "id": 782, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 776 }
+    },
+    {
+      "id": 783, "name": "Small paddock",
+      "exits": { "northeast": 778, "east": 779, "north": 777 }
+    },
+    {
+      "id": 784, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 775 }
+    },
+    {
+      "id": 785, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 775 }
+    },
+    {
+      "id": 786, "name": "Tack room",
+      "exits": { "south": 774 }
+    },
+    {
+      "id": 787, "name": "Feed room",
+      "exits": { "north": 774 }
+    },
+    {
+      "id": 788, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 773 }
+    },
+    {
+      "id": 789, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 773 }
+    },
+    {
+      "id": 790, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "north": 770 }
+    },
+    {
+      "id": 791, "name": "You swing open the wooden door and enter the stall.",
+      "exits": { "south": 770 }
+    },
+    {
+      "id": 792, "name": "A dingy alleyway",
+      "exits": { "south": 410, "east": 795, "north": 794 }
+    },
+    {
+      "id": 793, "name": "Effortlessly, you scale the brick wall and drop into a garden on the opposite",
+      "exits": { "east": 168 }
+    },
+    {
+      "id": 794, "name": "A small building.",
+      "exits": { "south": 792 }
+    },
+    {
+      "id": 795, "name": "A dingy alleyway",
+      "exits": { "south": 813, "west": 792, "east": 796, "north": 797 }
+    },
+    {
+      "id": 796, "name": "An alley",
+      "exits": { "south": 814, "west": 795, "east": 231, "north": 961 }
+    },
+    {
+      "id": 797, "name": "A dingy alley",
+      "exits": { "south": 795, "north": 798 }
+    },
+    {
+      "id": 798, "name": "A Dingy Alley",
+      "exits": { "south": 797, "north": 799 }
+    },
+    {
+      "id": 799, "name": "Stink Alley Way",
+      "exits": { "west": 802, "east": 800, "south": 798 }
+    },
+    {
+      "id": 800, "name": "Stink Alley Way",
+      "exits": { "west": 799, "east": 801, "north": 806 }
+    },
+    {
+      "id": 801, "name": "Stink Alley Way",
+      "exits": { "west": 800 }
+    },
+    {
+      "id": 802, "name": "Stink Alley Way",
+      "exits": { "south": 805, "west": 803, "east": 799, "north": 807 }
+    },
+    {
+      "id": 803, "name": "Stink Alley Way",
+      "exits": { "east": 802, "south": 804 }
+    },
+    {
+      "id": 804, "name": "Fish Mongery",
+      "exits": { "north": 803 }
+    },
+    {
+      "id": 805, "name": "Crazy Habib's Fertilizer",
+      "exits": { "north": 802 }
+    },
+    {
+      "id": 806, "name": "Barber Shop",
+      "exits": { "south": 800 }
+    },
+    {
+      "id": 807, "name": "Pornographers Den",
+      "exits": { "south": 802 }
+    },
+    {
+      "id": 808, "name": "Livery",
+      "exits": { "up": 809, "west": 161 }
+    },
+    {
+      "id": 809, "name": "Hayloft",
+      "exits": { "down": 808 }
+    },
+    {
+      "id": 810, "name": "Tailor's Shop",
+      "exits": { "west": 162 }
+    },
+    {
+      "id": 811, "name": "Hardware Store",
+      "exits": { "west": 163 }
+    },
+    {
+      "id": 812, "name": "Haseltine Engravers",
+      "exits": { "west": 164 }
+    },
+    {
+      "id": 813, "name": "Guild/Shop Space for rent",
+      "exits": { "north": 795 }
+    },
+    {
+      "id": 814, "name": "Flea Market",
+      "exits": { "north": 796 }
+    },
+    {
+      "id": 815, "name": "The Back Room",
+      "exits": { "east": 230, "north": 814 }
+    },
+    {
+      "id": 816, "name": "Castle Bridge",
+      "exits": { "north": 151 }
+    },
+    {
+      "id": 817, "name": "Manor House",
+      "exits": { "up": 818, "west": 152 }
+    },
+    {
+      "id": 818, "name": "Manor House",
+      "exits": { "down": 817 }
+    },
+    {
+      "id": 819, "name": "Guild/Shop Space for rent",
+      "exits": { "east": 152 }
+    },
+    {
+      "id": 820, "name": "Cleric Guild",
+      "exits": { "west": 839, "east": 153, "north": 838 }
+    },
+    {
+      "id": 821, "name": "Hall of the builders guild",
+      "exits": { "west": 154 }
+    },
+    {
+      "id": 822, "name": "City Hall",
+      "exits": { "east": 156, "up": 831 }
+    },
+    {
+      "id": 823, "name": "Tea Shop",
+      "exits": { "east": 157 }
+    },
+    {
+      "id": 824, "name": "Whore House",
+      "exits": { "east": 158, "up": 825 }
+    },
+    {
+      "id": 825, "name": "Second floor of whore house.",
+      "exits": { "south": 828, "west": 826, "up": 829, "down": 824, "north": 827 }
+    },
+    {
+      "id": 826, "name": "Viking's room",
+      "exits": { "east": 825 }
+    },
+    {
+      "id": 827, "name": "Sandra's room",
+      "exits": { "south": 825 }
+    },
+    {
+      "id": 828, "name": "Kathy's room",
+      "exits": { "north": 825 }
+    },
+    {
+      "id": 829, "name": "Robert's room",
+      "exits": { "down": 825 }
+    },
+    {
+      "id": 830, "name": "Baker's Shop",
+      "exits": { "west": 157 }
+    },
+    {
+      "id": 831, "name": "First Floor",
+      "exits": { "up": 833, "down": 822, "west": 832 }
+    },
+    {
+      "id": 832, "name": "Chamber of Commerce",
+      "exits": { "east": 831 }
+    },
+    {
+      "id": 833, "name": "Second Floor",
+      "exits": { "up": 835, "down": 831, "west": 834 }
+    },
+    {
+      "id": 834, "name": "Magistrate",
+      "exits": { "east": 833 }
+    },
+    {
+      "id": 835, "name": "City Archives",
+      "exits": { "down": 833, "west": 836 }
+    },
+    {
+      "id": 836, "name": "Inner Sanctum",
+      "exits": { "east": 835 }
+    },
+    {
+      "id": 837, "name": "Open Air Market:",
+      "exits": { "west": 422 }
+    },
+    {
+      "id": 838, "name": "Chapel of War",
+      "exits": { "south": 820 }
+    },
+    {
+      "id": 839, "name": "Reconciliation Chapel",
+      "exits": { "east": 820 }
+    },
+    {
+      "id": 840, "name": "Burned Area",
+      "exits": { "west": 841, "south": 148 }
+    },
+    {
+      "id": 841, "name": "Burned Area",
+      "exits": { "south": 147, "west": 842, "east": 840, "north": 843 }
+    },
+    {
+      "id": 842, "name": "Burned Area",
+      "exits": { "south": 146, "east": 841, "north": 844 }
+    },
+    {
+      "id": 843, "name": "Burned Area",
+      "exits": { "west": 844, "south": 841, "north": 201 }
+    },
+    {
+      "id": 844, "name": "Burned Area",
+      "exits": { "south": 842, "east": 843, "north": 202 }
+    },
+    {
+      "id": 845, "name": "Burned Area",
+      "exits": { "east": 846, "north": 146 }
+    },
+    {
+      "id": 846, "name": "Burned Area",
+      "exits": { "west": 845, "north": 147 }
+    },
+    {
+      "id": 847, "name": "Old City Offices",
+      "exits": { "west": 849, "east": 848, "north": 144 }
+    },
+    {
+      "id": 848, "name": "Old Office",
+      "exits": { "west": 847 }
+    },
+    {
+      "id": 849, "name": "Old Office",
+      "exits": { "east": 847 }
+    },
+    {
+      "id": 850, "name": "Howling Wolf Inn",
+      "exits": { "west": 142, "east": 852, "north": 851 }
+    },
+    {
+      "id": 851, "name": "Howling Wolf Inn",
+      "exits": { "south": 850 }
+    },
+    {
+      "id": 852, "name": "Howling Wolf Inn",
+      "exits": { "west": 850 }
+    },
+    {
+      "id": 853, "name": "Abandoned Building",
+      "exits": { "east": 139 }
+    },
+    {
+      "id": 854, "name": "Spice Merchant",
+      "exits": { "west": 139 }
+    },
+    {
+      "id": 855, "name": "Abandoned Building",
+      "exits": { "west": 138 }
+    },
+    {
+      "id": 856, "name": "Carvings Shop",
+      "exits": { "east": 138 }
+    },
+    {
+      "id": 857, "name": "Abandoned Warehouse",
+      "exits": { "west": 198 }
+    },
+    {
+      "id": 870, "name": "In Rohan's bedroom",
+      "exits": { "down": 869, "up": 871 }
+    },
+    {
+      "id": 871, "name": "In Gwyneth's bedroom",
+      "exits": { "down": 873, "up": 872 }
+    },
+    {
+      "id": 872, "name": "In Vella's bedroom",
+      "exits": { "down": 871 }
+    },
+    {
+      "id": 873, "name": "<> Aladrin escapes reality and falls into Moral Decay. <>",
+      "exits": { "down": 874, "up": 871 }
+    },
+    {
+      "id": 874, "name": "Bottom floor of the silo",
+      "exits": { "up": 873 }
+    },
+    {
+      "id": 878, "name": "Guild/Shop Space for rent",
+      "exits": { "south": 127 }
+    },
+    {
+      "id": 879, "name": "Vesla Post Office",
+      "exits": { "south": 126 }
+    },
+    {
+      "id": 880, "name": "Old Adventurer's Guild",
+      "exits": { "north": 126 }
+    },
+    {
+      "id": 893, "name": "The Players' lounge",
+      "exits": { "down": 229 }
+    },
+    {
+      "id": 961, "name": "Rising Phoenix",
+      "exits": { "south": 796 }
+    },
+    {
+      "id": 962, "name": "Abandoned Store",
+      "exits": { "west": 199 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"

--- a/maps/wheatfield.json
+++ b/maps/wheatfield.json
@@ -4,127 +4,52 @@
   },
   "rooms": [
     {
-      "name": "Road Through a Wheatfield",
-      "exits": {
-        "east": 1639,
-        "southeast": 1641,
-        "south": 1640
-      },
-      "id": 1638
+      "id": 1638, "name": "Road Through a Wheatfield",
+      "exits": { "east": 1639, "southeast": 1641, "south": 1640 }
     },
     {
-      "name": "Road Through a Wheatfield",
-      "exits": {
-        "southeast": 1648,
-        "south": 1641,
-        "southwest": 1640,
-        "east": 1649,
-        "west": 1638
-      },
-      "id": 1639
+      "id": 1639, "name": "Road Through a Wheatfield",
+      "exits": { "southeast": 1648, "south": 1641, "southwest": 1640, "east": 1649, "west": 1638 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "west": 1645,
-        "southeast": 1642,
-        "south": 1643,
-        "southwest": 1644,
-        "northeast": 1639,
-        "east": 1641,
-        "north": 1638
-      },
-      "id": 1640
+      "id": 1640, "name": "Wheatfield",
+      "exits": { "west": 1645, "southeast": 1642, "south": 1643, "southwest": 1644, "northeast": 1639, "east": 1641, "north": 1638 }
     },
     {
-      "name": "Road Through A Wheatfield",
-      "exits": {
-        "west": 1640,
-        "northwest": 1638,
-        "south": 1642,
-        "southwest": 1643,
-        "northeast": 1649,
-        "east": 1648,
-        "north": 1639
-      },
-      "id": 1641
+      "id": 1641, "name": "Road Through A Wheatfield",
+      "exits": { "west": 1640, "northwest": 1638, "south": 1642, "southwest": 1643, "northeast": 1649, "east": 1648, "north": 1639 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "northwest": 1640,
-        "west": 1643,
-        "northeast": 1648,
-        "east": 1646,
-        "north": 1641
-      },
-      "id": 1642
+      "id": 1642, "name": "Wheatfield",
+      "exits": { "northwest": 1640, "west": 1643, "northeast": 1648, "east": 1646, "north": 1641 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "northwest": 1645,
-        "south": 1623,
-        "west": 1644,
-        "northeast": 1641,
-        "east": 1642,
-        "north": 1640
-      },
-      "id": 1643
+      "id": 1643, "name": "Wheatfield",
+      "exits": { "northwest": 1645, "south": 1623, "west": 1644, "northeast": 1641, "east": 1642, "north": 1640 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "northeast": 1640,
-        "east": 1643,
-        "north": 1645
-      },
-      "id": 1644
+      "id": 1644, "name": "Wheatfield",
+      "exits": { "northeast": 1640, "east": 1643, "north": 1645 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "east": 1640,
-        "southeast": 1643,
-        "south": 1644
-      },
-      "id": 1645
+      "id": 1645, "name": "Wheatfield",
+      "exits": { "east": 1640, "southeast": 1643, "south": 1644 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "west": 1642,
-        "east": 1647,
-        "north": 1648
-      },
-      "id": 1646
+      "id": 1646, "name": "Wheatfield",
+      "exits": { "west": 1642, "east": 1647, "north": 1648 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "west": 1646
-      },
-      "id": 1647
+      "id": 1647, "name": "Wheatfield",
+      "exits": { "west": 1646 }
     },
     {
-      "name": "Road Through a Wheatfield",
-      "exits": {
-        "northwest": 1639,
-        "south": 1646,
-        "southwest": 1642,
-        "west": 1641,
-        "north": 1649
-      },
-      "id": 1648
+      "id": 1648, "name": "Road Through a Wheatfield",
+      "exits": { "northwest": 1639, "south": 1646, "southwest": 1642, "west": 1641, "north": 1649 }
     },
     {
-      "name": "Wheatfield",
-      "exits": {
-        "southwest": 1641,
-        "west": 1639,
-        "south": 1648
-      },
-      "id": 1649
+      "id": 1649, "name": "Wheatfield",
+      "exits": { "southwest": 1641, "west": 1639, "south": 1648 }
     }
   ],
   "exportedAt": "2026-01-05T00:19:21Z"


### PR DESCRIPTION
### Motivation
- Normalize the layout of room objects in all map JSON files so `id` and `name` appear on the same line and `exits` are grouped on the following line for easier diffing and readability.
- Preserve any additional room metadata (e.g. `area`, `weight`, `environment`) while keeping it after the `exits` entry.
- Apply a consistent ordering and formatting for all entries under `/maps` to make future automated changes less noisy.
- Ensure the reformatting is presentation-only and does not alter semantic data.

### Description
- Reformatted every room object in the files under `/maps` so the `id` and `name` fields appear together on one line and the `exits` object is on the next line, with any other room keys following thereafter.
- The formatter preserves existing values and additional keys such as `area`, `weight`, and `environment` and emits them after the `exits` line.
- A small Python formatting script was used to read each `/workspace/moraldecay/maps/*.json` file and rewrite it with the new layout and key order.
- The change was applied repository-wide to the map files (multiple area files and large maps such as `moraldecay.json`, `candera.json`, `balin.json` etc.).

### Testing
- The Python formatting script used to perform the change was executed across `/workspace/moraldecay/maps/*.json` and completed successfully without errors.
- Spot-checks with `head` on several files confirmed the new `id`/`name` and `exits` layout is present.
- No automated unit or integration tests were executed because these are formatting-only changes.
- Manual inspection of several large and small map files was performed to ensure metadata keys were preserved and formatting is consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8cb736988327b799a6e8bba0ec25)