### PR TITLE
Update island room links

### DIFF
--- a/domain/original/area/island/room605.c
+++ b/domain/original/area/island/room605.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Ocean before Beachhead";
     long_desc = "Ocean before Beachhead.\n";
     dest_dir = ({
-        "domain/original/area/balin/room606", "north",
+        "domain/original/area/island/room606", "north",
 	"domain/original/area/vesla/portal", "vesla",
     });
 }

--- a/domain/original/area/island/room606.c
+++ b/domain/original/area/island/room606.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "A sandy beachhead";
     long_desc = "A sandy beachhead.\n";
     dest_dir = ({
-        "domain/original/area/balin/room605", "south",
-        "domain/original/area/balin/room623", "west",
-        "domain/original/area/balin/room626", "east",
-        "domain/original/area/balin/room607", "north",
+        "domain/original/area/island/room605", "south",
+        "domain/original/area/island/room623", "west",
+        "domain/original/area/island/room626", "east",
+        "domain/original/area/island/room607", "north",
     });
 }

--- a/domain/original/area/island/room607.c
+++ b/domain/original/area/island/room607.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "A narrow path between the dunes";
     long_desc = "A narrow path between the dunes.\n";
     dest_dir = ({
-        "domain/original/area/balin/room606", "south",
-        "domain/original/area/balin/room628", "east",
-        "domain/original/area/balin/room608", "north",
+        "domain/original/area/island/room606", "south",
+        "domain/original/area/island/room628", "east",
+        "domain/original/area/island/room608", "north",
     });
 }

--- a/domain/original/area/island/room608.c
+++ b/domain/original/area/island/room608.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "A Dune Path";
     long_desc = "A Dune Path.\n";
     dest_dir = ({
-        "domain/original/area/balin/room607", "south",
-        "domain/original/area/balin/room609", "north",
+        "domain/original/area/island/room607", "south",
+        "domain/original/area/island/room609", "north",
     });
 }

--- a/domain/original/area/island/room609.c
+++ b/domain/original/area/island/room609.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "The City Gate";
     long_desc = "The City Gate.\n";
     dest_dir = ({
-        "domain/original/area/balin/room608", "south",
-        "domain/original/area/balin/room631", "west",
-        "domain/original/area/balin/room634", "east",
-        "domain/original/area/balin/room610", "north",
+        "domain/original/area/island/room608", "south",
+        "domain/original/area/island/room631", "west",
+        "domain/original/area/island/room634", "east",
+        "domain/original/area/island/room610", "north",
     });
 }

--- a/domain/original/area/island/room610.c
+++ b/domain/original/area/island/room610.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Intersection of Silver Street and Balin Road";
     long_desc = "Intersection of Silver Street and Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room609", "south",
-        "domain/original/area/balin/room635", "west",
-        "domain/original/area/balin/room660", "east",
-        "domain/original/area/balin/room611", "north",
+        "domain/original/area/island/room609", "south",
+        "domain/original/area/island/room635", "west",
+        "domain/original/area/island/room660", "east",
+        "domain/original/area/island/room611", "north",
     });
 }

--- a/domain/original/area/island/room611.c
+++ b/domain/original/area/island/room611.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room610", "south",
-        "domain/original/area/balin/room713", "east",
-        "domain/original/area/balin/room612", "north",
+        "domain/original/area/island/room610", "south",
+        "domain/original/area/island/room713", "east",
+        "domain/original/area/island/room612", "north",
     });
 }

--- a/domain/original/area/island/room612.c
+++ b/domain/original/area/island/room612.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room611", "south",
-        "domain/original/area/balin/room674", "east",
-        "domain/original/area/balin/room613", "north",
+        "domain/original/area/island/room611", "south",
+        "domain/original/area/island/room674", "east",
+        "domain/original/area/island/room613", "north",
     });
 }

--- a/domain/original/area/island/room613.c
+++ b/domain/original/area/island/room613.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room612", "south",
-        "domain/original/area/balin/room675", "west",
-        "domain/original/area/balin/room676", "east",
-        "domain/original/area/balin/room614", "north",
+        "domain/original/area/island/room612", "south",
+        "domain/original/area/island/room675", "west",
+        "domain/original/area/island/room676", "east",
+        "domain/original/area/island/room614", "north",
     });
 }

--- a/domain/original/area/island/room614.c
+++ b/domain/original/area/island/room614.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "A Grand Plaza";
     long_desc = "A Grand Plaza.\n";
     dest_dir = ({
-        "domain/original/area/balin/room613", "south",
-        "domain/original/area/balin/room678", "west",
-        "domain/original/area/balin/room677", "east",
-        "domain/original/area/balin/room615", "north",
+        "domain/original/area/island/room613", "south",
+        "domain/original/area/island/room678", "west",
+        "domain/original/area/island/room677", "east",
+        "domain/original/area/island/room615", "north",
     });
 }

--- a/domain/original/area/island/room615.c
+++ b/domain/original/area/island/room615.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room688", "west",
-        "domain/original/area/balin/room614", "south",
-        "domain/original/area/balin/room616", "north",
+        "domain/original/area/island/room688", "west",
+        "domain/original/area/island/room614", "south",
+        "domain/original/area/island/room616", "north",
     });
 }

--- a/domain/original/area/island/room616.c
+++ b/domain/original/area/island/room616.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room615", "south",
-        "domain/original/area/balin/room689", "east",
-        "domain/original/area/balin/room617", "north",
+        "domain/original/area/island/room615", "south",
+        "domain/original/area/island/room689", "east",
+        "domain/original/area/island/room617", "north",
     });
 }

--- a/domain/original/area/island/room617.c
+++ b/domain/original/area/island/room617.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room690", "west",
-        "domain/original/area/balin/room616", "south",
-        "domain/original/area/balin/room618", "north",
+        "domain/original/area/island/room690", "west",
+        "domain/original/area/island/room616", "south",
+        "domain/original/area/island/room618", "north",
     });
 }

