### PR TITLE
Add Village Green rooms and connect Vesla portal

### DIFF
--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -14,5 +14,6 @@ void reset(int arg) {
         "domain/original/area/preserve/room432", "preserve",
         "domain/original/area/forest/room529", "forest",
         "domain/original/area/pylus/room1205", "pylus",
+        "domain/original/area/village-green/room1687", "village-green",
     });
 }

--- a/domain/original/area/village-green/room1687.c
+++ b/domain/original/area/village-green/room1687.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Gate to the Village Green";
+    long_desc = "Gate to the Village Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1693", "east",
+        "domain/original/area/village-green/room1688", "south",
+        "domain/original/area/vesla/portal", "vesla",
+    });
+}

--- a/domain/original/area/village-green/room1688.c
+++ b/domain/original/area/village-green/room1688.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1689", "south",
+        "domain/original/area/village-green/room1694", "east",
+        "domain/original/area/village-green/room1687", "north",
+    });
+}

--- a/domain/original/area/village-green/room1689.c
+++ b/domain/original/area/village-green/room1689.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1699", "south",
+        "domain/original/area/village-green/room1690", "east",
+        "domain/original/area/village-green/room1688", "north",
+    });
+}

--- a/domain/original/area/village-green/room1690.c
+++ b/domain/original/area/village-green/room1690.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1700", "south",
+        "domain/original/area/village-green/room1689", "west",
+        "domain/original/area/village-green/room1691", "east",
+        "domain/original/area/village-green/room1694", "north",
+    });
+}

--- a/domain/original/area/village-green/room1691.c
+++ b/domain/original/area/village-green/room1691.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1701", "south",
+        "domain/original/area/village-green/room1690", "west",
+        "domain/original/area/village-green/room1692", "east",
+        "domain/original/area/village-green/room1704", "north",
+    });
+}

--- a/domain/original/area/village-green/room1692.c
+++ b/domain/original/area/village-green/room1692.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1702", "south",
+        "domain/original/area/village-green/room1691", "west",
+        "domain/original/area/village-green/room1706", "east",
+        "domain/original/area/village-green/room1703", "north",
+    });
+}

--- a/domain/original/area/village-green/room1693.c
+++ b/domain/original/area/village-green/room1693.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwestern Green";
+    long_desc = "Northwestern Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1687", "west",
+        "domain/original/area/village-green/room1695", "east",
+        "domain/original/area/village-green/room1694", "south",
+    });
+}

--- a/domain/original/area/village-green/room1694.c
+++ b/domain/original/area/village-green/room1694.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1690", "south",
+        "domain/original/area/village-green/room1688", "west",
+        "domain/original/area/village-green/room1704", "east",
+        "domain/original/area/village-green/room1693", "north",
+    });
+}

--- a/domain/original/area/village-green/room1695.c
+++ b/domain/original/area/village-green/room1695.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwestern Green";
+    long_desc = "Northwestern Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1693", "west",
+        "domain/original/area/village-green/room1696", "east",
+        "domain/original/area/village-green/room1704", "south",
+    });
+}

--- a/domain/original/area/village-green/room1696.c
+++ b/domain/original/area/village-green/room1696.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeastern Green";
+    long_desc = "Northeastern Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1695", "west",
+        "domain/original/area/village-green/room1697", "east",
+        "domain/original/area/village-green/room1703", "south",
+    });
+}

--- a/domain/original/area/village-green/room1697.c
+++ b/domain/original/area/village-green/room1697.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1696", "west",
+        "domain/original/area/village-green/room1698", "east",
+        "domain/original/area/village-green/room1705", "south",
+    });
+}

--- a/domain/original/area/village-green/room1698.c
+++ b/domain/original/area/village-green/room1698.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1697", "west",
+        "domain/original/area/village-green/room1710", "south",
+    });
+}

--- a/domain/original/area/village-green/room1699.c
+++ b/domain/original/area/village-green/room1699.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1713", "south",
+        "domain/original/area/village-green/room1700", "east",
+        "domain/original/area/village-green/room1689", "north",
+    });
+}

