### PR TITLE
Add Balin area room files (605–733)

### DIFF
--- a/domain/original/area/balin/room605.c
+++ b/domain/original/area/balin/room605.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ocean before Beachhead";
+    long_desc = "Ocean before Beachhead.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room606", "north",
+    });
+}

--- a/domain/original/area/balin/room606.c
+++ b/domain/original/area/balin/room606.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A sandy beachhead";
+    long_desc = "A sandy beachhead.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room605", "south",
+        "domain/original/area/balin/room623", "west",
+        "domain/original/area/balin/room626", "east",
+        "domain/original/area/balin/room607", "north",
+    });
+}

--- a/domain/original/area/balin/room607.c
+++ b/domain/original/area/balin/room607.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A narrow path between the dunes";
+    long_desc = "A narrow path between the dunes.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room606", "south",
+        "domain/original/area/balin/room628", "east",
+        "domain/original/area/balin/room608", "north",
+    });
+}

--- a/domain/original/area/balin/room608.c
+++ b/domain/original/area/balin/room608.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A Dune Path";
+    long_desc = "A Dune Path.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room607", "south",
+        "domain/original/area/balin/room609", "north",
+    });
+}

--- a/domain/original/area/balin/room609.c
+++ b/domain/original/area/balin/room609.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The City Gate";
+    long_desc = "The City Gate.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room608", "south",
+        "domain/original/area/balin/room631", "west",
+        "domain/original/area/balin/room634", "east",
+        "domain/original/area/balin/room610", "north",
+    });
+}

--- a/domain/original/area/balin/room610.c
+++ b/domain/original/area/balin/room610.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Intersection of Silver Street and Balin Road";
+    long_desc = "Intersection of Silver Street and Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room609", "south",
+        "domain/original/area/balin/room635", "west",
+        "domain/original/area/balin/room660", "east",
+        "domain/original/area/balin/room611", "north",
+    });
+}

--- a/domain/original/area/balin/room611.c
+++ b/domain/original/area/balin/room611.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room610", "south",
+        "domain/original/area/balin/room713", "east",
+        "domain/original/area/balin/room612", "north",
+    });
+}

--- a/domain/original/area/balin/room612.c
+++ b/domain/original/area/balin/room612.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room611", "south",
+        "domain/original/area/balin/room674", "east",
+        "domain/original/area/balin/room613", "north",
+    });
+}

--- a/domain/original/area/balin/room613.c
+++ b/domain/original/area/balin/room613.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room612", "south",
+        "domain/original/area/balin/room675", "west",
+        "domain/original/area/balin/room676", "east",
+        "domain/original/area/balin/room614", "north",
+    });
+}

--- a/domain/original/area/balin/room614.c
+++ b/domain/original/area/balin/room614.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A Grand Plaza";
+    long_desc = "A Grand Plaza.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room613", "south",
+        "domain/original/area/balin/room678", "west",
+        "domain/original/area/balin/room677", "east",
+        "domain/original/area/balin/room615", "north",
+    });
+}

--- a/domain/original/area/balin/room615.c
+++ b/domain/original/area/balin/room615.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room688", "west",
+        "domain/original/area/balin/room614", "south",
+        "domain/original/area/balin/room616", "north",
+    });
+}

--- a/domain/original/area/balin/room616.c
+++ b/domain/original/area/balin/room616.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room615", "south",
+        "domain/original/area/balin/room689", "east",
+        "domain/original/area/balin/room617", "north",
+    });
+}

--- a/domain/original/area/balin/room617.c
+++ b/domain/original/area/balin/room617.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room690", "west",
+        "domain/original/area/balin/room616", "south",
+        "domain/original/area/balin/room618", "north",
+    });
+}

--- a/domain/original/area/balin/room618.c
+++ b/domain/original/area/balin/room618.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Silver Street";
+    long_desc = "Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room617", "south",
+        "domain/original/area/balin/room622", "west",
+        "domain/original/area/balin/room691", "east",
+        "domain/original/area/balin/room619", "north",
+    });
+}

