### PR TITLE
Add Pylus area rooms and connect Vesla portal to room1205

### DIFF
--- a/domain/original/area/pylus/room1205.c
+++ b/domain/original/area/pylus/room1205.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Pylus road";
+    long_desc = "End of Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1206", "south",
+        "domain/original/area/vesla/portal", "vesla",
+    });
+}

--- a/domain/original/area/pylus/room1206.c
+++ b/domain/original/area/pylus/room1206.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1207", "south",
+        "domain/original/area/pylus/room1205", "north",
+    });
+}

--- a/domain/original/area/pylus/room1207.c
+++ b/domain/original/area/pylus/room1207.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1208", "south",
+        "domain/original/area/pylus/room1212", "east",
+        "domain/original/area/pylus/room1206", "north",
+    });
+}

--- a/domain/original/area/pylus/room1208.c
+++ b/domain/original/area/pylus/room1208.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1209", "west",
+        "domain/original/area/pylus/room1213", "south",
+        "domain/original/area/pylus/room1207", "north",
+    });
+}

--- a/domain/original/area/pylus/room1209.c
+++ b/domain/original/area/pylus/room1209.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Freemason's";
+    long_desc = "Freemason's.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1210", "south",
+        "domain/original/area/pylus/room1208", "east",
+        "domain/original/area/pylus/room1211", "north",
+    });
+}

--- a/domain/original/area/pylus/room1210.c
+++ b/domain/original/area/pylus/room1210.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Apprentice's";
+    long_desc = "Apprentice's.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1209", "north",
+    });
+}

--- a/domain/original/area/pylus/room1211.c
+++ b/domain/original/area/pylus/room1211.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Master stonemason's";
+    long_desc = "Master stonemason's.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1209", "south",
+    });
+}

--- a/domain/original/area/pylus/room1212.c
+++ b/domain/original/area/pylus/room1212.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mausoleum entrance";
+    long_desc = "Mausoleum entrance.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1207", "west",
+    });
+}

--- a/domain/original/area/pylus/room1213.c
+++ b/domain/original/area/pylus/room1213.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1214", "south",
+        "domain/original/area/pylus/room1208", "north",
+    });
+}

--- a/domain/original/area/pylus/room1214.c
+++ b/domain/original/area/pylus/room1214.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1215", "south",
+        "domain/original/area/pylus/room1218", "west",
+        "domain/original/area/pylus/room1219", "east",
+        "domain/original/area/pylus/room1213", "north",
+    });
+}

--- a/domain/original/area/pylus/room1215.c
+++ b/domain/original/area/pylus/room1215.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road";
+    long_desc = "Pylus road.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1216", "southwest",
+        "domain/original/area/pylus/room1222", "east",
+        "domain/original/area/pylus/room1217", "southeast",
+        "domain/original/area/pylus/room1214", "north",
+    });
+}

--- a/domain/original/area/pylus/room1216.c
+++ b/domain/original/area/pylus/room1216.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Porch";
+    long_desc = "Porch.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1215", "northeast",
+    });
+}

--- a/domain/original/area/pylus/room1217.c
+++ b/domain/original/area/pylus/room1217.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Sanity's Requiem";
+    long_desc = "Sanity's Requiem.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1215", "northwest",
+    });
+}

--- a/domain/original/area/pylus/room1218.c
+++ b/domain/original/area/pylus/room1218.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hall of Bacchus";
+    long_desc = "Hall of Bacchus.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1214", "east",
+    });
+}

--- a/domain/original/area/pylus/room1219.c
+++ b/domain/original/area/pylus/room1219.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Triage";
+    long_desc = "Triage.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1214", "west",
+        "domain/original/area/pylus/room1220", "north",
+    });
+}

--- a/domain/original/area/pylus/room1220.c
+++ b/domain/original/area/pylus/room1220.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Waiting room";
+    long_desc = "Waiting room.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1221", "east",
+        "domain/original/area/pylus/room1219", "south",
+    });
+}

--- a/domain/original/area/pylus/room1221.c
+++ b/domain/original/area/pylus/room1221.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Operating room";
+    long_desc = "Operating room.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1220", "west",
+    });
+}

--- a/domain/original/area/pylus/room1222.c
+++ b/domain/original/area/pylus/room1222.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Pylus road checkpoint";
+    long_desc = "Pylus road checkpoint.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1289", "east",
+        "domain/original/area/pylus/room1215", "west",
+    });
+}