--- a/domain/original/area/island/room618.c
+++ b/domain/original/area/island/room618.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Silver Street";
     long_desc = "Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room617", "south",
-        "domain/original/area/balin/room622", "west",
-        "domain/original/area/balin/room691", "east",
-        "domain/original/area/balin/room619", "north",
+        "domain/original/area/island/room617", "south",
+        "domain/original/area/island/room622", "west",
+        "domain/original/area/island/room691", "east",
+        "domain/original/area/island/room619", "north",
     });
 }

--- a/domain/original/area/island/room619.c
+++ b/domain/original/area/island/room619.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "End of Silver Street";
     long_desc = "End of Silver Street.\n";
     dest_dir = ({
-        "domain/original/area/balin/room620", "east",
-        "domain/original/area/balin/room618", "south",
+        "domain/original/area/island/room620", "east",
+        "domain/original/area/island/room618", "south",
     });
 }

--- a/domain/original/area/island/room620.c
+++ b/domain/original/area/island/room620.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Island smeltery";
     long_desc = "Island smeltery.\n";
     dest_dir = ({
-        "domain/original/area/balin/room621", "east",
-        "domain/original/area/balin/room619", "west",
+        "domain/original/area/island/room621", "east",
+        "domain/original/area/island/room619", "west",
     });
 }

--- a/domain/original/area/island/room621.c
+++ b/domain/original/area/island/room621.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Repair Shop";
     long_desc = "Repair Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room620", "west",
+        "domain/original/area/island/room620", "west",
     });
 }

--- a/domain/original/area/island/room623.c
+++ b/domain/original/area/island/room623.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Western Part of Beach";
     long_desc = "Western Part of Beach.\n";
     dest_dir = ({
-        "domain/original/area/balin/room606", "east",
-        "domain/original/area/balin/room624", "west",
+        "domain/original/area/island/room606", "east",
+        "domain/original/area/island/room624", "west",
     });
 }

--- a/domain/original/area/island/room624.c
+++ b/domain/original/area/island/room624.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "East of the waterfall";
     long_desc = "East of the waterfall.\n";
     dest_dir = ({
-        "domain/original/area/balin/room623", "east",
-        "domain/original/area/balin/room625", "west",
+        "domain/original/area/island/room623", "east",
+        "domain/original/area/island/room625", "west",
     });
 }

--- a/domain/original/area/island/room625.c
+++ b/domain/original/area/island/room625.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "The base of a waterfall";
     long_desc = "The base of a waterfall.\n";
     dest_dir = ({
-        "domain/original/area/balin/room624", "east",
+        "domain/original/area/island/room624", "east",
     });
 }

--- a/domain/original/area/island/room626.c
+++ b/domain/original/area/island/room626.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Ruins";
     long_desc = "Ruins.\n";
     dest_dir = ({
-        "domain/original/area/balin/room627", "east",
-        "domain/original/area/balin/room606", "west",
+        "domain/original/area/island/room627", "east",
+        "domain/original/area/island/room606", "west",
     });
 }

--- a/domain/original/area/island/room627.c
+++ b/domain/original/area/island/room627.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Eastern Beach";
     long_desc = "Eastern Beach.\n";
     dest_dir = ({
-        "domain/original/area/balin/room626", "west",
+        "domain/original/area/island/room626", "west",
     });
 }

--- a/domain/original/area/island/room628.c
+++ b/domain/original/area/island/room628.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "A valley between two large dunes";
     long_desc = "A valley between two large dunes.\n";
     dest_dir = ({
-        "domain/original/area/balin/room629", "east",
-        "domain/original/area/balin/room607", "west",
+        "domain/original/area/island/room629", "east",
+        "domain/original/area/island/room607", "west",
     });
 }

--- a/domain/original/area/island/room629.c
+++ b/domain/original/area/island/room629.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "A desert plain";
     long_desc = "A desert plain.\n";
     dest_dir = ({
-        "domain/original/area/balin/room628", "west",
-        "domain/original/area/balin/room630", "north",
+        "domain/original/area/island/room628", "west",
+        "domain/original/area/island/room630", "north",
     });
 }

--- a/domain/original/area/island/room630.c
+++ b/domain/original/area/island/room630.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "A dead end";
     long_desc = "A dead end.\n";
     dest_dir = ({
-        "domain/original/area/balin/room629", "south",
+        "domain/original/area/island/room629", "south",
     });
 }

--- a/domain/original/area/island/room631.c
+++ b/domain/original/area/island/room631.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Guard Room";
     long_desc = "Guard Room.\n";
     dest_dir = ({
-        "domain/original/area/balin/room609", "east",
-        "domain/original/area/balin/room632", "west",
+        "domain/original/area/island/room609", "east",
+        "domain/original/area/island/room632", "west",
     });
 }

--- a/domain/original/area/island/room632.c
+++ b/domain/original/area/island/room632.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Armoury";
     long_desc = "Armoury.\n";
     dest_dir = ({
-        "domain/original/area/balin/room631", "east",
-        "domain/original/area/balin/room633", "west",
+        "domain/original/area/island/room631", "east",
+        "domain/original/area/island/room633", "west",
     });
 }

--- a/domain/original/area/island/room633.c
+++ b/domain/original/area/island/room633.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Elderoak's Quarters";
     long_desc = "Elderoak's Quarters.\n";
     dest_dir = ({
-        "domain/original/area/balin/room632", "east",
+        "domain/original/area/island/room632", "east",
     });
 }

--- a/domain/original/area/island/room634.c
+++ b/domain/original/area/island/room634.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "A guard house";
     long_desc = "A guard house.\n";
     dest_dir = ({
-        "domain/original/area/balin/room609", "west",
+        "domain/original/area/island/room609", "west",
     });
 }