--- a/domain/original/area/balin/room619.c
+++ b/domain/original/area/balin/room619.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Silver Street";
+    long_desc = "End of Silver Street.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room620", "east",
+        "domain/original/area/balin/room618", "south",
+    });
+}

--- a/domain/original/area/balin/room620.c
+++ b/domain/original/area/balin/room620.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Island smeltery";
+    long_desc = "Island smeltery.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room621", "east",
+        "domain/original/area/balin/room619", "west",
+    });
+}

--- a/domain/original/area/balin/room621.c
+++ b/domain/original/area/balin/room621.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Repair Shop";
+    long_desc = "Repair Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room620", "west",
+    });
+}

--- a/domain/original/area/balin/room622.c
+++ b/domain/original/area/balin/room622.c
@@ -1,0 +1,12 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A Bloody Arena.";
+    long_desc = "A Bloody Arena..\n";
+    dest_dir = ({ });
+}

--- a/domain/original/area/balin/room623.c
+++ b/domain/original/area/balin/room623.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western Part of Beach";
+    long_desc = "Western Part of Beach.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room606", "east",
+        "domain/original/area/balin/room624", "west",
+    });
+}

--- a/domain/original/area/balin/room624.c
+++ b/domain/original/area/balin/room624.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East of the waterfall";
+    long_desc = "East of the waterfall.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room623", "east",
+        "domain/original/area/balin/room625", "west",
+    });
+}

--- a/domain/original/area/balin/room625.c
+++ b/domain/original/area/balin/room625.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The base of a waterfall";
+    long_desc = "The base of a waterfall.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room624", "east",
+    });
+}

--- a/domain/original/area/balin/room626.c
+++ b/domain/original/area/balin/room626.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ruins";
+    long_desc = "Ruins.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room627", "east",
+        "domain/original/area/balin/room606", "west",
+    });
+}

--- a/domain/original/area/balin/room627.c
+++ b/domain/original/area/balin/room627.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Beach";
+    long_desc = "Eastern Beach.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room626", "west",
+    });
+}

--- a/domain/original/area/balin/room628.c
+++ b/domain/original/area/balin/room628.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A valley between two large dunes";
+    long_desc = "A valley between two large dunes.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room629", "east",
+        "domain/original/area/balin/room607", "west",
+    });
+}

--- a/domain/original/area/balin/room629.c
+++ b/domain/original/area/balin/room629.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A desert plain";
+    long_desc = "A desert plain.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room628", "west",
+        "domain/original/area/balin/room630", "north",
+    });
+}

--- a/domain/original/area/balin/room630.c
+++ b/domain/original/area/balin/room630.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A dead end";
+    long_desc = "A dead end.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room629", "south",
+    });
+}

--- a/domain/original/area/balin/room631.c
+++ b/domain/original/area/balin/room631.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Room";
+    long_desc = "Guard Room.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room609", "east",
+        "domain/original/area/balin/room632", "west",
+    });
+}

--- a/domain/original/area/balin/room632.c
+++ b/domain/original/area/balin/room632.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Armoury";
+    long_desc = "Armoury.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room631", "east",
+        "domain/original/area/balin/room633", "west",
+    });
+}

--- a/domain/original/area/balin/room633.c
+++ b/domain/original/area/balin/room633.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Elderoak's Quarters";
+    long_desc = "Elderoak's Quarters.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room632", "east",
+    });
+}

--- a/domain/original/area/balin/room634.c
+++ b/domain/original/area/balin/room634.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A guard house";
+    long_desc = "A guard house.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room609", "west",
+    });
+}

--- a/domain/original/area/balin/room635.c
+++ b/domain/original/area/balin/room635.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room719", "northwest",
+        "domain/original/area/balin/room717", "south",
+        "domain/original/area/balin/room718", "northeast",
+        "domain/original/area/balin/room610", "east",
+        "domain/original/area/balin/room636", "west",
+    });
+}

