### PR TITLE
Add Barb Caves room files and connect Vesla portal to room 515

### DIFF
--- a/domain/original/area/barb-caves/room1292.c
+++ b/domain/original/area/barb-caves/room1292.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cave Waterfall";
+    long_desc = "Cave Waterfall.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room518", "northeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1293.c
+++ b/domain/original/area/barb-caves/room1293.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Throne Room";
+    long_desc = "Throne Room.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room525", "east",
+    });
+}

--- a/domain/original/area/barb-caves/room1294.c
+++ b/domain/original/area/barb-caves/room1294.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mess Hall";
+    long_desc = "Mess Hall.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room523", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room1295.c
+++ b/domain/original/area/barb-caves/room1295.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "New Tunnel";
+    long_desc = "New Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1296", "east",
+        "domain/original/area/barb-caves/room523", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1296.c
+++ b/domain/original/area/barb-caves/room1296.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "New Tunnel";
+    long_desc = "New Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1295", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1297.c
+++ b/domain/original/area/barb-caves/room1297.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "New Tunnel";
+    long_desc = "New Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1299", "south",
+        "domain/original/area/barb-caves/room1298", "west",
+        "domain/original/area/barb-caves/room1301", "east",
+        "domain/original/area/barb-caves/room1300", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1298.c
+++ b/domain/original/area/barb-caves/room1298.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You pass through the door and it closes and locks behind you.";
+    long_desc = "You pass through the door and it closes and locks behind you.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1297", "east",
+    });
+}

--- a/domain/original/area/barb-caves/room1299.c
+++ b/domain/original/area/barb-caves/room1299.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Nursery";
+    long_desc = "Nursery.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1297", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1300.c
+++ b/domain/original/area/barb-caves/room1300.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Barracks";
+    long_desc = "Barracks.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1297", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room1301.c
+++ b/domain/original/area/barb-caves/room1301.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "New Tunnel: Checkpoint";
+    long_desc = "New Tunnel: Checkpoint.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1302", "east",
+        "domain/original/area/barb-caves/room1297", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1302.c
+++ b/domain/original/area/barb-caves/room1302.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Top of the mine shaft";
+    long_desc = "Top of the mine shaft.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1303", "down",
+        "domain/original/area/barb-caves/room1301", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1303.c
+++ b/domain/original/area/barb-caves/room1303.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You let up on the ropes, and the counterweight slowly glides you down the";
+    long_desc = "You let up on the ropes, and the counterweight slowly glides you down the.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1304", "down",
+        "domain/original/area/barb-caves/room1302", "up",
+    });
+}

--- a/domain/original/area/barb-caves/room1304.c
+++ b/domain/original/area/barb-caves/room1304.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You let up on the ropes, and the counterweight slowly glides you down the";
+    long_desc = "You let up on the ropes, and the counterweight slowly glides you down the.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1305", "southwest",
+        "domain/original/area/barb-caves/room1303", "up",
+        "domain/original/area/barb-caves/room1320", "east",
+        "domain/original/area/barb-caves/room1311", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1305.c
+++ b/domain/original/area/barb-caves/room1305.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1306", "southwest",
+        "domain/original/area/barb-caves/room1304", "northeast",
+        "domain/original/area/barb-caves/room1309", "southeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1306.c
+++ b/domain/original/area/barb-caves/room1306.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1305", "northeast",
+        "domain/original/area/barb-caves/room1308", "northwest",
+        "domain/original/area/barb-caves/room1307", "southeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1307.c
+++ b/domain/original/area/barb-caves/room1307.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1306", "northwest",
+    });
+}

--- a/domain/original/area/barb-caves/room1308.c
+++ b/domain/original/area/barb-caves/room1308.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1306", "southeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1309.c
+++ b/domain/original/area/barb-caves/room1309.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1305", "northwest",
+        "domain/original/area/barb-caves/room1310", "northeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1310.c
+++ b/domain/original/area/barb-caves/room1310.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1309", "southwest",
+    });
+}

