### PR TITLE
Generate Forest rooms from area8 map and link Vesla portal

### DIFF
--- a/domain/original/area/forest/room529.c
+++ b/domain/original/area/forest/room529.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The start of a forest path";
+    long_desc = "The start of a forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room530", "northeast",
+        "domain/original/area/vesla/portal", "vesla",
+    });
+}

--- a/domain/original/area/forest/room530.c
+++ b/domain/original/area/forest/room530.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The start of a forest path";
+    long_desc = "The start of a forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room529", "southwest",
+        "domain/original/area/forest/room531", "northeast",
+        "domain/original/area/forest/room532", "northwest",
+    });
+}

--- a/domain/original/area/forest/room531.c
+++ b/domain/original/area/forest/room531.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room530", "southwest",
+        "domain/original/area/forest/room539", "northeast",
+        "domain/original/area/forest/room551", "east",
+    });
+}

--- a/domain/original/area/forest/room532.c
+++ b/domain/original/area/forest/room532.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room535", "west",
+        "domain/original/area/forest/room578", "northeast",
+        "domain/original/area/forest/room530", "southeast",
+        "domain/original/area/forest/room533", "north",
+    });
+}

--- a/domain/original/area/forest/room533.c
+++ b/domain/original/area/forest/room533.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room534", "west",
+        "domain/original/area/forest/room532", "south",
+        "domain/original/area/forest/room535", "southwest",
+        "domain/original/area/forest/room596", "northeast",
+        "domain/original/area/forest/room578", "east",
+        "domain/original/area/forest/room591", "north",
+    });
+}

--- a/domain/original/area/forest/room534.c
+++ b/domain/original/area/forest/room534.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room535", "south",
+        "domain/original/area/forest/room536", "west",
+        "domain/original/area/forest/room591", "northeast",
+        "domain/original/area/forest/room533", "east",
+        "domain/original/area/forest/room592", "north",
+    });
+}

--- a/domain/original/area/forest/room535.c
+++ b/domain/original/area/forest/room535.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room533", "northeast",
+        "domain/original/area/forest/room532", "east",
+        "domain/original/area/forest/room534", "north",
+    });
+}

--- a/domain/original/area/forest/room536.c
+++ b/domain/original/area/forest/room536.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "River Bank";
+    long_desc = "River Bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room537", "southwest",
+        "domain/original/area/forest/room592", "northeast",
+        "domain/original/area/forest/room534", "east",
+    });
+}

--- a/domain/original/area/forest/room537.c
+++ b/domain/original/area/forest/room537.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "River Bank";
+    long_desc = "River Bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room538", "southwest",
+        "domain/original/area/forest/room536", "northeast",
+    });
+}

--- a/domain/original/area/forest/room538.c
+++ b/domain/original/area/forest/room538.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gryphon Nest";
+    long_desc = "Gryphon Nest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room537", "northeast",
+    });
+}

--- a/domain/original/area/forest/room539.c
+++ b/domain/original/area/forest/room539.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A clearing in the forest";
+    long_desc = "A clearing in the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room531", "southwest",
+        "domain/original/area/forest/room540", "northeast",
+        "domain/original/area/forest/room550", "east",
+        "domain/original/area/forest/room551", "south",
+    });
+}

--- a/domain/original/area/forest/room540.c
+++ b/domain/original/area/forest/room540.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room539", "southwest",
+        "domain/original/area/forest/room541", "northeast",
+        "domain/original/area/forest/room549", "east",
+        "domain/original/area/forest/room550", "south",
+    });
+}

--- a/domain/original/area/forest/room541.c
+++ b/domain/original/area/forest/room541.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room549", "south",
+        "domain/original/area/forest/room540", "southwest",
+        "domain/original/area/forest/room542", "northeast",
+        "domain/original/area/forest/room548", "east",
+        "domain/original/area/forest/room575", "west",
+    });
+}

--- a/domain/original/area/forest/room542.c
+++ b/domain/original/area/forest/room542.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room541", "southwest",
+        "domain/original/area/forest/room543", "northeast",
+        "domain/original/area/forest/room547", "east",
+        "domain/original/area/forest/room548", "south",
+    });
+}