--- a/domain/original/area/island/room635.c
+++ b/domain/original/area/island/room635.c
@@ -9,10 +9,10 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room719", "northwest",
-        "domain/original/area/balin/room717", "south",
-        "domain/original/area/balin/room718", "northeast",
-        "domain/original/area/balin/room610", "east",
-        "domain/original/area/balin/room636", "west",
+        "domain/original/area/island/room719", "northwest",
+        "domain/original/area/island/room717", "south",
+        "domain/original/area/island/room718", "northeast",
+        "domain/original/area/island/room610", "east",
+        "domain/original/area/island/room636", "west",
     });
 }

--- a/domain/original/area/island/room636.c
+++ b/domain/original/area/island/room636.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room722", "southwest",
-        "domain/original/area/balin/room635", "east",
-        "domain/original/area/balin/room721", "southeast",
-        "domain/original/area/balin/room637", "west",
+        "domain/original/area/island/room722", "southwest",
+        "domain/original/area/island/room635", "east",
+        "domain/original/area/island/room721", "southeast",
+        "domain/original/area/island/room637", "west",
     });
 }

--- a/domain/original/area/island/room637.c
+++ b/domain/original/area/island/room637.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "West End of Balin Road";
     long_desc = "West End of Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room638", "west",
-        "domain/original/area/balin/room720", "northeast",
-        "domain/original/area/balin/room636", "east",
-        "domain/original/area/balin/room723", "south",
+        "domain/original/area/island/room638", "west",
+        "domain/original/area/island/room720", "northeast",
+        "domain/original/area/island/room636", "east",
+        "domain/original/area/island/room723", "south",
     });
 }

--- a/domain/original/area/island/room638.c
+++ b/domain/original/area/island/room638.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Tunnel Under Canal";
     long_desc = "Tunnel Under Canal.\n";
     dest_dir = ({
-        "domain/original/area/balin/room637", "east",
-        "domain/original/area/balin/room639", "west",
+        "domain/original/area/island/room637", "east",
+        "domain/original/area/island/room639", "west",
     });
 }

--- a/domain/original/area/island/room639.c
+++ b/domain/original/area/island/room639.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "South End of Highland Avenue";
     long_desc = "South End of Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room638", "east",
-        "domain/original/area/balin/room640", "west",
+        "domain/original/area/island/room638", "east",
+        "domain/original/area/island/room640", "west",
     });
 }

--- a/domain/original/area/island/room640.c
+++ b/domain/original/area/island/room640.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room657", "south",
-        "domain/original/area/balin/room639", "east",
-        "domain/original/area/balin/room641", "north",
+        "domain/original/area/island/room657", "south",
+        "domain/original/area/island/room639", "east",
+        "domain/original/area/island/room641", "north",
     });
 }

--- a/domain/original/area/island/room641.c
+++ b/domain/original/area/island/room641.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room640", "south",
-        "domain/original/area/balin/room642", "north",
+        "domain/original/area/island/room640", "south",
+        "domain/original/area/island/room642", "north",
     });
 }

--- a/domain/original/area/island/room642.c
+++ b/domain/original/area/island/room642.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room643", "west",
-        "domain/original/area/balin/room641", "south",
+        "domain/original/area/island/room643", "west",
+        "domain/original/area/island/room641", "south",
     });
 }

--- a/domain/original/area/island/room643.c
+++ b/domain/original/area/island/room643.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room647", "south",
-        "domain/original/area/balin/room642", "east",
-        "domain/original/area/balin/room644", "north",
+        "domain/original/area/island/room647", "south",
+        "domain/original/area/island/room642", "east",
+        "domain/original/area/island/room644", "north",
     });
 }

--- a/domain/original/area/island/room644.c
+++ b/domain/original/area/island/room644.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room643", "south",
-        "domain/original/area/balin/room646", "west",
-        "domain/original/area/balin/room648", "east",
-        "domain/original/area/balin/room645", "north",
+        "domain/original/area/island/room643", "south",
+        "domain/original/area/island/room646", "west",
+        "domain/original/area/island/room648", "east",
+        "domain/original/area/island/room645", "north",
     });
 }

--- a/domain/original/area/island/room645.c
+++ b/domain/original/area/island/room645.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Dwarven Hut";
     long_desc = "Dwarven Hut.\n";
     dest_dir = ({
-        "domain/original/area/balin/room644", "south",
+        "domain/original/area/island/room644", "south",
     });
 }

--- a/domain/original/area/island/room646.c
+++ b/domain/original/area/island/room646.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "You trundle past the facade and arrive on a beautiful street.";
     long_desc = "You trundle past the facade and arrive on a beautiful street..\n";
     dest_dir = ({
-        "domain/original/area/balin/room644", "east",
+        "domain/original/area/island/room644", "east",
     });
 }

--- a/domain/original/area/island/room647.c
+++ b/domain/original/area/island/room647.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Gnome Hut";
     long_desc = "Gnome Hut.\n";
     dest_dir = ({
-        "domain/original/area/balin/room643", "north",
+        "domain/original/area/island/room643", "north",
     });
 }

--- a/domain/original/area/island/room648.c
+++ b/domain/original/area/island/room648.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room651", "south",
-        "domain/original/area/balin/room644", "west",
-        "domain/original/area/balin/room649", "east",
-        "domain/original/area/balin/room650", "north",
+        "domain/original/area/island/room651", "south",
+        "domain/original/area/island/room644", "west",
+        "domain/original/area/island/room649", "east",
+        "domain/original/area/island/room650", "north",
     });
 }

--- a/domain/original/area/island/room649.c
+++ b/domain/original/area/island/room649.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Dwarven Home";
     long_desc = "Dwarven Home.\n";
     dest_dir = ({
-        "domain/original/area/balin/room648", "west",
+        "domain/original/area/island/room648", "west",
     });
 }

--- a/domain/original/area/island/room650.c
+++ b/domain/original/area/island/room650.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room652", "west",
-        "domain/original/area/balin/room648", "south",
+        "domain/original/area/island/room652", "west",
+        "domain/original/area/island/room648", "south",
     });
 }

--- a/domain/original/area/island/room651.c
+++ b/domain/original/area/island/room651.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Dwarven Shack";
     long_desc = "Dwarven Shack.\n";
     dest_dir = ({
-        "domain/original/area/balin/room648", "north",
+        "domain/original/area/island/room648", "north",
     });
 }