--- a/domain/original/area/barb-caves/room1311.c
+++ b/domain/original/area/barb-caves/room1311.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1304", "south",
+        "domain/original/area/barb-caves/room1312", "northeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1312.c
+++ b/domain/original/area/barb-caves/room1312.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1311", "southwest",
+        "domain/original/area/barb-caves/room1313", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1313.c
+++ b/domain/original/area/barb-caves/room1313.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1314", "east",
+        "domain/original/area/barb-caves/room1316", "northwest",
+        "domain/original/area/barb-caves/room1312", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room1314.c
+++ b/domain/original/area/barb-caves/room1314.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1315", "southeast",
+        "domain/original/area/barb-caves/room1313", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1315.c
+++ b/domain/original/area/barb-caves/room1315.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Your left arm is now in full health.";
+    long_desc = "Your left arm is now in full health.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1314", "northwest",
+    });
+}

--- a/domain/original/area/barb-caves/room1316.c
+++ b/domain/original/area/barb-caves/room1316.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1319", "northeast",
+        "domain/original/area/barb-caves/room1313", "southeast",
+        "domain/original/area/barb-caves/room1317", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1317.c
+++ b/domain/original/area/barb-caves/room1317.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1318", "northwest",
+        "domain/original/area/barb-caves/room1316", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room1318.c
+++ b/domain/original/area/barb-caves/room1318.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1317", "southeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1319.c
+++ b/domain/original/area/barb-caves/room1319.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1316", "southwest",
+    });
+}

--- a/domain/original/area/barb-caves/room1320.c
+++ b/domain/original/area/barb-caves/room1320.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1304", "west",
+        "domain/original/area/barb-caves/room1321", "northeast",
+    });
+}

--- a/domain/original/area/barb-caves/room1321.c
+++ b/domain/original/area/barb-caves/room1321.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1320", "southwest",
+        "domain/original/area/barb-caves/room1325", "west",
+        "domain/original/area/barb-caves/room1322", "southeast",
+        "domain/original/area/barb-caves/room1324", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room1322.c
+++ b/domain/original/area/barb-caves/room1322.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1321", "northwest",
+        "domain/original/area/barb-caves/room1323", "east",
+    });
+}

--- a/domain/original/area/barb-caves/room1323.c
+++ b/domain/original/area/barb-caves/room1323.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1322", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room1324.c
+++ b/domain/original/area/barb-caves/room1324.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1321", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room1325.c
+++ b/domain/original/area/barb-caves/room1325.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Twisting Tunnel";
+    long_desc = "Twisting Tunnel.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1321", "east",
+    });
+}

--- a/domain/original/area/barb-caves/room509.c
+++ b/domain/original/area/barb-caves/room509.c
@@ -1,0 +1,12 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Barbarian Caves";
+    long_desc = "Barbarian Caves.\n";
+    dest_dir = ({ });
+}

--- a/domain/original/area/barb-caves/room510.c
+++ b/domain/original/area/barb-caves/room510.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Barbarian Clearing";
+    long_desc = "Barbarian Clearing.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room511", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room511.c
+++ b/domain/original/area/barb-caves/room511.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Underground Pond";
+    long_desc = "Underground Pond.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room512", "southwest",
+        "domain/original/area/barb-caves/room518", "west",
+        "domain/original/area/barb-caves/room510", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room512.c
+++ b/domain/original/area/barb-caves/room512.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cave Passage";
+    long_desc = "Cave Passage.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room513", "south",
+        "domain/original/area/barb-caves/room511", "northeast",
+    });
+}

--- a/domain/original/area/barb-caves/room513.c
+++ b/domain/original/area/barb-caves/room513.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cave Passage";
+    long_desc = "Cave Passage.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room515", "south",
+        "domain/original/area/barb-caves/room512", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room514.c
+++ b/domain/original/area/barb-caves/room514.c
@@ -1,0 +1,12 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "You begin to climb into the pit, and the descent seems simple enough.";
+    long_desc = "You begin to climb into the pit, and the descent seems simple enough.\n";
+    dest_dir = ({ });
+}

--- a/domain/original/area/barb-caves/room515.c
+++ b/domain/original/area/barb-caves/room515.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Bottom of a Deep Dark Pit";
+    long_desc = "Bottom of a Deep Dark Pit.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room516", "east",
+        "domain/original/area/barb-caves/room513", "north",
+        "domain/original/area/vesla/portal", "vesla",
+    });
+}

