### PR TITLE
Ruin Vesla thoroughfares with dragon devastation

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Gate to the Wilderness";
-    long_desc = "The Gate to the Wilderness.\n";
+    short_desc = "Ruined Gate to the Wilderness";
+    long_desc = "The once-tall gatehouse is split and blackened, its stones scattered across the approach. Ash and rubble mark the way into the dead city.\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "west",
 	"domain/original/area/roadway/room14", "exit",

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Park Street and Caravan Road";
-    long_desc = "Intersection of Park Street and Caravan Road.\n";
+    short_desc = "Cindered Crossing of Park Street and Caravan Road";
+    long_desc = "Burned trees and shattered paving meet here where Park Street once touched Caravan Road. The air is stale with old smoke and drifting ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room233", "south",
         "domain/original/area/vesla/room117", "west",

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Park Street and Via Sacra";
-    long_desc = "Intersection of Park Street and Via Sacra.\n";
+    short_desc = "Cindered Crossing of Park Street and Via Sacra";
+    long_desc = "Charred trunks and broken stones frame the junction of Park Street and the Via Sacra. Only ash and rubble remain where the dragons swept through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "south",
         "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room227", "north",
         "domain/original/area/vesla/room221", "south",

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "south",
         "domain/original/area/vesla/room120", "west",

--- a/domain/original/area/vesla/room120.c
+++ b/domain/original/area/vesla/room120.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "west",
         "domain/original/area/vesla/room119", "east",

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "south",
         "domain/original/area/vesla/room122", "west",
         "domain/original/area/vesla/room120", "east",
         "domain/original/area/vesla/room425", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room122.c
+++ b/domain/original/area/vesla/room122.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "south",
         "domain/original/area/vesla/room123", "west",