--- a/domain/original/area/forest/room543.c
+++ b/domain/original/area/forest/room543.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A dark forest";
+    long_desc = "A dark forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room542", "southwest",
+        "domain/original/area/forest/room544", "northeast",
+        "domain/original/area/forest/room546", "east",
+        "domain/original/area/forest/room547", "south",
+    });
+}

--- a/domain/original/area/forest/room544.c
+++ b/domain/original/area/forest/room544.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room543", "southwest",
+        "domain/original/area/forest/room545", "east",
+        "domain/original/area/forest/room546", "south",
+    });
+}

--- a/domain/original/area/forest/room545.c
+++ b/domain/original/area/forest/room545.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room546", "southwest",
+        "domain/original/area/forest/room544", "west",
+        "domain/original/area/forest/room558", "east",
+        "domain/original/area/forest/room557", "south",
+    });
+}

--- a/domain/original/area/forest/room546.c
+++ b/domain/original/area/forest/room546.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room543", "west",
+        "domain/original/area/forest/room556", "south",
+        "domain/original/area/forest/room547", "southwest",
+        "domain/original/area/forest/room545", "northeast",
+        "domain/original/area/forest/room557", "east",
+        "domain/original/area/forest/room544", "north",
+    });
+}

--- a/domain/original/area/forest/room547.c
+++ b/domain/original/area/forest/room547.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room542", "west",
+        "domain/original/area/forest/room555", "south",
+        "domain/original/area/forest/room548", "southwest",
+        "domain/original/area/forest/room546", "northeast",
+        "domain/original/area/forest/room556", "east",
+        "domain/original/area/forest/room543", "north",
+    });
+}

--- a/domain/original/area/forest/room548.c
+++ b/domain/original/area/forest/room548.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A path in the forest";
+    long_desc = "A path in the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room541", "west",
+        "domain/original/area/forest/room554", "south",
+        "domain/original/area/forest/room549", "southwest",
+        "domain/original/area/forest/room547", "northeast",
+        "domain/original/area/forest/room555", "east",
+        "domain/original/area/forest/room542", "north",
+    });
+}

--- a/domain/original/area/forest/room549.c
+++ b/domain/original/area/forest/room549.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A clearing in the forest";
+    long_desc = "A clearing in the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room540", "west",
+        "domain/original/area/forest/room553", "south",
+        "domain/original/area/forest/room550", "southwest",
+        "domain/original/area/forest/room548", "northeast",
+        "domain/original/area/forest/room554", "east",
+        "domain/original/area/forest/room541", "north",
+    });
+}

--- a/domain/original/area/forest/room550.c
+++ b/domain/original/area/forest/room550.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room539", "west",
+        "domain/original/area/forest/room552", "south",
+        "domain/original/area/forest/room551", "southwest",
+        "domain/original/area/forest/room549", "northeast",
+        "domain/original/area/forest/room553", "east",
+        "domain/original/area/forest/room540", "north",
+    });
+}

--- a/domain/original/area/forest/room551.c
+++ b/domain/original/area/forest/room551.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room576", "south",
+        "domain/original/area/forest/room531", "west",
+        "domain/original/area/forest/room550", "northeast",
+        "domain/original/area/forest/room552", "east",
+        "domain/original/area/forest/room539", "north",
+    });
+}

--- a/domain/original/area/forest/room552.c
+++ b/domain/original/area/forest/room552.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room551", "west",
+        "domain/original/area/forest/room553", "northeast",
+        "domain/original/area/forest/room565", "east",
+        "domain/original/area/forest/room550", "north",
+    });
+}

--- a/domain/original/area/forest/room553.c
+++ b/domain/original/area/forest/room553.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room550", "west",
+        "domain/original/area/forest/room565", "south",
+        "domain/original/area/forest/room552", "southwest",
+        "domain/original/area/forest/room554", "northeast",
+        "domain/original/area/forest/room564", "east",
+        "domain/original/area/forest/room549", "north",
+    });
+}

--- a/domain/original/area/forest/room554.c
+++ b/domain/original/area/forest/room554.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room549", "west",
+        "domain/original/area/forest/room564", "south",
+        "domain/original/area/forest/room553", "southwest",
+        "domain/original/area/forest/room555", "northeast",
+        "domain/original/area/forest/room563", "east",
+        "domain/original/area/forest/room548", "north",
+    });
+}

