### PR TITLE
Add Nature Preserve rooms and connect Vesla portal to Preserve

### DIFF
--- a/domain/original/area/preserve/room432.c
+++ b/domain/original/area/preserve/room432.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bridge";
+    long_desc = "Bridge.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room433", "west",
+        "domain/original/area/vesla/portal", "vesla",
+    });
+}

--- a/domain/original/area/preserve/room433.c
+++ b/domain/original/area/preserve/room433.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Waterfall";
+    long_desc = "Waterfall.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room432", "east",
+    });
+}

--- a/domain/original/area/preserve/room434.c
+++ b/domain/original/area/preserve/room434.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room435", "north",
+    });
+}

--- a/domain/original/area/preserve/room435.c
+++ b/domain/original/area/preserve/room435.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room436", "west",
+        "domain/original/area/preserve/room434", "south",
+    });
+}

--- a/domain/original/area/preserve/room436.c
+++ b/domain/original/area/preserve/room436.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room435", "east",
+        "domain/original/area/preserve/room437", "west",
+    });
+}

--- a/domain/original/area/preserve/room437.c
+++ b/domain/original/area/preserve/room437.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room436", "east",
+        "domain/original/area/preserve/room438", "west",
+    });
+}

--- a/domain/original/area/preserve/room438.c
+++ b/domain/original/area/preserve/room438.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room439", "west",
+        "domain/original/area/preserve/room437", "east",
+        "domain/original/area/preserve/room440", "south",
+    });
+}

--- a/domain/original/area/preserve/room439.c
+++ b/domain/original/area/preserve/room439.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room438", "east",
+        "domain/original/area/preserve/room445", "west",
+    });
+}

--- a/domain/original/area/preserve/room440.c
+++ b/domain/original/area/preserve/room440.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room441", "south",
+        "domain/original/area/preserve/room438", "north",
+    });
+}

--- a/domain/original/area/preserve/room441.c
+++ b/domain/original/area/preserve/room441.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tropical Forest";
+    long_desc = "Tropical Forest.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room442", "south",
+        "domain/original/area/preserve/room440", "north",
+    });
+}

--- a/domain/original/area/preserve/room442.c
+++ b/domain/original/area/preserve/room442.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room443", "west",
+        "domain/original/area/preserve/room444", "east",
+        "domain/original/area/preserve/room441", "north",
+    });
+}

--- a/domain/original/area/preserve/room443.c
+++ b/domain/original/area/preserve/room443.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bird Sanctuary";
+    long_desc = "Bird Sanctuary.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room442", "east",
+    });
+}

--- a/domain/original/area/preserve/room444.c
+++ b/domain/original/area/preserve/room444.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room442", "west",
+    });
+}

--- a/domain/original/area/preserve/room445.c
+++ b/domain/original/area/preserve/room445.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room496", "west",
+        "domain/original/area/preserve/room439", "east",
+        "domain/original/area/preserve/room446", "north",
+    });
+}

--- a/domain/original/area/preserve/room446.c
+++ b/domain/original/area/preserve/room446.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entrance to Queen's Meadow";
+    long_desc = "Entrance to Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room445", "south",
+        "domain/original/area/preserve/room447", "north",
+    });
+}

--- a/domain/original/area/preserve/room447.c
+++ b/domain/original/area/preserve/room447.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room446", "south",
+        "domain/original/area/preserve/room448", "north",
+    });
+}

--- a/domain/original/area/preserve/room448.c
+++ b/domain/original/area/preserve/room448.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room447", "south",
+        "domain/original/area/preserve/room449", "north",
+    });
+}

--- a/domain/original/area/preserve/room449.c
+++ b/domain/original/area/preserve/room449.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room450", "west",
+        "domain/original/area/preserve/room448", "south",
+        "domain/original/area/preserve/room494", "north",
+    });
+}

--- a/domain/original/area/preserve/room450.c
+++ b/domain/original/area/preserve/room450.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room449", "east",
+        "domain/original/area/preserve/room451", "west",
+    });
+}

