### PR TITLE
Strip Mudlet metadata and exportedAt timestamps from maps JSON

### DIFF
--- a/maps/anshelm.json
+++ b/maps/anshelm.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 235, "name": "Before the Anshelm Gatehouse",
@@ -447,6 +444,5 @@
       "id": 1333, "name": "Northern statuary",
       "exits": { "south": 1330 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/anthill.json
+++ b/maps/anthill.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1723, "name": "Inside the Anthill",
@@ -274,6 +271,5 @@
     {
       "id": 1806, "name": "At the top of the anthill."
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area10.json
+++ b/maps/area10.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 931, "name": "Entryway",
@@ -91,6 +88,5 @@
       "id": 952, "name": "Storage",
       "exits": { "west": 948 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area11.json
+++ b/maps/area11.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 858, "name": "Entrance of a village",
@@ -95,6 +92,5 @@
       "id": 960, "name": "Above the shed",
       "exits": { "down": 959 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area12.json
+++ b/maps/area12.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 881, "name": "Cemetery Lane.",
@@ -51,6 +48,5 @@
       "id": 892, "name": "A cemetery.",
       "exits": { "west": 887 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area13.json
+++ b/maps/area13.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1000, "name": "Foyer",
@@ -63,6 +60,5 @@
       "id": 1014, "name": "Dark corner",
       "exits": { "east": 1013, "south": 1002 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area14.json
+++ b/maps/area14.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1018, "name": "Headquarter Entrance",
@@ -47,6 +44,5 @@
       "id": 1029, "name": "Strategist's Room",
       "exits": { "west": 1024 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area16.json
+++ b/maps/area16.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1036, "name": "Southwest Tower"
@@ -13,6 +10,5 @@
       "id": 1038, "name": "Thief Hideout Entrance",
       "exits": { "up": 1037 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area17.json
+++ b/maps/area17.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1039, "name": "Guard Post",
@@ -159,6 +156,5 @@
       "id": 1077, "name": "Prison cell",
       "exits": { "north": 1070 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area18.json
+++ b/maps/area18.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 77, "name": "House of Clan Lord Bracknar",
@@ -23,6 +20,5 @@
       "id": 1081, "name": "House of Clan Lord Bracknar",
       "exits": { "down": 77 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area19.json
+++ b/maps/area19.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1082, "name": "Gatehouse",
@@ -55,6 +52,5 @@
       "id": 1871, "name": "Stables",
       "exits": { "north": 1086 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area20.json
+++ b/maps/area20.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1099, "name": "Crypt of the Honored Dead",
@@ -107,6 +104,5 @@
       "id": 1124, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1116 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area21.json
+++ b/maps/area21.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1164, "name": "Living room",
@@ -19,6 +16,5 @@
       "id": 1167, "name": "You brush aside the blanket and duck to pass through the small door.",
       "exits": { "southwest": 1164 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area23.json
+++ b/maps/area23.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 416, "name": "City Unemployment Office",
@@ -19,6 +16,5 @@
       "id": 1203, "name": "City Unemployment Office",
       "exits": { "north": 416 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area25.json
+++ b/maps/area25.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1223, "name": "A short entryway",
@@ -111,6 +108,5 @@
       "id": 1288, "name": "The Lollipop Guild",
       "exits": { "north": 1274 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area27.json
+++ b/maps/area27.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1334, "name": "Tiled Entryway",
@@ -23,6 +20,5 @@
       "id": 1361, "name": "Clan Lord's Private Chambers",
       "exits": { "south": 1337 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area29.json
+++ b/maps/area29.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1440, "name": "Light forest",
@@ -267,6 +264,5 @@
       "id": 1506, "name": "Mine Entrance",
       "exits": { "up": 1491 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area32.json
+++ b/maps/area32.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1650, "name": "North Moat",
@@ -147,6 +144,5 @@
       "id": 1686, "name": "West Moat",
       "exits": { "south": 1672, "north": 1685 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area33.json
+++ b/maps/area33.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 990, "name": "Oak Treehouse landing",
@@ -211,6 +208,5 @@
       "id": 1738, "name": "Hall of Ministers",
       "exits": { "southwest": 1736, "south": 1737 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area36.json
+++ b/maps/area36.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1824, "name": "You are just inside the entrace to a large cave",
@@ -43,6 +40,5 @@
       "id": 1833, "name": "A small chamber",
       "exits": { "south": 1830 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area38.json
+++ b/maps/area38.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1863, "name": "You cross the sharply arching bridge.",
@@ -27,6 +24,5 @@
       "id": 1868, "name": "You slide back the fusumi with a flick of your hand.",
       "exits": { "south": 1867 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area6.json
+++ b/maps/area6.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 506, "name": "Entrance to Gorge",
@@ -15,6 +12,5 @@
       "id": 508, "name": "Old Guard Room",
       "exits": { "east": 507 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area7.json
+++ b/maps/area7.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 509, "name": ""
@@ -209,6 +206,5 @@
       "id": 1325, "name": "Twisting Tunnel",
       "exits": { "east": 1321 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/area8.json
+++ b/maps/area8.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 529, "name": "The start of a forest path",
@@ -295,6 +292,5 @@
       "id": 601, "name": "Large home",
       "exits": { "east": 567 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/balin.json
+++ b/maps/balin.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 605, "name": "Ocean before Beachhead",
@@ -517,6 +514,5 @@
       "id": 733, "name": "Administrative hallway",
       "exits": { "north": 732 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/candera.json
+++ b/maps/candera.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1, "name": "North Gate",
@@ -659,6 +656,5 @@
       "id": 1134, "name": "House of Lord Candera",
       "exits": { "down": 69 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/chikurin-forest.json
+++ b/maps/chikurin-forest.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1834, "name": "Chikurin Forest Path",
@@ -119,6 +116,5 @@
       "id": 1862, "name": "Chikurin Forest Path",
       "exits": { "south": 1857 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/crimsonaxe-mine.json
+++ b/maps/crimsonaxe-mine.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1807, "name": "Moist cavern",
@@ -71,6 +68,5 @@
       "id": 1823, "name": "The immense stone slab moves suprisingly easily.",
       "exits": { "south": 1813 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/exedoria.json
+++ b/maps/exedoria.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 286, "name": "Entrance to Exedoria",
@@ -603,6 +600,5 @@
       "id": 930, "name": "Machinery Room",
       "exits": { "down": 929 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/great-bazaar-of-candera.json
+++ b/maps/great-bazaar-of-candera.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 977, "name": "Great Bazaar of Candera",
@@ -75,6 +72,5 @@
       "id": 1739, "name": "Landak's Hut:",
       "exits": { "west": 995 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/ice-dragons-den.json
+++ b/maps/ice-dragons-den.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1338, "name": "Ice Dragon's Den",
@@ -99,6 +96,5 @@
       "id": 1869, "name": "down the waterfall.",
       "exits": { "down": 1339 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/indel-city-park.json
+++ b/maps/indel-city-park.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1606, "name": "Indel City Park",
@@ -63,6 +60,5 @@
       "id": 1620, "name": "Indel City Park",
       "exits": { "west": 1618, "south": 1617 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/indel.json
+++ b/maps/indel.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1401, "name": "City of Indel, Wilderness Gate",
@@ -631,6 +628,5 @@
       "id": 1653, "name": "Mudball Arena Entrance",
       "exits": { "up": 1583 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/moraldecay.json
+++ b/maps/moraldecay.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1, "name": "North Gate",
@@ -13093,6 +13090,5 @@
       "weight": 1,
       "area": {"id": 19}
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/nature-preserve.json
+++ b/maps/nature-preserve.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 432, "name": "Bridge",
@@ -295,6 +292,5 @@
       "id": 504, "name": "Nature Preserve",
       "exits": { "east": 502 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/promenade-des-trafficants.json
+++ b/maps/promenade-des-trafficants.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1169, "name": "Promenade des Trafficants",
@@ -67,6 +64,5 @@
       "id": 1184, "name": "Volshev's Advertising Agency",
       "exits": { "west": 1171 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/pylus.json
+++ b/maps/pylus.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1205, "name": "End of Pylus road",
@@ -399,6 +396,5 @@
       "id": 1400, "name": "The Consort's chambers",
       "exits": { "south": 1397 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/vesla.json
+++ b/maps/vesla.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 115, "name": "The Gate to the Wilderness",
@@ -1131,6 +1128,5 @@
       "id": 962, "name": "Abandoned Store",
       "exits": { "west": 199 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }

--- a/maps/wheatfield.json
+++ b/maps/wheatfield.json
@@ -1,7 +1,4 @@
 {
-  "mudlet": {
-    "version": "unknown"
-  },
   "rooms": [
     {
       "id": 1638, "name": "Road Through a Wheatfield",
@@ -51,6 +48,5 @@
       "id": 1649, "name": "Wheatfield",
       "exits": { "southwest": 1641, "west": 1639, "south": 1648 }
     }
-  ],
-  "exportedAt": "2026-01-05T00:19:21Z"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Remove Mudlet-specific metadata and automatic export timestamps from the map JSON files to keep exports canonical and tool-agnostic.
- Dropping the `mudlet` block prevents shipping a useless `"version": "unknown"` field in every map file.
- Removing `exportedAt` avoids committing transient timestamps that change on each export.

### Description
- Remove the `"mudlet": { "version": "unknown" },` block from every file in `maps/*.json`.
- Remove the final `"exportedAt": "..."` line from each map file and ensure the JSON trailing commas are corrected so the files remain valid.
- Changes were applied across the map set (39 files in `maps/`).

### Testing
- Ran the update via a Python script that edits all files under `maps/*.json` and writes the modified content back to disk, which executed without error.
- Inspected file samples with `python` prints of heads/tails to confirm the `mudlet` block and `exportedAt` lines were removed in representative files.
- Verified there are no remaining occurrences by running `rg "mudlet" maps` and `rg "exportedAt" maps`, which returned no matches.
- Confirmed the repository reflects the updates to the map JSON files (39 map files were updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8ef53c808327b8cd14160c6f718c)