--- a/domain/original/area/balin/room636.c
+++ b/domain/original/area/balin/room636.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room722", "southwest",
+        "domain/original/area/balin/room635", "east",
+        "domain/original/area/balin/room721", "southeast",
+        "domain/original/area/balin/room637", "west",
+    });
+}

--- a/domain/original/area/balin/room637.c
+++ b/domain/original/area/balin/room637.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West End of Balin Road";
+    long_desc = "West End of Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room638", "west",
+        "domain/original/area/balin/room720", "northeast",
+        "domain/original/area/balin/room636", "east",
+        "domain/original/area/balin/room723", "south",
+    });
+}

--- a/domain/original/area/balin/room638.c
+++ b/domain/original/area/balin/room638.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tunnel Under Canal";
+    long_desc = "Tunnel Under Canal.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room637", "east",
+        "domain/original/area/balin/room639", "west",
+    });
+}

--- a/domain/original/area/balin/room639.c
+++ b/domain/original/area/balin/room639.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South End of Highland Avenue";
+    long_desc = "South End of Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room638", "east",
+        "domain/original/area/balin/room640", "west",
+    });
+}

--- a/domain/original/area/balin/room640.c
+++ b/domain/original/area/balin/room640.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room657", "south",
+        "domain/original/area/balin/room639", "east",
+        "domain/original/area/balin/room641", "north",
+    });
+}

--- a/domain/original/area/balin/room641.c
+++ b/domain/original/area/balin/room641.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room640", "south",
+        "domain/original/area/balin/room642", "north",
+    });
+}

--- a/domain/original/area/balin/room642.c
+++ b/domain/original/area/balin/room642.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room643", "west",
+        "domain/original/area/balin/room641", "south",
+    });
+}

--- a/domain/original/area/balin/room643.c
+++ b/domain/original/area/balin/room643.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room647", "south",
+        "domain/original/area/balin/room642", "east",
+        "domain/original/area/balin/room644", "north",
+    });
+}

--- a/domain/original/area/balin/room644.c
+++ b/domain/original/area/balin/room644.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room643", "south",
+        "domain/original/area/balin/room646", "west",
+        "domain/original/area/balin/room648", "east",
+        "domain/original/area/balin/room645", "north",
+    });
+}

--- a/domain/original/area/balin/room645.c
+++ b/domain/original/area/balin/room645.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Hut";
+    long_desc = "Dwarven Hut.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room644", "south",
+    });
+}

--- a/domain/original/area/balin/room646.c
+++ b/domain/original/area/balin/room646.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You trundle past the facade and arrive on a beautiful street.";
+    long_desc = "You trundle past the facade and arrive on a beautiful street..\n";
+    dest_dir = ({
+        "domain/original/area/balin/room644", "east",
+    });
+}

--- a/domain/original/area/balin/room647.c
+++ b/domain/original/area/balin/room647.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gnome Hut";
+    long_desc = "Gnome Hut.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room643", "north",
+    });
+}

--- a/domain/original/area/balin/room648.c
+++ b/domain/original/area/balin/room648.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room651", "south",
+        "domain/original/area/balin/room644", "west",
+        "domain/original/area/balin/room649", "east",
+        "domain/original/area/balin/room650", "north",
+    });
+}

--- a/domain/original/area/balin/room649.c
+++ b/domain/original/area/balin/room649.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Home";
+    long_desc = "Dwarven Home.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room648", "west",
+    });
+}

--- a/domain/original/area/balin/room650.c
+++ b/domain/original/area/balin/room650.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room652", "west",
+        "domain/original/area/balin/room648", "south",
+    });
+}

--- a/domain/original/area/balin/room651.c
+++ b/domain/original/area/balin/room651.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Shack";
+    long_desc = "Dwarven Shack.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room648", "north",
+    });
+}