--- a/domain/original/area/island/room652.c
+++ b/domain/original/area/island/room652.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room653", "west",
-        "domain/original/area/balin/room650", "east",
-        "domain/original/area/balin/room654", "north",
+        "domain/original/area/island/room653", "west",
+        "domain/original/area/island/room650", "east",
+        "domain/original/area/island/room654", "north",
     });
 }

--- a/domain/original/area/island/room653.c
+++ b/domain/original/area/island/room653.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Dwarven Home";
     long_desc = "Dwarven Home.\n";
     dest_dir = ({
-        "domain/original/area/balin/room652", "east",
-        "domain/original/area/balin/room656", "south",
+        "domain/original/area/island/room652", "east",
+        "domain/original/area/island/room656", "south",
     });
 }

--- a/domain/original/area/island/room654.c
+++ b/domain/original/area/island/room654.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Highland Avenue";
     long_desc = "Highland Avenue.\n";
     dest_dir = ({
-        "domain/original/area/balin/room652", "south",
-        "domain/original/area/balin/room655", "north",
+        "domain/original/area/island/room652", "south",
+        "domain/original/area/island/room655", "north",
     });
 }

--- a/domain/original/area/island/room655.c
+++ b/domain/original/area/island/room655.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "House of Balin";
     long_desc = "House of Balin.\n";
     dest_dir = ({
-        "domain/original/area/balin/room712", "west",
-        "domain/original/area/balin/room654", "south",
+        "domain/original/area/island/room712", "west",
+        "domain/original/area/island/room654", "south",
     });
 }

--- a/domain/original/area/island/room656.c
+++ b/domain/original/area/island/room656.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Dwarven Home";
     long_desc = "Dwarven Home.\n";
     dest_dir = ({
-        "domain/original/area/balin/room653", "north",
+        "domain/original/area/island/room653", "north",
     });
 }

--- a/domain/original/area/island/room657.c
+++ b/domain/original/area/island/room657.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Keep Of Alcibiades";
     long_desc = "Keep Of Alcibiades.\n";
     dest_dir = ({
-        "domain/original/area/balin/room659", "west",
-        "domain/original/area/balin/room658", "east",
-        "domain/original/area/balin/room640", "north",
+        "domain/original/area/island/room659", "west",
+        "domain/original/area/island/room658", "east",
+        "domain/original/area/island/room640", "north",
     });
 }

--- a/domain/original/area/island/room658.c
+++ b/domain/original/area/island/room658.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Study";
     long_desc = "Study.\n";
     dest_dir = ({
-        "domain/original/area/balin/room657", "west",
+        "domain/original/area/island/room657", "west",
     });
 }

--- a/domain/original/area/island/room659.c
+++ b/domain/original/area/island/room659.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Bedroom:";
     long_desc = "Bedroom:.\n";
     dest_dir = ({
-        "domain/original/area/balin/room657", "east",
+        "domain/original/area/island/room657", "east",
     });
 }

--- a/domain/original/area/island/room660.c
+++ b/domain/original/area/island/room660.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room661", "east",
-        "domain/original/area/balin/room610", "west",
+        "domain/original/area/island/room661", "east",
+        "domain/original/area/island/room610", "west",
     });
 }

--- a/domain/original/area/island/room661.c
+++ b/domain/original/area/island/room661.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room660", "west",
-        "domain/original/area/balin/room662", "east",
-        "domain/original/area/balin/room673", "south",
+        "domain/original/area/island/room660", "west",
+        "domain/original/area/island/room662", "east",
+        "domain/original/area/island/room673", "south",
     });
 }

--- a/domain/original/area/island/room662.c
+++ b/domain/original/area/island/room662.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room661", "west",
-        "domain/original/area/balin/room663", "east",
-        "domain/original/area/balin/room672", "north",
+        "domain/original/area/island/room661", "west",
+        "domain/original/area/island/room663", "east",
+        "domain/original/area/island/room672", "north",
     });
 }

--- a/domain/original/area/island/room663.c
+++ b/domain/original/area/island/room663.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room670", "south",
-        "domain/original/area/balin/room662", "west",
-        "domain/original/area/balin/room664", "east",
-        "domain/original/area/balin/room671", "north",
+        "domain/original/area/island/room670", "south",
+        "domain/original/area/island/room662", "west",
+        "domain/original/area/island/room664", "east",
+        "domain/original/area/island/room671", "north",
     });
 }

--- a/domain/original/area/island/room664.c
+++ b/domain/original/area/island/room664.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Balin Road";
     long_desc = "Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room667", "south",
-        "domain/original/area/balin/room663", "west",
-        "domain/original/area/balin/room665", "east",
-        "domain/original/area/balin/room668", "north",
+        "domain/original/area/island/room667", "south",
+        "domain/original/area/island/room663", "west",
+        "domain/original/area/island/room665", "east",
+        "domain/original/area/island/room668", "north",
     });
 }

--- a/domain/original/area/island/room665.c
+++ b/domain/original/area/island/room665.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "East End of Balin Road";
     long_desc = "East End of Balin Road.\n";
     dest_dir = ({
-        "domain/original/area/balin/room664", "west",
-        "domain/original/area/balin/room666", "south",
+        "domain/original/area/island/room664", "west",
+        "domain/original/area/island/room666", "south",
     });
 }

--- a/domain/original/area/island/room666.c
+++ b/domain/original/area/island/room666.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Arched Gates";
     long_desc = "Arched Gates.\n";
     dest_dir = ({
-        "domain/original/area/balin/room665", "north",
+        "domain/original/area/island/room665", "north",
     });
 }

--- a/domain/original/area/island/room667.c
+++ b/domain/original/area/island/room667.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Guild/Shop Space for rent";
     long_desc = "Guild/Shop Space for rent.\n";
     dest_dir = ({
-        "domain/original/area/balin/room664", "north",
+        "domain/original/area/island/room664", "north",
     });
 }