--- a/domain/original/area/pylus/room1224.c
+++ b/domain/original/area/pylus/room1224.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola square";
+    long_desc = "Iola square.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1289", "west",
+        "domain/original/area/pylus/room1227", "south",
+        "domain/original/area/pylus/room1225", "north",
+    });
+}

--- a/domain/original/area/pylus/room1225.c
+++ b/domain/original/area/pylus/room1225.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola way";
+    long_desc = "Iola way.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1363", "west",
+        "domain/original/area/pylus/room1224", "south",
+        "domain/original/area/pylus/room1226", "north",
+    });
+}

--- a/domain/original/area/pylus/room1226.c
+++ b/domain/original/area/pylus/room1226.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola way";
+    long_desc = "Iola way.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1225", "south",
+        "domain/original/area/pylus/room1248", "north",
+    });
+}

--- a/domain/original/area/pylus/room1227.c
+++ b/domain/original/area/pylus/room1227.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola way";
+    long_desc = "Iola way.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1228", "south",
+        "domain/original/area/pylus/room1247", "west",
+        "domain/original/area/pylus/room1246", "east",
+        "domain/original/area/pylus/room1224", "north",
+    });
+}

--- a/domain/original/area/pylus/room1228.c
+++ b/domain/original/area/pylus/room1228.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola way";
+    long_desc = "Iola way.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1229", "south",
+        "domain/original/area/pylus/room1244", "west",
+        "domain/original/area/pylus/room1243", "east",
+        "domain/original/area/pylus/room1227", "north",
+    });
+}

--- a/domain/original/area/pylus/room1229.c
+++ b/domain/original/area/pylus/room1229.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola bridge";
+    long_desc = "Iola bridge.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1230", "southwest",
+        "domain/original/area/pylus/room1231", "east",
+        "domain/original/area/pylus/room1228", "north",
+    });
+}

--- a/domain/original/area/pylus/room1230.c
+++ b/domain/original/area/pylus/room1230.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Large field";
+    long_desc = "Large field.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1239", "west",
+        "domain/original/area/pylus/room1229", "northeast",
+    });
+}

--- a/domain/original/area/pylus/room1231.c
+++ b/domain/original/area/pylus/room1231.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Polema street";
+    long_desc = "Polema street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1229", "west",
+        "domain/original/area/pylus/room1233", "east",
+        "domain/original/area/pylus/room1232", "south",
+    });
+}

--- a/domain/original/area/pylus/room1232.c
+++ b/domain/original/area/pylus/room1232.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gay house";
+    long_desc = "Gay house.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1231", "north",
+    });
+}

--- a/domain/original/area/pylus/room1233.c
+++ b/domain/original/area/pylus/room1233.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Polema street";
+    long_desc = "Polema street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1234", "south",
+        "domain/original/area/pylus/room1231", "west",
+        "domain/original/area/pylus/room1235", "east",
+        "domain/original/area/pylus/room1238", "north",
+    });
+}

--- a/domain/original/area/pylus/room1234.c
+++ b/domain/original/area/pylus/room1234.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Short house";
+    long_desc = "Short house.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1233", "north",
+    });
+}

--- a/domain/original/area/pylus/room1235.c
+++ b/domain/original/area/pylus/room1235.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Polema street";
+    long_desc = "Polema street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1233", "west",
+        "domain/original/area/pylus/room1237", "east",
+        "domain/original/area/pylus/room1236", "north",
+    });
+}

--- a/domain/original/area/pylus/room1236.c
+++ b/domain/original/area/pylus/room1236.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bright house";
+    long_desc = "Bright house.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1235", "south",
+    });
+}

--- a/domain/original/area/pylus/room1237.c
+++ b/domain/original/area/pylus/room1237.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Foyer";
+    long_desc = "Foyer.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1235", "west",
+    });
+}

--- a/domain/original/area/pylus/room1238.c
+++ b/domain/original/area/pylus/room1238.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Tall house";
+    long_desc = "Tall house.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1233", "south",
+    });
+}

--- a/domain/original/area/pylus/room1239.c
+++ b/domain/original/area/pylus/room1239.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gymnasium foyer";
+    long_desc = "Gymnasium foyer.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1240", "west",
+        "domain/original/area/pylus/room1230", "east",
+        "domain/original/area/pylus/room1241", "south",
+    });
+}

--- a/domain/original/area/pylus/room1240.c
+++ b/domain/original/area/pylus/room1240.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Changing room";
+    long_desc = "Changing room.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1239", "east",
+    });
+}