--- a/domain/original/area/village-green/room1700.c
+++ b/domain/original/area/village-green/room1700.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1712", "south",
+        "domain/original/area/village-green/room1699", "west",
+        "domain/original/area/village-green/room1701", "east",
+        "domain/original/area/village-green/room1690", "north",
+    });
+}

--- a/domain/original/area/village-green/room1701.c
+++ b/domain/original/area/village-green/room1701.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1711", "south",
+        "domain/original/area/village-green/room1700", "west",
+        "domain/original/area/village-green/room1702", "east",
+        "domain/original/area/village-green/room1691", "north",
+    });
+}

--- a/domain/original/area/village-green/room1702.c
+++ b/domain/original/area/village-green/room1702.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southeast Green";
+    long_desc = "Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1714", "south",
+        "domain/original/area/village-green/room1701", "west",
+        "domain/original/area/village-green/room1707", "east",
+        "domain/original/area/village-green/room1692", "north",
+    });
+}

--- a/domain/original/area/village-green/room1703.c
+++ b/domain/original/area/village-green/room1703.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1692", "south",
+        "domain/original/area/village-green/room1704", "west",
+        "domain/original/area/village-green/room1705", "east",
+        "domain/original/area/village-green/room1696", "north",
+    });
+}

--- a/domain/original/area/village-green/room1704.c
+++ b/domain/original/area/village-green/room1704.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northwest Green";
+    long_desc = "Northwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1691", "south",
+        "domain/original/area/village-green/room1694", "west",
+        "domain/original/area/village-green/room1703", "east",
+        "domain/original/area/village-green/room1695", "north",
+    });
+}

--- a/domain/original/area/village-green/room1705.c
+++ b/domain/original/area/village-green/room1705.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1706", "south",
+        "domain/original/area/village-green/room1703", "west",
+        "domain/original/area/village-green/room1710", "east",
+        "domain/original/area/village-green/room1697", "north",
+    });
+}

--- a/domain/original/area/village-green/room1706.c
+++ b/domain/original/area/village-green/room1706.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1707", "south",
+        "domain/original/area/village-green/room1692", "west",
+        "domain/original/area/village-green/room1709", "east",
+        "domain/original/area/village-green/room1705", "north",
+    });
+}

--- a/domain/original/area/village-green/room1707.c
+++ b/domain/original/area/village-green/room1707.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ruins in the Southeast Green";
+    long_desc = "Ruins in the Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1715", "south",
+        "domain/original/area/village-green/room1702", "west",
+        "domain/original/area/village-green/room1708", "east",
+        "domain/original/area/village-green/room1706", "north",
+    });
+}

--- a/domain/original/area/village-green/room1708.c
+++ b/domain/original/area/village-green/room1708.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Ruins in the Southeast Green";
+    long_desc = "Ruins in the Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1707", "west",
+        "domain/original/area/village-green/room1716", "south",
+        "domain/original/area/village-green/room1709", "north",
+    });
+}

--- a/domain/original/area/village-green/room1709.c
+++ b/domain/original/area/village-green/room1709.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeastern Green";
+    long_desc = "Northeastern Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1706", "west",
+        "domain/original/area/village-green/room1708", "south",
+        "domain/original/area/village-green/room1710", "north",
+    });
+}

--- a/domain/original/area/village-green/room1710.c
+++ b/domain/original/area/village-green/room1710.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Northeast Green";
+    long_desc = "Northeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1709", "south",
+        "domain/original/area/village-green/room1705", "west",
+        "domain/original/area/village-green/room1722", "east",
+        "domain/original/area/village-green/room1698", "north",
+    });
+}

--- a/domain/original/area/village-green/room1711.c
+++ b/domain/original/area/village-green/room1711.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1717", "south",
+        "domain/original/area/village-green/room1712", "west",
+        "domain/original/area/village-green/room1714", "east",
+        "domain/original/area/village-green/room1701", "north",
+    });
+}