--- a/domain/original/area/island/room668.c
+++ b/domain/original/area/island/room668.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Island Historical Society";
     long_desc = "Island Historical Society.\n";
     dest_dir = ({
-        "domain/original/area/balin/room664", "south",
-        "domain/original/area/balin/room669", "north",
+        "domain/original/area/island/room664", "south",
+        "domain/original/area/island/room669", "north",
     });
 }

--- a/domain/original/area/island/room669.c
+++ b/domain/original/area/island/room669.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Office";
     long_desc = "Office.\n";
     dest_dir = ({
-        "domain/original/area/balin/room668", "south",
+        "domain/original/area/island/room668", "south",
     });
 }

--- a/domain/original/area/island/room670.c
+++ b/domain/original/area/island/room670.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Elven Mercantile";
     long_desc = "Elven Mercantile.\n";
     dest_dir = ({
-        "domain/original/area/balin/room663", "north",
+        "domain/original/area/island/room663", "north",
     });
 }

--- a/domain/original/area/island/room671.c
+++ b/domain/original/area/island/room671.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Temple Shop";
     long_desc = "Temple Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room672", "west",
-        "domain/original/area/balin/room663", "south",
+        "domain/original/area/island/room672", "west",
+        "domain/original/area/island/room663", "south",
     });
 }

--- a/domain/original/area/island/room672.c
+++ b/domain/original/area/island/room672.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Temple Plaza";
     long_desc = "Temple Plaza.\n";
     dest_dir = ({
-        "domain/original/area/balin/room715", "west",
-        "domain/original/area/balin/room671", "east",
-        "domain/original/area/balin/room662", "south",
+        "domain/original/area/island/room715", "west",
+        "domain/original/area/island/room671", "east",
+        "domain/original/area/island/room662", "south",
     });
 }

--- a/domain/original/area/island/room673.c
+++ b/domain/original/area/island/room673.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Seed Shop";
     long_desc = "Seed Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room661", "north",
+        "domain/original/area/island/room661", "north",
     });
 }

--- a/domain/original/area/island/room674.c
+++ b/domain/original/area/island/room674.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "City Pastry Shop";
     long_desc = "City Pastry Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room612", "west",
+        "domain/original/area/island/room612", "west",
     });
 }

--- a/domain/original/area/island/room675.c
+++ b/domain/original/area/island/room675.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Soylent Green";
     long_desc = "Soylent Green.\n";
     dest_dir = ({
-        "domain/original/area/balin/room613", "east",
+        "domain/original/area/island/room613", "east",
     });
 }

--- a/domain/original/area/island/room676.c
+++ b/domain/original/area/island/room676.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Mariner's Revenge";
     long_desc = "Mariner's Revenge.\n";
     dest_dir = ({
-        "domain/original/area/balin/room613", "west",
-        "domain/original/area/balin/room677", "north",
+        "domain/original/area/island/room613", "west",
+        "domain/original/area/island/room677", "north",
     });
 }

--- a/domain/original/area/island/room677.c
+++ b/domain/original/area/island/room677.c
@@ -9,9 +9,9 @@ void reset(int arg) {
     short_desc = "Gate House";
     long_desc = "Gate House.\n";
     dest_dir = ({
-        "domain/original/area/balin/room676", "south",
-        "domain/original/area/balin/room614", "west",
-        "domain/original/area/balin/room693", "east",
-        "domain/original/area/balin/room686", "north",
+        "domain/original/area/island/room676", "south",
+        "domain/original/area/island/room614", "west",
+        "domain/original/area/island/room693", "east",
+        "domain/original/area/island/room686", "north",
     });
 }

--- a/domain/original/area/island/room678.c
+++ b/domain/original/area/island/room678.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Gate House";
     long_desc = "Gate House.\n";
     dest_dir = ({
-        "domain/original/area/balin/room614", "east",
-        "domain/original/area/balin/room679", "west",
+        "domain/original/area/island/room614", "east",
+        "domain/original/area/island/room679", "west",
     });
 }

--- a/domain/original/area/island/room679.c
+++ b/domain/original/area/island/room679.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Foyer";
     long_desc = "Foyer.\n";
     dest_dir = ({
-        "domain/original/area/balin/room684", "south",
-        "domain/original/area/balin/room678", "east",
-        "domain/original/area/balin/room680", "north",
+        "domain/original/area/island/room684", "south",
+        "domain/original/area/island/room678", "east",
+        "domain/original/area/island/room680", "north",
     });
 }

--- a/domain/original/area/island/room680.c
+++ b/domain/original/area/island/room680.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Hallway";
     long_desc = "Hallway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room679", "south",
-        "domain/original/area/balin/room681", "north",
+        "domain/original/area/island/room679", "south",
+        "domain/original/area/island/room681", "north",
     });
 }

--- a/domain/original/area/island/room681.c
+++ b/domain/original/area/island/room681.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Audience Hall";
     long_desc = "Audience Hall.\n";
     dest_dir = ({
-        "domain/original/area/balin/room682", "west",
-        "domain/original/area/balin/room680", "south",
+        "domain/original/area/island/room682", "west",
+        "domain/original/area/island/room680", "south",
     });
 }

--- a/domain/original/area/island/room682.c
+++ b/domain/original/area/island/room682.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Council Chamber";
     long_desc = "Council Chamber.\n";
     dest_dir = ({
-        "domain/original/area/balin/room681", "east",
-        "domain/original/area/balin/room683", "west",
+        "domain/original/area/island/room681", "east",
+        "domain/original/area/island/room683", "west",
     });
 }

--- a/domain/original/area/island/room683.c
+++ b/domain/original/area/island/room683.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Trophy Room";
     long_desc = "Trophy Room.\n";
     dest_dir = ({
-        "domain/original/area/balin/room682", "east",
+        "domain/original/area/island/room682", "east",
     });
 }

--- a/domain/original/area/island/room684.c
+++ b/domain/original/area/island/room684.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Hallway";
     long_desc = "Hallway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room685", "south",