--- a/domain/original/area/balin/room652.c
+++ b/domain/original/area/balin/room652.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room653", "west",
+        "domain/original/area/balin/room650", "east",
+        "domain/original/area/balin/room654", "north",
+    });
+}

--- a/domain/original/area/balin/room653.c
+++ b/domain/original/area/balin/room653.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Home";
+    long_desc = "Dwarven Home.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room652", "east",
+        "domain/original/area/balin/room656", "south",
+    });
+}

--- a/domain/original/area/balin/room654.c
+++ b/domain/original/area/balin/room654.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Highland Avenue";
+    long_desc = "Highland Avenue.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room652", "south",
+        "domain/original/area/balin/room655", "north",
+    });
+}

--- a/domain/original/area/balin/room655.c
+++ b/domain/original/area/balin/room655.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "House of Balin";
+    long_desc = "House of Balin.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room712", "west",
+        "domain/original/area/balin/room654", "south",
+    });
+}

--- a/domain/original/area/balin/room656.c
+++ b/domain/original/area/balin/room656.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dwarven Home";
+    long_desc = "Dwarven Home.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room653", "north",
+    });
+}

--- a/domain/original/area/balin/room657.c
+++ b/domain/original/area/balin/room657.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Keep Of Alcibiades";
+    long_desc = "Keep Of Alcibiades.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room659", "west",
+        "domain/original/area/balin/room658", "east",
+        "domain/original/area/balin/room640", "north",
+    });
+}

--- a/domain/original/area/balin/room658.c
+++ b/domain/original/area/balin/room658.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Study";
+    long_desc = "Study.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room657", "west",
+    });
+}

--- a/domain/original/area/balin/room659.c
+++ b/domain/original/area/balin/room659.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bedroom:";
+    long_desc = "Bedroom:.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room657", "east",
+    });
+}

--- a/domain/original/area/balin/room660.c
+++ b/domain/original/area/balin/room660.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room661", "east",
+        "domain/original/area/balin/room610", "west",
+    });
+}

--- a/domain/original/area/balin/room661.c
+++ b/domain/original/area/balin/room661.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room660", "west",
+        "domain/original/area/balin/room662", "east",
+        "domain/original/area/balin/room673", "south",
+    });
+}

--- a/domain/original/area/balin/room662.c
+++ b/domain/original/area/balin/room662.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room661", "west",
+        "domain/original/area/balin/room663", "east",
+        "domain/original/area/balin/room672", "north",
+    });
+}

--- a/domain/original/area/balin/room663.c
+++ b/domain/original/area/balin/room663.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room670", "south",
+        "domain/original/area/balin/room662", "west",
+        "domain/original/area/balin/room664", "east",
+        "domain/original/area/balin/room671", "north",
+    });
+}

--- a/domain/original/area/balin/room664.c
+++ b/domain/original/area/balin/room664.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road";
+    long_desc = "Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room667", "south",
+        "domain/original/area/balin/room663", "west",
+        "domain/original/area/balin/room665", "east",
+        "domain/original/area/balin/room668", "north",
+    });
+}

--- a/domain/original/area/balin/room665.c
+++ b/domain/original/area/balin/room665.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East End of Balin Road";
+    long_desc = "East End of Balin Road.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room664", "west",
+        "domain/original/area/balin/room666", "south",
+    });
+}

--- a/domain/original/area/balin/room666.c
+++ b/domain/original/area/balin/room666.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Arched Gates";
+    long_desc = "Arched Gates.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room665", "north",
+    });
+}

--- a/domain/original/area/balin/room667.c
+++ b/domain/original/area/balin/room667.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room664", "north",
+    });
+}

--- a/domain/original/area/balin/room668.c
+++ b/domain/original/area/balin/room668.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Island Historical Society";
+    long_desc = "Island Historical Society.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room664", "south",
+        "domain/original/area/balin/room669", "north",
+    });
+}

--- a/domain/original/area/balin/room669.c
+++ b/domain/original/area/balin/room669.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Office";
+    long_desc = "Office.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room668", "south",
+    });
+}

