### PR TITLE
Fix brief exit display for special exits

### DIFF
--- a/room/room.c
+++ b/room/room.c
@@ -59,12 +59,15 @@ string exitsDescription(int brief) {
         i = 1;
         desc = "(Exits:";
         while (i < sizeof(dest_dir)) {
-            desc +=
-                " " + (["north":"n",
-                              "south":"s", "east":"e", "west":"w", "up":"u",
+            string short_dir;
+
+            short_dir = (["north":"n",
+                               "south":"s", "east":"e", "west":"w", "up":"u",
                                "down":"d", "northeast":"ne", "northwest":"nw",
-                          "southeast":"se", "southwest":"sw", ])[dest_dir[i]] ||
-                dest_dir[i];
+                               "southeast":"se", "southwest":"sw", ])[dest_dir[i]];
+            if (!short_dir)
+                short_dir = dest_dir[i];
+            desc += " " + short_dir;
             i += 2;
         }
         return desc + ")";


### PR DESCRIPTION
### Motivation
- Brief exit listings showed incorrect output (e.g. `(Exits: n 0)`) for special exits that have no short abbreviation.
- The mapping lookup was being combined with string concatenation in a way that caused `0` to appear when the mapping returned `0` or `nil`.
- Ensure the brief form falls back to the full direction name when no abbreviation exists.
- Improve clarity and correctness of `exitsDescription` in `room/room.c` for brief output.

### Description
- Modified the `exitsDescription(int brief)` logic in `room/room.c` to introduce a `short_dir` variable for the brief path rendering.
- Lookup the abbreviation from the direction mapping into `short_dir` and fall back to `dest_dir[i]` when no abbreviation is found using an explicit `if (!short_dir)` check.
- Replaced the previous inline `||` concatenation approach to avoid precedence/`0` display issues.
- Updated the return construction to append the resolved `short_dir` values for each exit.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9497c0848327ab017fe8038fe360)