--- a/domain/original/area/pylus/room1241.c
+++ b/domain/original/area/pylus/room1241.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gymnasium hallway";
+    long_desc = "Gymnasium hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1242", "south",
+        "domain/original/area/pylus/room1239", "north",
+    });
+}

--- a/domain/original/area/pylus/room1242.c
+++ b/domain/original/area/pylus/room1242.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Natatorium";
+    long_desc = "Natatorium.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1241", "north",
+    });
+}

--- a/domain/original/area/pylus/room1243.c
+++ b/domain/original/area/pylus/room1243.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Vegetable seller's";
+    long_desc = "Vegetable seller's.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1228", "west",
+    });
+}

--- a/domain/original/area/pylus/room1244.c
+++ b/domain/original/area/pylus/room1244.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Herbarium";
+    long_desc = "Herbarium.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1228", "east",
+        "domain/original/area/pylus/room1245", "south",
+    });
+}

--- a/domain/original/area/pylus/room1245.c
+++ b/domain/original/area/pylus/room1245.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Herb garden";
+    long_desc = "Herb garden.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1244", "north",
+    });
+}

--- a/domain/original/area/pylus/room1246.c
+++ b/domain/original/area/pylus/room1246.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Butcher shop";
+    long_desc = "Butcher shop.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1227", "west",
+    });
+}

--- a/domain/original/area/pylus/room1247.c
+++ b/domain/original/area/pylus/room1247.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1227", "east",
+    });
+}

--- a/domain/original/area/pylus/room1248.c
+++ b/domain/original/area/pylus/room1248.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Iola way";
+    long_desc = "Iola way.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1249", "west",
+        "domain/original/area/pylus/room1252", "east",
+        "domain/original/area/pylus/room1226", "south",
+    });
+}

--- a/domain/original/area/pylus/room1249.c
+++ b/domain/original/area/pylus/room1249.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Garden entry";
+    long_desc = "Garden entry.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1248", "east",
+        "domain/original/area/pylus/room1250", "north",
+    });
+}

--- a/domain/original/area/pylus/room1250.c
+++ b/domain/original/area/pylus/room1250.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Garden clearing";
+    long_desc = "Garden clearing.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1251", "west",
+        "domain/original/area/pylus/room1249", "south",
+    });
+}

--- a/domain/original/area/pylus/room1251.c
+++ b/domain/original/area/pylus/room1251.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Entry to akademos";
+    long_desc = "Entry to akademos.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1250", "east",
+        "domain/original/area/pylus/room1374", "west",
+    });
+}

--- a/domain/original/area/pylus/room1252.c
+++ b/domain/original/area/pylus/room1252.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ithsma street";
+    long_desc = "Ithsma street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1253", "east",
+        "domain/original/area/pylus/room1248", "west",
+    });
+}

--- a/domain/original/area/pylus/room1253.c
+++ b/domain/original/area/pylus/room1253.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ithsma street";
+    long_desc = "Ithsma street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1252", "west",
+        "domain/original/area/pylus/room1255", "east",
+        "domain/original/area/pylus/room1254", "south",
+    });
+}

--- a/domain/original/area/pylus/room1254.c
+++ b/domain/original/area/pylus/room1254.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Short path";
+    long_desc = "Short path.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1375", "south",
+        "domain/original/area/pylus/room1253", "north",
+    });
+}

--- a/domain/original/area/pylus/room1255.c
+++ b/domain/original/area/pylus/room1255.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ithsma street";
+    long_desc = "Ithsma street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1253", "west",
+        "domain/original/area/pylus/room1389", "east",
+        "domain/original/area/pylus/room1256", "north",
+    });
+}

--- a/domain/original/area/pylus/room1256.c
+++ b/domain/original/area/pylus/room1256.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Before the Palace";
+    long_desc = "Before the Palace.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1255", "south",
+        "domain/original/area/pylus/room1257", "north",
+    });
+}

--- a/domain/original/area/pylus/room1257.c
+++ b/domain/original/area/pylus/room1257.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Threshold to the Grand Rotunda";
+    long_desc = "Threshold to the Grand Rotunda.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1256", "south",
+        "domain/original/area/pylus/room1258", "north",
+    });
+}

--- a/domain/original/area/pylus/room1258.c
+++ b/domain/original/area/pylus/room1258.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Grand Rotunda";
+    long_desc = "Grand Rotunda.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1259", "west",
+        "domain/original/area/pylus/room1362", "east",
+        "domain/original/area/pylus/room1257", "south",
+    });
+}