--- a/domain/original/area/forest/room555.c
+++ b/domain/original/area/forest/room555.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A path through the forest";
+    long_desc = "A path through the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room548", "west",
+        "domain/original/area/forest/room563", "south",
+        "domain/original/area/forest/room554", "southwest",
+        "domain/original/area/forest/room556", "northeast",
+        "domain/original/area/forest/room562", "east",
+        "domain/original/area/forest/room547", "north",
+    });
+}

--- a/domain/original/area/forest/room556.c
+++ b/domain/original/area/forest/room556.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room547", "west",
+        "domain/original/area/forest/room562", "south",
+        "domain/original/area/forest/room555", "southwest",
+        "domain/original/area/forest/room557", "northeast",
+        "domain/original/area/forest/room561", "east",
+        "domain/original/area/forest/room546", "north",
+    });
+}

--- a/domain/original/area/forest/room557.c
+++ b/domain/original/area/forest/room557.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room546", "west",
+        "domain/original/area/forest/room561", "south",
+        "domain/original/area/forest/room556", "southwest",
+        "domain/original/area/forest/room558", "northeast",
+        "domain/original/area/forest/room560", "east",
+        "domain/original/area/forest/room545", "north",
+    });
+}

--- a/domain/original/area/forest/room558.c
+++ b/domain/original/area/forest/room558.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room557", "southwest",
+        "domain/original/area/forest/room545", "west",
+        "domain/original/area/forest/room559", "east",
+        "domain/original/area/forest/room560", "south",
+    });
+}

--- a/domain/original/area/forest/room559.c
+++ b/domain/original/area/forest/room559.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room560", "southwest",
+        "domain/original/area/forest/room558", "west",
+        "domain/original/area/forest/room573", "south",
+    });
+}

--- a/domain/original/area/forest/room560.c
+++ b/domain/original/area/forest/room560.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A path in the forest";
+    long_desc = "A path in the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room557", "west",
+        "domain/original/area/forest/room572", "south",
+        "domain/original/area/forest/room561", "southwest",
+        "domain/original/area/forest/room559", "northeast",
+        "domain/original/area/forest/room573", "east",
+        "domain/original/area/forest/room558", "north",
+    });
+}

--- a/domain/original/area/forest/room561.c
+++ b/domain/original/area/forest/room561.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room556", "west",
+        "domain/original/area/forest/room571", "south",
+        "domain/original/area/forest/room562", "southwest",
+        "domain/original/area/forest/room560", "northeast",
+        "domain/original/area/forest/room572", "east",
+        "domain/original/area/forest/room557", "north",
+    });
+}

--- a/domain/original/area/forest/room562.c
+++ b/domain/original/area/forest/room562.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room555", "west",
+        "domain/original/area/forest/room570", "south",
+        "domain/original/area/forest/room563", "southwest",
+        "domain/original/area/forest/room561", "northeast",
+        "domain/original/area/forest/room571", "east",
+        "domain/original/area/forest/room556", "north",
+    });
+}

--- a/domain/original/area/forest/room563.c
+++ b/domain/original/area/forest/room563.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room554", "west",
+        "domain/original/area/forest/room569", "south",
+        "domain/original/area/forest/room564", "southwest",
+        "domain/original/area/forest/room562", "northeast",
+        "domain/original/area/forest/room570", "east",
+        "domain/original/area/forest/room555", "north",
+    });
+}

--- a/domain/original/area/forest/room564.c
+++ b/domain/original/area/forest/room564.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room553", "west",
+        "domain/original/area/forest/room568", "south",
+        "domain/original/area/forest/room565", "southwest",
+        "domain/original/area/forest/room563", "northeast",
+        "domain/original/area/forest/room569", "east",
+        "domain/original/area/forest/room554", "north",
+    });
+}

--- a/domain/original/area/forest/room565.c
+++ b/domain/original/area/forest/room565.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room552", "west",
+        "domain/original/area/forest/room574", "south",
+        "domain/original/area/forest/room566", "southwest",
+        "domain/original/area/forest/room564", "northeast",
+        "domain/original/area/forest/room568", "east",
+        "domain/original/area/forest/room553", "north",
+    });
+}