-        "domain/original/area/balin/room679", "north",
+        "domain/original/area/island/room685", "south",
+        "domain/original/area/island/room679", "north",
     });
 }

--- a/domain/original/area/island/room685.c
+++ b/domain/original/area/island/room685.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Lady Roland's Bedroom";
     long_desc = "Lady Roland's Bedroom.\n";
     dest_dir = ({
-        "domain/original/area/balin/room684", "north",
+        "domain/original/area/island/room684", "north",
     });
 }

--- a/domain/original/area/island/room686.c
+++ b/domain/original/area/island/room686.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "RIIS";
     long_desc = "RIIS.\n";
     dest_dir = ({
-        "domain/original/area/balin/room687", "down",
-        "domain/original/area/balin/room677", "south",
+        "domain/original/area/island/room687", "down",
+        "domain/original/area/island/room677", "south",
     });
 }

--- a/domain/original/area/island/room687.c
+++ b/domain/original/area/island/room687.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Crack of Doom";
     long_desc = "Crack of Doom.\n";
     dest_dir = ({
-        "domain/original/area/balin/room686", "up",
+        "domain/original/area/island/room686", "up",
     });
 }

--- a/domain/original/area/island/room688.c
+++ b/domain/original/area/island/room688.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Rhian's Potion Shop";
     long_desc = "Rhian's Potion Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room615", "east",
+        "domain/original/area/island/room615", "east",
     });
 }

--- a/domain/original/area/island/room689.c
+++ b/domain/original/area/island/room689.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Alchemist Shop";
     long_desc = "Alchemist Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room616", "west",
+        "domain/original/area/island/room616", "west",
     });
 }

--- a/domain/original/area/island/room690.c
+++ b/domain/original/area/island/room690.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Entrance to the Hall of Records";
     long_desc = "Entrance to the Hall of Records.\n";
     dest_dir = ({
-        "domain/original/area/balin/room617", "east",
+        "domain/original/area/island/room617", "east",
     });
 }

--- a/domain/original/area/island/room691.c
+++ b/domain/original/area/island/room691.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Power System Generator";
     long_desc = "Power System Generator.\n";
     dest_dir = ({
-        "domain/original/area/balin/room692", "east",
-        "domain/original/area/balin/room618", "west",
+        "domain/original/area/island/room692", "east",
+        "domain/original/area/island/room618", "west",
     });
 }

--- a/domain/original/area/island/room692.c
+++ b/domain/original/area/island/room692.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Power System Internals";
     long_desc = "Power System Internals.\n";
     dest_dir = ({
-        "domain/original/area/balin/room691", "west",
+        "domain/original/area/island/room691", "west",
     });
 }

--- a/domain/original/area/island/room693.c
+++ b/domain/original/area/island/room693.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Entryway";
     long_desc = "Entryway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room677", "west",
-        "domain/original/area/balin/room694", "south",
-        "domain/original/area/balin/room696", "north",
+        "domain/original/area/island/room677", "west",
+        "domain/original/area/island/room694", "south",
+        "domain/original/area/island/room696", "north",
     });
 }

--- a/domain/original/area/island/room694.c
+++ b/domain/original/area/island/room694.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "South Corridor";
     long_desc = "South Corridor.\n";
     dest_dir = ({
-        "domain/original/area/balin/room695", "south",
-        "domain/original/area/balin/room693", "north",
+        "domain/original/area/island/room695", "south",
+        "domain/original/area/island/room693", "north",
     });
 }

--- a/domain/original/area/island/room695.c
+++ b/domain/original/area/island/room695.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Guard Post";
     long_desc = "Guard Post.\n";
     dest_dir = ({
-        "domain/original/area/balin/room694", "north",
+        "domain/original/area/island/room694", "north",
     });
 }

--- a/domain/original/area/island/room696.c
+++ b/domain/original/area/island/room696.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "North Corridor";
     long_desc = "North Corridor.\n";
     dest_dir = ({
-        "domain/original/area/balin/room693", "south",
-        "domain/original/area/balin/room697", "north",
+        "domain/original/area/island/room693", "south",
+        "domain/original/area/island/room697", "north",
     });
 }

--- a/domain/original/area/island/room697.c
+++ b/domain/original/area/island/room697.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Guard Room";
     long_desc = "Guard Room.\n";
     dest_dir = ({
-        "domain/original/area/balin/room698", "east",
-        "domain/original/area/balin/room696", "south",
+        "domain/original/area/island/room698", "east",
+        "domain/original/area/island/room696", "south",
     });
 }

--- a/domain/original/area/island/room698.c
+++ b/domain/original/area/island/room698.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "West Harem";
     long_desc = "West Harem.\n";
     dest_dir = ({
-        "domain/original/area/balin/room699", "east",
-        "domain/original/area/balin/room697", "west",
+        "domain/original/area/island/room699", "east",
+        "domain/original/area/island/room697", "west",
     });
 }

--- a/domain/original/area/island/room699.c
+++ b/domain/original/area/island/room699.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "East Harem";
     long_desc = "East Harem.\n";
     dest_dir = ({
-        "domain/original/area/balin/room700", "east",
-        "domain/original/area/balin/room698", "west",
+        "domain/original/area/island/room700", "east",
+        "domain/original/area/island/room698", "west",
     });
 }

--- a/domain/original/area/island/room700.c
+++ b/domain/original/area/island/room700.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Bedchamber";
     long_desc = "Bedchamber.\n";
     dest_dir = ({
-        "domain/original/area/balin/room701", "east",
-        "domain/original/area/balin/room699", "west",
+        "domain/original/area/island/room701", "east",
+        "domain/original/area/island/room699", "west",
     });
 }

--- a/domain/original/area/island/room701.c
+++ b/domain/original/area/island/room701.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Entryway";
     long_desc = "Entryway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room700", "west",
-        "domain/original/area/balin/room702", "south",
+        "domain/original/area/island/room700", "west",
+        "domain/original/area/island/room702", "south",
     });
 }