--- a/domain/original/area/pylus/room1259.c
+++ b/domain/original/area/pylus/room1259.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Administrative hallway";
+    long_desc = "Administrative hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1261", "west",
+        "domain/original/area/pylus/room1258", "east",
+        "domain/original/area/pylus/room1260", "north",
+    });
+}

--- a/domain/original/area/pylus/room1260.c
+++ b/domain/original/area/pylus/room1260.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Office of the Magistrate";
+    long_desc = "Office of the Magistrate.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1259", "south",
+    });
+}

--- a/domain/original/area/pylus/room1261.c
+++ b/domain/original/area/pylus/room1261.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Administrative hallway";
+    long_desc = "Administrative hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1262", "west",
+        "domain/original/area/pylus/room1259", "east",
+        "domain/original/area/pylus/room1391", "south",
+    });
+}

--- a/domain/original/area/pylus/room1262.c
+++ b/domain/original/area/pylus/room1262.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Royal Throne Room";
+    long_desc = "Royal Throne Room.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1261", "east",
+    });
+}

--- a/domain/original/area/pylus/room1289.c
+++ b/domain/original/area/pylus/room1289.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gate of Triumph";
+    long_desc = "Gate of Triumph.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1290", "south",
+        "domain/original/area/pylus/room1222", "west",
+        "domain/original/area/pylus/room1224", "east",
+        "domain/original/area/pylus/room1291", "north",
+    });
+}

--- a/domain/original/area/pylus/room1290.c
+++ b/domain/original/area/pylus/room1290.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southern niche";
+    long_desc = "Southern niche.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1289", "north",
+    });
+}

--- a/domain/original/area/pylus/room1291.c
+++ b/domain/original/area/pylus/room1291.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northern niche";
+    long_desc = "Northern niche.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1289", "south",
+    });
+}

--- a/domain/original/area/pylus/room1362.c
+++ b/domain/original/area/pylus/room1362.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Guard Post";
+    long_desc = "Guard Post.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1258", "west",
+        "domain/original/area/pylus/room1392", "east",
+        "domain/original/area/pylus/room1395", "north",
+    });
+}

--- a/domain/original/area/pylus/room1363.c
+++ b/domain/original/area/pylus/room1363.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Doorway";
+    long_desc = "Doorway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1225", "east",
+        "domain/original/area/pylus/room1364", "west",
+    });
+}

--- a/domain/original/area/pylus/room1364.c
+++ b/domain/original/area/pylus/room1364.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Statued hallway";
+    long_desc = "Statued hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1363", "east",
+        "domain/original/area/pylus/room1365", "west",
+    });
+}

--- a/domain/original/area/pylus/room1365.c
+++ b/domain/original/area/pylus/room1365.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hallway";
+    long_desc = "Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1366", "west",
+        "domain/original/area/pylus/room1364", "east",
+        "domain/original/area/pylus/room1367", "north",
+    });
+}

--- a/domain/original/area/pylus/room1366.c
+++ b/domain/original/area/pylus/room1366.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Captain's office";
+    long_desc = "Captain's office.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1365", "east",
+    });
+}

--- a/domain/original/area/pylus/room1367.c
+++ b/domain/original/area/pylus/room1367.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Courtyard";
+    long_desc = "Courtyard.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1365", "south",
+        "domain/original/area/pylus/room1368", "north",
+    });
+}

--- a/domain/original/area/pylus/room1368.c
+++ b/domain/original/area/pylus/room1368.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Courtyard";
+    long_desc = "Courtyard.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1367", "south",
+        "domain/original/area/pylus/room1369", "north",
+    });
+}

--- a/domain/original/area/pylus/room1369.c
+++ b/domain/original/area/pylus/room1369.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hallway";
+    long_desc = "Hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1373", "up",
+        "domain/original/area/pylus/room1370", "west",
+        "domain/original/area/pylus/room1371", "east",
+        "domain/original/area/pylus/room1368", "south",
+    });
+}

--- a/domain/original/area/pylus/room1370.c
+++ b/domain/original/area/pylus/room1370.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "West wing";
+    long_desc = "West wing.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1369", "east",
+    });
+}

--- a/domain/original/area/pylus/room1371.c
+++ b/domain/original/area/pylus/room1371.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East wing";
+    long_desc = "East wing.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1369", "west",
+        "domain/original/area/pylus/room1372", "south",
+    });
+}