--- a/domain/original/area/balin/room670.c
+++ b/domain/original/area/balin/room670.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Elven Mercantile";
+    long_desc = "Elven Mercantile.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room663", "north",
+    });
+}

--- a/domain/original/area/balin/room671.c
+++ b/domain/original/area/balin/room671.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple Shop";
+    long_desc = "Temple Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room672", "west",
+        "domain/original/area/balin/room663", "south",
+    });
+}

--- a/domain/original/area/balin/room672.c
+++ b/domain/original/area/balin/room672.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple Plaza";
+    long_desc = "Temple Plaza.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room715", "west",
+        "domain/original/area/balin/room671", "east",
+        "domain/original/area/balin/room662", "south",
+    });
+}

--- a/domain/original/area/balin/room673.c
+++ b/domain/original/area/balin/room673.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Seed Shop";
+    long_desc = "Seed Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room661", "north",
+    });
+}

--- a/domain/original/area/balin/room674.c
+++ b/domain/original/area/balin/room674.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "City Pastry Shop";
+    long_desc = "City Pastry Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room612", "west",
+    });
+}

--- a/domain/original/area/balin/room675.c
+++ b/domain/original/area/balin/room675.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Soylent Green";
+    long_desc = "Soylent Green.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room613", "east",
+    });
+}

--- a/domain/original/area/balin/room676.c
+++ b/domain/original/area/balin/room676.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mariner's Revenge";
+    long_desc = "Mariner's Revenge.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room613", "west",
+        "domain/original/area/balin/room677", "north",
+    });
+}

--- a/domain/original/area/balin/room677.c
+++ b/domain/original/area/balin/room677.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gate House";
+    long_desc = "Gate House.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room676", "south",
+        "domain/original/area/balin/room614", "west",
+        "domain/original/area/balin/room693", "east",
+        "domain/original/area/balin/room686", "north",
+    });
+}

--- a/domain/original/area/balin/room678.c
+++ b/domain/original/area/balin/room678.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gate House";
+    long_desc = "Gate House.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room614", "east",
+        "domain/original/area/balin/room679", "west",
+    });
+}

--- a/domain/original/area/balin/room679.c
+++ b/domain/original/area/balin/room679.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Foyer";
+    long_desc = "Foyer.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room684", "south",
+        "domain/original/area/balin/room678", "east",
+        "domain/original/area/balin/room680", "north",
+    });
+}

--- a/domain/original/area/balin/room680.c
+++ b/domain/original/area/balin/room680.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hallway";
+    long_desc = "Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room679", "south",
+        "domain/original/area/balin/room681", "north",
+    });
+}

--- a/domain/original/area/balin/room681.c
+++ b/domain/original/area/balin/room681.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Audience Hall";
+    long_desc = "Audience Hall.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room682", "west",
+        "domain/original/area/balin/room680", "south",
+    });
+}

--- a/domain/original/area/balin/room682.c
+++ b/domain/original/area/balin/room682.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Council Chamber";
+    long_desc = "Council Chamber.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room681", "east",
+        "domain/original/area/balin/room683", "west",
+    });
+}

--- a/domain/original/area/balin/room683.c
+++ b/domain/original/area/balin/room683.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Trophy Room";
+    long_desc = "Trophy Room.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room682", "east",
+    });
+}

--- a/domain/original/area/balin/room684.c
+++ b/domain/original/area/balin/room684.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hallway";
+    long_desc = "Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room685", "south",
+        "domain/original/area/balin/room679", "north",
+    });
+}

--- a/domain/original/area/balin/room685.c
+++ b/domain/original/area/balin/room685.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Lady Roland's Bedroom";
+    long_desc = "Lady Roland's Bedroom.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room684", "north",
+    });
+}

--- a/domain/original/area/balin/room686.c
+++ b/domain/original/area/balin/room686.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "RIIS";
+    long_desc = "RIIS.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room687", "down",
+        "domain/original/area/balin/room677", "south",
+    });
+}