--- a/domain/original/area/island/room702.c
+++ b/domain/original/area/island/room702.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room703", "south",
-        "domain/original/area/balin/room708", "east",
-        "domain/original/area/balin/room701", "north",
+        "domain/original/area/island/room703", "south",
+        "domain/original/area/island/room708", "east",
+        "domain/original/area/island/room701", "north",
     });
 }

--- a/domain/original/area/island/room703.c
+++ b/domain/original/area/island/room703.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room704", "south",
-        "domain/original/area/balin/room707", "east",
-        "domain/original/area/balin/room702", "north",
+        "domain/original/area/island/room704", "south",
+        "domain/original/area/island/room707", "east",
+        "domain/original/area/island/room702", "north",
     });
 }

--- a/domain/original/area/island/room704.c
+++ b/domain/original/area/island/room704.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room705", "south",
-        "domain/original/area/balin/room706", "east",
-        "domain/original/area/balin/room703", "north",
+        "domain/original/area/island/room705", "south",
+        "domain/original/area/island/room706", "east",
+        "domain/original/area/island/room703", "north",
     });
 }

--- a/domain/original/area/island/room705.c
+++ b/domain/original/area/island/room705.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "South Entryway";
     long_desc = "South Entryway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room704", "north",
+        "domain/original/area/island/room704", "north",
     });
 }

--- a/domain/original/area/island/room706.c
+++ b/domain/original/area/island/room706.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room704", "west",
-        "domain/original/area/balin/room710", "south",
-        "domain/original/area/balin/room707", "north",
+        "domain/original/area/island/room704", "west",
+        "domain/original/area/island/room710", "south",
+        "domain/original/area/island/room707", "north",
     });
 }

--- a/domain/original/area/island/room707.c
+++ b/domain/original/area/island/room707.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room703", "west",
-        "domain/original/area/balin/room706", "south",
-        "domain/original/area/balin/room708", "north",
+        "domain/original/area/island/room703", "west",
+        "domain/original/area/island/room706", "south",
+        "domain/original/area/island/room708", "north",
     });
 }

--- a/domain/original/area/island/room708.c
+++ b/domain/original/area/island/room708.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room702", "west",
-        "domain/original/area/balin/room707", "south",
-        "domain/original/area/balin/room709", "north",
+        "domain/original/area/island/room702", "west",
+        "domain/original/area/island/room707", "south",
+        "domain/original/area/island/room709", "north",
     });
 }

--- a/domain/original/area/island/room709.c
+++ b/domain/original/area/island/room709.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room708", "south",
+        "domain/original/area/island/room708", "south",
     });
 }

--- a/domain/original/area/island/room710.c
+++ b/domain/original/area/island/room710.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Turkish Bath";
     long_desc = "Turkish Bath.\n";
     dest_dir = ({
-        "domain/original/area/balin/room706", "north",
+        "domain/original/area/island/room706", "north",
     });
 }

--- a/domain/original/area/island/room712.c
+++ b/domain/original/area/island/room712.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Hermit's Chamber";
     long_desc = "Hermit's Chamber.\n";
     dest_dir = ({
-        "domain/original/area/balin/room655", "east",
+        "domain/original/area/island/room655", "east",
     });
 }

--- a/domain/original/area/island/room713.c
+++ b/domain/original/area/island/room713.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Temple";
     long_desc = "Temple.\n";
     dest_dir = ({
-        "domain/original/area/balin/room611", "west",
-        "domain/original/area/balin/room714", "east",
-        "domain/original/area/balin/room716", "north",
+        "domain/original/area/island/room611", "west",
+        "domain/original/area/island/room714", "east",
+        "domain/original/area/island/room716", "north",
     });
 }

--- a/domain/original/area/island/room714.c
+++ b/domain/original/area/island/room714.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Central Chamber";
     long_desc = "Central Chamber.\n";
     dest_dir = ({
-        "domain/original/area/balin/room715", "east",
-        "domain/original/area/balin/room713", "west",
+        "domain/original/area/island/room715", "east",
+        "domain/original/area/island/room713", "west",
     });
 }

--- a/domain/original/area/island/room715.c
+++ b/domain/original/area/island/room715.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Eastern Chamber";
     long_desc = "Eastern Chamber.\n";
     dest_dir = ({
-        "domain/original/area/balin/room672", "east",
-        "domain/original/area/balin/room714", "west",
+        "domain/original/area/island/room672", "east",
+        "domain/original/area/island/room714", "west",
     });
 }

--- a/domain/original/area/island/room716.c
+++ b/domain/original/area/island/room716.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
     long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
     dest_dir = ({
-        "domain/original/area/balin/room713", "south",
+        "domain/original/area/island/room713", "south",
     });
 }

--- a/domain/original/area/island/room717.c
+++ b/domain/original/area/island/room717.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Poison Shop";
     long_desc = "Poison Shop.\n";
     dest_dir = ({
-        "domain/original/area/balin/room635", "north",
+        "domain/original/area/island/room635", "north",
     });
 }

--- a/domain/original/area/island/room718.c
+++ b/domain/original/area/island/room718.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Taxidermist";
     long_desc = "Taxidermist.\n";
     dest_dir = ({
-        "domain/original/area/balin/room635", "southwest",
+        "domain/original/area/island/room635", "southwest",
     });
 }

--- a/domain/original/area/island/room719.c
+++ b/domain/original/area/island/room719.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Weaver's";
     long_desc = "Weaver's.\n";
     dest_dir = ({
-        "domain/original/area/balin/room635", "southeast",
+        "domain/original/area/island/room635", "southeast",
     });
 }

--- a/domain/original/area/island/room720.c
+++ b/domain/original/area/island/room720.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Foyer of House of Ill Repute";
     long_desc = "Foyer of House of Ill Repute.\n";
     dest_dir = ({
-        "domain/original/area/balin/room637", "southwest",
+        "domain/original/area/island/room637", "southwest",
     });
 }