--- a/domain/original/area/preserve/room451.c
+++ b/domain/original/area/preserve/room451.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room450", "east",
+        "domain/original/area/preserve/room452", "west",
+    });
+}

--- a/domain/original/area/preserve/room452.c
+++ b/domain/original/area/preserve/room452.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room451", "east",
+        "domain/original/area/preserve/room453", "west",
+    });
+}

--- a/domain/original/area/preserve/room453.c
+++ b/domain/original/area/preserve/room453.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room455", "south",
+        "domain/original/area/preserve/room452", "east",
+        "domain/original/area/preserve/room454", "north",
+    });
+}

--- a/domain/original/area/preserve/room454.c
+++ b/domain/original/area/preserve/room454.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room453", "south",
+    });
+}

--- a/domain/original/area/preserve/room455.c
+++ b/domain/original/area/preserve/room455.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room456", "south",
+        "domain/original/area/preserve/room453", "north",
+    });
+}

--- a/domain/original/area/preserve/room456.c
+++ b/domain/original/area/preserve/room456.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room457", "west",
+        "domain/original/area/preserve/room455", "north",
+    });
+}

--- a/domain/original/area/preserve/room457.c
+++ b/domain/original/area/preserve/room457.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room456", "east",
+        "domain/original/area/preserve/room458", "west",
+    });
+}

--- a/domain/original/area/preserve/room458.c
+++ b/domain/original/area/preserve/room458.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room457", "east",
+        "domain/original/area/preserve/room459", "north",
+    });
+}

--- a/domain/original/area/preserve/room459.c
+++ b/domain/original/area/preserve/room459.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room458", "south",
+        "domain/original/area/preserve/room460", "north",
+    });
+}

--- a/domain/original/area/preserve/room460.c
+++ b/domain/original/area/preserve/room460.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room495", "west",
+        "domain/original/area/preserve/room459", "south",
+        "domain/original/area/preserve/room461", "north",
+    });
+}

--- a/domain/original/area/preserve/room461.c
+++ b/domain/original/area/preserve/room461.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room463", "west",
+        "domain/original/area/preserve/room462", "east",
+        "domain/original/area/preserve/room460", "south",
+    });
+}

--- a/domain/original/area/preserve/room462.c
+++ b/domain/original/area/preserve/room462.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room461", "west",
+        "domain/original/area/preserve/room464", "north",
+    });
+}

--- a/domain/original/area/preserve/room463.c
+++ b/domain/original/area/preserve/room463.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Sink Hole";
+    long_desc = "Sink Hole.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room461", "east",
+    });
+}

--- a/domain/original/area/preserve/room464.c
+++ b/domain/original/area/preserve/room464.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room486", "west",
+        "domain/original/area/preserve/room465", "east",
+        "domain/original/area/preserve/room462", "south",
+    });
+}

--- a/domain/original/area/preserve/room465.c
+++ b/domain/original/area/preserve/room465.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room464", "west",
+        "domain/original/area/preserve/room466", "north",
+    });
+}

--- a/domain/original/area/preserve/room466.c
+++ b/domain/original/area/preserve/room466.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room467", "east",
+        "domain/original/area/preserve/room465", "south",
+    });
+}

--- a/domain/original/area/preserve/room467.c
+++ b/domain/original/area/preserve/room467.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room468", "east",
+        "domain/original/area/preserve/room466", "west",
+    });
+}

--- a/domain/original/area/preserve/room468.c
+++ b/domain/original/area/preserve/room468.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room469", "east",
+        "domain/original/area/preserve/room467", "west",
+    });
+}

--- a/domain/original/area/preserve/room469.c
+++ b/domain/original/area/preserve/room469.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room470", "east",
+        "domain/original/area/preserve/room468", "west",
+    });
+}

--- a/domain/original/area/preserve/room470.c
+++ b/domain/original/area/preserve/room470.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room469", "west",
+        "domain/original/area/preserve/room493", "south",
+        "domain/original/area/preserve/room471", "north",
+    });
+}

--- a/domain/original/area/preserve/room471.c
+++ b/domain/original/area/preserve/room471.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tropical Landscape";
+    long_desc = "Tropical Landscape.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room470", "south",
+        "domain/original/area/preserve/room472", "north",
+    });
+}