--- a/domain/original/area/balin/room687.c
+++ b/domain/original/area/balin/room687.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Crack of Doom";
+    long_desc = "Crack of Doom.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room686", "up",
+    });
+}

--- a/domain/original/area/balin/room688.c
+++ b/domain/original/area/balin/room688.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rhian's Potion Shop";
+    long_desc = "Rhian's Potion Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room615", "east",
+    });
+}

--- a/domain/original/area/balin/room689.c
+++ b/domain/original/area/balin/room689.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Alchemist Shop";
+    long_desc = "Alchemist Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room616", "west",
+    });
+}

--- a/domain/original/area/balin/room690.c
+++ b/domain/original/area/balin/room690.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to the Hall of Records";
+    long_desc = "Entrance to the Hall of Records.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room617", "east",
+    });
+}

--- a/domain/original/area/balin/room691.c
+++ b/domain/original/area/balin/room691.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Power System Generator";
+    long_desc = "Power System Generator.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room692", "east",
+        "domain/original/area/balin/room618", "west",
+    });
+}

--- a/domain/original/area/balin/room692.c
+++ b/domain/original/area/balin/room692.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Power System Internals";
+    long_desc = "Power System Internals.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room691", "west",
+    });
+}

--- a/domain/original/area/balin/room693.c
+++ b/domain/original/area/balin/room693.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entryway";
+    long_desc = "Entryway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room677", "west",
+        "domain/original/area/balin/room694", "south",
+        "domain/original/area/balin/room696", "north",
+    });
+}

--- a/domain/original/area/balin/room694.c
+++ b/domain/original/area/balin/room694.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Corridor";
+    long_desc = "South Corridor.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room695", "south",
+        "domain/original/area/balin/room693", "north",
+    });
+}

--- a/domain/original/area/balin/room695.c
+++ b/domain/original/area/balin/room695.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Post";
+    long_desc = "Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room694", "north",
+    });
+}

--- a/domain/original/area/balin/room696.c
+++ b/domain/original/area/balin/room696.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "North Corridor";
+    long_desc = "North Corridor.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room693", "south",
+        "domain/original/area/balin/room697", "north",
+    });
+}

--- a/domain/original/area/balin/room697.c
+++ b/domain/original/area/balin/room697.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Room";
+    long_desc = "Guard Room.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room698", "east",
+        "domain/original/area/balin/room696", "south",
+    });
+}

--- a/domain/original/area/balin/room698.c
+++ b/domain/original/area/balin/room698.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West Harem";
+    long_desc = "West Harem.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room699", "east",
+        "domain/original/area/balin/room697", "west",
+    });
+}

--- a/domain/original/area/balin/room699.c
+++ b/domain/original/area/balin/room699.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East Harem";
+    long_desc = "East Harem.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room700", "east",
+        "domain/original/area/balin/room698", "west",
+    });
+}

--- a/domain/original/area/balin/room700.c
+++ b/domain/original/area/balin/room700.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bedchamber";
+    long_desc = "Bedchamber.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room701", "east",
+        "domain/original/area/balin/room699", "west",
+    });
+}

--- a/domain/original/area/balin/room701.c
+++ b/domain/original/area/balin/room701.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entryway";
+    long_desc = "Entryway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room700", "west",
+        "domain/original/area/balin/room702", "south",
+    });
+}

--- a/domain/original/area/balin/room702.c
+++ b/domain/original/area/balin/room702.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room703", "south",
+        "domain/original/area/balin/room708", "east",
+        "domain/original/area/balin/room701", "north",
+    });
+}

--- a/domain/original/area/balin/room703.c
+++ b/domain/original/area/balin/room703.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room704", "south",
+        "domain/original/area/balin/room707", "east",
+        "domain/original/area/balin/room702", "north",
+    });
+}

--- a/domain/original/area/balin/room704.c
+++ b/domain/original/area/balin/room704.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room705", "south",
+        "domain/original/area/balin/room706", "east",
+        "domain/original/area/balin/room703", "north",
+    });
+}