--- a/domain/original/area/forest/room566.c
+++ b/domain/original/area/forest/room566.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A dark forest glade";
+    long_desc = "A dark forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room567", "southwest",
+        "domain/original/area/forest/room565", "northeast",
+    });
+}

--- a/domain/original/area/forest/room567.c
+++ b/domain/original/area/forest/room567.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room601", "west",
+        "domain/original/area/forest/room566", "northeast",
+    });
+}

--- a/domain/original/area/forest/room568.c
+++ b/domain/original/area/forest/room568.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room574", "southwest",
+        "domain/original/area/forest/room569", "northeast",
+        "domain/original/area/forest/room565", "west",
+        "domain/original/area/forest/room564", "north",
+    });
+}

--- a/domain/original/area/forest/room569.c
+++ b/domain/original/area/forest/room569.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A path through the forest";
+    long_desc = "A path through the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room568", "southwest",
+        "domain/original/area/forest/room570", "northeast",
+        "domain/original/area/forest/room564", "west",
+        "domain/original/area/forest/room563", "north",
+    });
+}

--- a/domain/original/area/forest/room570.c
+++ b/domain/original/area/forest/room570.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room569", "southwest",
+        "domain/original/area/forest/room571", "northeast",
+        "domain/original/area/forest/room563", "west",
+        "domain/original/area/forest/room562", "north",
+    });
+}

--- a/domain/original/area/forest/room571.c
+++ b/domain/original/area/forest/room571.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room570", "southwest",
+        "domain/original/area/forest/room572", "northeast",
+        "domain/original/area/forest/room562", "west",
+        "domain/original/area/forest/room561", "north",
+    });
+}

--- a/domain/original/area/forest/room572.c
+++ b/domain/original/area/forest/room572.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room571", "southwest",
+        "domain/original/area/forest/room573", "northeast",
+        "domain/original/area/forest/room561", "west",
+        "domain/original/area/forest/room560", "north",
+    });
+}

--- a/domain/original/area/forest/room573.c
+++ b/domain/original/area/forest/room573.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room572", "southwest",
+        "domain/original/area/forest/room560", "west",
+        "domain/original/area/forest/room559", "north",
+    });
+}

--- a/domain/original/area/forest/room574.c
+++ b/domain/original/area/forest/room574.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Forest Glade";
+    long_desc = "Forest Glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room568", "northeast",
+        "domain/original/area/forest/room565", "north",
+    });
+}

--- a/domain/original/area/forest/room575.c
+++ b/domain/original/area/forest/room575.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room541", "east",
+    });
+}

--- a/domain/original/area/forest/room576.c
+++ b/domain/original/area/forest/room576.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The start of a forest path";
+    long_desc = "The start of a forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room577", "southwest",
+        "domain/original/area/forest/room551", "north",
+    });
+}

--- a/domain/original/area/forest/room577.c
+++ b/domain/original/area/forest/room577.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The start of a forest path";
+    long_desc = "The start of a forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room576", "northeast",
+    });
+}

--- a/domain/original/area/forest/room578.c
+++ b/domain/original/area/forest/room578.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room533", "west",
+        "domain/original/area/forest/room532", "southwest",
+        "domain/original/area/forest/room579", "northeast",
+        "domain/original/area/forest/room600", "east",
+        "domain/original/area/forest/room596", "north",
+    });
+}

--- a/domain/original/area/forest/room579.c
+++ b/domain/original/area/forest/room579.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room578", "southwest",
+        "domain/original/area/forest/room580", "northeast",
+        "domain/original/area/forest/room596", "west",
+        "domain/original/area/forest/room597", "north",
+    });
+}

--- a/domain/original/area/forest/room580.c
+++ b/domain/original/area/forest/room580.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A clearing in the forest";
+    long_desc = "A clearing in the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room579", "southwest",
+        "domain/original/area/forest/room581", "northeast",
+        "domain/original/area/forest/room597", "west",
+        "domain/original/area/forest/room598", "north",
+    });
+}

--- a/domain/original/area/forest/room581.c
+++ b/domain/original/area/forest/room581.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room580", "southwest",
+        "domain/original/area/forest/room582", "northeast",
+        "domain/original/area/forest/room598", "west",
+        "domain/original/area/forest/room585", "north",
+    });
+}