--- a/domain/original/area/preserve/room472.c
+++ b/domain/original/area/preserve/room472.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room471", "south",
+        "domain/original/area/preserve/room473", "north",
+    });
+}

--- a/domain/original/area/preserve/room473.c
+++ b/domain/original/area/preserve/room473.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room476", "west",
+        "domain/original/area/preserve/room474", "east",
+        "domain/original/area/preserve/room472", "south",
+    });
+}

--- a/domain/original/area/preserve/room474.c
+++ b/domain/original/area/preserve/room474.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room475", "east",
+        "domain/original/area/preserve/room473", "west",
+    });
+}

--- a/domain/original/area/preserve/room475.c
+++ b/domain/original/area/preserve/room475.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room474", "west",
+    });
+}

--- a/domain/original/area/preserve/room476.c
+++ b/domain/original/area/preserve/room476.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room477", "northwest",
+        "domain/original/area/preserve/room473", "east",
+    });
+}

--- a/domain/original/area/preserve/room477.c
+++ b/domain/original/area/preserve/room477.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room478", "southwest",
+        "domain/original/area/preserve/room476", "southeast",
+        "domain/original/area/preserve/room490", "north",
+    });
+}

--- a/domain/original/area/preserve/room478.c
+++ b/domain/original/area/preserve/room478.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room479", "west",
+        "domain/original/area/preserve/room477", "northeast",
+    });
+}

--- a/domain/original/area/preserve/room479.c
+++ b/domain/original/area/preserve/room479.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room480", "west",
+        "domain/original/area/preserve/room478", "east",
+        "domain/original/area/preserve/room487", "south",
+    });
+}

--- a/domain/original/area/preserve/room480.c
+++ b/domain/original/area/preserve/room480.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room479", "east",
+        "domain/original/area/preserve/room481", "west",
+    });
+}

--- a/domain/original/area/preserve/room481.c
+++ b/domain/original/area/preserve/room481.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room480", "east",
+        "domain/original/area/preserve/room482", "south",
+    });
+}

--- a/domain/original/area/preserve/room482.c
+++ b/domain/original/area/preserve/room482.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room483", "west",
+        "domain/original/area/preserve/room484", "south",
+        "domain/original/area/preserve/room481", "north",
+    });
+}

--- a/domain/original/area/preserve/room483.c
+++ b/domain/original/area/preserve/room483.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room482", "east",
+    });
+}

--- a/domain/original/area/preserve/room484.c
+++ b/domain/original/area/preserve/room484.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room485", "south",
+        "domain/original/area/preserve/room482", "north",
+    });
+}

--- a/domain/original/area/preserve/room485.c
+++ b/domain/original/area/preserve/room485.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room486", "south",
+        "domain/original/area/preserve/room484", "north",
+    });
+}

--- a/domain/original/area/preserve/room486.c
+++ b/domain/original/area/preserve/room486.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room464", "east",
+        "domain/original/area/preserve/room485", "north",
+    });
+}

--- a/domain/original/area/preserve/room487.c
+++ b/domain/original/area/preserve/room487.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room488", "south",
+        "domain/original/area/preserve/room479", "north",
+    });
+}

--- a/domain/original/area/preserve/room488.c
+++ b/domain/original/area/preserve/room488.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room489", "east",
+        "domain/original/area/preserve/room487", "north",
+    });
+}

--- a/domain/original/area/preserve/room489.c
+++ b/domain/original/area/preserve/room489.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room488", "west",
+    });
+}

--- a/domain/original/area/preserve/room490.c
+++ b/domain/original/area/preserve/room490.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room477", "south",
+        "domain/original/area/preserve/room491", "north",
+    });
+}

--- a/domain/original/area/preserve/room491.c
+++ b/domain/original/area/preserve/room491.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room492", "east",
+        "domain/original/area/preserve/room490", "south",
+    });
+}

--- a/domain/original/area/preserve/room492.c
+++ b/domain/original/area/preserve/room492.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A Hollowed Tree";
+    long_desc = "A Hollowed Tree.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room491", "west",
+    });
+}