--- a/domain/original/area/island/room721.c
+++ b/domain/original/area/island/room721.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Balin Road Pub";
     long_desc = "Balin Road Pub.\n";
     dest_dir = ({
-        "domain/original/area/balin/room636", "northwest",
+        "domain/original/area/island/room636", "northwest",
     });
 }

--- a/domain/original/area/island/room722.c
+++ b/domain/original/area/island/room722.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Wheelwright";
     long_desc = "Wheelwright.\n";
     dest_dir = ({
-        "domain/original/area/balin/room636", "northeast",
+        "domain/original/area/island/room636", "northeast",
     });
 }

--- a/domain/original/area/island/room723.c
+++ b/domain/original/area/island/room723.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Crowded Thoroughfare";
     long_desc = "Crowded Thoroughfare.\n";
     dest_dir = ({
-        "domain/original/area/balin/room724", "south",
-        "domain/original/area/balin/room637", "north",
+        "domain/original/area/island/room724", "south",
+        "domain/original/area/island/room637", "north",
     });
 }

--- a/domain/original/area/island/room724.c
+++ b/domain/original/area/island/room724.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Archway of Servitude";
     long_desc = "Archway of Servitude.\n";
     dest_dir = ({
-        "domain/original/area/balin/room725", "south",
-        "domain/original/area/balin/room723", "north",
+        "domain/original/area/island/room725", "south",
+        "domain/original/area/island/room723", "north",
     });
 }

--- a/domain/original/area/island/room725.c
+++ b/domain/original/area/island/room725.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Bazaar Crossroad";
     long_desc = "Bazaar Crossroad.\n";
     dest_dir = ({
-        "domain/original/area/balin/room726", "west",
-        "domain/original/area/balin/room729", "east",
-        "domain/original/area/balin/room724", "north",
+        "domain/original/area/island/room726", "west",
+        "domain/original/area/island/room729", "east",
+        "domain/original/area/island/room724", "north",
     });
 }

--- a/domain/original/area/island/room726.c
+++ b/domain/original/area/island/room726.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Western District";
     long_desc = "Western District.\n";
     dest_dir = ({
-        "domain/original/area/balin/room725", "east",
-        "domain/original/area/balin/room727", "south",
+        "domain/original/area/island/room725", "east",
+        "domain/original/area/island/room727", "south",
     });
 }

--- a/domain/original/area/island/room727.c
+++ b/domain/original/area/island/room727.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Western District";
     long_desc = "Western District.\n";
     dest_dir = ({
-        "domain/original/area/balin/room728", "south",
-        "domain/original/area/balin/room726", "north",
+        "domain/original/area/island/room728", "south",
+        "domain/original/area/island/room726", "north",
     });
 }

--- a/domain/original/area/island/room728.c
+++ b/domain/original/area/island/room728.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Western slave bazaar";
     long_desc = "Western slave bazaar.\n";
     dest_dir = ({
-        "domain/original/area/balin/room732", "east",
-        "domain/original/area/balin/room727", "north",
+        "domain/original/area/island/room732", "east",
+        "domain/original/area/island/room727", "north",
     });
 }

--- a/domain/original/area/island/room729.c
+++ b/domain/original/area/island/room729.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Eastern District";
     long_desc = "Eastern District.\n";
     dest_dir = ({
-        "domain/original/area/balin/room725", "west",
-        "domain/original/area/balin/room730", "south",
+        "domain/original/area/island/room725", "west",
+        "domain/original/area/island/room730", "south",
     });
 }

--- a/domain/original/area/island/room730.c
+++ b/domain/original/area/island/room730.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Eastern District";
     long_desc = "Eastern District.\n";
     dest_dir = ({
-        "domain/original/area/balin/room731", "south",
-        "domain/original/area/balin/room729", "north",
+        "domain/original/area/island/room731", "south",
+        "domain/original/area/island/room729", "north",
     });
 }

--- a/domain/original/area/island/room731.c
+++ b/domain/original/area/island/room731.c
@@ -9,7 +9,7 @@ void reset(int arg) {
     short_desc = "Eastern slave bazaar";
     long_desc = "Eastern slave bazaar.\n";
     dest_dir = ({
-        "domain/original/area/balin/room732", "west",
-        "domain/original/area/balin/room730", "north",
+        "domain/original/area/island/room732", "west",
+        "domain/original/area/island/room730", "north",
     });
 }

--- a/domain/original/area/island/room732.c
+++ b/domain/original/area/island/room732.c
@@ -9,8 +9,8 @@ void reset(int arg) {
     short_desc = "Central slave bazaar";
     long_desc = "Central slave bazaar.\n";
     dest_dir = ({
-        "domain/original/area/balin/room728", "west",
-        "domain/original/area/balin/room731", "east",
-        "domain/original/area/balin/room733", "south",
+        "domain/original/area/island/room728", "west",
+        "domain/original/area/island/room731", "east",
+        "domain/original/area/island/room733", "south",
     });
 }

--- a/domain/original/area/island/room733.c
+++ b/domain/original/area/island/room733.c
@@ -9,6 +9,6 @@ void reset(int arg) {
     short_desc = "Administrative hallway";
     long_desc = "Administrative hallway.\n";
     dest_dir = ({
-        "domain/original/area/balin/room732", "north",
+        "domain/original/area/island/room732", "north",
     });
 }


### PR DESCRIPTION
### Motivation
- The `balin` area directory was renamed to `island`, so room exit paths needed to point to the new location.
- Room files under `domain/original/area/island` still referenced `domain/original/area/balin`, causing broken links between rooms.

### Description
- Replaced occurrences of `domain/original/area/balin` with `domain/original/area/island` across the room files in `domain/original/area/island`.
- Updated `dest_dir` string paths in 127 files under `domain/original/area/island` (about 265 lines changed: insertions/deletions).
- Changes were applied with a scripted replacement and committed with the message `Update island room links`.

### Testing
- No automated tests were run on the modified code.
- The changes were staged and committed successfully with `git`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da521f9108327a8954915becc1d45)