--- a/domain/original/area/balin/room705.c
+++ b/domain/original/area/balin/room705.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "South Entryway";
+    long_desc = "South Entryway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room704", "north",
+    });
+}

--- a/domain/original/area/balin/room706.c
+++ b/domain/original/area/balin/room706.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room704", "west",
+        "domain/original/area/balin/room710", "south",
+        "domain/original/area/balin/room707", "north",
+    });
+}

--- a/domain/original/area/balin/room707.c
+++ b/domain/original/area/balin/room707.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room703", "west",
+        "domain/original/area/balin/room706", "south",
+        "domain/original/area/balin/room708", "north",
+    });
+}

--- a/domain/original/area/balin/room708.c
+++ b/domain/original/area/balin/room708.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room702", "west",
+        "domain/original/area/balin/room707", "south",
+        "domain/original/area/balin/room709", "north",
+    });
+}

--- a/domain/original/area/balin/room709.c
+++ b/domain/original/area/balin/room709.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room708", "south",
+    });
+}

--- a/domain/original/area/balin/room710.c
+++ b/domain/original/area/balin/room710.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Turkish Bath";
+    long_desc = "Turkish Bath.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room706", "north",
+    });
+}

--- a/domain/original/area/balin/room711.c
+++ b/domain/original/area/balin/room711.c
@@ -1,0 +1,12 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The hermit says: Is there anything you would like to talk about?";
+    long_desc = "The hermit says: Is there anything you would like to talk about?.\n";
+    dest_dir = ({ });
+}

--- a/domain/original/area/balin/room712.c
+++ b/domain/original/area/balin/room712.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hermit's Chamber";
+    long_desc = "Hermit's Chamber.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room655", "east",
+    });
+}

--- a/domain/original/area/balin/room713.c
+++ b/domain/original/area/balin/room713.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple";
+    long_desc = "Temple.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room611", "west",
+        "domain/original/area/balin/room714", "east",
+        "domain/original/area/balin/room716", "north",
+    });
+}

--- a/domain/original/area/balin/room714.c
+++ b/domain/original/area/balin/room714.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Central Chamber";
+    long_desc = "Central Chamber.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room715", "east",
+        "domain/original/area/balin/room713", "west",
+    });
+}

--- a/domain/original/area/balin/room715.c
+++ b/domain/original/area/balin/room715.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern Chamber";
+    long_desc = "Eastern Chamber.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room672", "east",
+        "domain/original/area/balin/room714", "west",
+    });
+}

--- a/domain/original/area/balin/room716.c
+++ b/domain/original/area/balin/room716.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
+    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room713", "south",
+    });
+}

--- a/domain/original/area/balin/room717.c
+++ b/domain/original/area/balin/room717.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Poison Shop";
+    long_desc = "Poison Shop.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room635", "north",
+    });
+}

--- a/domain/original/area/balin/room718.c
+++ b/domain/original/area/balin/room718.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Taxidermist";
+    long_desc = "Taxidermist.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room635", "southwest",
+    });
+}

--- a/domain/original/area/balin/room719.c
+++ b/domain/original/area/balin/room719.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Weaver's";
+    long_desc = "Weaver's.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room635", "southeast",
+    });
+}

--- a/domain/original/area/balin/room720.c
+++ b/domain/original/area/balin/room720.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Foyer of House of Ill Repute";
+    long_desc = "Foyer of House of Ill Repute.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room637", "southwest",
+    });
+}

--- a/domain/original/area/balin/room721.c
+++ b/domain/original/area/balin/room721.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Balin Road Pub";
+    long_desc = "Balin Road Pub.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room636", "northwest",
+    });
+}

--- a/domain/original/area/balin/room722.c
+++ b/domain/original/area/balin/room722.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Wheelwright";
+    long_desc = "Wheelwright.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room636", "northeast",
+    });
+}