--- a/domain/original/area/pylus/room1372.c
+++ b/domain/original/area/pylus/room1372.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "East wing hallway";
+    long_desc = "East wing hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1371", "north",
+    });
+}

--- a/domain/original/area/pylus/room1373.c
+++ b/domain/original/area/pylus/room1373.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Climbing the tight stairwell, you open the trapdoor and climb to the roof.";
+    long_desc = "Climbing the tight stairwell, you open the trapdoor and climb to the roof..\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1369", "down",
+    });
+}

--- a/domain/original/area/pylus/room1374.c
+++ b/domain/original/area/pylus/room1374.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Akademos";
+    long_desc = "Akademos.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1251", "east",
+    });
+}

--- a/domain/original/area/pylus/room1375.c
+++ b/domain/original/area/pylus/room1375.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple entry";
+    long_desc = "Temple entry.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1376", "south",
+        "domain/original/area/pylus/room1254", "north",
+    });
+}

--- a/domain/original/area/pylus/room1376.c
+++ b/domain/original/area/pylus/room1376.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple rotunda";
+    long_desc = "Temple rotunda.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1377", "south",
+        "domain/original/area/pylus/room1381", "west",
+        "domain/original/area/pylus/room1384", "east",
+        "domain/original/area/pylus/room1375", "north",
+    });
+}

--- a/domain/original/area/pylus/room1377.c
+++ b/domain/original/area/pylus/room1377.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Temple hallway";
+    long_desc = "Temple hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1378", "south",
+        "domain/original/area/pylus/room1376", "north",
+    });
+}

--- a/domain/original/area/pylus/room1378.c
+++ b/domain/original/area/pylus/room1378.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of temple hallway";
+    long_desc = "End of temple hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1380", "west",
+        "domain/original/area/pylus/room1379", "east",
+        "domain/original/area/pylus/room1377", "north",
+    });
+}

--- a/domain/original/area/pylus/room1379.c
+++ b/domain/original/area/pylus/room1379.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Folio depository";
+    long_desc = "Folio depository.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1378", "west",
+    });
+}

--- a/domain/original/area/pylus/room1380.c
+++ b/domain/original/area/pylus/room1380.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Reliquary";
+    long_desc = "Reliquary.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1378", "east",
+    });
+}

--- a/domain/original/area/pylus/room1381.c
+++ b/domain/original/area/pylus/room1381.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hall of Peace";
+    long_desc = "Hall of Peace.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1376", "east",
+        "domain/original/area/pylus/room1382", "west",
+    });
+}

--- a/domain/original/area/pylus/room1382.c
+++ b/domain/original/area/pylus/room1382.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hall of Peace";
+    long_desc = "Hall of Peace.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1383", "west",
+        "domain/original/area/pylus/room1381", "east",
+        "domain/original/area/pylus/room1387", "south",
+    });
+}

--- a/domain/original/area/pylus/room1383.c
+++ b/domain/original/area/pylus/room1383.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rotunda of Peace";
+    long_desc = "Rotunda of Peace.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1382", "east",
+    });
+}

--- a/domain/original/area/pylus/room1384.c
+++ b/domain/original/area/pylus/room1384.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hall of War";
+    long_desc = "Hall of War.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1376", "west",
+        "domain/original/area/pylus/room1385", "east",
+        "domain/original/area/pylus/room1388", "south",
+    });
+}

--- a/domain/original/area/pylus/room1385.c
+++ b/domain/original/area/pylus/room1385.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Hall of War";
+    long_desc = "Hall of War.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1386", "east",
+        "domain/original/area/pylus/room1384", "west",
+    });
+}

--- a/domain/original/area/pylus/room1386.c
+++ b/domain/original/area/pylus/room1386.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Rotunda of War";
+    long_desc = "Rotunda of War.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1385", "west",
+    });
+}

--- a/domain/original/area/pylus/room1387.c
+++ b/domain/original/area/pylus/room1387.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Chapel of Peace";
+    long_desc = "Chapel of Peace.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1382", "north",
+    });
+}

--- a/domain/original/area/pylus/room1388.c
+++ b/domain/original/area/pylus/room1388.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Chapel of War";
+    long_desc = "Chapel of War.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1384", "north",
+    });
+}