--- a/domain/original/area/barb-caves/room516.c
+++ b/domain/original/area/barb-caves/room516.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Dark Barricade";
+    long_desc = "Dark Barricade.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room517", "east",
+        "domain/original/area/barb-caves/room515", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room517.c
+++ b/domain/original/area/barb-caves/room517.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Corridor";
+    long_desc = "Corridor.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room519", "east",
+        "domain/original/area/barb-caves/room516", "west",
+    });
+}

--- a/domain/original/area/barb-caves/room518.c
+++ b/domain/original/area/barb-caves/room518.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Cave Passage";
+    long_desc = "Cave Passage.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1292", "southwest",
+        "domain/original/area/barb-caves/room511", "east",
+    });
+}

--- a/domain/original/area/barb-caves/room519.c
+++ b/domain/original/area/barb-caves/room519.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Passage Way";
+    long_desc = "Passage Way.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room520", "south",
+        "domain/original/area/barb-caves/room517", "west",
+        "domain/original/area/barb-caves/room523", "east",
+        "domain/original/area/barb-caves/room521", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room520.c
+++ b/domain/original/area/barb-caves/room520.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Barracks";
+    long_desc = "Barracks.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room519", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room521.c
+++ b/domain/original/area/barb-caves/room521.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Mess Hall";
+    long_desc = "Mess Hall.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room519", "south",
+        "domain/original/area/barb-caves/room522", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room522.c
+++ b/domain/original/area/barb-caves/room522.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Kitchen";
+    long_desc = "Kitchen.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room521", "south",
+    });
+}

--- a/domain/original/area/barb-caves/room523.c
+++ b/domain/original/area/barb-caves/room523.c
@@ -1,0 +1,17 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Passage Way";
+    long_desc = "Passage Way.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room524", "south",
+        "domain/original/area/barb-caves/room519", "west",
+        "domain/original/area/barb-caves/room1295", "east",
+        "domain/original/area/barb-caves/room1294", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room524.c
+++ b/domain/original/area/barb-caves/room524.c
@@ -1,0 +1,15 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Passage Way";
+    long_desc = "Passage Way.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room525", "south",
+        "domain/original/area/barb-caves/room523", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room525.c
+++ b/domain/original/area/barb-caves/room525.c
@@ -1,0 +1,16 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Passage Way";
+    long_desc = "Passage Way.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room1293", "west",
+        "domain/original/area/barb-caves/room526", "south",
+        "domain/original/area/barb-caves/room524", "north",
+    });
+}

--- a/domain/original/area/barb-caves/room526.c
+++ b/domain/original/area/barb-caves/room526.c
@@ -1,0 +1,14 @@
+inherit "room/room";
+
+void reset(int arg) {
+    if (arg)
+        return;
+
+    set_light(1);
+
+    short_desc = "Circular room";
+    long_desc = "Circular room.\n";
+    dest_dir = ({
+        "domain/original/area/barb-caves/room525", "north",
+    });
+}

--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -15,5 +15,6 @@ void reset(int arg) {
         "domain/original/area/forest/room529", "forest",
         "domain/original/area/pylus/room1205", "pylus",
         "domain/original/area/village-green/room1687", "green",
+        "domain/original/area/barb-caves/room515", "caves",
     });
 }


### PR DESCRIPTION
### Motivation
- Add the Barb Caves area to the codebase from the authoritative map data so the zone is playable and navigable.
- Connect the new Barb Caves area into the world map via the existing Vesla portal so players can travel between areas.
- Keep new rooms consistent with existing room implementations by using the `room/room` template.

### Description
- Generated room files under `domain/original/area/barb-caves/` for each entry in `maps/barb-caves.json`, creating individual `room<ID>.c` files with `short_desc`, `long_desc`, and `dest_dir` exits.
- Each new room file inherits `room/room` and sets `set_light(1)` along with the mapped exits from the JSON data.
- Updated `domain/original/area/vesla/portal.c` to add the exit `"domain/original/area/barb-caves/room515", "caves"` so the portal leads into the caves.
- Updated `domain/original/area/barb-caves/room515.c` to add the reciprocal exit `"domain/original/area/vesla/portal", "vesla"`, and committed the changes (53 files changed, ~772 insertions).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da7172d388327a91dcfa1d1e1e89b)