--- a/domain/original/area/balin/room723.c
+++ b/domain/original/area/balin/room723.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Crowded Thoroughfare";
+    long_desc = "Crowded Thoroughfare.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room724", "south",
+        "domain/original/area/balin/room637", "north",
+    });
+}

--- a/domain/original/area/balin/room724.c
+++ b/domain/original/area/balin/room724.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Archway of Servitude";
+    long_desc = "Archway of Servitude.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room725", "south",
+        "domain/original/area/balin/room723", "north",
+    });
+}

--- a/domain/original/area/balin/room725.c
+++ b/domain/original/area/balin/room725.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bazaar Crossroad";
+    long_desc = "Bazaar Crossroad.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room726", "west",
+        "domain/original/area/balin/room729", "east",
+        "domain/original/area/balin/room724", "north",
+    });
+}

--- a/domain/original/area/balin/room726.c
+++ b/domain/original/area/balin/room726.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western District";
+    long_desc = "Western District.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room725", "east",
+        "domain/original/area/balin/room727", "south",
+    });
+}

--- a/domain/original/area/balin/room727.c
+++ b/domain/original/area/balin/room727.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western District";
+    long_desc = "Western District.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room728", "south",
+        "domain/original/area/balin/room726", "north",
+    });
+}

--- a/domain/original/area/balin/room728.c
+++ b/domain/original/area/balin/room728.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Western slave bazaar";
+    long_desc = "Western slave bazaar.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room732", "east",
+        "domain/original/area/balin/room727", "north",
+    });
+}

--- a/domain/original/area/balin/room729.c
+++ b/domain/original/area/balin/room729.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern District";
+    long_desc = "Eastern District.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room725", "west",
+        "domain/original/area/balin/room730", "south",
+    });
+}

--- a/domain/original/area/balin/room730.c
+++ b/domain/original/area/balin/room730.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern District";
+    long_desc = "Eastern District.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room731", "south",
+        "domain/original/area/balin/room729", "north",
+    });
+}

--- a/domain/original/area/balin/room731.c
+++ b/domain/original/area/balin/room731.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Eastern slave bazaar";
+    long_desc = "Eastern slave bazaar.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room732", "west",
+        "domain/original/area/balin/room730", "north",
+    });
+}

--- a/domain/original/area/balin/room732.c
+++ b/domain/original/area/balin/room732.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Central slave bazaar";
+    long_desc = "Central slave bazaar.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room728", "west",
+        "domain/original/area/balin/room731", "east",
+        "domain/original/area/balin/room733", "south",
+    });
+}

--- a/domain/original/area/balin/room733.c
+++ b/domain/original/area/balin/room733.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Administrative hallway";
+    long_desc = "Administrative hallway.\n";
+    dest_dir = ({
+        "domain/original/area/balin/room732", "north",
+    });
+}


### PR DESCRIPTION
### Motivation

- Populate the world with the Balin area by converting `maps/balin.json` into room definitions. 
- Use the existing room template used in `domain/original/area/vesla/room227.c` so rooms follow the same layout and conventions. 
- Ensure rooms are interconnected via `dest_dir` entries matching the JSON exit map. 

### Description

- Create `domain/original/area/balin/` and add room files `room605.c` through `room733.c` generated from `maps/balin.json`. 
- Each room file uses `inherit "room/room"`, `set_light(1)`, `short_desc`, `long_desc`, and a wired `dest_dir` block referencing other Balin room paths. 
- Rooms with no exits use an empty `dest_dir` formatted as `({ })` to match project style. 
- Add and commit all generated files to the repository as a single change set. 

### Testing

- Ran the generation script which produced the room files and inspected a number of outputs with `sed` to verify contents and formatting. 
- Used `rg` to search for `dest_dir` patterns and confirm presence/format of exit blocks. 
- Performed a `git commit` which completed successfully including 129 files added. 
- No automated unit or integration test suite was run against the new rooms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d91f7bc088327bd09fa37907e75a3)