--- a/domain/original/area/preserve/room493.c
+++ b/domain/original/area/preserve/room493.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room494", "south",
+        "domain/original/area/preserve/room470", "north",
+    });
+}

--- a/domain/original/area/preserve/room494.c
+++ b/domain/original/area/preserve/room494.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Queen's Meadow";
+    long_desc = "Queen's Meadow.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room449", "south",
+        "domain/original/area/preserve/room493", "north",
+    });
+}

--- a/domain/original/area/preserve/room495.c
+++ b/domain/original/area/preserve/room495.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room460", "east",
+    });
+}

--- a/domain/original/area/preserve/room496.c
+++ b/domain/original/area/preserve/room496.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room445", "east",
+        "domain/original/area/preserve/room497", "west",
+    });
+}

--- a/domain/original/area/preserve/room497.c
+++ b/domain/original/area/preserve/room497.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room498", "west",
+        "domain/original/area/preserve/room496", "east",
+        "domain/original/area/preserve/room501", "south",
+    });
+}

--- a/domain/original/area/preserve/room498.c
+++ b/domain/original/area/preserve/room498.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Canopy Trail";
+    long_desc = "Canopy Trail.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room497", "east",
+        "domain/original/area/preserve/room499", "north",
+    });
+}

--- a/domain/original/area/preserve/room499.c
+++ b/domain/original/area/preserve/room499.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room500", "east",
+        "domain/original/area/preserve/room498", "south",
+    });
+}

--- a/domain/original/area/preserve/room500.c
+++ b/domain/original/area/preserve/room500.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dragon's Den";
+    long_desc = "Dragon's Den.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room499", "west",
+    });
+}

--- a/domain/original/area/preserve/room501.c
+++ b/domain/original/area/preserve/room501.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room502", "south",
+        "domain/original/area/preserve/room497", "north",
+    });
+}

--- a/domain/original/area/preserve/room502.c
+++ b/domain/original/area/preserve/room502.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room504", "west",
+        "domain/original/area/preserve/room503", "east",
+        "domain/original/area/preserve/room501", "north",
+    });
+}

--- a/domain/original/area/preserve/room503.c
+++ b/domain/original/area/preserve/room503.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room502", "west",
+    });
+}

--- a/domain/original/area/preserve/room504.c
+++ b/domain/original/area/preserve/room504.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nature Preserve";
+    long_desc = "Nature Preserve.\n";
+    dest_dir = ({
+        "domain/original/area/preserve/room502", "east",
+    });
+}

--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -11,5 +11,6 @@ void reset(int arg) {
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "up",
         "domain/original/area/balin/room605", "island",
+        "domain/original/area/preserve/room432", "preserve",
     });
 }


### PR DESCRIPTION
### Motivation

- Populate the game world with the Nature Preserve area by generating room files from `maps/nature-preserve.json`.
- Use the existing Vesla room template (e.g. `domain/original/area/vesla/room227.c`) to produce consistent room files.
- Provide a direct connection from the Vesla portal into the Preserve by linking the portal to the Preserve `Bridge` room and vice versa.

### Description

- Added 73 new room files under `domain/original/area/preserve/` (rooms `room432.c` through `room504.c`) following the `room/room` template and wiring exits as specified in the JSON map.
- Updated `domain/original/area/preserve/room432.c` (the "Bridge") to include a reciprocal exit to `domain/original/area/vesla/portal` named `vesla`.
- Updated `domain/original/area/vesla/portal.c` to add a `preserve` exit pointing to `domain/original/area/preserve/room432`.
- Changes were staged and committed with the message "Add preserve area rooms and portal exit".

### Testing

- Ran the Python generator script which completed and reported `generated 73` files (succeeded).
- Performed spot checks with `sed` on sample generated files such as `room432.c` and `room434.c` to confirm expected structure and exits (succeeded).
- Added the new files and committed the changes with `git` to verify VCS operations succeeded (succeeded).
- No automated unit or gameplay tests were executed as part of this change (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9726feb88327b869c7bbfb4c2970)