--- a/domain/original/area/forest/room582.c
+++ b/domain/original/area/forest/room582.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Forest Mound";
+    long_desc = "Forest Mound.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room585", "west",
+        "domain/original/area/forest/room581", "southwest",
+        "domain/original/area/forest/room583", "northeast",
+        "domain/original/area/forest/room599", "east",
+        "domain/original/area/forest/room584", "north",
+    });
+}

--- a/domain/original/area/forest/room583.c
+++ b/domain/original/area/forest/room583.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room582", "southwest",
+        "domain/original/area/forest/room584", "west",
+    });
+}

--- a/domain/original/area/forest/room584.c
+++ b/domain/original/area/forest/room584.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room585", "southwest",
+        "domain/original/area/forest/room586", "west",
+        "domain/original/area/forest/room583", "east",
+        "domain/original/area/forest/room582", "south",
+    });
+}

--- a/domain/original/area/forest/room585.c
+++ b/domain/original/area/forest/room585.c
@@ -1,0 +1,18 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room581", "south",
+        "domain/original/area/forest/room595", "west",
+        "domain/original/area/forest/room584", "northeast",
+        "domain/original/area/forest/room582", "east",
+        "domain/original/area/forest/room586", "north",
+    });
+}

--- a/domain/original/area/forest/room586.c
+++ b/domain/original/area/forest/room586.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room588", "southwest",
+        "domain/original/area/forest/room587", "west",
+        "domain/original/area/forest/room584", "east",
+        "domain/original/area/forest/room585", "south",
+    });
+}

--- a/domain/original/area/forest/room587.c
+++ b/domain/original/area/forest/room587.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A river bank";
+    long_desc = "A river bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room595", "southwest",
+        "domain/original/area/forest/room586", "east",
+        "domain/original/area/forest/room588", "south",
+    });
+}

--- a/domain/original/area/forest/room588.c
+++ b/domain/original/area/forest/room588.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A dark forest glade";
+    long_desc = "A dark forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room595", "west",
+        "domain/original/area/forest/room598", "south",
+        "domain/original/area/forest/room589", "southwest",
+        "domain/original/area/forest/room586", "northeast",
+        "domain/original/area/forest/room589", "east",
+        "domain/original/area/forest/room587", "north",
+    });
+}

--- a/domain/original/area/forest/room589.c
+++ b/domain/original/area/forest/room589.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest glade";
+    long_desc = "A forest glade.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room594", "west",
+        "domain/original/area/forest/room597", "south",
+        "domain/original/area/forest/room590", "southwest",
+        "domain/original/area/forest/room588", "northeast",
+        "domain/original/area/forest/room598", "east",
+        "domain/original/area/forest/room595", "north",
+    });
+}

--- a/domain/original/area/forest/room590.c
+++ b/domain/original/area/forest/room590.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room593", "west",
+        "domain/original/area/forest/room596", "south",
+        "domain/original/area/forest/room591", "southwest",
+        "domain/original/area/forest/room589", "northeast",
+        "domain/original/area/forest/room597", "east",
+        "domain/original/area/forest/room594", "north",
+    });
+}

--- a/domain/original/area/forest/room591.c
+++ b/domain/original/area/forest/room591.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest";
+    long_desc = "A forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room592", "west",
+        "domain/original/area/forest/room533", "south",
+        "domain/original/area/forest/room534", "southwest",
+        "domain/original/area/forest/room590", "northeast",
+        "domain/original/area/forest/room596", "east",
+        "domain/original/area/forest/room593", "north",
+    });
+}

--- a/domain/original/area/forest/room592.c
+++ b/domain/original/area/forest/room592.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A river bank";
+    long_desc = "A river bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room536", "southwest",
+        "domain/original/area/forest/room593", "northeast",
+        "domain/original/area/forest/room591", "east",
+        "domain/original/area/forest/room534", "south",
+    });
+}

--- a/domain/original/area/forest/room593.c
+++ b/domain/original/area/forest/room593.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A river bank";
+    long_desc = "A river bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room592", "southwest",
+        "domain/original/area/forest/room594", "northeast",
+        "domain/original/area/forest/room590", "east",
+        "domain/original/area/forest/room591", "south",
+    });
+}

