### PR TITLE
Remove default `environment` and `weight` fields from maps/moraldecay.json

### DIFF
--- a/maps/moraldecay.json
+++ b/maps/moraldecay.json
@@ -3,13092 +3,9350 @@
     {
       "id": 1, "name": "North Gate",
       "exits": { "west": 56, "east": 2, "south": 57 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 2, "name": "New Outer Wall",
       "exits": { "east": 3, "west": 1 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 3, "name": "New Outer Wall",
       "exits": { "east": 4, "west": 2 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 4, "name": "New Outer Wall",
       "exits": { "east": 5, "west": 3 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 5, "name": "New Outer Wall",
       "exits": { "east": 6, "west": 4 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 6, "name": "New Outer Wall",
       "exits": { "east": 7, "west": 5 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 7, "name": "Entrance to the Northeast Tower",
       "exits": { "east": 8, "west": 6 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 8, "name": "Northeast Corner",
       "exits": { "west": 7, "south": 9 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 9, "name": "Entrance to the Northeast Tower",
       "exits": { "south": 10, "north": 8 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 10, "name": "New Outer Wall",
       "exits": { "south": 11, "north": 9 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 11, "name": "New Outer Wall",
       "exits": { "south": 12, "north": 10 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 12, "name": "New Outer Wall",
       "exits": { "south": 13, "north": 11 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 13, "name": "New Outer Wall",
       "exits": { "south": 14, "north": 12 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 14, "name": "New Outer Wall",
       "exits": { "south": 15, "north": 13 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 15, "name": "East Wall Guard Station",
       "exits": { "south": 16, "east": 973, "north": 14 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 16, "name": "New Outer Wall",
       "exits": { "south": 17, "north": 15 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 17, "name": "New Outer Wall",
       "exits": { "south": 18, "north": 16 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 18, "name": "New Outer Wall",
       "exits": { "south": 19, "north": 17 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 19, "name": "New Outer Wall",
       "exits": { "south": 20, "north": 18 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 20, "name": "New Outer Wall",
       "exits": { "south": 21, "north": 19 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 21, "name": "New Outer Wall",
       "exits": { "south": 22, "north": 20 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 22, "name": "New Outer Wall",
       "exits": { "west": 23, "north": 21 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 23, "name": "New Outer Wall",
       "exits": { "east": 22, "west": 24 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 24, "name": "New Outer Wall",
       "exits": { "east": 23, "west": 25 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 25, "name": "New Outer Wall",
       "exits": { "east": 24, "west": 26 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 26, "name": "New Outer Wall",
       "exits": { "east": 25, "west": 27 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 27, "name": "New Outer Wall",
       "exits": { "east": 26, "west": 28 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 28, "name": "New Outer Wall",
       "exits": { "east": 27, "west": 29 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 29, "name": "South Wall Guard Station",
       "exits": { "west": 30, "east": 28, "south": 1030 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 30, "name": "New Outer Wall",
       "exits": { "east": 29, "west": 31 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 31, "name": "New Outer Wall",
       "exits": { "east": 30, "west": 32 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 32, "name": "New Outer Wall",
       "exits": { "east": 31, "west": 33 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 33, "name": "New Outer Wall",
       "exits": { "east": 32, "west": 34 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 34, "name": "New Outer Wall",
       "exits": { "east": 33, "west": 35 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 35, "name": "New Outer Wall",
       "exits": { "east": 34, "west": 36 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 36, "name": "Southwest Corner",
       "exits": { "east": 35, "north": 37 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 37, "name": "New Outer Wall",
       "exits": { "south": 36, "north": 38 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 38, "name": "New Outer Wall",
       "exits": { "south": 37, "north": 39 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 39, "name": "New Outer Wall",
       "exits": { "south": 38, "north": 40 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 40, "name": "New Outer Wall",
       "exits": { "south": 39, "north": 41 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 41, "name": "New Outer Wall",
       "exits": { "south": 40, "north": 42 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 42, "name": "New Outer Wall",
       "exits": { "south": 41, "north": 43 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 43, "name": "West Wall Guard Station",
       "exits": { "west": 1033, "south": 42, "north": 44 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 44, "name": "New Outer Wall",
       "exits": { "south": 43, "north": 45 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 45, "name": "New Outer Wall",
       "exits": { "south": 44, "north": 46 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 46, "name": "New Outer Wall",
       "exits": { "south": 45, "north": 47 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 47, "name": "New Outer Wall",
       "exits": { "south": 46, "north": 48 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 48, "name": "New Outer Wall",
       "exits": { "south": 47, "north": 49 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 49, "name": "Entrance to the Northwest Tower",
       "exits": { "south": 48, "north": 50 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 50, "name": "Northwest Corner",
       "exits": { "east": 51, "south": 49 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 51, "name": "Entrance to the Northwest Tower",
       "exits": { "east": 52, "west": 50 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 52, "name": "New Outer Wall",
       "exits": { "east": 53, "west": 51 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 53, "name": "New Outer Wall",
       "exits": { "east": 54, "west": 52 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 54, "name": "New Outer Wall",
       "exits": { "east": 55, "west": 53 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 55, "name": "New Outer Wall",
       "exits": { "east": 56, "west": 54 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 56, "name": "New Outer Wall",
       "exits": { "east": 1, "west": 55 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 57, "name": "Warrior's Walk",
       "exits": { "south": 58, "west": 963, "east": 964, "north": 1 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 58, "name": "Warrior's Walk",
       "exits": { "south": 59, "west": 965, "east": 966, "north": 57 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 59, "name": "Warrior's Walk",
       "exits": { "west": 967, "south": 60, "north": 58 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 60, "name": "Warrior's Walk",
       "exits": { "south": 61, "west": 968, "east": 969, "north": 59 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 61, "name": "Warrior's Walk",
       "exits": { "west": 970, "south": 62, "north": 60 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 62, "name": "Warrior's Walk",
       "exits": { "south": 63, "west": 971, "east": 972, "north": 61 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 63, "name": "Canderan Well",
       "exits": { "south": 64, "west": 72, "east": 94, "north": 62 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 64, "name": "Warrior's Walk",
       "exits": { "south": 65, "west": 429, "east": 427, "north": 63 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 65, "name": "Warrior's Walk",
       "exits": { "south": 66, "west": 430, "east": 1015, "north": 64 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 66, "name": "Warrior's Walk",
       "exits": { "south": 67, "north": 65 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 67, "name": "Warrior's Walk",
       "exits": { "south": 68, "north": 66 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 68, "name": "Warrior's Walk",
       "exits": { "south": 69, "east": 431, "north": 67 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 69, "name": "House of Lord Candera",
       "exits": { "up": 1134, "west": 70, "east": 71, "north": 68 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 70, "name": "House of Lord Candera",
       "exits": { "east": 69 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 71, "name": "House of Lord Candera",
       "exits": { "west": 69 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 72, "name": "Clansmen Way",
       "exits": { "west": 73, "east": 63, "south": 429 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 73, "name": "Clansmen Way",
       "exits": { "south": 1016, "west": 74, "east": 72, "north": 1017 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 74, "name": "Clansmen Way",
       "exits": { "south": 1019, "west": 75, "east": 73, "north": 1018 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 75, "name": "Clansmen Way",
       "exits": { "west": 76, "east": 74, "south": 1095 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 76, "name": "Clansmen Way",
       "exits": { "south": 78, "west": 77, "east": 75, "north": 86 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 77, "name": "House of Clan Lord Bracknar",
       "exits": { "west": 1080, "up": 1081, "south": 1079, "east": 76, "north": 1078 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 18}
+                  "area": {"id": 18}
     },
     {
       "id": 78, "name": "Zoman's Flat",
       "exits": { "south": 79, "north": 76 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 79, "name": "Zoman's Flat",
       "exits": { "south": 80, "east": 1096, "north": 78 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 80, "name": "Zoman's Flat",
       "exits": { "south": 81, "north": 79 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 81, "name": "Zoman's Flat",
       "exits": { "south": 82, "north": 80 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 82, "name": "Zoman's Flat",
       "exits": { "south": 83, "west": 1097, "east": 1098, "north": 81 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 83, "name": "Temple of Air",
       "exits": { "west": 84, "east": 85, "north": 82 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 84, "name": "Temple of Air",
       "exits": { "east": 83, "up": 1130 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 85, "name": "Temple of Air",
       "exits": { "up": 1131, "west": 83 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 86, "name": "Suran's Flat",
       "exits": { "south": 76, "north": 87 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 87, "name": "Suran's Flat",
       "exits": { "west": 1082, "south": 86, "north": 88 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 88, "name": "Suran's Flat",
       "exits": { "south": 87, "north": 89 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 89, "name": "Suran's Flat",
       "exits": { "south": 88, "north": 90 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 90, "name": "Suran's Flat",
       "exits": { "south": 89, "west": 1093, "east": 1094, "north": 91 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 91, "name": "Temple of Water",
       "exits": { "west": 92, "east": 93, "south": 90 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 92, "name": "Temple of Water",
       "exits": { "east": 91, "up": 1132 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 93, "name": "Temple of Water",
       "exits": { "up": 1133, "west": 91 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 94, "name": "Clansmen Way",
       "exits": { "south": 427, "west": 63, "east": 95, "north": 972 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 95, "name": "Clansmen Way",
       "exits": { "west": 94, "east": 96, "south": 975 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 96, "name": "Clansmen Way",
       "exits": { "south": 976, "west": 95, "east": 97, "north": 977 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 97, "name": "Clansmen Way",
       "exits": { "west": 96, "east": 98, "north": 428 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 98, "name": "Clansmen Way",
       "exits": { "south": 99, "west": 97, "east": 1000, "north": 107 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 99, "name": "Fallah's Flat:",
       "exits": { "south": 100, "north": 98 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 100, "name": "Fallah's Flat:",
       "exits": { "south": 101, "west": 505, "east": 997, "north": 99 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 101, "name": "Fallah's Flat",
       "exits": { "south": 102, "north": 100 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 102, "name": "Fallah's Flat",
       "exits": { "south": 103, "north": 101 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 103, "name": "Fallah's Flat:",
       "exits": { "south": 104, "west": 998, "east": 999, "north": 102 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 104, "name": "Temple of Earth",
       "exits": { "west": 105, "east": 106, "north": 103 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 105, "name": "Temple of Earth",
       "exits": { "east": 104, "up": 1127 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 106, "name": "Temple of Earth",
       "exits": { "up": 1126, "west": 104 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 107, "name": "Phaekads Flat:",
       "exits": { "south": 98, "north": 108 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 108, "name": "Phaekads Flat:",
       "exits": { "south": 107, "north": 109 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 109, "name": "Phaekads Flat",
       "exits": { "south": 108, "north": 110 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 110, "name": "Phaekads Flat",
       "exits": { "south": 109, "north": 111 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 111, "name": "Phaekads Flat:",
       "exits": { "south": 110, "east": 996, "north": 112 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 112, "name": "Temple of Fire",
       "exits": { "west": 113, "east": 114, "south": 111 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 113, "name": "Temple of Fire",
       "exits": { "east": 112, "up": 1129 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 114, "name": "Temple of Fire",
       "exits": { "up": 1128, "west": 112 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 115, "name": "The Gate to the Wilderness",
       "exits": { "west": 116 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 116, "name": "Intersection of Park Street and Caravan Road",
       "exits": { "south": 233, "west": 117, "east": 115, "north": 172 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 117, "name": "Intersection of Park Street and Via Sacra",
       "exits": { "south": 220, "west": 118, "east": 116, "north": 226 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 118, "name": "A shaded walk",
       "exits": { "south": 221, "west": 119, "east": 117, "north": 227 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 119, "name": "A shaded walk",
       "exits": { "south": 222, "west": 120, "east": 118, "north": 230 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 120, "name": "A shaded walk",
       "exits": { "west": 121, "east": 119, "south": 223 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 121, "name": "A shaded walk",
       "exits": { "south": 224, "west": 122, "east": 120, "north": 425 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 122, "name": "A shaded walk",
       "exits": { "south": 225, "west": 123, "east": 121, "north": 410 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 123, "name": "A shaded walk",
       "exits": { "west": 124, "east": 122, "north": 411 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 124, "name": "A break in the coverage",
       "exits": { "west": 125, "east": 123, "north": 412 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 125, "name": "A busy intersection",
       "exits": { "south": 159, "west": 126, "east": 124, "north": 160 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 126, "name": "The end of the park street",
       "exits": { "south": 880, "west": 127, "east": 125, "north": 879 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 127, "name": "Entrance to the Old City.",
       "exits": { "west": 128, "east": 126, "north": 878 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 128, "name": "Westroad, The Entrance to the Old City.",
       "exits": { "west": 129, "east": 127, "north": 881 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 129, "name": "Westroad",
       "exits": { "west": 130, "east": 128, "south": 419 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 130, "name": "Westroad",
       "exits": { "west": 131, "east": 129, "south": 420 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 131, "name": "Westroad",
       "exits": { "west": 132, "east": 130, "north": 858 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 132, "name": "Westroad",
       "exits": { "west": 133, "east": 131, "south": 421 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 133, "name": "The corner of Westroad and Basalt Avenue",
       "exits": { "west": 134, "east": 132, "south": 135 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 134, "name": "Western Gate of Vesla",
       "exits": { "east": 133 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 135, "name": "Basalt Avenue",
       "exits": { "south": 136, "north": 133 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 136, "name": "Basalt Avenue",
       "exits": { "south": 137, "north": 135 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 137, "name": "Intersection of Basalt Avenue and Rapier Way",
       "exits": { "south": 138, "east": 193, "north": 136 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 138, "name": "Basalt Avenue",
       "exits": { "south": 139, "west": 856, "east": 855, "north": 137 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 139, "name": "Basalt Avenue",
       "exits": { "south": 140, "west": 853, "east": 854, "north": 138 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 140, "name": "Intersection of Basalt Avenue and Street of the Bells",
       "exits": { "south": 141, "east": 204, "north": 139 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 141, "name": "Basalt Avenue",
       "exits": { "south": 142, "north": 140 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 142, "name": "Basalt Avenue",
       "exits": { "south": 143, "east": 850, "north": 141 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 143, "name": "Corner of Basalt Avenue and West River Street",
       "exits": { "east": 144, "north": 142 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 144, "name": "West River Street",
       "exits": { "west": 143, "east": 145, "south": 847 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 145, "name": "West River Street",
       "exits": { "east": 146, "west": 144 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 146, "name": "West River Street",
       "exits": { "south": 845, "west": 145, "east": 147, "north": 842 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 147, "name": "West River Street",
       "exits": { "south": 846, "west": 146, "east": 148, "north": 841 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 148, "name": "West River Street",
       "exits": { "west": 147, "east": 149, "north": 840 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 149, "name": "West River street",
       "exits": { "east": 150, "west": 148 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 150, "name": "West River street",
       "exits": { "east": 151, "west": 149 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 151, "name": "River Street and South Main",
       "exits": { "south": 816, "west": 150, "east": 205, "north": 152 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 152, "name": "South Main street",
       "exits": { "south": 151, "west": 819, "east": 817, "north": 153 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 153, "name": "South Main Street",
       "exits": { "west": 820, "south": 152, "north": 154 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 154, "name": "South Main Street",
       "exits": { "south": 153, "east": 821, "north": 155 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 155, "name": "South Main Street",
       "exits": { "south": 154, "west": 423, "east": 422, "north": 156 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 156, "name": "South Main Street",
       "exits": { "south": 155, "west": 822, "east": 424, "north": 157 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 157, "name": "South Main Street",
       "exits": { "south": 156, "west": 823, "east": 830, "north": 158 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 158, "name": "South Main street",
       "exits": { "west": 824, "south": 157, "north": 159 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 159, "name": "South Main street",
       "exits": { "south": 158, "north": 125 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 160, "name": "Northern Main",
       "exits": { "south": 125, "east": 412, "north": 161 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 161, "name": "Northern Main Street",
       "exits": { "south": 160, "east": 808, "north": 162 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 162, "name": "Northern Main street",
       "exits": { "south": 161, "east": 810, "north": 163 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 163, "name": "Northern Main Street",
       "exits": { "south": 162, "east": 811, "north": 164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 164, "name": "Northern Main street",
       "exits": { "south": 163, "east": 812, "north": 165 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 165, "name": "Northern Main street",
       "exits": { "south": 164, "north": 166 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 166, "name": "Intersection of North Main and Scholar's Way",
       "exits": { "south": 165, "east": 192, "north": 167 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 167, "name": "Northern Main street",
       "exits": { "south": 166, "north": 168 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 168, "name": "Intersection of North Main and Wall Street",
       "exits": { "south": 167, "west": 793, "east": 170, "north": 169 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 169, "name": "Northern Gate",
       "exits": { "south": 168, "northeast": 753 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 170, "name": "Western End of Wall Street",
       "exits": { "east": 171, "west": 168 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 171, "name": "Wall Street",
       "exits": { "west": 170 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 172, "name": "Caravan Road",
       "exits": { "south": 116, "west": 226, "east": 735, "north": 173 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 173, "name": "Caravan Road",
       "exits": { "south": 172, "west": 232, "east": 736, "north": 174 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 174, "name": "Caravan Road",
       "exits": { "south": 173, "north": 175 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 175, "name": "Caravan Road",
       "exits": { "south": 174, "north": 176 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 176, "name": "Caravan Road",
       "exits": { "south": 175, "north": 177 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 177, "name": "Caravan Road",
       "exits": { "south": 176, "north": 178 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 178, "name": "Intersection of Scholar's Way and Caravan Road",
       "exits": { "west": 185, "south": 177, "north": 179 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 179, "name": "Caravan Road",
       "exits": { "south": 178, "north": 180 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 180, "name": "Intersection of Caravan Road and Wall Street",
       "exits": { "west": 181, "south": 179 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 181, "name": "Eastern End of Wall Street",
       "exits": { "east": 180, "west": 182 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 182, "name": "Wall Street",
       "exits": { "east": 181, "west": 183 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 183, "name": "Wall Street",
       "exits": { "east": 182, "west": 184 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 184, "name": "Wall Street",
       "exits": { "east": 183 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 185, "name": "Scholar's Way",
       "exits": { "east": 178, "west": 186 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 186, "name": "Scholar's Way",
       "exits": { "east": 185, "west": 187 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 187, "name": "Scholar's Way",
       "exits": { "west": 188, "east": 186, "north": 737 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 188, "name": "Scholar's Way",
       "exits": { "west": 189, "east": 187, "north": 738 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 189, "name": "Scholar's Way",
       "exits": { "west": 190, "east": 188, "south": 739 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 190, "name": "Scholar's Way",
       "exits": { "south": 740, "west": 191, "east": 189, "north": 741 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 191, "name": "Scholar's Way",
       "exits": { "south": 742, "west": 192, "east": 190, "north": 743 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 192, "name": "Scholar's Way",
       "exits": { "west": 166, "east": 191, "south": 744 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 193, "name": "Rapier Way",
       "exits": { "east": 194, "west": 137 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 194, "name": "Rapier Way",
       "exits": { "east": 195, "west": 193 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 195, "name": "Rapier Way",
       "exits": { "east": 196, "west": 194 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 196, "name": "Rapier Way",
       "exits": { "east": 197, "west": 195 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 197, "name": "Intersection of Rapier Way and Zand Boulevard",
       "exits": { "west": 196, "south": 198 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 198, "name": "Zand Boulevard",
       "exits": { "south": 199, "east": 857, "north": 197 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 199, "name": "Zand Boulevard",
       "exits": { "south": 200, "east": 962, "north": 198 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 200, "name": "Intersection of Street of the Bells and Zand Boulevard",
       "exits": { "west": 201, "north": 199 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 201, "name": "Street of the Bells",
       "exits": { "south": 843, "west": 202, "east": 200, "north": 931 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 202, "name": "Street of the Bells",
       "exits": { "west": 203, "east": 201, "south": 844 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 203, "name": "Street of the Bells",
       "exits": { "east": 202, "west": 204 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 204, "name": "Street of the Bells",
       "exits": { "east": 203, "west": 140 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 205, "name": "East River Street",
       "exits": { "east": 206, "west": 151 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 206, "name": "East River Street",
       "exits": { "west": 205, "east": 207, "north": 397 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 207, "name": "East River Street",
       "exits": { "east": 208, "west": 206 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 208, "name": "East River Street",
       "exits": { "west": 207, "east": 209, "north": 396 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 209, "name": "East River Street",
       "exits": { "west": 208, "east": 210, "north": 395 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 210, "name": "East River Street",
       "exits": { "west": 209, "east": 211, "north": 394 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 211, "name": "End of East River Street",
       "exits": { "east": 212, "west": 210 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 212, "name": "Intersection of Via Sacra and River Street",
       "exits": { "west": 211, "north": 213 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 213, "name": "South End of Via Sacra",
       "exits": { "south": 212, "east": 399, "north": 214 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 214, "name": "Southern Via Sacra",
       "exits": { "south": 213, "west": 400, "east": 401, "north": 215 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 215, "name": "Via Sacra",
       "exits": { "south": 214, "north": 216 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 216, "name": "Via Sacra",
       "exits": { "south": 215, "west": 402, "east": 403, "north": 217 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 217, "name": "Via Sacra",
       "exits": { "west": 408, "south": 216, "north": 218 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 218, "name": "Via Sacra",
       "exits": { "south": 217, "north": 219 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 219, "name": "Via Sacra",
       "exits": { "west": 409, "south": 218, "north": 220 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 220, "name": "Northern End of Via Sacra",
       "exits": { "south": 219, "west": 221, "east": 233, "north": 117 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 221, "name": "General Store",
       "exits": { "west": 222, "east": 220, "north": 118 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 222, "name": "Comfortably Numb",
       "exits": { "west": 223, "east": 221, "north": 119 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 223, "name": "Medieval Mounts",
       "exits": { "west": 224, "east": 222, "north": 120 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 224, "name": "Big Hole Banking",
       "exits": { "west": 225, "east": 223, "north": 121 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 225, "name": "Brimstone",
       "exits": { "east": 224, "north": 122 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 226, "name": "A peaceful park",
       "exits": { "south": 117, "west": 227, "east": 172, "north": 232 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 227, "name": "A peaceful park",
       "exits": { "south": 118, "west": 230, "east": 226, "north": 228 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 228, "name": "A peaceful park",
       "exits": { "south": 227, "west": 231, "east": 232, "north": 229 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 229, "name": "Sanctuary",
       "exits": { "up": 893, "south": 228 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 230, "name": "A peaceful park",
       "exits": { "south": 119, "west": 815, "east": 227, "north": 231 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 231, "name": "A peaceful park",
       "exits": { "south": 230, "west": 796, "east": 228, "north": 426 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 232, "name": "A peaceful park",
       "exits": { "south": 226, "west": 228, "east": 173, "north": 234 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 233, "name": "The Shadowed Anvil",
       "exits": { "west": 220, "north": 116 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 234, "name": "Andre's Clothing",
       "exits": { "south": 232 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 235, "name": "Before the Anshelm Gatehouse",
       "exits": { "north": 236 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 236, "name": "Under the Anshelmish Gatehouse",
       "exits": { "west": 1143, "south": 235, "north": 237 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 237, "name": "Southern end of Rue du Nord",
       "exits": { "southwest": 1135, "south": 236, "southeast": 1154, "north": 238 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 238, "name": "Rue du Nord",
       "exits": { "west": 413, "south": 237, "north": 239 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 239, "name": "Intersection of Rue du Nord and Beitel Straat",
       "exits": { "south": 238, "west": 414, "east": 1185, "north": 240 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 240, "name": "Rue du Nord",
       "exits": { "south": 239, "west": 415, "east": 1192, "north": 241 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 241, "name": "Rue du Nord",
       "exits": { "west": 416, "south": 240, "north": 242 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 242, "name": "Gateway to Middle Bailey",
       "exits": { "south": 241, "north": 243 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 243, "name": "Rue du Nord",
       "exits": { "south": 242, "north": 244 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 244, "name": "Western intersection of Rue du Nord and Kirsch Lane",
       "exits": { "west": 245, "east": 250, "south": 243 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 245, "name": "Kirsch Lane",
       "exits": { "east": 244, "west": 246 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 246, "name": "Kirsch Lane",
       "exits": { "west": 247, "east": 245, "south": 249 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 247, "name": "Western end of Kirsch Lane",
       "exits": { "east": 246, "south": 248 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 248, "name": "Construction site",
       "exits": { "north": 247 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 249, "name": "Kaneohe Armory",
       "exits": { "north": 246 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 250, "name": "Eastern intersection of Rue du Nord and Kirsch Lane",
       "exits": { "west": 244, "east": 283, "north": 251 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 251, "name": "Rue du Nord",
       "exits": { "south": 250, "east": 1193, "north": 252 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 252, "name": "Rue du Nord",
       "exits": { "south": 251, "north": 253 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 253, "name": "Rue du Nord",
       "exits": { "south": 252, "north": 254 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 254, "name": "Rue du Nord",
       "exits": { "south": 253, "north": 255 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 255, "name": "Central Square on the Rue du Nord",
       "exits": { "south": 254, "west": 1195, "east": 1194, "north": 256 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 256, "name": "Rue du Nord",
       "exits": { "south": 255, "north": 257 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 257, "name": "Rue du Nord",
       "exits": { "south": 256, "north": 258 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 258, "name": "Intersection of Rue du Nord and East Geld Strasse",
       "exits": { "west": 259, "east": 281, "south": 257 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 259, "name": "Rue du Nord",
       "exits": { "east": 258, "west": 260 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 260, "name": "Intersection of Rue du Nord and West Geld Strasse",
       "exits": { "west": 261, "east": 259, "north": 264 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 261, "name": "Geld Strasse",
       "exits": { "east": 260, "west": 262 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 262, "name": "Geld Strasse",
       "exits": { "east": 261, "west": 263 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 263, "name": "Western end of Geld Strasse",
       "exits": { "east": 262 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 264, "name": "Rue du Nord",
       "exits": { "south": 260, "north": 265 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 265, "name": "Gateway to Upper Bailey",
       "exits": { "south": 264, "west": 282, "east": 1198, "north": 266 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 266, "name": "Rue du Nord",
       "exits": { "south": 265, "north": 267 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 267, "name": "Intersection of Rue du Nord and Kasernegade",
       "exits": { "south": 266, "west": 268, "east": 276, "north": 273 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 268, "name": "Kasernegade",
       "exits": { "east": 267, "west": 269 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 269, "name": "Kasernegade",
       "exits": { "east": 268, "west": 270 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 270, "name": "Kasernegade",
       "exits": { "west": 271, "east": 269, "south": 1199 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 271, "name": "Western end of Kasernegade",
       "exits": { "east": 270, "north": 272 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 272, "name": "Construction site",
       "exits": { "south": 271 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 273, "name": "Rue du Nord",
       "exits": { "south": 267, "northwest": 1202, "north": 274 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 274, "name": "Under the Town Gate",
       "exits": { "south": 273, "north": 275 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 275, "name": "Before the Anshelm Town Gate",
       "exits": { "south": 274 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 276, "name": "Kasernegade",
       "exits": { "west": 267, "east": 277, "north": 1200 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 277, "name": "Kasernegade",
       "exits": { "east": 278, "west": 276 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 278, "name": "Kasernegade",
       "exits": { "east": 279, "west": 277 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 279, "name": "Kasernegade",
       "exits": { "east": 280, "west": 278 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 280, "name": "Eastern end of Kasernegade",
       "exits": { "west": 279, "south": 1201 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 281, "name": "Geld Strasse",
       "exits": { "west": 258, "east": 1328, "north": 1197 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 282, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
       "exits": { "east": 265 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 283, "name": "Kirsch Lane",
       "exits": { "west": 250, "east": 284, "north": 1326 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 284, "name": "Kirsch Lane",
       "exits": { "west": 283, "east": 285, "north": 1327 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 285, "name": "Eastern end of Kirsch Lane",
       "exits": { "west": 284 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 286, "name": "Entrance to Exedoria",
       "exits": { "east": 287 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 287, "name": "Main Street",
       "exits": { "west": 286, "east": 288, "south": 330 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 288, "name": "Main Street",
       "exits": { "south": 368, "west": 287, "east": 289, "north": 367 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 289, "name": "Main Street",
       "exits": { "west": 288, "east": 290, "south": 366 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 290, "name": "Monument Circle, Main Street",
       "exits": { "south": 299, "west": 289, "east": 291, "north": 369 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 291, "name": "Main Street",
       "exits": { "south": 298, "west": 290, "east": 292, "north": 370 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 292, "name": "Main Street",
       "exits": { "west": 291, "east": 293, "south": 383 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 293, "name": "Main Street",
       "exits": { "east": 294, "west": 292 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 294, "name": "Main Street",
       "exits": { "east": 295, "west": 293 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 295, "name": "Main Street",
       "exits": { "east": 296, "west": 294 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 296, "name": "Main Street",
       "exits": { "east": 297, "west": 295 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 297, "name": "Corigan Court Intersection",
       "exits": { "west": 296 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 298, "name": "City Hall",
       "exits": { "north": 291 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 299, "name": "Eithel Sirion",
       "exits": { "south": 300, "north": 290 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 300, "name": "Brapnor Road",
       "exits": { "south": 301, "west": 302, "east": 385, "north": 299 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 301, "name": "Frenchie's II",
       "exits": { "north": 300 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 302, "name": "Brapnor Road",
       "exits": { "west": 303, "east": 300, "south": 392 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 303, "name": "Middle of Brapnor Road",
       "exits": { "west": 304, "east": 302, "south": 329 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 304, "name": "Brapnor Road",
       "exits": { "west": 305, "east": 303, "north": 330 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 305, "name": "Brapnor Road",
       "exits": { "west": 306, "east": 304, "north": 393 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 306, "name": "Brapnor Road",
       "exits": { "east": 305, "west": 307 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 307, "name": "End of Brapnor Road",
       "exits": { "east": 306, "northwest": 331, "south": 308 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 308, "name": "Beginning of Lilu Lane",
       "exits": { "south": 309, "north": 307 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 309, "name": "Lilu Lane",
       "exits": { "south": 310, "north": 308 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 310, "name": "Middle of Lilu Lane",
       "exits": { "west": 355, "south": 311, "north": 309 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 311, "name": "Lilu Lane",
       "exits": { "south": 312, "north": 310 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 312, "name": "End of Lilu Lane",
       "exits": { "west": 354, "south": 313, "north": 311 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 313, "name": "Beginning of Embassy Row",
       "exits": { "east": 314, "north": 312 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 314, "name": "Embassy Row",
       "exits": { "west": 313, "east": 315, "south": 322 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 315, "name": "Embassy Row",
       "exits": { "south": 320, "west": 314, "east": 316, "north": 321 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 316, "name": "Embassy Row",
       "exits": { "south": 318, "west": 315, "east": 317, "north": 319 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 317, "name": "Embassy Row",
       "exits": { "west": 316, "east": 323, "north": 333 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 318, "name": "A Dark Hole in the Ground",
       "exits": { "north": 316 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 319, "name": "Guard Post for Gnome Embassy",
       "exits": { "south": 316, "north": 926 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 320, "name": "Before a round door",
       "exits": { "north": 315 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 321, "name": "Junk yard",
       "exits": { "south": 315 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 322, "name": "Elven Embassy checkpoint",
       "exits": { "north": 314 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 323, "name": "End of Embassy Row",
       "exits": { "west": 317, "north": 324 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 324, "name": "Southern end of alley",
       "exits": { "south": 323, "north": 325 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 325, "name": "Bend in an alley",
       "exits": { "west": 326, "south": 324 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 326, "name": "A bend in the alley",
       "exits": { "east": 325, "north": 327 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 327, "name": "Dark and narrow alley",
       "exits": { "south": 326, "north": 328 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 328, "name": "Dark alley",
       "exits": { "south": 327, "north": 329 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 329, "name": "Alley entrance",
       "exits": { "south": 328, "north": 303 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 330, "name": "The Excalibur, a closed guild",
       "exits": { "south": 304, "north": 287 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 331, "name": "Foyer of the Exedorian Inn",
       "exits": { "southeast": 307, "west": 332 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 332, "name": "Exedorian saloon",
       "exits": { "east": 331 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 333, "name": "Before the Dwarven Embassy",
       "exits": { "south": 317, "north": 920 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 334, "name": "Keen Street West",
       "exits": { "east": 335 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 335, "name": "Keen Street",
       "exits": { "east": 336, "west": 334 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 336, "name": "Keen Street",
       "exits": { "west": 335, "east": 337, "north": 602 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 337, "name": "Keen Street",
       "exits": { "west": 336, "east": 338, "south": 603 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 338, "name": "East Keen Street Bridge",
       "exits": { "west": 337, "east": 339, "north": 604 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 339, "name": "Keen Street Bridge",
       "exits": { "east": 340, "west": 338 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 340, "name": "Keen Street",
       "exits": { "west": 339, "east": 341, "south": 343 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 341, "name": "Keen Street East",
       "exits": { "west": 340, "north": 342 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 342, "name": "Guard Post",
       "exits": { "south": 341, "north": 350 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 343, "name": "Statued lawn",
       "exits": { "south": 344, "north": 340 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 344, "name": "Statued lawn",
       "exits": { "south": 345, "north": 343 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 345, "name": "Manicured lawn",
       "exits": { "south": 346, "north": 344 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 346, "name": "Cavernous foyer",
       "exits": { "west": 348, "east": 347, "north": 345 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 347, "name": "Icy room",
       "exits": { "west": 346 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 348, "name": "Cold hallway",
       "exits": { "east": 346, "south": 349 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 349, "name": "Snowy cave",
       "exits": { "north": 348 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 350, "name": "With no gate guard present, you are able to enter the walled estate",
       "exits": { "south": 342, "north": 351 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 351, "name": "Foyer",
       "exits": { "east": 352, "south": 350 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 352, "name": "Wood-paneled Hallway",
       "exits": { "west": 351, "north": 353 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 353, "name": "Busy Kitchen",
       "exits": { "south": 352 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 354, "name": "Mom's General Store",
       "exits": { "east": 312 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 355, "name": "Drawbridge",
       "exits": { "east": 310, "west": 356 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 356, "name": "Library's entrance",
       "exits": { "south": 357, "west": 361, "east": 355, "north": 362 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 357, "name": "Cobblestoned hallway",
       "exits": { "south": 358, "east": 360, "north": 356 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 358, "name": "A bend in the hallway",
       "exits": { "west": 359, "north": 357 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 359, "name": "A monk's cell",
       "exits": { "east": 358 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 360, "name": "A monk's cell",
       "exits": { "west": 357 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 361, "name": "With a grunt of effort, you manage to push open the heavy door, and enter",
       "exits": { "east": 356 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 362, "name": "Cobblestoned hallway",
       "exits": { "south": 356, "east": 363, "north": 364 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 363, "name": "A monk's cell",
       "exits": { "west": 362 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 364, "name": "A bend in the hallway",
       "exits": { "west": 365, "south": 362 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 365, "name": "A monk's cell",
       "exits": { "east": 364 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 366, "name": "The Cadaver Emporium",
       "exits": { "north": 289 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 367, "name": "Velvet Unicorn",
       "exits": { "south": 288 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 368, "name": "Eidolon Warlords",
       "exits": { "north": 288 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 369, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": { "south": 290 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 370, "name": "Beginning of park path",
       "exits": { "south": 291, "north": 371 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 371, "name": "Park path intersection",
       "exits": { "south": 370, "west": 372, "east": 378, "north": 373 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 372, "name": "Exedoria Pet Cemetary",
       "exits": { "east": 371 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 373, "name": "Park path on the hill",
       "exits": { "south": 371, "north": 374 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 374, "name": "Elevated park path",
       "exits": { "south": 373, "north": 375 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 375, "name": "End of park path",
       "exits": { "east": 376, "south": 374 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 376, "name": "Temple ruins",
       "exits": { "east": 377, "west": 375 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 377, "name": "Temple rotunda",
       "exits": { "west": 376 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 378, "name": "Gravel path to the mansion",
       "exits": { "east": 379, "west": 371 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 379, "name": "Gravel path on the hill",
       "exits": { "east": 380, "west": 378 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 380, "name": "Intersection in the gravel path",
       "exits": { "west": 379, "southeast": 382, "north": 381 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 381, "name": "Before a white mansion",
       "exits": { "south": 380 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 382, "name": "Outside the cemetery gate",
       "exits": { "northwest": 380 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 383, "name": "Guard Post",
       "exits": { "south": 384, "north": 292 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 384, "name": "Beginning of Brapnor Road",
       "exits": { "west": 385, "southeast": 386, "north": 383 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 385, "name": "Brapnor Road",
       "exits": { "east": 384, "west": 300 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 386, "name": "Necrom's Gate",
       "exits": { "northwest": 384, "southeast": 387 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 387, "name": "Paved intersection",
       "exits": { "east": 388, "northwest": 386, "south": 527 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 388, "name": "Eastern path through the University",
       "exits": { "east": 389, "west": 387 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 389, "name": "Eastern path through the University",
       "exits": { "east": 390, "west": 388 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 390, "name": "In front of a temporary building",
       "exits": { "west": 389, "east": 391, "south": 904 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 391, "name": "Construction site",
       "exits": { "west": 390 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 392, "name": "Delilah's Deli",
       "exits": { "north": 302 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 393, "name": "Guard Tower Entrance",
       "exits": { "south": 305 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 394, "name": "Smoke House",
       "exits": { "south": 210 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 395, "name": "The Lathe",
       "exits": { "south": 209 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 396, "name": "Antique Shop",
       "exits": { "south": 208 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 397, "name": "Mage's House",
       "exits": { "east": 398, "south": 206 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 398, "name": "Mage's Apprentice House",
       "exits": { "west": 397 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 399, "name": "Retired Warrior's House",
       "exits": { "up": 734, "west": 213 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 400, "name": "Bell maker's shop",
       "exits": { "east": 214 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 401, "name": "Candle Shop",
       "exits": { "west": 214 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 402, "name": "Do-it-Yourself Distiller",
       "exits": { "east": 216 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 403, "name": "Entrance to a temple",
       "exits": { "east": 404, "west": 216 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 404, "name": "Temple of Amaterasu",
       "exits": { "east": 405, "west": 403 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 405, "name": "Temple of Amaterasu",
       "exits": { "west": 404, "south": 407, "north": 406 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 406, "name": "Candle Room",
       "exits": { "south": 405 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 407, "name": "Quiet Room",
       "exits": { "north": 405 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 408, "name": "MD Banking",
       "exits": { "east": 217 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 409, "name": "Bounty Room",
       "exits": { "east": 219 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 410, "name": "A dingy alleyway",
       "exits": { "west": 411, "south": 122, "north": 792 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 411, "name": "Vesla Times Press Office",
       "exits": { "east": 410, "south": 123 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 412, "name": "Smithy",
       "exits": { "west": 160, "south": 124 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 413, "name": "Hawaiian Ryan's",
       "exits": { "east": 238, "north": 414 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 414, "name": "Beitel Straad",
       "exits": { "south": 413, "west": 1147, "east": 239, "north": 415 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 415, "name": "Club Femme Nu",
       "exits": { "east": 240, "south": 414 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 416, "name": "City Unemployment Office",
       "exits": { "south": 1203, "west": 417, "east": 241, "north": 418 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 23}
+                  "area": {"id": 23}
     },
     {
       "id": 417, "name": "City Unemployment Office",
       "exits": { "east": 416 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 23}
+                  "area": {"id": 23}
     },
     {
       "id": 418, "name": "City Unemployment Office",
       "exits": { "south": 416 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 23}
+                  "area": {"id": 23}
     },
     {
       "id": 419, "name": "A dark alleyway",
       "exits": { "north": 129 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 420, "name": "The Old Temple",
       "exits": { "north": 130 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 421, "name": "Mage's Guild",
       "exits": { "north": 132 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 422, "name": "Mercantile Guild Office",
       "exits": { "east": 837, "west": 155 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 423, "name": "Glassblower",
       "exits": { "east": 155 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 424, "name": "Fighter's Guild",
       "exits": { "west": 156 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 425, "name": "Omar's Oils II",
       "exits": { "south": 121 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 426, "name": "Deora's Outfitters",
       "exits": { "south": 231 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 427, "name": "The Rabbit's Hole",
       "exits": { "west": 64, "north": 94 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 428, "name": "6 Feet Under",
       "exits": { "west": 977, "south": 97 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 429, "name": "Morbid Curiosity",
       "exits": { "east": 64, "north": 72 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 430, "name": "Scribe",
       "exits": { "east": 65 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 431, "name": "Servants Quarters",
       "exits": { "west": 68 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 432, "name": "Bridge",
       "exits": { "west": 433 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 433, "name": "Waterfall",
       "exits": { "east": 432 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 434, "name": "",
       "exits": { "north": 435 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 435, "name": "Canopy Trail",
       "exits": { "west": 436, "south": 434 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 436, "name": "Canopy Trail",
       "exits": { "east": 435, "west": 437 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 437, "name": "Canopy Trail",
       "exits": { "east": 436, "west": 438 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 438, "name": "Canopy Trail",
       "exits": { "west": 439, "east": 437, "south": 440 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 439, "name": "Canopy Trail",
       "exits": { "east": 438, "west": 445 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 440, "name": "Nature Preserve",
       "exits": { "south": 441, "north": 438 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 441, "name": "Tropical Forest",
       "exits": { "south": 442, "north": 440 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 442, "name": "Nature Preserve",
       "exits": { "west": 443, "east": 444, "north": 441 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 443, "name": "Bird Sanctuary",
       "exits": { "east": 442 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 444, "name": "Nature Preserve",
       "exits": { "west": 442 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 445, "name": "Canopy Trail",
       "exits": { "west": 496, "east": 439, "north": 446 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 446, "name": "Entrance to Queen's Meadow",
       "exits": { "south": 445, "north": 447 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 447, "name": "Queen's Meadow",
       "exits": { "south": 446, "north": 448 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 448, "name": "Queen's Meadow",
       "exits": { "south": 447, "north": 449 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 449, "name": "Queen's Meadow",
       "exits": { "west": 450, "south": 448, "north": 494 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 450, "name": "Nature Preserve",
       "exits": { "east": 449, "west": 451 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 451, "name": "Nature Preserve",
       "exits": { "east": 450, "west": 452 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 452, "name": "Nature Preserve",
       "exits": { "east": 451, "west": 453 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 453, "name": "Nature Preserve",
       "exits": { "south": 455, "east": 452, "north": 454 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 454, "name": "Nature Preserve",
       "exits": { "south": 453 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 455, "name": "Nature Preserve",
       "exits": { "south": 456, "north": 453 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 456, "name": "Nature Preserve",
       "exits": { "west": 457, "north": 455 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 457, "name": "Nature Preserve",
       "exits": { "east": 456, "west": 458 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 458, "name": "Nature Preserve",
       "exits": { "east": 457, "north": 459 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 459, "name": "Nature Preserve",
       "exits": { "south": 458, "north": 460 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 460, "name": "Nature Preserve",
       "exits": { "west": 495, "south": 459, "north": 461 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 461, "name": "Nature Preserve",
       "exits": { "west": 463, "east": 462, "south": 460 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 462, "name": "Nature Preserve",
       "exits": { "west": 461, "north": 464 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 463, "name": "Sink Hole",
       "exits": { "east": 461 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 464, "name": "Nature Preserve",
       "exits": { "west": 486, "east": 465, "south": 462 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 465, "name": "Nature Preserve",
       "exits": { "west": 464, "north": 466 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 466, "name": "Nature Preserve",
       "exits": { "east": 467, "south": 465 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 467, "name": "Nature Preserve",
       "exits": { "east": 468, "west": 466 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 468, "name": "Nature Preserve",
       "exits": { "east": 469, "west": 467 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 469, "name": "Nature Preserve",
       "exits": { "east": 470, "west": 468 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 470, "name": "Queen's Meadow",
       "exits": { "west": 469, "south": 493, "north": 471 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 471, "name": "Tropical Landscape",
       "exits": { "south": 470, "north": 472 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 472, "name": "Nature Preserve",
       "exits": { "south": 471, "north": 473 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 473, "name": "Nature Preserve",
       "exits": { "west": 476, "east": 474, "south": 472 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 474, "name": "Nature Preserve",
       "exits": { "east": 475, "west": 473 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 475, "name": "Nature Preserve",
       "exits": { "west": 474 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 476, "name": "Nature Preserve",
       "exits": { "northwest": 477, "east": 473 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 477, "name": "Nature Preserve",
       "exits": { "southwest": 478, "southeast": 476, "north": 490 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 478, "name": "Nature Preserve",
       "exits": { "west": 479, "northeast": 477 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 479, "name": "Nature Preserve",
       "exits": { "west": 480, "east": 478, "south": 487 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 480, "name": "Nature Preserve",
       "exits": { "east": 479, "west": 481 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 481, "name": "Nature Preserve",
       "exits": { "east": 480, "south": 482 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 482, "name": "Nature Preserve",
       "exits": { "west": 483, "south": 484, "north": 481 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 483, "name": "Nature Preserve",
       "exits": { "east": 482 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 484, "name": "Nature Preserve",
       "exits": { "south": 485, "north": 482 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 485, "name": "Nature Preserve",
       "exits": { "south": 486, "north": 484 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 486, "name": "Nature Preserve",
       "exits": { "east": 464, "north": 485 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 487, "name": "Nature Preserve",
       "exits": { "south": 488, "north": 479 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 488, "name": "Nature Preserve",
       "exits": { "east": 489, "north": 487 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 489, "name": "Nature Preserve",
       "exits": { "west": 488 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 490, "name": "Nature Preserve",
       "exits": { "south": 477, "north": 491 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 491, "name": "Nature Preserve",
       "exits": { "east": 492, "south": 490 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 492, "name": "A Hollowed Tree",
       "exits": { "west": 491 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 493, "name": "Queen's Meadow",
       "exits": { "south": 494, "north": 470 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 494, "name": "Queen's Meadow",
       "exits": { "south": 449, "north": 493 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 495, "name": "Nature Preserve",
       "exits": { "east": 460 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 496, "name": "Canopy Trail",
       "exits": { "east": 445, "west": 497 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 497, "name": "Canopy Trail",
       "exits": { "west": 498, "east": 496, "south": 501 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 498, "name": "Canopy Trail",
       "exits": { "east": 497, "north": 499 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 499, "name": "Nature Preserve",
       "exits": { "east": 500, "south": 498 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 500, "name": "Dragon's Den",
       "exits": { "west": 499 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 501, "name": "Nature Preserve",
       "exits": { "south": 502, "north": 497 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 502, "name": "Nature Preserve",
       "exits": { "west": 504, "east": 503, "north": 501 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 503, "name": "Nature Preserve",
       "exits": { "west": 502 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 504, "name": "Nature Preserve",
       "exits": { "east": 502 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 5}
+                  "area": {"id": 5}
     },
     {
       "id": 505, "name": "Slave Auction:",
       "exits": { "east": 100 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 506, "name": "Entrance to Gorge",
       "exits": { "north": 507 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 6}
+                  "area": {"id": 6}
     },
     {
       "id": 507, "name": "Narrow Gorge",
       "exits": { "west": 508, "south": 506 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 6}
+                  "area": {"id": 6}
     },
     {
       "id": 508, "name": "Old Guard Room",
       "exits": { "east": 507 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 6}
+                  "area": {"id": 6}
     },
     {
       "id": 509, "name": "",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 510, "name": "Barbarian Clearing",
       "exits": { "north": 511 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 511, "name": "Underground Pond",
       "exits": { "southwest": 512, "west": 518, "south": 510 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 512, "name": "Cave Passage",
       "exits": { "south": 513, "northeast": 511 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 513, "name": "Cave Passage",
       "exits": { "south": 515, "north": 512 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 514, "name": "You begin to climb into the pit, and the descent seems simple enough.",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 515, "name": "Bottom of a Deep Dark Pit",
       "exits": { "east": 516, "north": 513 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 516, "name": "Dark Barricade",
       "exits": { "east": 517, "west": 515 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 517, "name": "Corridor",
       "exits": { "east": 519, "west": 516 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 518, "name": "Cave Passage",
       "exits": { "southwest": 1292, "east": 511 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 519, "name": "Passage Way",
       "exits": { "south": 520, "west": 517, "east": 523, "north": 521 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 520, "name": "Barracks",
       "exits": { "north": 519 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 521, "name": "Mess Hall",
       "exits": { "south": 519, "north": 522 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 522, "name": "Kitchen",
       "exits": { "south": 521 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 523, "name": "Passage Way",
       "exits": { "south": 524, "west": 519, "east": 1295, "north": 1294 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 524, "name": "Passage Way",
       "exits": { "south": 525, "north": 523 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 525, "name": "Passage Way",
       "exits": { "west": 1293, "south": 526, "north": 524 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 526, "name": "Circular room",
       "exits": { "north": 525 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 527, "name": "Southern path through the University",
       "exits": { "south": 528, "north": 387 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 528, "name": "Southern path through the University",
       "exits": { "south": 896, "east": 894, "north": 527 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 529, "name": "The start of a forest path",
       "exits": { "northeast": 530 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 530, "name": "The start of a forest path",
       "exits": { "southwest": 529, "northeast": 531, "northwest": 532 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 531, "name": "A forest path",
       "exits": { "southwest": 530, "northeast": 539, "east": 551 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 532, "name": "A forest path",
       "exits": { "west": 535, "northeast": 578, "southeast": 530, "north": 533 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 533, "name": "A forest path",
       "exits": { "west": 534, "south": 532, "southwest": 535, "northeast": 596, "east": 578, "north": 591 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 534, "name": "A forest path",
       "exits": { "south": 535, "west": 536, "northeast": 591, "east": 533, "north": 592 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 535, "name": "A forest path",
       "exits": { "northeast": 533, "east": 532, "north": 534 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 536, "name": "River Bank",
       "exits": { "southwest": 537, "northeast": 592, "east": 534 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 537, "name": "River Bank",
       "exits": { "southwest": 538, "northeast": 536 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 538, "name": "Gryphon Nest",
       "exits": { "northeast": 537 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 539, "name": "A clearing in the forest",
       "exits": { "southwest": 531, "northeast": 540, "east": 550, "south": 551 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 540, "name": "A forest path",
       "exits": { "southwest": 539, "northeast": 541, "east": 549, "south": 550 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 541, "name": "A forest path",
       "exits": { "south": 549, "southwest": 540, "northeast": 542, "east": 548, "west": 575 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 542, "name": "A forest",
       "exits": { "southwest": 541, "northeast": 543, "east": 547, "south": 548 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 543, "name": "A dark forest",
       "exits": { "southwest": 542, "northeast": 544, "east": 546, "south": 547 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 544, "name": "A forest",
       "exits": { "southwest": 543, "east": 545, "south": 546 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 545, "name": "A forest glade",
       "exits": { "southwest": 546, "west": 544, "east": 558, "south": 557 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 546, "name": "A forest glade",
       "exits": { "west": 543, "south": 556, "southwest": 547, "northeast": 545, "east": 557, "north": 544 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 547, "name": "A forest path",
       "exits": { "west": 542, "south": 555, "southwest": 548, "northeast": 546, "east": 556, "north": 543 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 548, "name": "A path in the forest",
       "exits": { "west": 541, "south": 554, "southwest": 549, "northeast": 547, "east": 555, "north": 542 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 549, "name": "A clearing in the forest",
       "exits": { "west": 540, "south": 553, "southwest": 550, "northeast": 548, "east": 554, "north": 541 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 550, "name": "A forest",
       "exits": { "west": 539, "south": 552, "southwest": 551, "northeast": 549, "east": 553, "north": 540 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 551, "name": "A forest path",
       "exits": { "south": 576, "west": 531, "northeast": 550, "east": 552, "north": 539 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 552, "name": "A forest path",
       "exits": { "west": 551, "northeast": 553, "east": 565, "north": 550 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 553, "name": "A forest path",
       "exits": { "west": 550, "south": 565, "southwest": 552, "northeast": 554, "east": 564, "north": 549 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 554, "name": "A forest path",
       "exits": { "west": 549, "south": 564, "southwest": 553, "northeast": 555, "east": 563, "north": 548 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 555, "name": "A path through the forest",
       "exits": { "west": 548, "south": 563, "southwest": 554, "northeast": 556, "east": 562, "north": 547 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 556, "name": "A forest path",
       "exits": { "west": 547, "south": 562, "southwest": 555, "northeast": 557, "east": 561, "north": 546 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 557, "name": "A forest",
       "exits": { "west": 546, "south": 561, "southwest": 556, "northeast": 558, "east": 560, "north": 545 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 558, "name": "A forest path",
       "exits": { "southwest": 557, "west": 545, "east": 559, "south": 560 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 559, "name": "A forest path",
       "exits": { "southwest": 560, "west": 558, "south": 573 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 560, "name": "A path in the forest",
       "exits": { "west": 557, "south": 572, "southwest": 561, "northeast": 559, "east": 573, "north": 558 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 561, "name": "A forest path",
       "exits": { "west": 556, "south": 571, "southwest": 562, "northeast": 560, "east": 572, "north": 557 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 562, "name": "A forest path",
       "exits": { "west": 555, "south": 570, "southwest": 563, "northeast": 561, "east": 571, "north": 556 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 563, "name": "A forest",
       "exits": { "west": 554, "south": 569, "southwest": 564, "northeast": 562, "east": 570, "north": 555 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 564, "name": "A forest path",
       "exits": { "west": 553, "south": 568, "southwest": 565, "northeast": 563, "east": 569, "north": 554 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 565, "name": "A forest path",
       "exits": { "west": 552, "south": 574, "southwest": 566, "northeast": 564, "east": 568, "north": 553 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 566, "name": "A dark forest glade",
       "exits": { "southwest": 567, "northeast": 565 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 567, "name": "A forest path",
       "exits": { "west": 601, "northeast": 566 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 568, "name": "A forest path",
       "exits": { "southwest": 574, "northeast": 569, "west": 565, "north": 564 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 569, "name": "A path through the forest",
       "exits": { "southwest": 568, "northeast": 570, "west": 564, "north": 563 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 570, "name": "A forest glade",
       "exits": { "southwest": 569, "northeast": 571, "west": 563, "north": 562 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 571, "name": "A forest path",
       "exits": { "southwest": 570, "northeast": 572, "west": 562, "north": 561 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 572, "name": "A forest path",
       "exits": { "southwest": 571, "northeast": 573, "west": 561, "north": 560 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 573, "name": "A forest path",
       "exits": { "southwest": 572, "west": 560, "north": 559 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 574, "name": "Forest Glade",
       "exits": { "northeast": 568, "north": 565 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 575, "name": "A forest",
       "exits": { "east": 541 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 576, "name": "The start of a forest path",
       "exits": { "southwest": 577, "north": 551 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 577, "name": "The start of a forest path",
       "exits": { "northeast": 576 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 578, "name": "A forest path",
       "exits": { "west": 533, "southwest": 532, "northeast": 579, "east": 600, "north": 596 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 579, "name": "A forest path",
       "exits": { "southwest": 578, "northeast": 580, "west": 596, "north": 597 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 580, "name": "A clearing in the forest",
       "exits": { "southwest": 579, "northeast": 581, "west": 597, "north": 598 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 581, "name": "A forest path",
       "exits": { "southwest": 580, "northeast": 582, "west": 598, "north": 585 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 582, "name": "Forest Mound",
       "exits": { "west": 585, "southwest": 581, "northeast": 583, "east": 599, "north": 584 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 583, "name": "A forest path",
       "exits": { "southwest": 582, "west": 584 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 584, "name": "A forest glade",
       "exits": { "southwest": 585, "west": 586, "east": 583, "south": 582 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 585, "name": "A forest path",
       "exits": { "south": 581, "west": 595, "northeast": 584, "east": 582, "north": 586 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 586, "name": "A forest glade",
       "exits": { "southwest": 588, "west": 587, "east": 584, "south": 585 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 587, "name": "A river bank",
       "exits": { "southwest": 595, "east": 586, "south": 588 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 588, "name": "A dark forest glade",
       "exits": { "west": 595, "south": 598, "southwest": 589, "northeast": 586, "east": 589, "north": 587 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 589, "name": "A forest glade",
       "exits": { "west": 594, "south": 597, "southwest": 590, "northeast": 588, "east": 598, "north": 595 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 590, "name": "A forest",
       "exits": { "west": 593, "south": 596, "southwest": 591, "northeast": 589, "east": 597, "north": 594 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 591, "name": "A forest",
       "exits": { "west": 592, "south": 533, "southwest": 534, "northeast": 590, "east": 596, "north": 593 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 592, "name": "A river bank",
       "exits": { "southwest": 536, "northeast": 593, "east": 591, "south": 534 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 593, "name": "A river bank",
       "exits": { "southwest": 592, "northeast": 594, "east": 590, "south": 591 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 594, "name": "A riverbank",
       "exits": { "southwest": 593, "northeast": 595, "east": 589, "south": 590 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 595, "name": "A river bank",
       "exits": { "southwest": 594, "northeast": 587, "east": 585, "south": 589 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 596, "name": "A path through the forest",
       "exits": { "west": 591, "south": 578, "southwest": 533, "northeast": 597, "east": 579, "north": 590 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 597, "name": "A forest path",
       "exits": { "west": 590, "south": 579, "southwest": 596, "northeast": 598, "east": 580, "north": 589 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 598, "name": "A forest path",
       "exits": { "west": 589, "south": 580, "southwest": 597, "northeast": 589, "east": 581, "north": 588 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 599, "name": "A small clearing",
       "exits": { "west": 582 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 600, "name": "Druids Guild",
       "exits": { "west": 578 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 601, "name": "Large home",
       "exits": { "east": 567 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 8}
+                  "area": {"id": 8}
     },
     {
       "id": 602, "name": "Railed entrance",
       "exits": { "south": 336 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 603, "name": "Flagstoned entry",
       "exits": { "south": 915, "north": 337 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 604, "name": "You rudely trespass on the private property.",
       "exits": { "northeast": 907, "northwest": 910, "south": 338 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 605, "name": "Ocean before Beachhead",
       "exits": { "north": 606 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 606, "name": "A sandy beachhead",
       "exits": { "south": 605, "west": 623, "east": 626, "north": 607 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 607, "name": "A narrow path between the dunes",
       "exits": { "south": 606, "east": 628, "north": 608 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 608, "name": "A Dune Path",
       "exits": { "south": 607, "north": 609 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 609, "name": "The City Gate",
       "exits": { "south": 608, "west": 631, "east": 634, "north": 610 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 610, "name": "Intersection of Silver Street and Balin Road",
       "exits": { "south": 609, "west": 635, "east": 660, "north": 611 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 611, "name": "Silver Street",
       "exits": { "south": 610, "east": 713, "north": 612 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 612, "name": "Silver Street",
       "exits": { "south": 611, "east": 674, "north": 613 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 613, "name": "Silver Street",
       "exits": { "south": 612, "west": 675, "east": 676, "north": 614 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 614, "name": "A Grand Plaza",
       "exits": { "south": 613, "west": 678, "east": 677, "north": 615 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 615, "name": "Silver Street",
       "exits": { "west": 688, "south": 614, "north": 616 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 616, "name": "Silver Street",
       "exits": { "south": 615, "east": 689, "north": 617 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 617, "name": "Silver Street",
       "exits": { "west": 690, "south": 616, "north": 618 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 618, "name": "Silver Street",
       "exits": { "south": 617, "west": 622, "east": 691, "north": 619 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 619, "name": "End of Silver Street",
       "exits": { "east": 620, "south": 618 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 620, "name": "Island smeltery",
       "exits": { "east": 621, "west": 619 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 621, "name": "Repair Shop",
       "exits": { "west": 620 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 622, "name": "A Bloody Arena.",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 623, "name": "Western Part of Beach",
       "exits": { "east": 606, "west": 624 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 624, "name": "East of the waterfall",
       "exits": { "east": 623, "west": 625 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 625, "name": "The base of a waterfall",
       "exits": { "east": 624 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 626, "name": "Ruins",
       "exits": { "east": 627, "west": 606 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 627, "name": "Eastern Beach",
       "exits": { "west": 626 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 628, "name": "A valley between two large dunes",
       "exits": { "east": 629, "west": 607 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 629, "name": "A desert plain",
       "exits": { "west": 628, "north": 630 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 630, "name": "A dead end",
       "exits": { "south": 629 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 631, "name": "Guard Room",
       "exits": { "east": 609, "west": 632 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 632, "name": "Armoury",
       "exits": { "east": 631, "west": 633 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 633, "name": "Elderoak's Quarters",
       "exits": { "east": 632 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 634, "name": "A guard house",
       "exits": { "west": 609 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 635, "name": "Balin Road",
       "exits": { "northwest": 719, "south": 717, "northeast": 718, "east": 610, "west": 636 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 636, "name": "Balin Road",
       "exits": { "southwest": 722, "east": 635, "southeast": 721, "west": 637 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 637, "name": "West End of Balin Road",
       "exits": { "west": 638, "northeast": 720, "east": 636, "south": 723 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 638, "name": "Tunnel Under Canal",
       "exits": { "east": 637, "west": 639 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 639, "name": "South End of Highland Avenue",
       "exits": { "east": 638, "west": 640 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 640, "name": "Highland Avenue",
       "exits": { "south": 657, "east": 639, "north": 641 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 641, "name": "Highland Avenue",
       "exits": { "south": 640, "north": 642 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 642, "name": "Highland Avenue",
       "exits": { "west": 643, "south": 641 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 643, "name": "Highland Avenue",
       "exits": { "south": 647, "east": 642, "north": 644 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 644, "name": "Highland Avenue",
       "exits": { "south": 643, "west": 646, "east": 648, "north": 645 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 645, "name": "Dwarven Hut",
       "exits": { "south": 644 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 646, "name": "You trundle past the facade and arrive on a beautiful street.",
       "exits": { "east": 644 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 647, "name": "Gnome Hut",
       "exits": { "north": 643 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 648, "name": "Highland Avenue",
       "exits": { "south": 651, "west": 644, "east": 649, "north": 650 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 649, "name": "Dwarven Home",
       "exits": { "west": 648 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 650, "name": "Highland Avenue",
       "exits": { "west": 652, "south": 648 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 651, "name": "Dwarven Shack",
       "exits": { "north": 648 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 652, "name": "Highland Avenue",
       "exits": { "west": 653, "east": 650, "north": 654 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 653, "name": "Dwarven Home",
       "exits": { "east": 652, "south": 656 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 654, "name": "Highland Avenue",
       "exits": { "south": 652, "north": 655 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 655, "name": "House of Balin",
       "exits": { "west": 712, "south": 654 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 656, "name": "Dwarven Home",
       "exits": { "north": 653 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 657, "name": "Keep Of Alcibiades",
       "exits": { "west": 659, "east": 658, "north": 640 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 658, "name": "Study",
       "exits": { "west": 657 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 659, "name": "Bedroom:",
       "exits": { "east": 657 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 660, "name": "Balin Road",
       "exits": { "east": 661, "west": 610 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 661, "name": "Balin Road",
       "exits": { "west": 660, "east": 662, "south": 673 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 662, "name": "Balin Road",
       "exits": { "west": 661, "east": 663, "north": 672 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 663, "name": "Balin Road",
       "exits": { "south": 670, "west": 662, "east": 664, "north": 671 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 664, "name": "Balin Road",
       "exits": { "south": 667, "west": 663, "east": 665, "north": 668 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 665, "name": "East End of Balin Road",
       "exits": { "west": 664, "south": 666 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 666, "name": "Arched Gates",
       "exits": { "north": 665 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 667, "name": "Guild/Shop Space for rent",
       "exits": { "north": 664 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 668, "name": "Island Historical Society",
       "exits": { "south": 664, "north": 669 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 669, "name": "Office",
       "exits": { "south": 668 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 670, "name": "Elven Mercantile",
       "exits": { "north": 663 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 671, "name": "Temple Shop",
       "exits": { "west": 672, "south": 663 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 672, "name": "Temple Plaza",
       "exits": { "west": 715, "east": 671, "south": 662 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 673, "name": "Seed Shop",
       "exits": { "north": 661 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 674, "name": "City Pastry Shop",
       "exits": { "west": 612 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 675, "name": "Soylent Green",
       "exits": { "east": 613 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 676, "name": "Mariner's Revenge",
       "exits": { "west": 613, "north": 677 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 677, "name": "Gate House",
       "exits": { "south": 676, "west": 614, "east": 693, "north": 686 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 678, "name": "Gate House",
       "exits": { "east": 614, "west": 679 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 679, "name": "Foyer",
       "exits": { "south": 684, "east": 678, "north": 680 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 680, "name": "Hallway",
       "exits": { "south": 679, "north": 681 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 681, "name": "Audience Hall",
       "exits": { "west": 682, "south": 680 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 682, "name": "Council Chamber",
       "exits": { "east": 681, "west": 683 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 683, "name": "Trophy Room",
       "exits": { "east": 682 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 684, "name": "Hallway",
       "exits": { "south": 685, "north": 679 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 685, "name": "Lady Roland's Bedroom",
       "exits": { "north": 684 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 686, "name": "RIIS",
       "exits": { "down": 687, "south": 677 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 687, "name": "Crack of Doom",
       "exits": { "up": 686 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 688, "name": "Rhian's Potion Shop",
       "exits": { "east": 615 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 689, "name": "Alchemist Shop",
       "exits": { "west": 616 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 690, "name": "Entrance to the Hall of Records",
       "exits": { "east": 617 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 691, "name": "Power System Generator",
       "exits": { "east": 692, "west": 618 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 692, "name": "Power System Internals",
       "exits": { "west": 691 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 693, "name": "Entryway",
       "exits": { "west": 677, "south": 694, "north": 696 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 694, "name": "South Corridor",
       "exits": { "south": 695, "north": 693 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 695, "name": "Guard Post",
       "exits": { "north": 694 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 696, "name": "North Corridor",
       "exits": { "south": 693, "north": 697 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 697, "name": "Guard Room",
       "exits": { "east": 698, "south": 696 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 698, "name": "West Harem",
       "exits": { "east": 699, "west": 697 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 699, "name": "East Harem",
       "exits": { "east": 700, "west": 698 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 700, "name": "Bedchamber",
       "exits": { "east": 701, "west": 699 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 701, "name": "Entryway",
       "exits": { "west": 700, "south": 702 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 702, "name": "Turkish Bath",
       "exits": { "south": 703, "east": 708, "north": 701 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 703, "name": "Turkish Bath",
       "exits": { "south": 704, "east": 707, "north": 702 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 704, "name": "Turkish Bath",
       "exits": { "south": 705, "east": 706, "north": 703 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 705, "name": "South Entryway",
       "exits": { "north": 704 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 706, "name": "Turkish Bath",
       "exits": { "west": 704, "south": 710, "north": 707 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 707, "name": "Turkish Bath",
       "exits": { "west": 703, "south": 706, "north": 708 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 708, "name": "Turkish Bath",
       "exits": { "west": 702, "south": 707, "north": 709 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 709, "name": "Turkish Bath",
       "exits": { "south": 708 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 710, "name": "Turkish Bath",
       "exits": { "north": 706 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 711, "name": "The hermit says: Is there anything you would like to talk about?",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 712, "name": "Hermit's Chamber",
       "exits": { "east": 655 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 713, "name": "Temple",
       "exits": { "west": 611, "east": 714, "north": 716 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 714, "name": "Central Chamber",
       "exits": { "east": 715, "west": 713 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 715, "name": "Eastern Chamber",
       "exits": { "east": 672, "west": 714 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 716, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": { "south": 713 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 717, "name": "Poison Shop",
       "exits": { "north": 635 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 718, "name": "Taxidermist",
       "exits": { "southwest": 635 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 719, "name": "Weaver's",
       "exits": { "southeast": 635 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 720, "name": "Foyer of House of Ill Repute",
       "exits": { "southwest": 637 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 721, "name": "Balin Road Pub",
       "exits": { "northwest": 636 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 722, "name": "Wheelwright",
       "exits": { "northeast": 636 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 723, "name": "Crowded Thoroughfare",
       "exits": { "south": 724, "north": 637 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 724, "name": "Archway of Servitude",
       "exits": { "south": 725, "north": 723 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 725, "name": "Bazaar Crossroad",
       "exits": { "west": 726, "east": 729, "north": 724 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 726, "name": "Western District",
       "exits": { "east": 725, "south": 727 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 727, "name": "Western District",
       "exits": { "south": 728, "north": 726 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 728, "name": "Western slave bazaar",
       "exits": { "east": 732, "north": 727 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 729, "name": "Eastern District",
       "exits": { "west": 725, "south": 730 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 730, "name": "Eastern District",
       "exits": { "south": 731, "north": 729 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 731, "name": "Eastern slave bazaar",
       "exits": { "west": 732, "north": 730 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 732, "name": "Central slave bazaar",
       "exits": { "west": 728, "east": 731, "south": 733 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 733, "name": "Administrative hallway",
       "exits": { "north": 732 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 9}
+                  "area": {"id": 9}
     },
     {
       "id": 734, "name": "Weapon Master's Bedroom",
       "exits": { "down": 399 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 735, "name": "Guild/Shop Space for rent",
       "exits": { "west": 172 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 736, "name": "Guild/Shop Space for rent",
       "exits": { "west": 173 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 737, "name": "Chamber of Commerce",
       "exits": { "south": 187 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 738, "name": "Alley",
       "exits": { "south": 188 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 739, "name": "The School of Guild Skills",
       "exits": { "north": 189 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 740, "name": "Stationery Store",
       "exits": { "north": 190 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 741, "name": "Dormitory Hallway",
       "exits": { "up": 748, "south": 190, "east": 747, "north": 745 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 742, "name": "Magoo's Bookstore",
       "exits": { "north": 191 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 743, "name": "Frenchie's Cafe",
       "exits": { "south": 191 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 744, "name": "An empty lot.",
       "exits": { "north": 192 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 745, "name": "Dormitory Kitchen",
       "exits": { "east": 746, "south": 741 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 746, "name": "Store Room",
       "exits": { "west": 745 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 747, "name": "Dormitory Administrator's Room",
       "exits": { "west": 741 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 748, "name": "Dormitory Hallway",
       "exits": { "west": 751, "down": 741, "south": 752, "east": 750, "north": 749 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 749, "name": "Dormer",
       "exits": { "south": 748 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 750, "name": "Dormer",
       "exits": { "west": 748 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 751, "name": "Dormer",
       "exits": { "east": 748 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 752, "name": "Dormer",
       "exits": { "north": 748 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 753, "name": "The drawbridge",
       "exits": { "southwest": 169, "north": 754 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 754, "name": "Between the towers",
       "exits": { "south": 753, "north": 755 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 755, "name": "Between the towers",
       "exits": { "south": 754, "north": 756 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 756, "name": "The inner ward",
       "exits": { "south": 755, "north": 757 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 757, "name": "The inner ward",
       "exits": { "south": 756, "northeast": 765, "east": 758, "north": 766 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 758, "name": "The inner ward",
       "exits": { "west": 757, "south": 759, "northwest": 766, "north": 765 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 759, "name": "Eastern guard room",
       "exits": { "northeast": 760, "north": 758 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 760, "name": "Lower eastern stairwell",
       "exits": { "southwest": 759, "up": 761 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 761, "name": "Middle eastern stairwell",
       "exits": { "southwest": 762, "down": 760, "up": 763 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 762, "name": "Eastern guard quarters",
       "exits": { "northeast": 761 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 763, "name": "Upper eastern stairwell",
       "exits": { "southwest": 764, "down": 761 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 764, "name": "Eastern tower observatory",
       "exits": { "northeast": 763 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 765, "name": "The inner ward",
       "exits": { "west": 766, "northwest": 767, "south": 758, "southwest": 757, "northeast": 769, "east": 770, "north": 768 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 766, "name": "The inner ward",
       "exits": { "southeast": 758, "south": 757, "northeast": 768, "east": 765, "north": 767 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 767, "name": "The inner ward",
       "exits": { "east": 768, "southeast": 765, "south": 766 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 768, "name": "The inner ward",
       "exits": { "southwest": 766, "west": 767, "east": 769, "south": 765 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 769, "name": "The well",
       "exits": { "southwest": 765, "east": 771, "west": 768 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 770, "name": "Castle stables",
       "exits": { "south": 790, "west": 765, "east": 773, "north": 791 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 771, "name": "The blacksmith",
       "exits": { "east": 772, "west": 769 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 772, "name": "The storage room",
       "exits": { "west": 771 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 773, "name": "Castle stables",
       "exits": { "south": 789, "west": 770, "east": 774, "north": 788 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 774, "name": "Castle stables",
       "exits": { "south": 787, "west": 773, "east": 775, "north": 786 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 775, "name": "Castle stables",
       "exits": { "south": 784, "west": 774, "east": 776, "north": 785 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 776, "name": "Castle stables",
       "exits": { "south": 782, "west": 775, "east": 777, "north": 781 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 777, "name": "Small paddock",
       "exits": { "southeast": 779, "south": 783, "west": 776, "east": 778, "north": 780 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 778, "name": "Small paddock",
       "exits": { "southwest": 783, "west": 777, "northwest": 780, "south": 779 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 779, "name": "Small paddock",
       "exits": { "west": 783, "northwest": 777, "north": 778 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 780, "name": "Wash area",
       "exits": { "southeast": 778, "south": 777 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 781, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "south": 776 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 782, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "north": 776 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 783, "name": "Small paddock",
       "exits": { "northeast": 778, "east": 779, "north": 777 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 784, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "north": 775 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 785, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "south": 775 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 786, "name": "Tack room",
       "exits": { "south": 774 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 787, "name": "Feed room",
       "exits": { "north": 774 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 788, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "south": 773 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 789, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "north": 773 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 790, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "north": 770 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 791, "name": "You swing open the wooden door and enter the stall.",
       "exits": { "south": 770 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 792, "name": "A dingy alleyway",
       "exits": { "south": 410, "east": 795, "north": 794 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 793, "name": "Effortlessly, you scale the brick wall and drop into a garden on the opposite",
       "exits": { "east": 168 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 794, "name": "A small building.",
       "exits": { "south": 792 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 795, "name": "A dingy alleyway",
       "exits": { "south": 813, "west": 792, "east": 796, "north": 797 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 796, "name": "An alley",
       "exits": { "south": 814, "west": 795, "east": 231, "north": 961 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 797, "name": "A dingy alley",
       "exits": { "south": 795, "north": 798 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 798, "name": "A Dingy Alley",
       "exits": { "south": 797, "north": 799 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 799, "name": "Stink Alley Way",
       "exits": { "west": 802, "east": 800, "south": 798 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 800, "name": "Stink Alley Way",
       "exits": { "west": 799, "east": 801, "north": 806 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 801, "name": "Stink Alley Way",
       "exits": { "west": 800 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 802, "name": "Stink Alley Way",
       "exits": { "south": 805, "west": 803, "east": 799, "north": 807 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 803, "name": "Stink Alley Way",
       "exits": { "east": 802, "south": 804 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 804, "name": "Fish Mongery",
       "exits": { "north": 803 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 805, "name": "Crazy Habib's Fertilizer",
       "exits": { "north": 802 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 806, "name": "Barber Shop",
       "exits": { "south": 800 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 807, "name": "Pornographers Den",
       "exits": { "south": 802 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 808, "name": "Livery",
       "exits": { "up": 809, "west": 161 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 809, "name": "Hayloft",
       "exits": { "down": 808 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 810, "name": "Tailor's Shop",
       "exits": { "west": 162 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 811, "name": "Hardware Store",
       "exits": { "west": 163 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 812, "name": "Haseltine Engravers",
       "exits": { "west": 164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 813, "name": "Guild/Shop Space for rent",
       "exits": { "north": 795 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 814, "name": "Flea Market",
       "exits": { "north": 796 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 815, "name": "The Back Room",
       "exits": { "east": 230, "north": 814 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 816, "name": "Castle Bridge",
       "exits": { "north": 151 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 817, "name": "Manor House",
       "exits": { "up": 818, "west": 152 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 818, "name": "Manor House",
       "exits": { "down": 817 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 819, "name": "Guild/Shop Space for rent",
       "exits": { "east": 152 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 820, "name": "Cleric Guild",
       "exits": { "west": 839, "east": 153, "north": 838 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 821, "name": "Hall of the builders guild",
       "exits": { "west": 154 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 822, "name": "City Hall",
       "exits": { "east": 156, "up": 831 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 823, "name": "Tea Shop",
       "exits": { "east": 157 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 824, "name": "Whore House",
       "exits": { "east": 158, "up": 825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 825, "name": "Second floor of whore house.",
       "exits": { "south": 828, "west": 826, "up": 829, "down": 824, "north": 827 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 826, "name": "Viking's room",
       "exits": { "east": 825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 827, "name": "Sandra's room",
       "exits": { "south": 825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 828, "name": "Kathy's room",
       "exits": { "north": 825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 829, "name": "Robert's room",
       "exits": { "down": 825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 830, "name": "Baker's Shop",
       "exits": { "west": 157 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 831, "name": "First Floor",
       "exits": { "up": 833, "down": 822, "west": 832 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 832, "name": "Chamber of Commerce",
       "exits": { "east": 831 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 833, "name": "Second Floor",
       "exits": { "up": 835, "down": 831, "west": 834 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 834, "name": "Magistrate",
       "exits": { "east": 833 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 835, "name": "City Archives",
       "exits": { "down": 833, "west": 836 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 836, "name": "Inner Sanctum",
       "exits": { "east": 835 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 837, "name": "Open Air Market:",
       "exits": { "west": 422 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 838, "name": "Chapel of War",
       "exits": { "south": 820 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 839, "name": "Reconciliation Chapel",
       "exits": { "east": 820 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 840, "name": "Burned Area",
       "exits": { "west": 841, "south": 148 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 841, "name": "Burned Area",
       "exits": { "south": 147, "west": 842, "east": 840, "north": 843 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 842, "name": "Burned Area",
       "exits": { "south": 146, "east": 841, "north": 844 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 843, "name": "Burned Area",
       "exits": { "west": 844, "south": 841, "north": 201 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 844, "name": "Burned Area",
       "exits": { "south": 842, "east": 843, "north": 202 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 845, "name": "Burned Area",
       "exits": { "east": 846, "north": 146 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 846, "name": "Burned Area",
       "exits": { "west": 845, "north": 147 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 847, "name": "Old City Offices",
       "exits": { "west": 849, "east": 848, "north": 144 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 848, "name": "Old Office",
       "exits": { "west": 847 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 849, "name": "Old Office",
       "exits": { "east": 847 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 850, "name": "Howling Wolf Inn",
       "exits": { "west": 142, "east": 852, "north": 851 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 851, "name": "Howling Wolf Inn",
       "exits": { "south": 850 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 852, "name": "Howling Wolf Inn",
       "exits": { "west": 850 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 853, "name": "Abandoned Building",
       "exits": { "east": 139 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 854, "name": "Spice Merchant",
       "exits": { "west": 139 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 855, "name": "Abandoned Building",
       "exits": { "west": 138 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 856, "name": "Carvings Shop",
       "exits": { "east": 138 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 857, "name": "Abandoned Warehouse",
       "exits": { "west": 198 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 858, "name": "Entrance of a village",
       "exits": { "west": 859, "east": 877, "south": 131 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 859, "name": "On a dusty path",
       "exits": { "east": 858, "northwest": 860, "north": 864 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 860, "name": "A living room made of glass",
       "exits": { "southwest": 863, "northwest": 861, "southeast": 859 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 861, "name": "A kitchen made of glass",
       "exits": { "southwest": 862, "southeast": 860 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 862, "name": "Sylvia's workroom",
       "exits": { "southeast": 863, "northeast": 861 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 863, "name": "A bedroom made of glass",
       "exits": { "northwest": 862, "northeast": 860 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 864, "name": "On a dusty path",
       "exits": { "south": 859, "north": 865 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 865, "name": "On a dusty path",
       "exits": { "east": 868, "northwest": 866, "south": 864 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 866, "name": "Inside a small home",
       "exits": { "southeast": 865, "west": 867 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 867, "name": "A large kitchen",
       "exits": { "east": 866 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 868, "name": "On a dusty path",
       "exits": { "west": 865, "east": 875, "north": 869 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 869, "name": "Bottom floor of the silo",
       "exits": { "up": 870, "south": 868 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 870, "name": "In Rohan's bedroom",
       "exits": { "down": 869, "up": 871 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 871, "name": "In Gwyneth's bedroom",
       "exits": { "down": 873, "up": 872 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 872, "name": "In Vella's bedroom",
       "exits": { "down": 871 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 873, "name": "<> Aladrin escapes reality and falls into Moral Decay. <>",
       "exits": { "down": 874, "up": 871 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 874, "name": "Bottom floor of the silo",
       "exits": { "up": 873 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 875, "name": "On a dusty path",
       "exits": { "west": 868, "south": 876 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 876, "name": "On a dusty path",
       "exits": { "south": 877, "east": 953, "north": 875 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 877, "name": "On a dusty path",
       "exits": { "west": 858, "north": 876 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 878, "name": "Guild/Shop Space for rent",
       "exits": { "south": 127 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 879, "name": "Vesla Post Office",
       "exits": { "south": 126 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 880, "name": "Old Adventurer's Guild",
       "exits": { "north": 126 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 881, "name": "Cemetery Lane.",
       "exits": { "south": 128, "north": 882 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 882, "name": "Cemetery Lane.",
       "exits": { "south": 881, "north": 883 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 883, "name": "A cemetery.",
       "exits": { "east": 884, "south": 882 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 884, "name": "A cemetery.",
       "exits": { "west": 883, "north": 885 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 885, "name": "A cemetery.",
       "exits": { "west": 886, "south": 884 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 886, "name": "A cemetery.",
       "exits": { "east": 885, "north": 887 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 887, "name": "A cemetery.",
       "exits": { "south": 886, "west": 889, "east": 892, "north": 888 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 888, "name": "A cemetery.",
       "exits": { "south": 887 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 889, "name": "A cemetery.",
       "exits": { "east": 887, "south": 890 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 890, "name": "A cemetery.",
       "exits": { "south": 891, "north": 889 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 891, "name": "Thieves Guild",
       "exits": { "north": 890 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 892, "name": "A cemetery.",
       "exits": { "west": 887 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 12}
+                  "area": {"id": 12}
     },
     {
       "id": 893, "name": "The Players' lounge",
       "exits": { "down": 229 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 894, "name": "Dormitory foyer",
       "exits": { "west": 528, "south": 895, "north": 903 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 895, "name": "Dining commons",
       "exits": { "north": 894 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 896, "name": "Southern path through the University",
       "exits": { "south": 897, "north": 528 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 897, "name": "Southern path through the University",
       "exits": { "south": 898, "north": 896 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 898, "name": "Southern path through the University",
       "exits": { "south": 899, "north": 897 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 899, "name": "Southern path through the University",
       "exits": { "south": 902, "east": 900, "north": 898 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 900, "name": "School of Business",
       "exits": { "west": 899, "north": 901 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 901, "name": "Dean's office",
       "exits": { "south": 900 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 902, "name": "Construction site",
       "exits": { "north": 899 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 903, "name": "Resident Advisor's office",
       "exits": { "south": 894 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 904, "name": "Science building's entry",
       "exits": { "west": 905, "east": 906, "north": 390 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 905, "name": "Science laboratory",
       "exits": { "east": 904 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 906, "name": "Science lecture hall",
       "exits": { "west": 904 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 907, "name": "Gravel Path",
       "exits": { "northwest": 908, "southwest": 604 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 908, "name": "Vine-covered Entry",
       "exits": { "southwest": 910, "southeast": 907, "north": 909 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 909, "name": "Grand Foyer",
       "exits": { "up": 914, "west": 911, "east": 912, "south": 908 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 910, "name": "Gravel Path",
       "exits": { "southeast": 604, "northeast": 908 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 911, "name": "Child's Den",
       "exits": { "east": 909 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 912, "name": "Wooded Hallway",
       "exits": { "east": 913, "west": 909 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 913, "name": "Brushing aside the hanging vines, you walk east into the servants' quarters.",
       "exits": { "west": 912 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 914, "name": "Treetop Bedroom",
       "exits": { "down": 909 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 915, "name": "Flagstoned path",
       "exits": { "south": 916, "west": 919, "east": 918, "north": 603 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 916, "name": "Gray foyer",
       "exits": { "south": 917, "north": 915 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 917, "name": "Trinian merchant's office",
       "exits": { "north": 916 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 918, "name": "Carriage house",
       "exits": { "west": 915 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 919, "name": "Slave quarters",
       "exits": { "east": 915 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 920, "name": "Dwarven Embassy foyer",
       "exits": { "west": 923, "up": 921, "south": 333, "east": 925, "north": 924 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 921, "name": "Dwarven watchtower",
       "exits": { "down": 920, "north": 922 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 922, "name": "Ambassadors Suite",
       "exits": { "south": 921 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 923, "name": "Dwarven brewery",
       "exits": { "east": 920 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 924, "name": "Dwarven Ambassador's office",
       "exits": { "south": 920 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 925, "name": "Dwarven armoury",
       "exits": { "west": 920 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 926, "name": "Ground Floor of the Windmill",
       "exits": { "up": 929, "west": 927, "east": 928, "south": 319 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 927, "name": "Garden of Machines",
       "exits": { "east": 926 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 928, "name": "Cemetery",
       "exits": { "west": 926 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 929, "name": "Gnome Laboratory",
       "exits": { "down": 926, "up": 930 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 930, "name": "Machinery Room",
       "exits": { "down": 929 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 4}
+                  "area": {"id": 4}
     },
     {
       "id": 931, "name": "Entryway",
       "exits": { "south": 201, "north": 932 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 932, "name": "Hallway",
       "exits": { "south": 931, "west": 933, "east": 934, "north": 937 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 933, "name": "Corner",
       "exits": { "east": 932, "north": 939 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 934, "name": "Corner",
       "exits": { "west": 932, "north": 935 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 935, "name": "Hallway",
       "exits": { "south": 934, "east": 945, "north": 936 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 936, "name": "Hallway",
       "exits": { "south": 935, "east": 946, "north": 947 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 937, "name": "Courtyard",
       "exits": { "south": 932, "north": 938 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 938, "name": "Courtyard",
       "exits": { "south": 937, "north": 941 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 939, "name": "Hallway",
       "exits": { "west": 942, "south": 933, "north": 940 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 940, "name": "Hallway",
       "exits": { "west": 943, "south": 939, "north": 944 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 941, "name": "Archway",
       "exits": { "south": 938, "west": 944, "east": 947, "north": 948 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 942, "name": "Quarters",
       "exits": { "east": 939 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 943, "name": "Quarters",
       "exits": { "east": 940 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 944, "name": "Corner",
       "exits": { "east": 941, "south": 940 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 945, "name": "Quarters",
       "exits": { "west": 935 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 946, "name": "Quarters",
       "exits": { "west": 936 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 947, "name": "Corner",
       "exits": { "west": 941, "south": 936 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 948, "name": "Temple Chamber",
       "exits": { "south": 941, "west": 951, "east": 952, "north": 949 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 949, "name": "Hallway",
       "exits": { "south": 948, "north": 950 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 950, "name": "Library",
       "exits": { "south": 949 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 951, "name": "Kitchen",
       "exits": { "east": 948 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 952, "name": "Storage",
       "exits": { "west": 948 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 10}
+                  "area": {"id": 10}
     },
     {
       "id": 953, "name": "On the porch",
       "exits": { "east": 954, "west": 876 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 954, "name": "In the sitting room",
       "exits": { "west": 953, "east": 955, "south": 958 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 955, "name": "In the kitchen",
       "exits": { "west": 954, "south": 956 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 956, "name": "In the dining room",
       "exits": { "west": 958, "east": 957, "north": 955 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 957, "name": "You leave the farmhouse and enter the backyard.",
       "exits": { "east": 959, "west": 956 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 958, "name": "In the study",
       "exits": { "east": 956, "north": 954 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 959, "name": "In a shed",
       "exits": { "up": 960, "west": 957 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 960, "name": "Above the shed",
       "exits": { "down": 959 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 11}
+                  "area": {"id": 11}
     },
     {
       "id": 961, "name": "Rising Phoenix",
       "exits": { "south": 796 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 962, "name": "Abandoned Store",
       "exits": { "west": 199 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 2}
+                  "area": {"id": 2}
     },
     {
       "id": 963, "name": "Eastern Entrance",
       "exits": { "east": 57, "west": 1027 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 964, "name": "Widow's House",
       "exits": { "west": 57 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 965, "name": "A Jeweler's Shop",
       "exits": { "east": 58 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 966, "name": "Farmer's Smith",
       "exits": { "east": 989, "west": 58 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 967, "name": "Candera Information Bureau",
       "exits": { "east": 59, "north": 1125 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 968, "name": "Lizard Skin Trader",
       "exits": { "east": 60 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 969, "name": "Shaman's Shack",
       "exits": { "west": 60 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 970, "name": "Silk Shop",
       "exits": { "east": 61 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 971, "name": "Barbarian's Guild",
       "exits": { "east": 62 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 972, "name": "Trader's Shack",
       "exits": { "west": 62, "south": 94 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 973, "name": "East Wall Guard Station",
       "exits": { "west": 15, "south": 974, "north": 986 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 974, "name": "Living Quarters",
       "exits": { "north": 973 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 975, "name": "Guild/Shop Space for rent",
       "exits": { "north": 95 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 976, "name": "Back Alley",
       "exits": { "north": 96 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 977, "name": "Great Bazaar of Candera",
       "exits": { "south": 96, "east": 428, "north": 995 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 978, "name": "Nut Shop",
       "exits": { "south": 989 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 979, "name": "Great Bazaar of Candera",
       "exits": { "south": 980, "west": 984, "east": 991, "north": 989 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 980, "name": "Great Bazaar of Candera",
       "exits": { "south": 981, "west": 983, "east": 993, "north": 979 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 981, "name": "Great Bazaar of Candera",
       "exits": { "west": 982, "east": 995, "north": 980 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 982, "name": "Shader's Scales",
       "exits": { "east": 981 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 983, "name": "Omars' Oil:",
       "exits": { "east": 980 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 984, "name": "Smithy",
       "exits": { "east": 979 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 985, "name": "Great Bazaar of Candera",
       "exits": { "south": 991, "west": 989, "east": 987, "north": 988 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 986, "name": "Sleeping Quarters",
       "exits": { "south": 973 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 987, "name": "Lord Candera's Lottery",
       "exits": { "west": 985 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 988, "name": "Empty Tent",
       "exits": { "south": 985 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 989, "name": "Great Bazaar of Candera",
       "exits": { "south": 979, "west": 966, "east": 985, "north": 978 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 990, "name": "Oak Treehouse landing",
       "exits": { "southwest": 1725, "northeast": 1726, "southeast": 1724 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 991, "name": "Great Bazaar of Candera",
       "exits": { "south": 993, "west": 979, "east": 992, "north": 985 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 992, "name": "Kamal's Camel Lot:",
       "exits": { "west": 991 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 993, "name": "Great Bazaar of Candera",
       "exits": { "south": 995, "west": 980, "east": 994, "north": 991 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 994, "name": "Perfume Tent:",
       "exits": { "west": 993 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 995, "name": "Great Bazaar of Candera",
       "exits": { "south": 977, "west": 981, "east": 1739, "north": 993 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 996, "name": "Candera Priest's Hut",
       "exits": { "west": 111 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 997, "name": "Pillow Shop:",
       "exits": { "west": 100 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 998, "name": "Relic Shop:",
       "exits": { "east": 103 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 999, "name": "Butcher Shop:",
       "exits": { "west": 103 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1000, "name": "Foyer",
       "exits": { "west": 98, "up": 1011, "south": 1010, "east": 1001, "north": 1009 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1001, "name": "Hallway",
       "exits": { "northeast": 1008, "east": 1002, "west": 1000 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1002, "name": "Ballroom",
       "exits": { "south": 1007, "west": 1001, "east": 1003, "north": 1014 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1003, "name": "Dance Floor",
       "exits": { "west": 1002, "east": 1004, "south": 1006 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1004, "name": "Gaston's table",
       "exits": { "west": 1003, "south": 1005, "north": 1013 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1005, "name": "Dance Floor",
       "exits": { "west": 1006, "south": 1012, "north": 1004 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1006, "name": "Dance Floor",
       "exits": { "west": 1007, "east": 1005, "north": 1003 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1007, "name": "Buffet table",
       "exits": { "east": 1006, "north": 1002 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1008, "name": "Kitchen",
       "exits": { "southwest": 1001 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1009, "name": "Library",
       "exits": { "south": 1000 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1010, "name": "Map Room",
       "exits": { "north": 1000 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1011, "name": "House of Clan Lord Gaston",
       "exits": { "down": 1000 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1012, "name": "Deck",
       "exits": { "north": 1005 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1013, "name": "Bandstand",
       "exits": { "west": 1014, "south": 1004 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1014, "name": "Dark corner",
       "exits": { "east": 1013, "south": 1002 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 13}
+                  "area": {"id": 13}
     },
     {
       "id": 1015, "name": "Snake Charmer",
       "exits": { "west": 65 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1016, "name": "Guild/Shop Space for rent",
       "exits": { "north": 73 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1017, "name": "Kaimuki Q's",
       "exits": { "west": 1018, "south": 73 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1018, "name": "Headquarter Entrance",
       "exits": { "south": 74, "east": 1017, "north": 1020 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1019, "name": "Guild/Shop Space for rent",
       "exits": { "north": 74 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1020, "name": "Hallway",
       "exits": { "south": 1018, "north": 1021 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1021, "name": "Hallway",
       "exits": { "south": 1020, "east": 1022, "north": 1024 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1022, "name": "Bunk Area",
       "exits": { "west": 1021, "south": 1023 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1023, "name": "Banquet Hall",
       "exits": { "north": 1022 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1024, "name": "Hallway",
       "exits": { "south": 1021, "east": 1029, "north": 1025 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1025, "name": "Ready Room",
       "exits": { "south": 1024, "east": 1028, "north": 1026 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1026, "name": "Outer Wall",
       "exits": { "east": 1027, "south": 1025 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1027, "name": "Outer Wall",
       "exits": { "east": 963, "west": 1026 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1028, "name": "Armoury",
       "exits": { "west": 1025 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1029, "name": "Strategist's Room",
       "exits": { "west": 1024 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 14}
+                  "area": {"id": 14}
     },
     {
       "id": 1030, "name": "South Wall Guard Station",
       "exits": { "west": 1031, "east": 1032, "north": 29 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1031, "name": "Living Quarters",
       "exits": { "east": 1030 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1032, "name": "Sleeping Quarters",
       "exits": { "west": 1030 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1033, "name": "West Wall Guard Station",
       "exits": { "south": 1034, "east": 43, "north": 1035 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1034, "name": "Living Quarters",
       "exits": { "north": 1033 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1035, "name": "Sleeping Quarters",
       "exits": { "south": 1033 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1036, "name": "Southwest Tower",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 16}
+                  "area": {"id": 16}
     },
     {
       "id": 1037, "name": "Empty Closet",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 16}
+                  "area": {"id": 16}
     },
     {
       "id": 1038, "name": "Thief Hideout Entrance",
       "exits": { "up": 1037 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 16}
+                  "area": {"id": 16}
     },
     {
       "id": 1039, "name": "Guard Post",
       "exits": { "east": 1049, "north": 1040 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1040, "name": "A bend in the hallway",
       "exits": { "east": 1041, "south": 1039 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1041, "name": "Cobwebs brush against the left side of your face as you walk through them.",
       "exits": { "east": 1042, "west": 1040 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1042, "name": "The Great Hall",
       "exits": { "east": 1043, "west": 1041 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1043, "name": "A bend in the hallway",
       "exits": { "west": 1042, "south": 1044 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1044, "name": "Barrack",
       "exits": { "west": 1045, "south": 1046, "north": 1043 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1045, "name": "First floor landing",
       "exits": { "east": 1044, "up": 1050 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1046, "name": "Barrack",
       "exits": { "south": 1047, "north": 1044 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1047, "name": "Staging Room",
       "exits": { "west": 1048, "north": 1046 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1048, "name": "Sally Port",
       "exits": { "east": 1047 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1049, "name": "An office",
       "exits": { "west": 1039 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1050, "name": "Second floor landing",
       "exits": { "up": 1051, "down": 1045, "north": 1069 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1051, "name": "Third floor landing",
       "exits": { "down": 1050, "up": 1052, "east": 1065, "north": 1064 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1052, "name": "Stairwell",
       "exits": { "west": 1060, "down": 1051, "south": 1053, "east": 1059, "north": 1057 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1053, "name": "Northeast Tower Roof",
       "exits": { "south": 1054, "east": 1056, "north": 1052 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1054, "name": "Northeast Tower Roof",
       "exits": { "east": 1055, "north": 1053 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1055, "name": "Southeast corner of roof",
       "exits": { "west": 1054, "north": 1056 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1056, "name": "Northeast Tower Roof",
       "exits": { "west": 1053, "south": 1055, "north": 1059 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1057, "name": "Northeast Tower Roof",
       "exits": { "east": 1058, "south": 1052 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1058, "name": "Northeast corner of roof",
       "exits": { "west": 1057, "south": 1059 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1059, "name": "Northeast Tower Roof",
       "exits": { "west": 1052, "south": 1056, "north": 1058 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1060, "name": "Northeast Tower Roof",
       "exits": { "west": 1063, "east": 1052, "north": 1061 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1061, "name": "Northeast Tower Roof",
       "exits": { "west": 1062, "south": 1060 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1062, "name": "Northwest corner of roof",
       "exits": { "east": 1061, "south": 1063 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1063, "name": "Northeast Tower Roof",
       "exits": { "east": 1060, "north": 1062 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1064, "name": "Guard Post",
       "exits": { "south": 1051 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1065, "name": "Hallway",
       "exits": { "west": 1051, "south": 1066 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1066, "name": "Hall",
       "exits": { "south": 1067, "north": 1065 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1067, "name": "War Room",
       "exits": { "west": 1068, "north": 1066 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1068, "name": "Portal Chamber",
       "exits": { "east": 1067 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1069, "name": "Guard Post",
       "exits": { "west": 1070, "east": 1072, "south": 1050 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1070, "name": "Prison Wing",
       "exits": { "west": 1071, "east": 1069, "south": 1077 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1071, "name": "Prison cell",
       "exits": { "east": 1070 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1072, "name": "Hallway",
       "exits": { "west": 1069, "south": 1073 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1073, "name": "An alarm sounds as you pass the threshold of the magic barrier.",
       "exits": { "south": 1074, "north": 1072 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1074, "name": "Witch's Workroom",
       "exits": { "west": 1075, "south": 1076, "north": 1073 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1075, "name": "Library",
       "exits": { "east": 1074 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1076, "name": "Morgue",
       "exits": { "north": 1074 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1077, "name": "Prison cell",
       "exits": { "north": 1070 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 17}
+                  "area": {"id": 17}
     },
     {
       "id": 1078, "name": "Lord's Stable",
       "exits": { "south": 77 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 18}
+                  "area": {"id": 18}
     },
     {
       "id": 1079, "name": "Kitchen",
       "exits": { "north": 77 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 18}
+                  "area": {"id": 18}
     },
     {
       "id": 1080, "name": "Bracknar's Garden",
       "exits": { "east": 77 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 18}
+                  "area": {"id": 18}
     },
     {
       "id": 1081, "name": "House of Clan Lord Bracknar",
       "exits": { "down": 77 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 18}
+                  "area": {"id": 18}
     },
     {
       "id": 1082, "name": "Gatehouse",
       "exits": { "up": 1083, "east": 87, "west": 1084 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1083, "name": "Blockhouse",
       "exits": { "down": 1082 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1084, "name": "You cautiously enter the mansion, knowing danger lurks hidden throughout.",
       "exits": { "south": 1087, "west": 1085, "east": 1082, "north": 1092 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1085, "name": "Eastern bailey",
       "exits": { "east": 1084, "west": 1086 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1086, "name": "Western bailey",
       "exits": { "south": 1871, "east": 1085, "north": 1870 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1087, "name": "Long hallway",
       "exits": { "west": 1089, "south": 1088, "north": 1084 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1088, "name": "Passage",
       "exits": { "up": 1090, "north": 1087 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1089, "name": "Sun Court",
       "exits": { "east": 1087 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1090, "name": "Stairwell",
       "exits": { "down": 1088, "up": 1091 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1091, "name": "Southeast Watchtower",
       "exits": { "down": 1090 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1092, "name": "Long hallway",
       "exits": { "south": 1084 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1093, "name": "Goondala's Flowers",
       "exits": { "east": 90 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1094, "name": "Weapon Master's Shop",
       "exits": { "west": 90 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1095, "name": "Guild/Shop Space for rent",
       "exits": { "north": 75 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1096, "name": "Alchemist's Shop",
       "exits": { "west": 79 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1097, "name": "Canderan Guard House",
       "exits": { "east": 82 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1098, "name": "Crypt of the Honored Dead",
       "exits": { "down": 1099, "west": 82 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1099, "name": "Crypt of the Honored Dead",
       "exits": { "up": 1098, "east": 1100, "south": 1101 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1100, "name": "Crypt of the Honored Dead",
       "exits": { "northeast": 1103, "southeast": 1102, "west": 1099 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1101, "name": "Crypt of the Honored Dead.",
       "exits": { "north": 1099 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1102, "name": "Crypt of the Honored Dead",
       "exits": { "northwest": 1100, "southeast": 1115 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1103, "name": "Crypt of the Honored Dead",
       "exits": { "southwest": 1100, "northeast": 1104 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1104, "name": "Crypt of the Honored Dead",
       "exits": { "southwest": 1103, "east": 1105 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1105, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1108, "west": 1104, "east": 1106, "north": 1107 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1106, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1111, "west": 1105, "east": 1110, "north": 1109 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1107, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1105 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1108, "name": "Battle of the Sand Gargoyles",
       "exits": { "north": 1105 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1109, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1106 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1110, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1113, "west": 1106, "east": 1114, "north": 1112 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1111, "name": "Battle of the Sand Gargoyles",
       "exits": { "north": 1106 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1112, "name": "Battle of the Sand Gargoyles",
       "exits": { "south": 1110 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1113, "name": "Battle of the Sand Gargoyles",
       "exits": { "north": 1110 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1114, "name": "Battle of the Sand Gargoyles",
       "exits": { "west": 1110 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1115, "name": "Crypt of the Honored Dead",
       "exits": { "northwest": 1102, "east": 1116 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1116, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1123, "west": 1115, "east": 1117, "north": 1124 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1117, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1121, "west": 1116, "east": 1118, "north": 1122 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1118, "name": "Battle of Maiden's Kiss",
       "exits": { "west": 1117, "south": 1119, "north": 1120 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1119, "name": "Battle of Maiden's Kiss",
       "exits": { "north": 1118 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1120, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1118 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1121, "name": "Battle of Maiden's Kiss",
       "exits": { "north": 1117 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1122, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1117 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1123, "name": "Battle of Maiden's Kiss",
       "exits": { "north": 1116 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1124, "name": "Battle of Maiden's Kiss",
       "exits": { "south": 1116 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 20}
+                  "area": {"id": 20}
     },
     {
       "id": 1125, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": { "south": 967 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1126, "name": "Temple of Earth",
       "exits": { "down": 106 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1127, "name": "Temple of Earth",
       "exits": { "down": 105 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1128, "name": "Temple of Fire",
       "exits": { "down": 114 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1129, "name": "Temple of Fire",
       "exits": { "down": 113 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1130, "name": "Temple of Air",
       "exits": { "down": 84 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1131, "name": "Temple of Air",
       "exits": { "down": 85 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1132, "name": "Temple of Water",
       "exits": { "down": 92 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1133, "name": "Temple of Water",
       "exits": { "down": 93 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1134, "name": "House of Lord Candera",
       "exits": { "down": 69 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 1}
+                  "area": {"id": 1}
     },
     {
       "id": 1135, "name": "Western Guard Post",
       "exits": { "up": 1136, "northeast": 237 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1136, "name": "Arleg bows to you.",
       "exits": { "down": 1135, "up": 1137 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1137, "name": "Second Floor Landing",
       "exits": { "down": 1136, "east": 1142, "up": 1138 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1138, "name": "Third Floor Passage",
       "exits": { "down": 1137, "east": 1144, "up": 1139 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1139, "name": "Western Spire Stairwell",
       "exits": { "down": 1138, "up": 1140 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1140, "name": "Roof of the Western Spire",
       "exits": { "down": 1139 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1141, "name": "Western Stairwell",
       "exits": { "up": 1137 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1142, "name": "Killing Room",
       "exits": { "east": 1153, "west": 1137 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1143, "name": "Anshelm Lounge",
       "exits": { "east": 236, "west": 1204 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1144, "name": "Gatehouse Mess Hall",
       "exits": { "east": 1145, "west": 1138 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1145, "name": "Gatehouse Barracks",
       "exits": { "east": 1146, "west": 1144 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1146, "name": "Third Floor Passage",
       "exits": { "up": 1151, "west": 1145 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1147, "name": "Beitel Straad at the Promenade",
       "exits": { "west": 1150, "east": 414, "north": 1169 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1148, "name": "Eastern Stairwell",
       "exits": { "down": 1149 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1149, "name": "Base of the Eastern Stairwell",
       "exits": { "up": 1148 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1150, "name": "Beitel Straad",
       "exits": { "west": 1157, "east": 1147, "south": 1168 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1151, "name": "Eastern Spire Stairwell",
       "exits": { "down": 1149, "up": 1152 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1152, "name": "Roof of the Eastern Spire",
       "exits": { "down": 1151 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1153, "name": "Tider bows to you.",
       "exits": { "west": 1142 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1154, "name": "Eastern Guard Post",
       "exits": { "northwest": 237, "east": 1155 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1155, "name": "Ganran bows to you.",
       "exits": { "up": 1158, "down": 1156, "west": 1154 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1156, "name": "Gatehouse Armoury",
       "exits": { "up": 1155 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1157, "name": "Western end of Beitel Straad",
       "exits": { "east": 1150, "north": 1164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1158, "name": "Eastern Stairwell",
       "exits": { "down": 1155, "up": 1159 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1159, "name": "Olotia bows to you.",
       "exits": { "down": 1158, "west": 1160 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1160, "name": "Tiran bows to you.",
       "exits": { "east": 1159, "west": 1161 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1161, "name": "Killing Room",
       "exits": { "east": 1160, "west": 1162 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1162, "name": "Second Floor Landing",
       "exits": { "east": 1161, "down": 1163 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1163, "name": "Western Stairwell",
       "exits": { "down": 1135, "up": 1162 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1164, "name": "Living room",
       "exits": { "south": 1157, "northeast": 1167, "northwest": 1165, "north": 1166 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 21}
+                  "area": {"id": 21}
     },
     {
       "id": 1165, "name": "You brush aside the blanket and duck to pass through the small door.",
       "exits": { "southeast": 1164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 21}
+                  "area": {"id": 21}
     },
     {
       "id": 1166, "name": "You feel strange walking into the kitchen - that's where women belong.",
       "exits": { "south": 1164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 21}
+                  "area": {"id": 21}
     },
     {
       "id": 1167, "name": "You brush aside the blanket and duck to pass through the small door.",
       "exits": { "southwest": 1164 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 21}
+                  "area": {"id": 21}
     },
     {
       "id": 1168, "name": "The Inner Bailey",
       "exits": { "north": 1150 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1169, "name": "Promenade des Trafficants",
       "exits": { "south": 1147, "north": 1170 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1170, "name": "The Promenade's gate",
       "exits": { "south": 1169, "north": 1171 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1171, "name": "You squeeze yourself through the bars in the gate and enter the Promenade.",
       "exits": { "south": 1170, "east": 1184, "north": 1172 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1172, "name": "Moonlit Promenade",
       "exits": { "west": 1173, "south": 1171, "north": 1174 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1173, "name": "Mekalar's Outdoor Gear",
       "exits": { "east": 1172 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1174, "name": "Moonlit Promenade",
       "exits": { "south": 1172, "east": 1183, "north": 1175 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1175, "name": "Middle of the moonlit Promenade",
       "exits": { "south": 1174, "north": 1176 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1176, "name": "Moonlit Promenade",
       "exits": { "south": 1175, "north": 1177 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1177, "name": "Moonlit Promenade",
       "exits": { "west": 1182, "south": 1176, "north": 1178 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1178, "name": "Moonlit Promenade",
       "exits": { "south": 1177, "north": 1179 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1179, "name": "Northern end of the moonlit Promenade",
       "exits": { "west": 1181, "south": 1178, "north": 1180 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1180, "name": "Enchanter's Store",
       "exits": { "south": 1179 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1181, "name": "Gere's Petshop",
       "exits": { "east": 1179 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1182, "name": "Carpenter's shop",
       "exits": { "east": 1177 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1183, "name": "Roget's Furrier",
       "exits": { "west": 1174 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1184, "name": "Volshev's Advertising Agency",
       "exits": { "west": 1171 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 22}
+                  "area": {"id": 22}
     },
     {
       "id": 1185, "name": "Beitel Straad",
       "exits": { "west": 239, "east": 1186, "north": 1191 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1186, "name": "Beitel Straad",
       "exits": { "west": 1185, "east": 1187, "north": 1190 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1187, "name": "Beitel Straad",
       "exits": { "east": 1188, "west": 1186 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1188, "name": "Beitel Straad",
       "exits": { "east": 1189, "west": 1187 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1189, "name": "Eastern end of Beitel Straad",
       "exits": { "west": 1188 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1190, "name": "The Banana Hammock",
       "exits": { "west": 1191, "south": 1186 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1191, "name": "Jack's Bistro",
       "exits": { "east": 1190, "south": 1185 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1192, "name": "Second Bank of Anshelm",
       "exits": { "west": 240 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1193, "name": "The Anshelmish General Store",
       "exits": { "west": 251 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1194, "name": "Construction site",
       "exits": { "west": 255 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1195, "name": "Anshelmish Keep's drawbridge",
       "exits": { "east": 255, "west": 1196 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1196, "name": "Construction site",
       "exits": { "east": 1195 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1197, "name": "Private Entry",
       "exits": { "south": 281 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1198, "name": "You have to turn sideways a bit to squeeze through the narrow passage.",
       "exits": { "west": 265 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1199, "name": "Armourer's Shack",
       "exits": { "north": 270 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1200, "name": "Construction site",
       "exits": { "south": 276 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1201, "name": "Construction site",
       "exits": { "north": 280 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1202, "name": "Construction site",
       "exits": { "southeast": 273 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1203, "name": "City Unemployment Office",
       "exits": { "north": 416 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 23}
+                  "area": {"id": 23}
     },
     {
       "id": 1204, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible",
       "exits": { "east": 1143 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1205, "name": "End of Pylus road",
       "exits": { "south": 1206 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1206, "name": "Pylus road",
       "exits": { "south": 1207, "north": 1205 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1207, "name": "Pylus road",
       "exits": { "south": 1208, "east": 1212, "north": 1206 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1208, "name": "Pylus road",
       "exits": { "west": 1209, "south": 1213, "north": 1207 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1209, "name": "Freemason's",
       "exits": { "south": 1210, "east": 1208, "north": 1211 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1210, "name": "Apprentice's",
       "exits": { "north": 1209 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1211, "name": "Master stonemason's",
       "exits": { "south": 1209 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1212, "name": "Mausoleum entrance",
       "exits": { "west": 1207 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1213, "name": "Pylus road",
       "exits": { "south": 1214, "north": 1208 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1214, "name": "Pylus road",
       "exits": { "south": 1215, "west": 1218, "east": 1219, "north": 1213 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1215, "name": "Pylus road",
       "exits": { "southwest": 1216, "east": 1222, "southeast": 1217, "north": 1214 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1216, "name": "Porch",
       "exits": { "northeast": 1215 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1217, "name": "Sanity's Requiem",
       "exits": { "northwest": 1215 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1218, "name": "Hall of Bacchus",
       "exits": { "east": 1214 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1219, "name": "Triage",
       "exits": { "west": 1214, "north": 1220 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1220, "name": "Waiting room",
       "exits": { "east": 1221, "south": 1219 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1221, "name": "Operating room",
       "exits": { "west": 1220 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1222, "name": "Pylus road checkpoint",
       "exits": { "east": 1289, "west": 1215 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1223, "name": "A short entryway",
       "exits": { "north": 1263 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1224, "name": "Iola square",
       "exits": { "west": 1289, "south": 1227, "north": 1225 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1225, "name": "Iola way",
       "exits": { "west": 1363, "south": 1224, "north": 1226 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1226, "name": "Iola way",
       "exits": { "south": 1225, "north": 1248 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1227, "name": "Iola way",
       "exits": { "south": 1228, "west": 1247, "east": 1246, "north": 1224 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1228, "name": "Iola way",
       "exits": { "south": 1229, "west": 1244, "east": 1243, "north": 1227 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1229, "name": "Iola bridge",
       "exits": { "southwest": 1230, "east": 1231, "north": 1228 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1230, "name": "Large field",
       "exits": { "west": 1239, "northeast": 1229 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1231, "name": "Polema street",
       "exits": { "west": 1229, "east": 1233, "south": 1232 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1232, "name": "Gay house",
       "exits": { "north": 1231 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1233, "name": "Polema street",
       "exits": { "south": 1234, "west": 1231, "east": 1235, "north": 1238 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1234, "name": "Short house",
       "exits": { "north": 1233 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1235, "name": "Polema street",
       "exits": { "west": 1233, "east": 1237, "north": 1236 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1236, "name": "Bright house",
       "exits": { "south": 1235 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1237, "name": "Foyer",
       "exits": { "west": 1235 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1238, "name": "Tall house",
       "exits": { "south": 1233 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1239, "name": "Gymnasium foyer",
       "exits": { "west": 1240, "east": 1230, "south": 1241 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1240, "name": "Changing room",
       "exits": { "east": 1239 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1241, "name": "Gymnasium hallway",
       "exits": { "south": 1242, "north": 1239 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1242, "name": "Natatorium",
       "exits": { "north": 1241 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1243, "name": "Vegetable seller's",
       "exits": { "west": 1228 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1244, "name": "Herbarium",
       "exits": { "east": 1228, "south": 1245 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1245, "name": "Herb garden",
       "exits": { "north": 1244 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1246, "name": "Butcher shop",
       "exits": { "west": 1227 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1247, "name": "Guild/Shop Space for rent",
       "exits": { "east": 1227 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1248, "name": "Iola way",
       "exits": { "west": 1249, "east": 1252, "south": 1226 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1249, "name": "Garden entry",
       "exits": { "east": 1248, "north": 1250 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1250, "name": "Garden clearing",
       "exits": { "west": 1251, "south": 1249 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1251, "name": "Entry to akademos",
       "exits": { "east": 1250, "west": 1374 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1252, "name": "Ithsma street",
       "exits": { "east": 1253, "west": 1248 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1253, "name": "Ithsma street",
       "exits": { "west": 1252, "east": 1255, "south": 1254 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1254, "name": "Short path",
       "exits": { "south": 1375, "north": 1253 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1255, "name": "Ithsma street",
       "exits": { "west": 1253, "east": 1389, "north": 1256 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1256, "name": "Before the Palace",
       "exits": { "south": 1255, "north": 1257 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1257, "name": "Threshold to the Grand Rotunda",
       "exits": { "south": 1256, "north": 1258 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1258, "name": "Grand Rotunda",
       "exits": { "west": 1259, "east": 1362, "south": 1257 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1259, "name": "Administrative hallway",
       "exits": { "west": 1261, "east": 1258, "north": 1260 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1260, "name": "Office of the Magistrate",
       "exits": { "south": 1259 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1261, "name": "Administrative hallway",
       "exits": { "west": 1262, "east": 1259, "south": 1391 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1262, "name": "Royal Throne Room",
       "exits": { "east": 1261 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1263, "name": "Hallway",
       "exits": { "south": 1223, "west": 1276, "east": 1278, "north": 1264 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1264, "name": "Hallway",
       "exits": { "south": 1263, "north": 1265 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1265, "name": "Hallway",
       "exits": { "south": 1264, "east": 1275, "north": 1266 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1266, "name": "Hallway",
       "exits": { "south": 1265, "west": 1271, "east": 1273, "north": 1267 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1267, "name": "End of Hallway",
       "exits": { "west": 1268, "east": 1269, "south": 1266 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1268, "name": "Munchkin Romper Room",
       "exits": { "east": 1267 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1269, "name": "Mages' Barracks",
       "exits": { "east": 1270, "west": 1267 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1270, "name": "Munchkin Library",
       "exits": { "west": 1269 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1271, "name": "Munchkin Mess Hall",
       "exits": { "east": 1266, "west": 1272 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1272, "name": "Kitchen",
       "exits": { "east": 1271 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1273, "name": "Fighters' Barracks",
       "exits": { "east": 1274, "west": 1266 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1274, "name": "Fighters' Barracks",
       "exits": { "west": 1273, "south": 1288 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1275, "name": "Munchkin Smithy",
       "exits": { "west": 1265 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1276, "name": "Hallway",
       "exits": { "east": 1263, "west": 1277 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1277, "name": "Hallway",
       "exits": { "west": 1281, "east": 1276, "south": 1280 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1278, "name": "Narrow Hallway",
       "exits": { "west": 1263, "east": 1279, "north": 1286 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1279, "name": "End of Narrow Hallway",
       "exits": { "west": 1278, "north": 1287 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1280, "name": "A Dark Tunnel",
       "exits": { "south": 1284, "north": 1277 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1281, "name": "End of Hallway",
       "exits": { "south": 1282, "east": 1277, "north": 1283 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1282, "name": "Munchkin Leader's Quarters",
       "exits": { "north": 1281 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1283, "name": "Munchkin Leader's Harem",
       "exits": { "south": 1281 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1284, "name": "A Dark Tunnel",
       "exits": { "northeast": 1285, "north": 1280 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1285, "name": "A Dark Tunnel",
       "exits": { "southwest": 1284 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1286, "name": "Dank Cell",
       "exits": { "south": 1278 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1287, "name": "Dank Cell",
       "exits": { "south": 1279 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1288, "name": "The Lollipop Guild",
       "exits": { "north": 1274 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 25}
+                  "area": {"id": 25}
     },
     {
       "id": 1289, "name": "Gate of Triumph",
       "exits": { "south": 1290, "west": 1222, "east": 1224, "north": 1291 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1290, "name": "Southern niche",
       "exits": { "north": 1289 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1291, "name": "Northern niche",
       "exits": { "south": 1289 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1292, "name": "Cave Waterfall",
       "exits": { "northeast": 518 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1293, "name": "Throne Room",
       "exits": { "east": 525 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1294, "name": "Mess Hall",
       "exits": { "south": 523 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1295, "name": "New Tunnel",
       "exits": { "east": 1296, "west": 523 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1296, "name": "New Tunnel",
       "exits": { "west": 1295 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1297, "name": "New Tunnel",
       "exits": { "south": 1299, "west": 1298, "east": 1301, "north": 1300 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1298, "name": "You pass through the door and it closes and locks behind you.",
       "exits": { "east": 1297 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1299, "name": "Nursery",
       "exits": { "north": 1297 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1300, "name": "Barracks",
       "exits": { "south": 1297 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1301, "name": "New Tunnel: Checkpoint",
       "exits": { "east": 1302, "west": 1297 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1302, "name": "Top of the mine shaft",
       "exits": { "down": 1303, "west": 1301 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1303, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
       "exits": { "down": 1304, "up": 1302 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1304, "name": "You let up on the ropes, and the counterweight slowly glides you down the",
       "exits": { "southwest": 1305, "up": 1303, "east": 1320, "north": 1311 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1305, "name": "Twisting Tunnel",
       "exits": { "southwest": 1306, "northeast": 1304, "southeast": 1309 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1306, "name": "Twisting Tunnel",
       "exits": { "northeast": 1305, "northwest": 1308, "southeast": 1307 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1307, "name": "Twisting Tunnel",
       "exits": { "northwest": 1306 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1308, "name": "Twisting Tunnel",
       "exits": { "southeast": 1306 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1309, "name": "Twisting Tunnel",
       "exits": { "northwest": 1305, "northeast": 1310 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1310, "name": "Twisting Tunnel",
       "exits": { "southwest": 1309 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1311, "name": "Twisting Tunnel",
       "exits": { "south": 1304, "northeast": 1312 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1312, "name": "Twisting Tunnel",
       "exits": { "southwest": 1311, "north": 1313 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1313, "name": "Twisting Tunnel",
       "exits": { "east": 1314, "northwest": 1316, "south": 1312 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1314, "name": "Twisting Tunnel",
       "exits": { "southeast": 1315, "west": 1313 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1315, "name": "Your left arm is now in full health.",
       "exits": { "northwest": 1314 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1316, "name": "Twisting Tunnel",
       "exits": { "northeast": 1319, "southeast": 1313, "north": 1317 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1317, "name": "Twisting Tunnel",
       "exits": { "northwest": 1318, "south": 1316 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1318, "name": "Twisting Tunnel",
       "exits": { "southeast": 1317 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1319, "name": "Twisting Tunnel",
       "exits": { "southwest": 1316 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1320, "name": "Twisting Tunnel",
       "exits": { "west": 1304, "northeast": 1321 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1321, "name": "Twisting Tunnel",
       "exits": { "southwest": 1320, "west": 1325, "southeast": 1322, "north": 1324 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1322, "name": "Twisting Tunnel",
       "exits": { "northwest": 1321, "east": 1323 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1323, "name": "Twisting Tunnel",
       "exits": { "west": 1322 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1324, "name": "Twisting Tunnel",
       "exits": { "south": 1321 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1325, "name": "Twisting Tunnel",
       "exits": { "east": 1321 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 7}
+                  "area": {"id": 7}
     },
     {
       "id": 1326, "name": "La Cosa Nostra",
       "exits": { "south": 283 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1327, "name": "Anshelm Stables",
       "exits": { "south": 284 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1328, "name": "Eastern end of Geld Strasse",
       "exits": { "east": 1329, "west": 281 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1329, "name": "With a little strain, you are able to pull open the heavy doors and enter",
       "exits": { "east": 1330, "west": 1328 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1330, "name": "Naive",
       "exits": { "south": 1332, "west": 1329, "east": 1331, "north": 1333 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1331, "name": "Altar of the Rose",
       "exits": { "west": 1330 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1332, "name": "Southern statuary",
       "exits": { "north": 1330 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1333, "name": "Northern statuary",
       "exits": { "south": 1330 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 3}
+                  "area": {"id": 3}
     },
     {
       "id": 1334, "name": "Tiled Entryway",
       "exits": { "west": 1336, "south": 1335 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 27}
+                  "area": {"id": 27}
     },
     {
       "id": 1335, "name": "Inside of Bracknar Gate",
       "exits": { "south": 261, "north": 1334 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 27}
+                  "area": {"id": 27}
     },
     {
       "id": 1336, "name": "Sitting Room",
       "exits": { "east": 1334, "north": 1337 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 27}
+                  "area": {"id": 27}
     },
     {
       "id": 1337, "name": "Guarded hallway",
       "exits": { "south": 1336, "north": 1361 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 27}
+                  "area": {"id": 27}
     },
     {
       "id": 1338, "name": "Ice Dragon's Den",
       "exits": { "down": 1339 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1339, "name": "Near a Frozen Waterfall",
       "exits": { "northwest": 1340, "east": 1342 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1340, "name": "By an Icy Gate",
       "exits": { "southeast": 1339, "east": 1341 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1341, "name": "Edge of an Icy Cliff",
       "exits": { "west": 1340 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1342, "name": "On Top of a Frozen River",
       "exits": { "west": 1339, "north": 1343 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1343, "name": "On Top of a Frozen River",
       "exits": { "south": 1342, "north": 1344 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1344, "name": "Under a Snowy Overhang",
       "exits": { "northwest": 1345, "south": 1343 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1345, "name": "On Top of an Icy Stream",
       "exits": { "southeast": 1344, "west": 1346 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1346, "name": "On Top of an Icy Lake",
       "exits": { "east": 1345, "northwest": 1347, "southeast": 1360, "west": 1358 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1347, "name": "On Top of an Icy Lake",
       "exits": { "west": 1351, "northeast": 1348, "southeast": 1346, "south": 1358 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1348, "name": "Entrance to a Frozen Cavern",
       "exits": { "southwest": 1347, "southeast": 1349 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1349, "name": "Frozen Cavern",
       "exits": { "northwest": 1348, "east": 1350 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1350, "name": "End of a Frozen Cavern",
       "exits": { "west": 1349 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1351, "name": "On Top of an Icy Lake",
       "exits": { "west": 1352, "east": 1347, "south": 1356 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1352, "name": "On Top of an Icy Lake",
       "exits": { "east": 1351, "northwest": 1359, "south": 1353 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1353, "name": "On Top of an Icy Lake",
       "exits": { "southwest": 1354, "east": 1356, "north": 1352 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1354, "name": "Ice Cave Entrance",
       "exits": { "east": 1355, "northeast": 1353 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1355, "name": "Inside an Ice Cave",
       "exits": { "west": 1354 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1356, "name": "On Top of an Icy Lake",
       "exits": { "south": 1357, "west": 1353, "east": 1358, "north": 1351 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1357, "name": "Isolated Icy Area",
       "exits": { "north": 1356 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1358, "name": "On Top of an Icy Lake",
       "exits": { "west": 1356, "east": 1346, "north": 1347 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1359, "name": "Northern Shore of an Icy Lake",
       "exits": { "southeast": 1352 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1360, "name": "Snowy Overhang",
       "exits": { "northwest": 1346 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1361, "name": "Clan Lord's Private Chambers",
       "exits": { "south": 1337 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 27}
+                  "area": {"id": 27}
     },
     {
       "id": 1362, "name": "Guard Post",
       "exits": { "west": 1258, "east": 1392, "north": 1395 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1363, "name": "Doorway",
       "exits": { "east": 1225, "west": 1364 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1364, "name": "Statued hallway",
       "exits": { "east": 1363, "west": 1365 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1365, "name": "Hallway",
       "exits": { "west": 1366, "east": 1364, "north": 1367 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1366, "name": "Captain's office",
       "exits": { "east": 1365 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1367, "name": "Courtyard",
       "exits": { "south": 1365, "north": 1368 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1368, "name": "Courtyard",
       "exits": { "south": 1367, "north": 1369 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1369, "name": "Hallway",
       "exits": { "up": 1373, "west": 1370, "east": 1371, "south": 1368 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1370, "name": "West wing",
       "exits": { "east": 1369 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1371, "name": "East wing",
       "exits": { "west": 1369, "south": 1372 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1372, "name": "East wing hallway",
       "exits": { "north": 1371 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1373, "name": "Climbing the tight stairwell, you open the trapdoor and climb to the roof.",
       "exits": { "down": 1369 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1374, "name": "Akademos",
       "exits": { "east": 1251 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1375, "name": "Temple entry",
       "exits": { "south": 1376, "north": 1254 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1376, "name": "Temple rotunda",
       "exits": { "south": 1377, "west": 1381, "east": 1384, "north": 1375 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1377, "name": "Temple hallway",
       "exits": { "south": 1378, "north": 1376 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1378, "name": "End of temple hallway",
       "exits": { "west": 1380, "east": 1379, "north": 1377 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1379, "name": "Folio depository",
       "exits": { "west": 1378 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1380, "name": "Reliquary",
       "exits": { "east": 1378 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1381, "name": "Hall of Peace",
       "exits": { "east": 1376, "west": 1382 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1382, "name": "Hall of Peace",
       "exits": { "west": 1383, "east": 1381, "south": 1387 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1383, "name": "Rotunda of Peace",
       "exits": { "east": 1382 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1384, "name": "Hall of War",
       "exits": { "west": 1376, "east": 1385, "south": 1388 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1385, "name": "Hall of War",
       "exits": { "east": 1386, "west": 1384 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1386, "name": "Rotunda of War",
       "exits": { "west": 1385 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1387, "name": "Chapel of Peace",
       "exits": { "north": 1382 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1388, "name": "Chapel of War",
       "exits": { "north": 1384 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1389, "name": "Ithsma street",
       "exits": { "east": 1390, "west": 1255 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1390, "name": "End of Ithsma street",
       "exits": { "west": 1389 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1391, "name": "Office of the Secretary",
       "exits": { "north": 1261 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1392, "name": "Formal gardens",
       "exits": { "west": 1362, "east": 1393, "south": 1394 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1393, "name": "A private corner in the garden",
       "exits": { "west": 1392 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1394, "name": "A private corner in the garden",
       "exits": { "north": 1392 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1395, "name": "Residential hallway",
       "exits": { "east": 1396, "south": 1362 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1396, "name": "Residential hallway",
       "exits": { "west": 1395, "east": 1397, "north": 1398 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1397, "name": "The harem",
       "exits": { "west": 1396, "north": 1400 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1398, "name": "The Royal Chambers",
       "exits": { "west": 1399, "south": 1396 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1399, "name": "The royal dressing room",
       "exits": { "east": 1398 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1400, "name": "The Consort's chambers",
       "exits": { "south": 1397 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 24}
+                  "area": {"id": 24}
     },
     {
       "id": 1401, "name": "City of Indel, Wilderness Gate",
       "exits": { "west": 1635, "east": 1636, "south": 1402 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1402, "name": "Castle Road",
       "exits": { "south": 1403, "west": 1631, "east": 1633, "north": 1401 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1403, "name": "Castle Road",
       "exits": { "south": 1404, "west": 1628, "east": 1630, "north": 1402 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1404, "name": "Castle Road Courtyard",
       "exits": { "south": 1405, "west": 1626, "east": 1627, "north": 1403 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1405, "name": "Castle Road",
       "exits": { "west": 1625, "south": 1406, "north": 1404 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1406, "name": "Intersection of Castle Road and Merchant's Row",
       "exits": { "south": 1584, "west": 1407, "east": 1508, "north": 1405 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1407, "name": "West Merchant's Row",
       "exits": { "east": 1406, "west": 1408 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1408, "name": "West Merchant's Row, north of the Silver Griffin",
       "exits": { "west": 1409, "east": 1407, "south": 1589 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1409, "name": "West Merchant's Row, south of Big Bob's Sign Shop",
       "exits": { "west": 1410, "east": 1408, "south": 1590 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1410, "name": "West Merchant's Row",
       "exits": { "east": 1409, "west": 1411 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1411, "name": "West Merchant's Row",
       "exits": { "east": 1410, "west": 1412 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1412, "name": "West Merchant's Row",
       "exits": { "east": 1411, "west": 1413 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1413, "name": "West Merchant's Row, south of Knights of Solamnia",
       "exits": { "east": 1412, "west": 1414 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1414, "name": "West Merchant's Row",
       "exits": { "east": 1413, "west": 1415 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1415, "name": "West Merchant's Row, south of the Cobbler's Shop",
       "exits": { "east": 1414, "west": 1416 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1416, "name": "West Merchant's Row, south of Laird's Forge",
       "exits": { "east": 1415, "west": 1417 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1417, "name": "West Merchant's Row",
       "exits": { "east": 1416, "west": 1418 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1418, "name": "Pier Street and Merchant's Row",
       "exits": { "south": 1419, "east": 1417, "north": 1448 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1419, "name": "Pier Street",
       "exits": { "south": 1420, "north": 1418 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1420, "name": "Pier Street",
       "exits": { "south": 1421, "north": 1419 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1421, "name": "Pier Street",
       "exits": { "south": 1422, "north": 1420 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1422, "name": "Pier Street west of the Waterfront Gate",
       "exits": { "south": 1423, "north": 1421 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1423, "name": "Pier Street",
       "exits": { "south": 1424, "north": 1422 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1424, "name": "Pier Street",
       "exits": { "south": 1425, "north": 1423 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1425, "name": "Pier Street",
       "exits": { "south": 1426, "north": 1424 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1426, "name": "Pier Street",
       "exits": { "south": 1427, "north": 1425 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1427, "name": "Pier Street",
       "exits": { "south": 1428, "north": 1426 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1428, "name": "Pier Street",
       "exits": { "south": 1429, "north": 1427 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1429, "name": "South Pier Street",
       "exits": { "south": 1430, "north": 1428 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1430, "name": "South Pier Street",
       "exits": { "south": 1431, "north": 1429 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1431, "name": "South Pier Street",
       "exits": { "south": 1432, "north": 1430 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1432, "name": "South Pier Street",
       "exits": { "south": 1433, "north": 1431 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1433, "name": "South Pier Street",
       "exits": { "south": 1434, "north": 1432 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1434, "name": "South Pier Street",
       "exits": { "south": 1435, "east": 1545, "north": 1433 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1435, "name": "South Pier Street",
       "exits": { "south": 1436, "north": 1434 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1436, "name": "South Pier Street",
       "exits": { "south": 1437, "north": 1435 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1437, "name": "South Pier Street",
       "exits": { "south": 1438, "north": 1436 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1438, "name": "South Pier Street",
       "exits": { "south": 1439, "north": 1437 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1439, "name": "Forester's Gate",
       "exits": { "north": 1438 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1440, "name": "Light forest",
       "exits": { "west": 1492, "east": 1496, "south": 1441 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1441, "name": "Light forest",
       "exits": { "south": 1442, "west": 1493, "east": 1495, "north": 1440 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1442, "name": "The Valley",
       "exits": { "south": 1475, "west": 1494, "east": 1443, "north": 1441 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1443, "name": "The Valley",
       "exits": { "south": 1476, "west": 1442, "east": 1444, "north": 1495 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1444, "name": "The Valley",
       "exits": { "south": 1477, "west": 1443, "east": 1445, "north": 1498 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1445, "name": "Light forest",
       "exits": { "west": 1444, "east": 1446, "south": 1460 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1446, "name": "Meadow",
       "exits": { "west": 1445, "east": 1447, "south": 1459 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1447, "name": "Meadow",
       "exits": { "west": 1446, "east": 1449, "south": 1452 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1448, "name": "North Pier Street",
       "exits": { "south": 1418, "north": 1507 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1449, "name": "Light forest",
       "exits": { "east": 1450, "west": 1447 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1450, "name": "Light forest",
       "exits": { "east": 1451, "west": 1449 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1451, "name": "Light forest",
       "exits": { "west": 1450 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1452, "name": "Light forest",
       "exits": { "west": 1459, "south": 1453, "north": 1447 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1453, "name": "Light forest",
       "exits": { "west": 1458, "south": 1454, "north": 1452 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1454, "name": "Dense forest",
       "exits": { "west": 1457, "south": 1455, "north": 1453 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1455, "name": "Light forest",
       "exits": { "west": 1456, "north": 1454 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1456, "name": "Dense forest",
       "exits": { "south": 1499, "west": 1463, "east": 1455, "north": 1457 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1457, "name": "Dense forest",
       "exits": { "south": 1456, "west": 1462, "east": 1454, "north": 1458 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1458, "name": "Light forest",
       "exits": { "south": 1457, "west": 1461, "east": 1453, "north": 1459 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1459, "name": "Meadow",
       "exits": { "south": 1458, "west": 1460, "east": 1452, "north": 1446 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1460, "name": "Meadow",
       "exits": { "south": 1461, "west": 1477, "east": 1459, "north": 1445 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1461, "name": "Meadow",
       "exits": { "south": 1462, "west": 1478, "east": 1458, "north": 1460 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1462, "name": "Dense forest",
       "exits": { "south": 1463, "west": 1479, "east": 1457, "north": 1461 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1463, "name": "Dense forest",
       "exits": { "south": 1464, "west": 1480, "east": 1456, "north": 1462 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1464, "name": "Mountain Range",
       "exits": { "west": 1465, "east": 1499, "north": 1463 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1465, "name": "Mountain Range",
       "exits": { "west": 1466, "east": 1464, "north": 1480 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1466, "name": "Mountain Range",
       "exits": { "west": 1467, "east": 1465, "north": 1481 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1467, "name": "Mountain Range",
       "exits": { "west": 1468, "east": 1466, "north": 1482 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1468, "name": "Mountain Range",
       "exits": { "east": 1467, "west": 1469 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1469, "name": "Mountain Range",
       "exits": { "east": 1468, "north": 1470 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1470, "name": "Mountain Range",
       "exits": { "south": 1469, "north": 1471 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1471, "name": "Mountain Range",
       "exits": { "south": 1470, "east": 1484, "north": 1472 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1472, "name": "Mountain Range",
       "exits": { "south": 1471, "east": 1485, "north": 1473 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1473, "name": "Mountain Range",
       "exits": { "south": 1472, "east": 1474, "north": 1489 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1474, "name": "Light forest",
       "exits": { "south": 1485, "west": 1473, "east": 1475, "north": 1494 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1475, "name": "Light forest",
       "exits": { "south": 1486, "west": 1474, "east": 1476, "north": 1442 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1476, "name": "Light forest",
       "exits": { "south": 1487, "west": 1475, "east": 1477, "north": 1443 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1477, "name": "The Valley",
       "exits": { "south": 1478, "west": 1476, "east": 1460, "north": 1444 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1478, "name": "The Valley",
       "exits": { "south": 1479, "west": 1487, "east": 1461, "north": 1477 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1479, "name": "The Valley",
       "exits": { "south": 1480, "west": 1488, "east": 1462, "north": 1478 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1480, "name": "The Valley",
       "exits": { "south": 1465, "west": 1481, "east": 1463, "north": 1479 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1481, "name": "Dense forest",
       "exits": { "south": 1466, "west": 1482, "east": 1480, "north": 1488 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1482, "name": "Dense forest",
       "exits": { "south": 1467, "east": 1481, "north": 1483 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1483, "name": "Dense forest",
       "exits": { "south": 1482, "west": 1484, "east": 1488, "north": 1486 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1484, "name": "Dense forest",
       "exits": { "west": 1471, "east": 1483, "north": 1485 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1485, "name": "Light forest",
       "exits": { "south": 1484, "west": 1472, "east": 1486, "north": 1474 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1486, "name": "Light forest",
       "exits": { "south": 1483, "west": 1485, "east": 1487, "north": 1475 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1487, "name": "Light forest",
       "exits": { "south": 1488, "west": 1486, "east": 1478, "north": 1476 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1488, "name": "Dense forest",
       "exits": { "south": 1481, "west": 1483, "east": 1479, "north": 1487 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1489, "name": "Mountain Range",
       "exits": { "south": 1473, "east": 1494, "north": 1490 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1490, "name": "Mountain Range",
       "exits": { "south": 1489, "east": 1493, "north": 1491 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1491, "name": "Mountain Range",
       "exits": { "down": 1506, "east": 1492, "south": 1490 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1492, "name": "The Valley",
       "exits": { "west": 1491, "east": 1440, "south": 1493 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1493, "name": "The Valley",
       "exits": { "south": 1494, "west": 1490, "east": 1441, "north": 1492 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1494, "name": "The Valley",
       "exits": { "south": 1474, "west": 1489, "east": 1442, "north": 1493 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1495, "name": "Light forest",
       "exits": { "south": 1443, "west": 1441, "east": 1498, "north": 1496 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1496, "name": "Light forest",
       "exits": { "west": 1440, "east": 1497, "south": 1495 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1497, "name": "Light forest",
       "exits": { "west": 1496, "south": 1498 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1498, "name": "Light forest",
       "exits": { "west": 1495, "south": 1444, "north": 1497 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1499, "name": "Meadow",
       "exits": { "west": 1464, "south": 1505, "north": 1456 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1500, "name": "Path",
       "exits": { "south": 1501, "west": 1503, "east": 1473, "north": 1504 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1501, "name": "Forest",
       "exits": { "west": 1502, "north": 1500 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1502, "name": "Beach",
       "exits": { "east": 1501, "north": 1503 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1503, "name": "Beach",
       "exits": { "east": 1500, "south": 1502 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1504, "name": "Lighthouse Base",
       "exits": { "south": 1500 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1505, "name": "Mountain Range",
       "exits": { "north": 1499 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1506, "name": "Mine Entrance",
       "exits": { "up": 1491 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 29}
+                  "area": {"id": 29}
     },
     {
       "id": 1507, "name": "Cobblestone courtyard",
       "exits": { "south": 1448 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1508, "name": "East Merchant's Row",
       "exits": { "east": 1509, "west": 1406 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1509, "name": "East Merchant's Row, south of Saul's Formal Wear",
       "exits": { "west": 1508, "east": 1510, "north": 1624 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1510, "name": "East Merchant's Row, south of a livestock lot",
       "exits": { "west": 1509, "east": 1511, "north": 1623 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1511, "name": "East Merchant's Row, south of Mother Whitman's",
       "exits": { "west": 1510, "east": 1512, "north": 1622 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1512, "name": "East Merchant's Row",
       "exits": { "east": 1513, "west": 1511 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1513, "name": "East Merchant's Row",
       "exits": { "east": 1514, "west": 1512 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1514, "name": "East Merchant's Row, south of Sithicus",
       "exits": { "west": 1513, "east": 1515, "north": 1621 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1515, "name": "East Merchant's Row",
       "exits": { "east": 1516, "west": 1514 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1516, "name": "Merchant's Row and Pensji Lane",
       "exits": { "west": 1515, "east": 1517, "south": 1520 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1517, "name": "East Merchant's Row",
       "exits": { "east": 1518, "west": 1516 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1518, "name": "East Merchant's Row",
       "exits": { "east": 1519, "west": 1517 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1519, "name": "End of Merchant's Row",
       "exits": { "west": 1518 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1520, "name": "Pensji Lane",
       "exits": { "south": 1521, "north": 1516 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1521, "name": "Pensji Lane",
       "exits": { "south": 1522, "north": 1520 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1522, "name": "Pensji Lane",
       "exits": { "south": 1523, "north": 1521 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1523, "name": "Pensji Lane",
       "exits": { "south": 1524, "north": 1522 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1524, "name": "Pensji Lane",
       "exits": { "south": 1525, "north": 1523 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1525, "name": "Pensji Lane",
       "exits": { "south": 1526, "east": 1606, "north": 1524 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1526, "name": "Pensji Lane",
       "exits": { "south": 1527, "north": 1525 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1527, "name": "Pensji Lane",
       "exits": { "south": 1528, "north": 1526 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1528, "name": "Pensji Lane",
       "exits": { "south": 1529, "north": 1527 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1529, "name": "Pensji Lane",
       "exits": { "south": 1530, "north": 1528 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1530, "name": "Pensji Lane",
       "exits": { "south": 1531, "north": 1529 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1531, "name": "Pensji Lane",
       "exits": { "south": 1532, "north": 1530 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1532, "name": "Pensji Lane",
       "exits": { "south": 1533, "north": 1531 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1533, "name": "Pensji Lane",
       "exits": { "south": 1534, "east": 1597, "north": 1532 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1534, "name": "Pensji Lane",
       "exits": { "south": 1542, "north": 1533 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1535, "name": "Embassy Row",
       "exits": { "east": 1536, "west": 1557 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1536, "name": "Embassy Row",
       "exits": { "east": 1537, "west": 1535 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1537, "name": "Embassy Row",
       "exits": { "east": 1538, "west": 1536 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1538, "name": "City Barracks Gate",
       "exits": { "east": 1539, "west": 1537 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1539, "name": "West Martial Row",
       "exits": { "east": 1540, "west": 1538 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1540, "name": "West Martial Row",
       "exits": { "east": 1541, "west": 1539 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1541, "name": "West Martial Row",
       "exits": { "east": 1542, "west": 1540 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1542, "name": "Intersection of Martial Row and Pensji Lane",
       "exits": { "west": 1541, "east": 1591, "north": 1534 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1543, "name": "West Church Road",
       "exits": { "south": 1546, "north": 1544 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1544, "name": "West Church Road",
       "exits": { "south": 1543, "north": 1558 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1545, "name": "Ambassador Gate",
       "exits": { "east": 1546, "west": 1434 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1546, "name": "Intersection of Church Road and Embassy Row",
       "exits": { "west": 1545, "east": 1547, "north": 1543 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1547, "name": "Embassy Row",
       "exits": { "east": 1548, "west": 1546 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1548, "name": "Embassy Row",
       "exits": { "east": 1549, "west": 1547 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1549, "name": "Embassy Row",
       "exits": { "east": 1550, "west": 1548 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1550, "name": "Embassy Row",
       "exits": { "east": 1551, "west": 1549 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1551, "name": "Embassy Row",
       "exits": { "east": 1552, "west": 1550 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1552, "name": "Embassy Row",
       "exits": { "east": 1553, "west": 1551 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1553, "name": "Embassy Row",
       "exits": { "east": 1554, "west": 1552 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1554, "name": "Embassy Row",
       "exits": { "east": 1555, "west": 1553 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1555, "name": "Embassy Row",
       "exits": { "east": 1556, "west": 1554 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1556, "name": "Embassy Row",
       "exits": { "east": 1557, "west": 1555 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1557, "name": "Embassy Row",
       "exits": { "east": 1535, "west": 1556 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1558, "name": "West Church Road",
       "exits": { "south": 1544, "north": 1559 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1559, "name": "West Church Road",
       "exits": { "south": 1558, "north": 1560 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1560, "name": "West Church Road",
       "exits": { "south": 1559, "north": 1561 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1561, "name": "West Church Road",
       "exits": { "south": 1560, "north": 1562 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1562, "name": "West Church Road",
       "exits": { "south": 1561, "north": 1563 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1563, "name": "West Church Road",
       "exits": { "south": 1562, "north": 1564 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1564, "name": "West Church Road",
       "exits": { "south": 1563, "north": 1565 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1565, "name": "West Church Road",
       "exits": { "south": 1564, "north": 1566 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1566, "name": "West Church Road",
       "exits": { "south": 1565, "north": 1567 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1567, "name": "West Church Road",
       "exits": { "south": 1566, "north": 1568 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1568, "name": "West Church Road",
       "exits": { "south": 1567, "north": 1569 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1569, "name": "Church Road Bend",
       "exits": { "east": 1570, "south": 1568 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1570, "name": "North Church Road",
       "exits": { "east": 1571, "west": 1569 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1571, "name": "North Church Road",
       "exits": { "east": 1572, "west": 1570 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1572, "name": "North Church Road",
       "exits": { "east": 1573, "west": 1571 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1573, "name": "North Church Road",
       "exits": { "east": 1574, "west": 1572 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1574, "name": "North Church Road",
       "exits": { "east": 1575, "west": 1573 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1575, "name": "North Church Road",
       "exits": { "east": 1576, "west": 1574 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1576, "name": "North Church Road",
       "exits": { "east": 1577, "west": 1575 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1577, "name": "North Church Road",
       "exits": { "east": 1578, "west": 1576 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1578, "name": "North Church Road",
       "exits": { "east": 1579, "west": 1577 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1579, "name": "Intersection of Castle Road and Church Road",
       "exits": { "south": 1585, "west": 1578, "east": 1580, "north": 1584 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1580, "name": "North Church Road",
       "exits": { "east": 1581, "west": 1579 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1581, "name": "North Church Road",
       "exits": { "east": 1582, "west": 1580 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1582, "name": "North Church Road",
       "exits": { "east": 1583, "west": 1581 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1583, "name": "North Church Road",
       "exits": { "down": 1653, "west": 1582 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1584, "name": "Olde City Gate",
       "exits": { "south": 1579, "west": 1588, "east": 1587, "north": 1406 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1585, "name": "Castle Drawbridge",
       "exits": { "south": 1586, "north": 1579 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1586, "name": "Castle Gatehouse",
       "exits": { "north": 1585 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1587, "name": "Krakenwater",
       "exits": { "west": 1584 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1588, "name": "Deep Sea Thunder",
       "exits": { "east": 1584, "west": 1589 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1589, "name": "The Silver Griffin",
       "exits": { "west": 1590, "east": 1588, "north": 1408 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1590, "name": "Horrors of the Deep",
       "exits": { "east": 1589, "north": 1409 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1591, "name": "East Martial Row",
       "exits": { "east": 1592, "west": 1542 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1592, "name": "East Martial Row",
       "exits": { "east": 1593, "west": 1591 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1593, "name": "East Martial Row",
       "exits": { "west": 1592, "north": 1594 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1594, "name": "Army Encampment Gate",
       "exits": { "west": 1595, "south": 1593 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1595, "name": "Punishment Grounds",
       "exits": { "east": 1594, "west": 1596 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1596, "name": "Parade Grounds",
       "exits": { "east": 1595, "north": 1597 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1597, "name": "Cavalry Gate",
       "exits": { "west": 1533, "south": 1596, "north": 1598 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1598, "name": "Training Grounds",
       "exits": { "south": 1597, "east": 1600, "north": 1599 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1599, "name": "Combat Training",
       "exits": { "south": 1598 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1600, "name": "Post Exchange",
       "exits": { "south": 1602, "west": 1598, "east": 1601, "north": 1603 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1601, "name": "Stockade",
       "exits": { "west": 1600 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1602, "name": "Infirmary",
       "exits": { "east": 1605, "north": 1600 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1603, "name": "Soldiers' Tent",
       "exits": { "east": 1604, "south": 1600 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1604, "name": "Soldiers' Tent",
       "exits": { "west": 1603 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1605, "name": "You move the partition to the side and walk into the back of the tent.",
       "exits": { "west": 1602 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1606, "name": "Indel City Park",
       "exits": { "west": 1525, "east": 1607, "north": 1608 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1607, "name": "Indel City Park",
       "exits": { "west": 1606, "east": 1613, "north": 1609 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1608, "name": "Indel City Park",
       "exits": { "south": 1606, "east": 1609, "north": 1611 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1609, "name": "Indel City Park",
       "exits": { "south": 1607, "west": 1608, "east": 1610, "north": 1612 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1610, "name": "Indel City Park",
       "exits": { "west": 1609, "south": 1613, "north": 1614 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1611, "name": "Indel City Park",
       "exits": { "south": 1608, "east": 1612, "north": 1615 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1612, "name": "Indel City Park",
       "exits": { "south": 1609, "west": 1611, "east": 1614, "north": 1616 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1613, "name": "Gazebo in the Park",
       "exits": { "west": 1607, "north": 1610 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1614, "name": "Indel City Park",
       "exits": { "west": 1612, "south": 1610, "north": 1617 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1615, "name": "Indel City Park",
       "exits": { "south": 1611, "east": 1616, "north": 1619 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1616, "name": "Indel City Park",
       "exits": { "south": 1612, "west": 1615, "east": 1617, "north": 1618 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1617, "name": "Indel City Park",
       "exits": { "west": 1616, "south": 1614, "north": 1620 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1618, "name": "Indel City Park",
       "exits": { "west": 1619, "east": 1620, "south": 1616 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1619, "name": "Indel City Park",
       "exits": { "east": 1618, "south": 1615 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1620, "name": "Indel City Park",
       "exits": { "west": 1618, "south": 1617 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 30}
+                  "area": {"id": 30}
     },
     {
       "id": 1621, "name": "Sithicus",
       "exits": { "south": 1514 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1622, "name": "Mother Whitman's Confections Shop",
       "exits": { "south": 1511 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1623, "name": "Livestock Lot",
       "exits": { "south": 1510, "north": 1643 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1624, "name": "Saul's formal wear",
       "exits": { "south": 1509 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1625, "name": "Quicksilver Delivery Service",
       "exits": { "east": 1405 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1626, "name": "Jusonah's Pawn and Polearms",
       "exits": { "east": 1404 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1627, "name": "You feel a STRONG urge to read the Sanctuary board... You are responsible for",
       "exits": { "west": 1404, "south": 1637 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1628, "name": "Zomar's Dry Goods",
       "exits": { "east": 1403, "down": 1629 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1629, "name": "The Art of Darkness",
       "exits": { "up": 1628 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1630, "name": "Burrow's Map Shop",
       "exits": { "west": 1403 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1631, "name": "Muddy Lane",
       "exits": { "east": 1402, "west": 1632 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1632, "name": "Muddy Lane",
       "exits": { "east": 1631 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1633, "name": "Muddy Lane",
       "exits": { "east": 1634, "west": 1402 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1634, "name": "Farm Road",
       "exits": { "west": 1633 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1635, "name": "West Ready Room",
       "exits": { "east": 1401 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1636, "name": "East Ready Room",
       "exits": { "west": 1401 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1637, "name": "Player Appreciation Week Discussions",
       "exits": { "north": 1627 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1638, "name": "Road Through a Wheatfield",
       "exits": { "east": 1639, "southeast": 1641, "south": 1640 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1639, "name": "Road Through a Wheatfield",
       "exits": { "southeast": 1648, "south": 1641, "southwest": 1640, "east": 1649, "west": 1638 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1640, "name": "Wheatfield",
       "exits": { "west": 1645, "southeast": 1642, "south": 1643, "southwest": 1644, "northeast": 1639, "east": 1641, "north": 1638 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1641, "name": "Road Through A Wheatfield",
       "exits": { "west": 1640, "northwest": 1638, "south": 1642, "southwest": 1643, "northeast": 1649, "east": 1648, "north": 1639 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1642, "name": "Wheatfield",
       "exits": { "northwest": 1640, "west": 1643, "northeast": 1648, "east": 1646, "north": 1641 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1643, "name": "Wheatfield",
       "exits": { "northwest": 1645, "south": 1623, "west": 1644, "northeast": 1641, "east": 1642, "north": 1640 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1644, "name": "Wheatfield",
       "exits": { "northeast": 1640, "east": 1643, "north": 1645 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1645, "name": "Wheatfield",
       "exits": { "east": 1640, "southeast": 1643, "south": 1644 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1646, "name": "Wheatfield",
       "exits": { "west": 1642, "east": 1647, "north": 1648 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1647, "name": "Wheatfield",
       "exits": { "west": 1646 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1648, "name": "Road Through a Wheatfield",
       "exits": { "northwest": 1639, "south": 1646, "southwest": 1642, "west": 1641, "north": 1649 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1649, "name": "Wheatfield",
       "exits": { "southwest": 1641, "west": 1639, "south": 1648 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 31}
+                  "area": {"id": 31}
     },
     {
       "id": 1650, "name": "North Moat",
       "exits": { "east": 1651, "west": 1673 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1651, "name": "North Moat",
       "exits": { "east": 1652, "west": 1650 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1652, "name": "North Moat",
       "exits": { "east": 1654, "west": 1651 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1653, "name": "Mudball Arena Entrance",
       "exits": { "up": 1583 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 28}
+                  "area": {"id": 28}
     },
     {
       "id": 1654, "name": "North Moat",
       "exits": { "west": 1652, "south": 1655 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1655, "name": "East Moat",
       "exits": { "south": 1656, "north": 1654 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1656, "name": "East Moat",
       "exits": { "south": 1657, "north": 1655 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1657, "name": "East Moat",
       "exits": { "south": 1658, "north": 1656 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1658, "name": "East Moat",
       "exits": { "south": 1659, "north": 1657 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1659, "name": "East Moat",
       "exits": { "south": 1660, "north": 1658 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1660, "name": "East Moat",
       "exits": { "south": 1661, "north": 1659 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1661, "name": "East Moat",
       "exits": { "south": 1662, "north": 1660 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1662, "name": "East Moat",
       "exits": { "south": 1663, "north": 1661 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1663, "name": "East Moat",
       "exits": { "south": 1664, "north": 1662 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1664, "name": "South Moat",
       "exits": { "west": 1665, "north": 1663 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1665, "name": "South Moat",
       "exits": { "east": 1664, "west": 1666 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1666, "name": "South Moat",
       "exits": { "east": 1665, "west": 1667 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1667, "name": "South Moat",
       "exits": { "east": 1666, "west": 1668 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1668, "name": "South Moat",
       "exits": { "east": 1667, "west": 1669 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1669, "name": "South Moat",
       "exits": { "east": 1668, "west": 1670 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1670, "name": "South Moat",
       "exits": { "east": 1669, "west": 1671 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1671, "name": "South Moat",
       "exits": { "east": 1670, "west": 1672 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1672, "name": "South Moat",
       "exits": { "east": 1671, "north": 1686 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1673, "name": "North Moat - Under Draw Bridge",
       "exits": { "east": 1650, "west": 1674 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1674, "name": "North Moat",
       "exits": { "east": 1673, "west": 1675 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1675, "name": "North Moat",
       "exits": { "east": 1674, "west": 1676 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1676, "name": "North Moat",
       "exits": { "east": 1675, "west": 1677 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1677, "name": "North Moat",
       "exits": { "east": 1676, "south": 1678 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1678, "name": "West Moat",
       "exits": { "south": 1679, "north": 1677 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1679, "name": "West Moat",
       "exits": { "south": 1680, "north": 1678 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1680, "name": "West Moat",
       "exits": { "south": 1681, "north": 1679 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1681, "name": "West Moat",
       "exits": { "south": 1682, "north": 1680 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1682, "name": "West Moat",
       "exits": { "south": 1683, "north": 1681 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1683, "name": "West Moat",
       "exits": { "south": 1684, "north": 1682 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1684, "name": "West Moat",
       "exits": { "south": 1685, "north": 1683 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1685, "name": "West Moat",
       "exits": { "south": 1686, "north": 1684 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1686, "name": "West Moat",
       "exits": { "south": 1672, "north": 1685 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 32}
+                  "area": {"id": 32}
     },
     {
       "id": 1687, "name": "Gate to the Village Green",
       "exits": { "east": 1693, "south": 1688 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1688, "name": "Northwest Green",
       "exits": { "south": 1689, "east": 1694, "north": 1687 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1689, "name": "Northwest Green",
       "exits": { "south": 1699, "east": 1690, "north": 1688 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1690, "name": "Northwest Green",
       "exits": { "south": 1700, "west": 1689, "east": 1691, "north": 1694 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1691, "name": "Northwest Green",
       "exits": { "south": 1701, "west": 1690, "east": 1692, "north": 1704 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1692, "name": "Northeast Green",
       "exits": { "south": 1702, "west": 1691, "east": 1706, "north": 1703 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1693, "name": "Northwestern Green",
       "exits": { "west": 1687, "east": 1695, "south": 1694 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1694, "name": "Northwest Green",
       "exits": { "south": 1690, "west": 1688, "east": 1704, "north": 1693 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1695, "name": "Northwestern Green",
       "exits": { "west": 1693, "east": 1696, "south": 1704 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1696, "name": "Northeastern Green",
       "exits": { "west": 1695, "east": 1697, "south": 1703 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1697, "name": "Northeast Green",
       "exits": { "west": 1696, "east": 1698, "south": 1705 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1698, "name": "Northeast Green",
       "exits": { "west": 1697, "south": 1710 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1699, "name": "Southwest Green",
       "exits": { "south": 1713, "east": 1700, "north": 1689 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1700, "name": "Southwest Green",
       "exits": { "south": 1712, "west": 1699, "east": 1701, "north": 1690 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1701, "name": "Southwest Green",
       "exits": { "south": 1711, "west": 1700, "east": 1702, "north": 1691 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1702, "name": "Southeast Green",
       "exits": { "south": 1714, "west": 1701, "east": 1707, "north": 1692 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1703, "name": "Northeast Green",
       "exits": { "south": 1692, "west": 1704, "east": 1705, "north": 1696 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1704, "name": "Northwest Green",
       "exits": { "south": 1691, "west": 1694, "east": 1703, "north": 1695 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1705, "name": "Northeast Green",
       "exits": { "south": 1706, "west": 1703, "east": 1710, "north": 1697 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1706, "name": "Northeast Green",
       "exits": { "south": 1707, "west": 1692, "east": 1709, "north": 1705 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1707, "name": "Ruins in the Southeast Green",
       "exits": { "south": 1715, "west": 1702, "east": 1708, "north": 1706 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1708, "name": "Ruins in the Southeast Green",
       "exits": { "west": 1707, "south": 1716, "north": 1709 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1709, "name": "Northeastern Green",
       "exits": { "west": 1706, "south": 1708, "north": 1710 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1710, "name": "Northeast Green",
       "exits": { "south": 1709, "west": 1705, "east": 1722, "north": 1698 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1711, "name": "Southwest Green",
       "exits": { "south": 1717, "west": 1712, "east": 1714, "north": 1701 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1712, "name": "Southwest Green",
       "exits": { "south": 1718, "west": 1713, "east": 1711, "north": 1700 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1713, "name": "Southwest Green",
       "exits": { "south": 1719, "east": 1712, "north": 1699 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1714, "name": "Southeast Green",
       "exits": { "west": 1711, "east": 1715, "north": 1702 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1715, "name": "Southeast Green",
       "exits": { "west": 1714, "east": 1716, "north": 1707 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1716, "name": "Southeast Green",
       "exits": { "west": 1715, "north": 1708 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1717, "name": "Southwest Green",
       "exits": { "west": 1718, "north": 1711 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1718, "name": "Dark Southwest Green",
       "exits": { "south": 1721, "west": 1719, "east": 1717, "north": 1712 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1719, "name": "Dark Southwest Green",
       "exits": { "south": 1720, "east": 1718, "north": 1713 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1720, "name": "Dark Southwest Green",
       "exits": { "east": 1721, "north": 1719 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1721, "name": "Dark Southwest Green",
       "exits": { "west": 1720, "north": 1718 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1722, "name": "The Herb Exchange",
       "exits": { "west": 1710 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1723, "name": "Inside the Anthill",
       "exits": { "up": 1806, "down": 1744, "north": 1740 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1724, "name": "Oak Treehouse Rope Bridge",
       "exits": { "northwest": 990, "southeast": 1729 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1725, "name": "Oak Treehouse Rope Bridge",
       "exits": { "southwest": 1728, "northeast": 990 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1726, "name": "Oak Treehouse Rope Bridge",
       "exits": { "southwest": 990, "northeast": 1727 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1727, "name": "Living Quarters in the Oak",
       "exits": { "southwest": 1726 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1728, "name": "Living Quarters in the Oak",
       "exits": { "northeast": 1725 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1729, "name": "Oak Treehouse Gazebo",
       "exits": { "northwest": 1724, "east": 1730 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1730, "name": "Long Rope Bridge",
       "exits": { "east": 1731, "west": 1729 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1731, "name": "The rope bridge sways underfoot, but you maintain your balance.",
       "exits": { "west": 1730, "northeast": 1732, "east": 1733, "south": 1734 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1732, "name": "You push open the door and proceed northeast into the large room.",
       "exits": { "southwest": 1731 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1733, "name": "You push open the door to the private quarters.",
       "exits": { "west": 1731 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1734, "name": "Gingerly, you step out onto the taunt rope bridge.",
       "exits": { "south": 1735, "north": 1731 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1735, "name": "You scurry across the swinging rope bridge.",
       "exits": { "southeast": 1736, "north": 1734 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1736, "name": "Tel'Quesir Throne Room",
       "exits": { "northeast": 1738, "northwest": 1735, "southeast": 1737 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1737, "name": "White Chapel",
       "exits": { "northwest": 1736, "north": 1738 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1738, "name": "Hall of Ministers",
       "exits": { "southwest": 1736, "south": 1737 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 33}
+                  "area": {"id": 33}
     },
     {
       "id": 1739, "name": "Landak's Hut:",
       "exits": { "west": 995 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 15}
+                  "area": {"id": 15}
     },
     {
       "id": 1740, "name": "Inside the Anthill",
       "exits": { "southwest": 1741, "southeast": 1743, "south": 1723 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1741, "name": "Inside the Anthill",
       "exits": { "southeast": 1742, "northeast": 1740 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1742, "name": "Inside the Anthill",
       "exits": { "northwest": 1741, "northeast": 1743 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1743, "name": "Inside the Anthill",
       "exits": { "northwest": 1740, "southwest": 1742 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1744, "name": "In the Heart of the Anthill",
       "exits": { "southeast": 1751, "up": 1723, "southwest": 1750, "northeast": 1745, "down": 1754, "northwest": 1747 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1745, "name": "In the Heart of the Anthill",
       "exits": { "southwest": 1744, "south": 1746 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1746, "name": "In the Heart of the Anthill",
       "exits": { "north": 1745 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1747, "name": "In the Heart of the Anthill",
       "exits": { "southwest": 1749, "northeast": 1748, "southeast": 1744 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1748, "name": "In the Heart of the Anthill",
       "exits": { "southwest": 1747 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1749, "name": "In the Heart of the Anthill",
       "exits": { "northeast": 1747 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1750, "name": "In the Heart of the Anthill",
       "exits": { "northeast": 1744 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1751, "name": "In the Heart of the Anthill",
       "exits": { "southwest": 1753, "northeast": 1752, "northwest": 1744 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1752, "name": "In the Heart of the Anthill",
       "exits": { "southwest": 1751 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1753, "name": "In the Heart of the Anthill",
       "exits": { "northeast": 1751 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1754, "name": "At the Base of the Anthill",
       "exits": { "up": 1744, "east": 1758, "south": 1755 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1755, "name": "At the Base of the Anthill",
       "exits": { "southeast": 1756, "north": 1754 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1756, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1755, "southwest": 1757 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1757, "name": "At the Base of the Anthill",
       "exits": { "northeast": 1756 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1758, "name": "At the Base of the Anthill",
       "exits": { "southeast": 1763, "northeast": 1759, "northwest": 1762, "west": 1754 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1759, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1760, "southwest": 1758 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1760, "name": "At the Base of the Anthill",
       "exits": { "southwest": 1762, "northwest": 1761, "southeast": 1759 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1761, "name": "At the Base of the Anthill",
       "exits": { "southeast": 1760 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1762, "name": "At the Base of the Anthill",
       "exits": { "southwest": 1765, "northeast": 1760, "southeast": 1758 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1763, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1758, "northeast": 1764 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1764, "name": "At the Base of the Anthill",
       "exits": { "southwest": 1763 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1765, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1766, "northeast": 1762 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1766, "name": "At the Base of the Anthill",
       "exits": { "southwest": 1767, "northeast": 1770, "southeast": 1765 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1767, "name": "At the Base of the Anthill",
       "exits": { "southeast": 1768, "northeast": 1766 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1768, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1767, "southeast": 1769 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1769, "name": "At the Base of the Anthill",
       "exits": { "northwest": 1768 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1770, "name": "At the Base of the Anthill",
       "exits": { "southwest": 1766 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1771, "name": "Beneath the Anthill",
       "exits": { "south": 1798, "west": 1772, "east": 1782, "north": 1797 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1772, "name": "Beneath the Anthill",
       "exits": { "northwest": 1773, "east": 1771 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1773, "name": "Beneath the Anthill",
       "exits": { "east": 1774, "southeast": 1772, "south": 1791 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1774, "name": "Beneath the Anthill",
       "exits": { "northeast": 1775, "west": 1773, "north": 1783 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1775, "name": "Beneath the Anthill",
       "exits": { "southwest": 1774, "east": 1776 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1776, "name": "Beneath the Anthill",
       "exits": { "west": 1775, "south": 1777 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1777, "name": "Beneath the Anthill",
       "exits": { "south": 1782, "west": 1797, "northeast": 1778, "east": 1799, "north": 1776 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1778, "name": "Beneath the Anthill",
       "exits": { "southwest": 1777, "east": 1779 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1779, "name": "Beneath the Anthill",
       "exits": { "west": 1778, "south": 1780 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1780, "name": "Beneath the Anthill",
       "exits": { "southwest": 1781, "south": 1803, "north": 1779 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1781, "name": "Beneath the Anthill",
       "exits": { "northeast": 1780, "west": 1782, "south": 1800 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1782, "name": "Beneath the Anthill",
       "exits": { "west": 1771, "east": 1781, "north": 1777 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1783, "name": "Beneath the Anthill",
       "exits": { "west": 1784, "south": 1774 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1784, "name": "Beneath the Anthill",
       "exits": { "southwest": 1785, "east": 1783 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1785, "name": "Beneath the Anthill",
       "exits": { "west": 1786, "northeast": 1784 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1786, "name": "Beneath the Anthill",
       "exits": { "east": 1785, "south": 1787 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1787, "name": "Beneath the Anthill",
       "exits": { "southwest": 1788, "north": 1786 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1788, "name": "Near the Queen's Lair",
       "exits": { "northeast": 1787, "north": 1789 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1789, "name": "Near the Queen's Lair",
       "exits": { "south": 1788, "north": 1790 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1790, "name": "The Ant Lair",
       "exits": { "south": 1789 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1791, "name": "Beneath the Anthill",
       "exits": { "south": 1792, "southeast": 1796, "north": 1773 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1792, "name": "Beneath the Anthill",
       "exits": { "west": 1793, "east": 1796, "north": 1791 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1793, "name": "Beneath the Anthill",
       "exits": { "east": 1792, "north": 1794 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1794, "name": "Beneath the Anthill",
       "exits": { "southwest": 1795, "south": 1793 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1795, "name": "Beneath the Anthill",
       "exits": { "northeast": 1794 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1796, "name": "Beneath the Anthill",
       "exits": { "northwest": 1791, "west": 1792 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1797, "name": "Beneath the Anthill",
       "exits": { "east": 1777, "south": 1771 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1798, "name": "Beneath the Anthill",
       "exits": { "north": 1771 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1799, "name": "Beneath the Anthill",
       "exits": { "west": 1777 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1800, "name": "Beneath the Anthill",
       "exits": { "west": 1801, "east": 1802, "north": 1781 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1801, "name": "Beneath the Anthill",
       "exits": { "east": 1800 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1802, "name": "Beneath the Anthill",
       "exits": { "west": 1800, "north": 1803 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1803, "name": "Beneath the Anthill",
       "exits": { "south": 1802, "east": 1804, "north": 1780 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1804, "name": "Beneath the Anthill",
       "exits": { "west": 1803, "north": 1805 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1805, "name": "Beneath the Anthill",
       "exits": { "south": 1804 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1806, "name": "At the top of the anthill.",
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 34}
+                  "area": {"id": 34}
     },
     {
       "id": 1807, "name": "Moist cavern",
       "exits": { "down": 1809, "up": 1808 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1808, "name": "Crack in the mountainside",
       "exits": { "down": 1807 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1809, "name": "Giant cavern",
       "exits": { "up": 1807, "west": 1810 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1810, "name": "Bright niche",
       "exits": { "east": 1809 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1811, "name": "The ore lift",
       "exits": { "south": 1812 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1812, "name": "The Crimsonaxe mine",
       "exits": { "west": 1813, "south": 1815, "north": 1811 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1813, "name": "A guard point",
       "exits": { "south": 1814, "east": 1812, "north": 1823 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1814, "name": "The immense stone slab moves suprisingly easily.",
       "exits": { "north": 1813 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1815, "name": "The Crimsonaxe mine",
       "exits": { "south": 1816, "east": 1821, "north": 1812 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1816, "name": "A bend in the tunnel.",
       "exits": { "southeast": 1817, "north": 1815 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1817, "name": "A mine shaft.",
       "exits": { "northwest": 1816, "east": 1818, "up": 1820 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1818, "name": "A guard house.",
       "exits": { "up": 1819, "west": 1817 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1819, "name": "A sentry room",
       "exits": { "down": 1818 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1820, "name": "A darkened entrance.",
       "exits": { "down": 1817 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1821, "name": "Mine catering",
       "exits": { "west": 1815, "north": 1822 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1822, "name": "A smelly crevice.",
       "exits": { "south": 1821 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1823, "name": "The immense stone slab moves suprisingly easily.",
       "exits": { "south": 1813 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 35}
+                  "area": {"id": 35}
     },
     {
       "id": 1824, "name": "You are just inside the entrace to a large cave",
       "exits": { "east": 1825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1825, "name": "A wide tunnel",
       "exits": { "west": 1824, "south": 1826, "north": 1827 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1826, "name": "A den",
       "exits": { "north": 1825 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1827, "name": "A tunnel",
       "exits": { "south": 1825, "north": 1828 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1828, "name": "A bend in the tunnel",
       "exits": { "east": 1829, "south": 1827 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1829, "name": "A tunnel",
       "exits": { "east": 1830, "west": 1828 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1830, "name": "T-intersection",
       "exits": { "west": 1829, "south": 1831, "north": 1833 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1831, "name": "The widening tunnel",
       "exits": { "east": 1832, "north": 1830 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1832, "name": "A large chamber",
       "exits": { "west": 1831 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1833, "name": "A small chamber",
       "exits": { "south": 1830 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 36}
+                  "area": {"id": 36}
     },
     {
       "id": 1834, "name": "Chikurin Forest Path",
       "exits": { "northeast": 1858, "northwest": 1835, "north": 1856 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1835, "name": "Bamboo Forest",
       "exits": { "east": 1856, "northeast": 1857, "southeast": 1834, "north": 1836 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1836, "name": "Bamboo Forest",
       "exits": { "northwest": 1837, "south": 1835, "northeast": 1862, "east": 1857, "north": 1855 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1837, "name": "Bamboo Forest",
       "exits": { "east": 1855, "northeast": 1851, "southeast": 1836, "north": 1838 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1838, "name": "Calm Clearing in the Bamboo Forest",
       "exits": { "southeast": 1855, "south": 1837, "northeast": 1850, "east": 1851, "north": 1839 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1839, "name": "Bamboo Forest",
       "exits": { "east": 1850, "northeast": 1840, "southeast": 1851, "south": 1838 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1840, "name": "Bamboo Forest, Near a Pond",
       "exits": { "southeast": 1849, "south": 1850, "southwest": 1839, "northeast": 1842, "east": 1846, "north": 1841 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1841, "name": "Bamboo Forest",
       "exits": { "east": 1842, "southeast": 1846, "south": 1840 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1842, "name": "Chikurin Forest Path",
       "exits": { "south": 1846, "west": 1841, "east": 1845, "north": 1843 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1843, "name": "Chikurin Path, south of Semai Pass",
       "exits": { "south": 1842, "north": 1844 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1844, "name": "Heading north, you enter the narrow Semai Pass.",
       "exits": { "south": 1843 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1845, "name": "Bamboo Forest",
       "exits": { "southwest": 1846, "west": 1842, "south": 1848 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1846, "name": "Chikurin Forest Path",
       "exits": { "southeast": 1847, "west": 1840, "northwest": 1841, "south": 1849, "southwest": 1850, "northeast": 1845, "east": 1848, "north": 1842 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1847, "name": "Bamboo Forest",
       "exits": { "northwest": 1846, "south": 1853, "west": 1849, "east": 1852, "north": 1848 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1848, "name": "Bamboo Forest",
       "exits": { "northwest": 1842, "south": 1847, "southwest": 1849, "west": 1846, "southeast": 1852, "north": 1845 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1849, "name": "Chikurin Forest Path",
       "exits": { "southeast": 1853, "south": 1854, "southwest": 1851, "west": 1850, "north": 1846 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1850, "name": "Bamboo Forest",
       "exits": { "west": 1839, "south": 1851, "southwest": 1838, "northeast": 1846, "east": 1849, "north": 1840 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1851, "name": "Bamboo Forest",
       "exits": { "southeast": 1862, "west": 1838, "northwest": 1839, "south": 1855, "southwest": 1837, "northeast": 1849, "east": 1854, "north": 1850 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1852, "name": "Bamboo Forest, North of a Monastery",
       "exits": { "northwest": 1848, "west": 1847 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1853, "name": "Bamboo Forest, West of a Monastery",
       "exits": { "northwest": 1849, "south": 1860, "southwest": 1862, "west": 1854, "north": 1847 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1854, "name": "Chikurin Forest Path",
       "exits": { "south": 1862, "southwest": 1855, "west": 1851, "east": 1853, "north": 1849 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1855, "name": "Bamboo Forest",
       "exits": { "southeast": 1857, "northwest": 1838, "south": 1836, "west": 1837, "northeast": 1854, "east": 1862, "north": 1851 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1856, "name": "Chikurin Forest Path",
       "exits": { "south": 1834, "west": 1835, "east": 1858, "north": 1857 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1857, "name": "Chikurin Forest Path",
       "exits": { "north": 1862 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1858, "name": "Bamboo Forest",
       "exits": { "southwest": 1834, "west": 1856, "northwest": 1857, "north": 1859 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1859, "name": "Bamboo Forest",
       "exits": { "west": 1857, "south": 1858, "northwest": 1862, "north": 1860 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1860, "name": "Bamboo Forest",
       "exits": { "south": 1859, "southwest": 1857, "west": 1862, "east": 1861, "north": 1853 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1861, "name": "Bamboo Forest, South of a Monastery",
       "exits": { "southwest": 1859, "west": 1860, "north": 1863 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1862, "name": "Chikurin Forest Path",
       "exits": { "south": 1857 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 37}
+                  "area": {"id": 37}
     },
     {
       "id": 1863, "name": "You cross the sharply arching bridge.",
       "exits": { "south": 1861, "north": 1864 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1864, "name": "You push on the massive golden doors and, perfectly balanced, they swing open",
       "exits": { "south": 1863, "north": 1865 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1865, "name": "You step down into the sandy courtyard.",
       "exits": { "south": 1864, "north": 1866 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1866, "name": "Northwest Training Yard",
       "exits": { "south": 1865, "north": 1867 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1867, "name": "You step up onto the boardwalk that rings the practice yard.",
       "exits": { "south": 1866, "north": 1868 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1868, "name": "You slide back the fusumi with a flick of your hand.",
       "exits": { "south": 1867 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 38}
+                  "area": {"id": 38}
     },
     {
       "id": 1869, "name": "down the waterfall.",
       "exits": { "down": 1339 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 26}
+                  "area": {"id": 26}
     },
     {
       "id": 1870, "name": "Armoury",
       "exits": { "south": 1086 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     },
     {
       "id": 1871, "name": "Stables",
       "exits": { "north": 1086 },
-      "environment": -1,
-      "weight": 1,
-      "area": {"id": 19}
+                  "area": {"id": 19}
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Clean up redundant default properties in the map data by removing `"environment": -1` and `"weight": 1` entries. 
- Reduce noise and file size in `maps/moraldecay.json` where those defaults are repeatedly present. 

### Description
- Removed every occurrence of `"environment": -1` and `"weight": 1` from `maps/moraldecay.json`. 
- The update was applied via a small script and saved back to the same file, and the change was committed with message `Remove environment and weight defaults from map`.
- The file now omits those default fields and retains the rest of the room data and structure.

### Testing
- Verified with `rg -n "\"environment\": -1|\"weight\": 1" maps/moraldecay.json` which returned no matches after the change. 
- No unit or integration tests were required for this data-only change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8fc1b47c8327b84fba5abe65534f)