--- a/domain/original/area/village-green/room1712.c
+++ b/domain/original/area/village-green/room1712.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1718", "south",
+        "domain/original/area/village-green/room1713", "west",
+        "domain/original/area/village-green/room1711", "east",
+        "domain/original/area/village-green/room1700", "north",
+    });
+}

--- a/domain/original/area/village-green/room1713.c
+++ b/domain/original/area/village-green/room1713.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1719", "south",
+        "domain/original/area/village-green/room1712", "east",
+        "domain/original/area/village-green/room1699", "north",
+    });
+}

--- a/domain/original/area/village-green/room1714.c
+++ b/domain/original/area/village-green/room1714.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southeast Green";
+    long_desc = "Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1711", "west",
+        "domain/original/area/village-green/room1715", "east",
+        "domain/original/area/village-green/room1702", "north",
+    });
+}

--- a/domain/original/area/village-green/room1715.c
+++ b/domain/original/area/village-green/room1715.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southeast Green";
+    long_desc = "Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1714", "west",
+        "domain/original/area/village-green/room1716", "east",
+        "domain/original/area/village-green/room1707", "north",
+    });
+}

--- a/domain/original/area/village-green/room1716.c
+++ b/domain/original/area/village-green/room1716.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southeast Green";
+    long_desc = "Southeast Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1715", "west",
+        "domain/original/area/village-green/room1708", "north",
+    });
+}

--- a/domain/original/area/village-green/room1717.c
+++ b/domain/original/area/village-green/room1717.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Southwest Green";
+    long_desc = "Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1718", "west",
+        "domain/original/area/village-green/room1711", "north",
+    });
+}

--- a/domain/original/area/village-green/room1718.c
+++ b/domain/original/area/village-green/room1718.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark Southwest Green";
+    long_desc = "Dark Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1721", "south",
+        "domain/original/area/village-green/room1719", "west",
+        "domain/original/area/village-green/room1717", "east",
+        "domain/original/area/village-green/room1712", "north",
+    });
+}

--- a/domain/original/area/village-green/room1719.c
+++ b/domain/original/area/village-green/room1719.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark Southwest Green";
+    long_desc = "Dark Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1720", "south",
+        "domain/original/area/village-green/room1718", "east",
+        "domain/original/area/village-green/room1713", "north",
+    });
+}

--- a/domain/original/area/village-green/room1720.c
+++ b/domain/original/area/village-green/room1720.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark Southwest Green";
+    long_desc = "Dark Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1721", "east",
+        "domain/original/area/village-green/room1719", "north",
+    });
+}

--- a/domain/original/area/village-green/room1721.c
+++ b/domain/original/area/village-green/room1721.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark Southwest Green";
+    long_desc = "Dark Southwest Green.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1720", "west",
+        "domain/original/area/village-green/room1718", "north",
+    });
+}

--- a/domain/original/area/village-green/room1722.c
+++ b/domain/original/area/village-green/room1722.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "The Herb Exchange";
+    long_desc = "The Herb Exchange.\n";
+    dest_dir = ({
+        "domain/original/area/village-green/room1710", "west",
+    });
+}


### PR DESCRIPTION
### Motivation
- Populate the codebase with the Village Green area rooms derived from the existing area map so the area exists as navigable rooms.
- Allow players to travel between Vesla and the Village Green by linking the Vesla portal to the Village Green gate and adding a reciprocal exit.

### Description
- Generated 36 new room files `domain/original/area/village-green/room1687.c` through `room1722.c` from `maps/area33.json` and added them to the repository.
- Each new room file inherits `room/room`, sets `short_desc`, `long_desc`, `set_light(1)`, and populates `dest_dir` with appropriate exits.
- Updated `domain/original/area/vesla/portal.c` to add the exit `"domain/original/area/village-green/room1687", "village-green"`.
- Added the reciprocal exit `"domain/original/area/vesla/portal", "vesla"` in `domain/original/area/village-green/room1687.c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da25963a4832783e359a60f069204)