--- a/domain/original/area/vesla/room123.c
+++ b/domain/original/area/vesla/room123.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk.\n";
+    short_desc = "Cindered Park Walk";
+    long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room124", "west",
         "domain/original/area/vesla/room122", "east",

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A break in the coverage";
-    long_desc = "A break in the coverage.\n";
+    short_desc = "Ruptured Park Walk";
+    long_desc = "The ruined canopy opens to a gap of fallen trees and collapsed paving. Ash swirls where the dragons' fire tore the park apart.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "west",
         "domain/original/area/vesla/room123", "east",

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A busy intersection";
-    long_desc = "A busy intersection.\n";
+    short_desc = "Cindered Park Junction";
+    long_desc = "Broken flagstones and scorched roots mark a junction that once bustled with traffic. Only rubble and silence connect the dead streets.\n";
     dest_dir = ({
         "domain/original/area/vesla/room159", "south",
         "domain/original/area/vesla/room126", "west",

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The end of the park street";
-    long_desc = "The end of the park street.\n";
+    short_desc = "Cindered End of Park Street";
+    long_desc = "Park Street ends in a jumble of shattered stones and charred stumps. The dragons' passage left the road broken and dead.\n";
     dest_dir = ({
         "domain/original/area/vesla/room880", "south",
         "domain/original/area/vesla/room127", "west",
         "domain/original/area/vesla/room125", "east",
         "domain/original/area/vesla/room879", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room127.c
+++ b/domain/original/area/vesla/room127.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Entrance to the Old City.";
-    long_desc = "Entrance to the Old City.\n";
+    short_desc = "Ruined Entrance to the Old City";
+    long_desc = "A battered arch and toppled stones mark the entrance into Vesla's ruins. The road ahead is cracked and choked with debris.\n";
     dest_dir = ({
         "domain/original/area/vesla/room128", "west",
         "domain/original/area/vesla/room126", "east",

--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Westroad, The Entrance to the Old City.";
-    long_desc = "Westroad, The Entrance to the Old City.\n";
+    short_desc = "Broken Westroad, Entrance to the Old City";
+    long_desc = "Westroad begins here amid collapsed paving and scattered masonry. The way into the old city lies ruined and abandoned.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "west",
         "domain/original/area/vesla/room127", "east",

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad.\n";
+    short_desc = "Broken Westroad";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "west",
         "domain/original/area/vesla/room128", "east",

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad.\n";
+    short_desc = "Broken Westroad";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
     dest_dir = ({
         "domain/original/area/vesla/room131", "west",
         "domain/original/area/vesla/room129", "east",
         "domain/original/area/vesla/room420", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad.\n";
+    short_desc = "Broken Westroad";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "west",
         "domain/original/area/vesla/room130", "east",

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad.\n";
+    short_desc = "Broken Westroad";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "west",
         "domain/original/area/vesla/room131", "east",
         "domain/original/area/vesla/room421", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room133.c
+++ b/domain/original/area/vesla/room133.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The corner of Westroad and Basalt Avenue";
-    long_desc = "The corner of Westroad and Basalt Avenue.\n";
+    short_desc = "Broken Corner of Westroad and Basalt Avenue";
+    long_desc = "Two ruined streets meet among rubble and scorched debris. The corner is choked with broken stone and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room134", "west",
         "domain/original/area/vesla/room132", "east",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Western Gate of Vesla";
-    long_desc = "Western Gate of Vesla.\n";
+    short_desc = "Ruined Western Gate of Vesla";
+    long_desc = "The western gate lies smashed, its stones scattered across the approach. Whatever once guarded Vesla now stands as a blackened ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "east",
         "domain/original/area/roadway/room29", "exit",

--- a/domain/original/area/vesla/room135.c
+++ b/domain/original/area/vesla/room135.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room136", "south",
         "domain/original/area/vesla/room133", "north",

--- a/domain/original/area/vesla/room136.c
+++ b/domain/original/area/vesla/room136.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room137", "south",
         "domain/original/area/vesla/room135", "north",

--- a/domain/original/area/vesla/room137.c
+++ b/domain/original/area/vesla/room137.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Basalt Avenue and Rapier Way";
-    long_desc = "Intersection of Basalt Avenue and Rapier Way.\n";
+    short_desc = "Scorched Crossing of Basalt Avenue and Rapier Way";
+    long_desc = "Melted basalt and splintered cobbles meet where the avenues cross. The junction is a smear of slag and rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "south",
         "domain/original/area/vesla/room193", "east",

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "south",
         "domain/original/area/vesla/room856", "west",
         "domain/original/area/vesla/room855", "east",
         "domain/original/area/vesla/room137", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room140", "south",
         "domain/original/area/vesla/room853", "west",
         "domain/original/area/vesla/room854", "east",
         "domain/original/area/vesla/room138", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room140.c
+++ b/domain/original/area/vesla/room140.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Basalt Avenue and Street of the Bells";
-    long_desc = "Intersection of Basalt Avenue and Street of the Bells.\n";
+    short_desc = "Scorched Crossing of Basalt Avenue and Street of the Bells";
+    long_desc = "Shattered paving and vitrified basalt mark this ruined crossing. The bells are long silent, and ash coats the stones.\n";
     dest_dir = ({
         "domain/original/area/vesla/room141", "south",
         "domain/original/area/vesla/room204", "east",

--- a/domain/original/area/vesla/room141.c
+++ b/domain/original/area/vesla/room141.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "south",
         "domain/original/area/vesla/room140", "north",

--- a/domain/original/area/vesla/room142.c
+++ b/domain/original/area/vesla/room142.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue.\n";
+    short_desc = "Scorched Basalt Avenue";
+    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "south",
         "domain/original/area/vesla/room850", "east",

--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Corner of Basalt Avenue and West River Street";
-    long_desc = "Corner of Basalt Avenue and West River Street.\n";
+    short_desc = "Scorched Corner of Basalt Avenue and West River Street";
+    long_desc = "The corner is buried under fused basalt and broken river stones. Dragonfire has left the ground warped and cracked.\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",
         "domain/original/area/vesla/room142", "north",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River Street";
-    long_desc = "West River Street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River Street";
-    long_desc = "West River Street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River Street";
-    long_desc = "West River Street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River Street";
-    long_desc = "West River Street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River Street";
-    long_desc = "West River Street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River street";
-    long_desc = "West River street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "West River street";
-    long_desc = "West River street.\n";
+    short_desc = "Silt-Choked West River Street";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "River Street and South Main";
-    long_desc = "River Street and South Main.\n";
+    short_desc = "Rubble-Choked River Street and Broken South Main";
+    long_desc = "Two ruined streets meet in a heap of collapsed stone and shattered timbers. The crossing is quiet, the scars of dragonfire still visible.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",
         "domain/original/area/vesla/room205", "east",
         "domain/original/area/vesla/room152", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main street";
-    long_desc = "South Main street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
         "domain/original/area/vesla/room819", "west",
         "domain/original/area/vesla/room817", "east",
         "domain/original/area/vesla/room153", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main Street";
-    long_desc = "South Main Street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",
         "domain/original/area/vesla/room152", "south",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main Street";
-    long_desc = "South Main Street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
         "domain/original/area/vesla/room821", "east",
         "domain/original/area/vesla/room155", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main Street";
-    long_desc = "South Main Street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
         "domain/original/area/vesla/room423", "west",
         "domain/original/area/vesla/room422", "east",
         "domain/original/area/vesla/room156", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main Street";
-    long_desc = "South Main Street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
         "domain/original/area/vesla/room822", "west",
         "domain/original/area/vesla/room424", "east",
         "domain/original/area/vesla/room157", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main Street";
-    long_desc = "South Main Street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
         "domain/original/area/vesla/room823", "west",
         "domain/original/area/vesla/room830", "east",
         "domain/original/area/vesla/room158", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main street";
-    long_desc = "South Main street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",
         "domain/original/area/vesla/room157", "south",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South Main street";
-    long_desc = "South Main street.\n";
+    short_desc = "Broken South Main Street";
+    long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",
         "domain/original/area/vesla/room125", "north",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main";
-    long_desc = "Northern Main.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",
         "domain/original/area/vesla/room163", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",
         "domain/original/area/vesla/room164", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",
         "domain/original/area/vesla/room165", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of North Main and Scholar's Way";
-    long_desc = "Intersection of North Main and Scholar's Way.\n";
+    short_desc = "Shattered Crossing of North Main and Scholar's Way";
+    long_desc = "Cracked paving and toppled stones mark where North Main once met Scholar's Way. The junction is choked with rubble and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street.\n";
+    short_desc = "Shattered North Main Street";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of North Main and Wall Street";
-    long_desc = "Intersection of North Main and Wall Street.\n";
+    short_desc = "Shattered Crossing of North Main and Wall Street";
+    long_desc = "The crossing is a churn of broken stone where the wall once stood strong. It is quiet now, a ruin of intersecting streets.\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
         "domain/original/area/vesla/room793", "west",
         "domain/original/area/vesla/room170", "east",
         "domain/original/area/vesla/room169", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room169.c
+++ b/domain/original/area/vesla/room169.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern Gate";
-    long_desc = "Northern Gate.\n";
+    short_desc = "Ruined Northern Gate";
+    long_desc = "The northern gate has been smashed and scorched, its arch collapsed into the road. Dragonfire left only ruins and silence here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room168", "south",
         "domain/original/area/vesla/room753", "northeast",

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Western End of Wall Street";
-    long_desc = "Western End of Wall Street.\n";
+    short_desc = "Breached Western End of Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room171", "east",
         "domain/original/area/vesla/room168", "west",

--- a/domain/original/area/vesla/room171.c
+++ b/domain/original/area/vesla/room171.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "Wall Street.\n";
+    short_desc = "Breached Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room170", "west",
     });

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "south",
         "domain/original/area/vesla/room226", "west",
         "domain/original/area/vesla/room735", "east",
         "domain/original/area/vesla/room173", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "south",
         "domain/original/area/vesla/room232", "west",
         "domain/original/area/vesla/room736", "east",
         "domain/original/area/vesla/room174", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room174.c
+++ b/domain/original/area/vesla/room174.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "south",
         "domain/original/area/vesla/room175", "north",

--- a/domain/original/area/vesla/room175.c
+++ b/domain/original/area/vesla/room175.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room174", "south",
         "domain/original/area/vesla/room176", "north",

--- a/domain/original/area/vesla/room176.c
+++ b/domain/original/area/vesla/room176.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room175", "south",
         "domain/original/area/vesla/room177", "north",

--- a/domain/original/area/vesla/room177.c
+++ b/domain/original/area/vesla/room177.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room176", "south",
         "domain/original/area/vesla/room178", "north",

--- a/domain/original/area/vesla/room178.c
+++ b/domain/original/area/vesla/room178.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Scholar's Way and Caravan Road";
-    long_desc = "Intersection of Scholar's Way and Caravan Road.\n";
+    short_desc = "Rutted Crossing of Scholar's Way and Caravan Road";
+    long_desc = "Broken paving and gouged stone meet where the caravan route crosses Scholar's Way. The junction is littered with debris and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "west",
         "domain/original/area/vesla/room177", "south",

--- a/domain/original/area/vesla/room179.c
+++ b/domain/original/area/vesla/room179.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road.\n";
+    short_desc = "Rutted Caravan Road";
+    long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "south",
         "domain/original/area/vesla/room180", "north",

--- a/domain/original/area/vesla/room180.c
+++ b/domain/original/area/vesla/room180.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Caravan Road and Wall Street";
-    long_desc = "Intersection of Caravan Road and Wall Street.\n";
+    short_desc = "Rutted Crossing of Caravan Road and Breached Wall Street";
+    long_desc = "Rutted Caravan Road meets the shattered wall here, the stones broken into a mound of debris. Ash and rubble choke the crossing.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "west",
         "domain/original/area/vesla/room179", "south",

--- a/domain/original/area/vesla/room181.c
+++ b/domain/original/area/vesla/room181.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Eastern End of Wall Street";
-    long_desc = "Eastern End of Wall Street.\n";
+    short_desc = "Breached Eastern End of Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room180", "east",
         "domain/original/area/vesla/room182", "west",

--- a/domain/original/area/vesla/room182.c
+++ b/domain/original/area/vesla/room182.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "Wall Street.\n";
+    short_desc = "Breached Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "east",
         "domain/original/area/vesla/room183", "west",

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "Wall Street.\n";
+    short_desc = "Breached Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room182", "east",
         "domain/original/area/vesla/room184", "west",

--- a/domain/original/area/vesla/room184.c
+++ b/domain/original/area/vesla/room184.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "Wall Street.\n";
+    short_desc = "Breached Wall Street";
+    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room183", "east",
     });

--- a/domain/original/area/vesla/room185.c
+++ b/domain/original/area/vesla/room185.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "east",
         "domain/original/area/vesla/room186", "west",

--- a/domain/original/area/vesla/room186.c
+++ b/domain/original/area/vesla/room186.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "east",
         "domain/original/area/vesla/room187", "west",

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "west",
         "domain/original/area/vesla/room186", "east",
         "domain/original/area/vesla/room737", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "west",
         "domain/original/area/vesla/room187", "east",

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "west",
         "domain/original/area/vesla/room188", "east",
         "domain/original/area/vesla/room739", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room740", "south",
         "domain/original/area/vesla/room191", "west",
         "domain/original/area/vesla/room189", "east",
         "domain/original/area/vesla/room741", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room742", "south",
         "domain/original/area/vesla/room192", "west",
         "domain/original/area/vesla/room190", "east",
         "domain/original/area/vesla/room743", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way.\n";
+    short_desc = "Forsaken Scholar's Way";
+    long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "west",
         "domain/original/area/vesla/room191", "east",
         "domain/original/area/vesla/room744", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rapier Way";
-    long_desc = "Rapier Way.\n";
+    short_desc = "Splintered Rapier Way";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room194", "east",
         "domain/original/area/vesla/room137", "west",

--- a/domain/original/area/vesla/room194.c
+++ b/domain/original/area/vesla/room194.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rapier Way";
-    long_desc = "Rapier Way.\n";
+    short_desc = "Splintered Rapier Way";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room195", "east",
         "domain/original/area/vesla/room193", "west",

--- a/domain/original/area/vesla/room195.c
+++ b/domain/original/area/vesla/room195.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rapier Way";
-    long_desc = "Rapier Way.\n";
+    short_desc = "Splintered Rapier Way";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "east",
         "domain/original/area/vesla/room194", "west",

--- a/domain/original/area/vesla/room196.c
+++ b/domain/original/area/vesla/room196.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rapier Way";
-    long_desc = "Rapier Way.\n";
+    short_desc = "Splintered Rapier Way";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room197", "east",
         "domain/original/area/vesla/room195", "west",

--- a/domain/original/area/vesla/room197.c
+++ b/domain/original/area/vesla/room197.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Rapier Way and Zand Boulevard";
-    long_desc = "Intersection of Rapier Way and Zand Boulevard.\n";
+    short_desc = "Ash-Choked Crossing of Rapier Way and Zand Boulevard";
+    long_desc = "Ash drifts over the crossing, softening the edges of shattered cobbles. The ruined streets meet in a haze of gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "west",
         "domain/original/area/vesla/room198", "south",

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Zand Boulevard";
-    long_desc = "Zand Boulevard.\n";
+    short_desc = "Ash-Choked Zand Boulevard";
+    long_desc = "Fine ash has settled in drifts along the boulevard, muffling the crunch of broken stone. The road is deserted and choked with gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "south",
         "domain/original/area/vesla/room857", "east",
         "domain/original/area/vesla/room197", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Zand Boulevard";
-    long_desc = "Zand Boulevard.\n";
+    short_desc = "Ash-Choked Zand Boulevard";
+    long_desc = "Fine ash has settled in drifts along the boulevard, muffling the crunch of broken stone. The road is deserted and choked with gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room200", "south",
         "domain/original/area/vesla/room962", "east",
         "domain/original/area/vesla/room198", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room200.c
+++ b/domain/original/area/vesla/room200.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Street of the Bells and Zand Boulevard";
-    long_desc = "Intersection of Street of the Bells and Zand Boulevard.\n";
+    short_desc = "Silent Crossing of the Bells and Zand Boulevard";
+    long_desc = "The crossing is quiet, its stones cracked and coated in ash. No bells ring here now, only the hush of ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room201", "west",
         "domain/original/area/vesla/room199", "north",

--- a/domain/original/area/vesla/room201.c
+++ b/domain/original/area/vesla/room201.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells.\n";
+    short_desc = "Silent Street of the Bells";
+    long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room843", "south",
         "domain/original/area/vesla/room202", "west",

--- a/domain/original/area/vesla/room202.c
+++ b/domain/original/area/vesla/room202.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells.\n";
+    short_desc = "Silent Street of the Bells";
+    long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "west",
         "domain/original/area/vesla/room201", "east",

--- a/domain/original/area/vesla/room203.c
+++ b/domain/original/area/vesla/room203.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells.\n";
+    short_desc = "Silent Street of the Bells";
+    long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room202", "east",
         "domain/original/area/vesla/room204", "west",

--- a/domain/original/area/vesla/room204.c
+++ b/domain/original/area/vesla/room204.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells.\n";
+    short_desc = "Silent Street of the Bells";
+    long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "east",
         "domain/original/area/vesla/room140", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",
         "domain/original/area/vesla/room396", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",
         "domain/original/area/vesla/room395", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "East River Street";
-    long_desc = "East River Street.\n";
+    short_desc = "Broken East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",
         "domain/original/area/vesla/room394", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "End of East River Street";
-    long_desc = "End of East River Street.\n";
+    short_desc = "Broken End of East River Street";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Via Sacra and River Street";
-    long_desc = "Intersection of Via Sacra and River Street.\n";
+    short_desc = "Desecrated Crossing of Via Sacra and River Street";
+    long_desc = "The sacred road meets the river street in a churn of broken stone and ash. The dragons left the junction desecrated and silent.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "South End of Via Sacra";
-    long_desc = "South End of Via Sacra.\n";
+    short_desc = "Desecrated South End of Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",
         "domain/original/area/vesla/room399", "east",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Southern Via Sacra";
-    long_desc = "Southern Via Sacra.\n";
+    short_desc = "Desecrated Southern Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
         "domain/original/area/vesla/room400", "west",

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra.\n";
+    short_desc = "Desecrated Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",
         "domain/original/area/vesla/room216", "north",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra.\n";
+    short_desc = "Desecrated Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
         "domain/original/area/vesla/room402", "west",

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra.\n";
+    short_desc = "Desecrated Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
         "domain/original/area/vesla/room216", "south",

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra.\n";
+    short_desc = "Desecrated Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",
         "domain/original/area/vesla/room219", "north",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra.\n";
+    short_desc = "Desecrated Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
         "domain/original/area/vesla/room218", "south",

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Northern End of Via Sacra";
-    long_desc = "Northern End of Via Sacra.\n";
+    short_desc = "Desecrated Northern End of Via Sacra";
+    long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",
         "domain/original/area/vesla/room221", "west",

--- a/domain/original/area/vesla/room410.c
+++ b/domain/original/area/vesla/room410.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway.\n";
+    short_desc = "Rubble-Choked Alleyway";
+    long_desc = "Broken walls lean inward over a narrow way packed with debris. The alley is quiet, the stones scorched by long-ago flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room411", "west",
         "domain/original/area/vesla/room122", "south",

--- a/domain/original/area/vesla/room419.c
+++ b/domain/original/area/vesla/room419.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A dark alleyway";
-    long_desc = "A dark alleyway.\n";
+    short_desc = "Lightless Ruined Alleyway";
+    long_desc = "No light reaches this narrow cut between ruins, only soot and broken masonry. The place feels abandoned even by the dragons.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "north",
     });

--- a/domain/original/area/vesla/room738.c
+++ b/domain/original/area/vesla/room738.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Alley";
-    long_desc = "Alley.\n";
+    short_desc = "Rubble-Choked Alley";
+    long_desc = "The alley is little more than a trench of shattered stone and collapsed timbers. Ash and rubble fill the cramped passage.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "south",
     });

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway.\n";
+    short_desc = "Rubble-Choked Alleyway";
+    long_desc = "Broken walls lean inward over a narrow way packed with debris. The alley is quiet, the stones scorched by long-ago flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room410", "south",
         "domain/original/area/vesla/room795", "east",
         "domain/original/area/vesla/room794", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -6,12 +6,21 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway.\n";
+    short_desc = "Rubble-Choked Alleyway";
+    long_desc = "Broken walls lean inward over a narrow way packed with debris. The alley is quiet, the stones scorched by long-ago flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room813", "south",
         "domain/original/area/vesla/room792", "west",
         "domain/original/area/vesla/room796", "east",
         "domain/original/area/vesla/room797", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "An alley";
-    long_desc = "An alley.\n";
+    short_desc = "Rubble-Choked Alley";
+    long_desc = "The alley is little more than a trench of shattered stone and collapsed timbers. Ash and rubble fill the cramped passage.\n";
     dest_dir = ({
         "domain/original/area/vesla/room814", "south",
         "domain/original/area/vesla/room795", "west",
         "domain/original/area/vesla/room231", "east",
         "domain/original/area/vesla/room961", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room797.c
+++ b/domain/original/area/vesla/room797.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A dingy alley";
-    long_desc = "A dingy alley.\n";
+    short_desc = "Rubble-Choked Alley";
+    long_desc = "The alley is little more than a trench of shattered stone and collapsed timbers. Ash and rubble fill the cramped passage.\n";
     dest_dir = ({
         "domain/original/area/vesla/room795", "south",
         "domain/original/area/vesla/room798", "north",

--- a/domain/original/area/vesla/room798.c
+++ b/domain/original/area/vesla/room798.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A Dingy Alley";
-    long_desc = "A Dingy Alley.\n";
+    short_desc = "Rubble-Choked Alley";
+    long_desc = "The alley is little more than a trench of shattered stone and collapsed timbers. Ash and rubble fill the cramped passage.\n";
     dest_dir = ({
         "domain/original/area/vesla/room797", "south",
         "domain/original/area/vesla/room799", "north",

--- a/domain/original/area/vesla/room799.c
+++ b/domain/original/area/vesla/room799.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way.\n";
+    short_desc = "Reeking Ruin Alley";
+    long_desc = "Stagnant filth and ash cling to the broken stones, and a sour reek hangs in the air. The alleyway is collapsed and deserted.\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "west",
         "domain/original/area/vesla/room800", "east",

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -6,11 +6,20 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way.\n";
+    short_desc = "Reeking Ruin Alley";
+    long_desc = "Stagnant filth and ash cling to the broken stones, and a sour reek hangs in the air. The alleyway is collapsed and deserted.\n";
     dest_dir = ({
         "domain/original/area/vesla/room799", "west",
         "domain/original/area/vesla/room801", "east",
         "domain/original/area/vesla/room806", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room801.c
+++ b/domain/original/area/vesla/room801.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way.\n";
+    short_desc = "Reeking Ruin Alley";
+    long_desc = "Stagnant filth and ash cling to the broken stones, and a sour reek hangs in the air. The alleyway is collapsed and deserted.\n";
     dest_dir = ({
         "domain/original/area/vesla/room800", "west",
     });

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -6,12 +6,22 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way.\n";
+    short_desc = "Reeking Ruin Alley";
+    long_desc = "Stagnant filth and ash cling to the broken stones, and a sour reek hangs in the air. The alleyway is collapsed and deserted.\n";
     dest_dir = ({
         "domain/original/area/vesla/room805", "south",
         "domain/original/area/vesla/room803", "west",
         "domain/original/area/vesla/room799", "east",
         "domain/original/area/vesla/room807", "north",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -6,10 +6,19 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way.\n";
+    short_desc = "Reeking Ruin Alley";
+    long_desc = "Stagnant filth and ash cling to the broken stones, and a sour reek hangs in the air. The alleyway is collapsed and deserted.\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "east",
         "domain/original/area/vesla/room804", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the structure collapsed long ago.\n");
+    return 1;
 }


### PR DESCRIPTION
### Motivation

- Reflect an in-world narrative that Vesla was devastated by dragons and has been dead and abandoned for two hundred years.
- Make thoroughfare names and descriptions convey a consistent theme of ruin, fire, ash, and collapsed masonry.
- Prevent access to single-room structures off ruined streets by reporting they have collapsed into rubble rather than removing exits.
- Keep each thoroughfare `long_desc` short (one or two sentences) to match the requested style.

### Description

- Rewrote `short_desc` and `long_desc` in 119 room files under `domain/original/area/vesla` to present ruined/abandoned thoroughfares with dragonfire imagery and consistent naming.
- Added `init()` handlers and a `block_structure()` action in 34 room files so specific exits now call `add_action(...)` and print `"Only rubble remains there; the structure collapsed long ago.\n"` instead of allowing passage to single-room destinations.
- Total edits recorded in the commit: `119 files modified`, `551 insertions`, and `238 deletions`.
- Changes were committed with the message `Ruin Vesla thoroughfares`.

### Testing

- No automated tests were run for these text-only content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8f4e66e08327a68cf1739baab343)