--- a/domain/original/area/pylus/room1389.c
+++ b/domain/original/area/pylus/room1389.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ithsma street";
+    long_desc = "Ithsma street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1390", "east",
+        "domain/original/area/pylus/room1255", "west",
+    });
+}

--- a/domain/original/area/pylus/room1390.c
+++ b/domain/original/area/pylus/room1390.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "End of Ithsma street";
+    long_desc = "End of Ithsma street.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1389", "west",
+    });
+}

--- a/domain/original/area/pylus/room1391.c
+++ b/domain/original/area/pylus/room1391.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Office of the Secretary";
+    long_desc = "Office of the Secretary.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1261", "north",
+    });
+}

--- a/domain/original/area/pylus/room1392.c
+++ b/domain/original/area/pylus/room1392.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Formal gardens";
+    long_desc = "Formal gardens.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1362", "west",
+        "domain/original/area/pylus/room1393", "east",
+        "domain/original/area/pylus/room1394", "south",
+    });
+}

--- a/domain/original/area/pylus/room1393.c
+++ b/domain/original/area/pylus/room1393.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A private corner in the garden";
+    long_desc = "A private corner in the garden.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1392", "west",
+    });
+}

--- a/domain/original/area/pylus/room1394.c
+++ b/domain/original/area/pylus/room1394.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "A private corner in the garden";
+    long_desc = "A private corner in the garden.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1392", "north",
+    });
+}

--- a/domain/original/area/pylus/room1395.c
+++ b/domain/original/area/pylus/room1395.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Residential hallway";
+    long_desc = "Residential hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1396", "east",
+        "domain/original/area/pylus/room1362", "south",
+    });
+}

--- a/domain/original/area/pylus/room1396.c
+++ b/domain/original/area/pylus/room1396.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Residential hallway";
+    long_desc = "Residential hallway.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1395", "west",
+        "domain/original/area/pylus/room1397", "east",
+        "domain/original/area/pylus/room1398", "north",
+    });
+}

--- a/domain/original/area/pylus/room1397.c
+++ b/domain/original/area/pylus/room1397.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The harem";
+    long_desc = "The harem.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1396", "west",
+        "domain/original/area/pylus/room1400", "north",
+    });
+}

--- a/domain/original/area/pylus/room1398.c
+++ b/domain/original/area/pylus/room1398.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Royal Chambers";
+    long_desc = "The Royal Chambers.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1399", "west",
+        "domain/original/area/pylus/room1396", "south",
+    });
+}

--- a/domain/original/area/pylus/room1399.c
+++ b/domain/original/area/pylus/room1399.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The royal dressing room";
+    long_desc = "The royal dressing room.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1398", "east",
+    });
+}

--- a/domain/original/area/pylus/room1400.c
+++ b/domain/original/area/pylus/room1400.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Consort's chambers";
+    long_desc = "The Consort's chambers.\n";
+    dest_dir = ({
+        "domain/original/area/pylus/room1397", "south",
+    });
+}

--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -13,5 +13,6 @@ void reset(int arg) {
         "domain/original/area/balin/room605", "island",
         "domain/original/area/preserve/room432", "preserve",
         "domain/original/area/forest/room529", "forest",
+        "domain/original/area/pylus/room1205", "pylus",
     });
 }


### PR DESCRIPTION
### Motivation
- Populate the Pylus area by creating room source files from the map data in `maps/pylus.json` so the area is available in-game.
- Ensure navigation between Vesla and Pylus by adding a portal exit from the Vesla portal room into Pylus and a reciprocal exit back.
- Use the existing room template pattern (e.g. `inherit "room/room"` and the layout used in `domain/original/area/vesla/room227.c`) for consistency.

### Description
- Generated 99 room files under `domain/original/area/pylus/` from `maps/pylus.json`, each setting `short_desc`, `long_desc`, and `dest_dir` entries following the room template.
- Updated `domain/original/area/pylus/room1205.c` to include a `"vesla"` exit pointing to `domain/original/area/vesla/portal`.
- Updated `domain/original/area/vesla/portal.c` to add a `"pylus"` exit pointing to `domain/original/area/pylus/room1205`.
- Changes were committed with the message `Add Pylus area rooms and portal exit`.

### Testing
- Ran a JSON consistency check during generation which verified there were no missing exit targets (reported `missing exits count 0`).
- Executed the generation script to write the room files from `maps/pylus.json`, which created 99 files successfully. 
- Performed an automated `git` commit of the new files and the portal change, which completed successfully. 
- No automated unit test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da01d7a788327994344db99bb86fd)