--- a/domain/original/area/forest/room594.c
+++ b/domain/original/area/forest/room594.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A riverbank";
+    long_desc = "A riverbank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room593", "southwest",
+        "domain/original/area/forest/room595", "northeast",
+        "domain/original/area/forest/room589", "east",
+        "domain/original/area/forest/room590", "south",
+    });
+}

--- a/domain/original/area/forest/room595.c
+++ b/domain/original/area/forest/room595.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A river bank";
+    long_desc = "A river bank.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room594", "southwest",
+        "domain/original/area/forest/room587", "northeast",
+        "domain/original/area/forest/room585", "east",
+        "domain/original/area/forest/room589", "south",
+    });
+}

--- a/domain/original/area/forest/room596.c
+++ b/domain/original/area/forest/room596.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A path through the forest";
+    long_desc = "A path through the forest.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room591", "west",
+        "domain/original/area/forest/room578", "south",
+        "domain/original/area/forest/room533", "southwest",
+        "domain/original/area/forest/room597", "northeast",
+        "domain/original/area/forest/room579", "east",
+        "domain/original/area/forest/room590", "north",
+    });
+}

--- a/domain/original/area/forest/room597.c
+++ b/domain/original/area/forest/room597.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room590", "west",
+        "domain/original/area/forest/room579", "south",
+        "domain/original/area/forest/room596", "southwest",
+        "domain/original/area/forest/room598", "northeast",
+        "domain/original/area/forest/room580", "east",
+        "domain/original/area/forest/room589", "north",
+    });
+}

--- a/domain/original/area/forest/room598.c
+++ b/domain/original/area/forest/room598.c
@@ -1,0 +1,19 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A forest path";
+    long_desc = "A forest path.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room589", "west",
+        "domain/original/area/forest/room580", "south",
+        "domain/original/area/forest/room597", "southwest",
+        "domain/original/area/forest/room589", "northeast",
+        "domain/original/area/forest/room581", "east",
+        "domain/original/area/forest/room588", "north",
+    });
+}

--- a/domain/original/area/forest/room599.c
+++ b/domain/original/area/forest/room599.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A small clearing";
+    long_desc = "A small clearing.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room582", "west",
+    });
+}

--- a/domain/original/area/forest/room600.c
+++ b/domain/original/area/forest/room600.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Druids Guild";
+    long_desc = "Druids Guild.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room578", "west",
+    });
+}

--- a/domain/original/area/forest/room601.c
+++ b/domain/original/area/forest/room601.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Large home";
+    long_desc = "Large home.\n";
+    dest_dir = ({
+        "domain/original/area/forest/room567", "east",
+    });
+}

--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -12,5 +12,6 @@ void reset(int arg) {
         "domain/original/area/vesla/sanctuary", "up",
         "domain/original/area/balin/room605", "island",
         "domain/original/area/preserve/room432", "preserve",
+        "domain/original/area/forest/room529", "forest",
     });
 }


### PR DESCRIPTION
### Motivation
- Populate the Forest area using the `maps/area8.json` layout so the in-game map is available as individual room files.  
- Ensure the Forest is reachable from the Vesla portal and provides a reciprocal link back.  
- Use the existing Vesla room layout as a template for consistent room structure and reset behavior.  
- Create straightforward room files that map exits to the corresponding room paths for the game driver.

### Description
- Added a new directory `domain/original/area/forest` and generated room files `room529.c` through `room601.c` from `maps/area8.json`, creating 73 room files in total.  
- Each generated room inherits `room/room` and follows the structure used by `domain/original/area/vesla/room227.c` (short/long descriptions and `dest_dir` entries).  
- `room529.c` includes a reciprocal exit back to the Vesla portal via the `"vesla"` direction (path `domain/original/area/vesla/portal`).  
- Updated `domain/original/area/vesla/portal.c` to add a `"forest"` exit pointing to `domain/original/area/forest/room529`.

### Testing
- No automated tests were executed against the modified code as part of this change.  
- Basic repository verification (`git status`, `git commit`) and spot-checks of generated files with `sed` were performed to confirm files were created and the portal change was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9caf9018832795bb0147cf9de162)