### PR TITLE
Vesla: imply ancient devastation, block ruined exits, and show room short before long

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -13,3 +13,12 @@ void reset(int arg) {
 	"domain/original/area/roadway/room14", "exit",
     });
 }
+
+void init() {
+    add_action("block_wilderness", "exit");
+}
+
+int block_wilderness() {
+    write("The ruined gate has collapsed; the way to the wilderness is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Cindered Crossing of Park Street and Via Sacra";
-    long_desc = "Charred trunks and broken stones frame the junction of Park Street and the Via Sacra. Only ash and rubble remain where the dragons swept through.\n";
+    long_desc = "Charred trunks and broken stones frame the junction of Park Street and the Via Sacra. Ash and rubble lie in wind-swept drifts, and the stone bears long talon-like scars.\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "south",
         "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Ruptured Park Walk";
-    long_desc = "The ruined canopy opens to a gap of fallen trees and collapsed paving. Ash swirls where the dragons' fire tore the park apart.\n";
+    long_desc = "The ruined canopy opens to a gap of fallen trees and collapsed paving. Ash swirls where blistering heat tore the park apart, and bone shards lie in the loam.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "west",
         "domain/original/area/vesla/room123", "east",

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Cindered End of Park Street";
-    long_desc = "Park Street ends in a jumble of shattered stones and charred stumps. The dragons' passage left the road broken and dead.\n";
+    long_desc = "Park Street ends in a jumble of shattered stones and charred stumps. The road lies broken and dead, gouged by something enormous.\n";
     dest_dir = ({
         "domain/original/area/vesla/room880", "south",
         "domain/original/area/vesla/room127", "west",

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -7,10 +7,19 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "west",
         "domain/original/area/vesla/room128", "east",
         "domain/original/area/vesla/room419", "south",
     });
+}
+
+void init() {
+    add_action("block_structure", "south");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
 }

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room131", "west",
         "domain/original/area/vesla/room129", "east",

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "west",
         "domain/original/area/vesla/room130", "east",

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of dragonfire.\n";
+    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "west",
         "domain/original/area/vesla/room131", "east",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -13,3 +13,12 @@ void reset(int arg) {
         "domain/original/area/roadway/room29", "exit",
     });
 }
+
+void init() {
+    add_action("block_wilderness", "exit");
+}
+
+int block_wilderness() {
+    write("The ruined gate is choked with stone; the wilderness beyond is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room135.c
+++ b/domain/original/area/vesla/room135.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room136", "south",
         "domain/original/area/vesla/room133", "north",

--- a/domain/original/area/vesla/room136.c
+++ b/domain/original/area/vesla/room136.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room137", "south",
         "domain/original/area/vesla/room135", "north",

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "south",
         "domain/original/area/vesla/room856", "west",

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room140", "south",
         "domain/original/area/vesla/room853", "west",

--- a/domain/original/area/vesla/room141.c
+++ b/domain/original/area/vesla/room141.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "south",
         "domain/original/area/vesla/room140", "north",

--- a/domain/original/area/vesla/room142.c
+++ b/domain/original/area/vesla/room142.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scorched Basalt Avenue";
-    long_desc = "Basalt blocks are cracked and glassy, fused by ancient dragonfire. The avenue runs like a blackened scar through the ruins.\n";
+    long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "south",
         "domain/original/area/vesla/room850", "east",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Silt-Choked West River Street";
-    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments and ash show where the dragons tore through.\n";
+    long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rubble-Choked River Street and Broken South Main";
-    long_desc = "Two ruined streets meet in a heap of collapsed stone and shattered timbers. The crossing is quiet, the scars of dragonfire still visible.\n";
+    long_desc = "Two ruined streets meet in a heap of collapsed stone and shattered timbers. The crossing is quiet, the stones glazed by ancient heat.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Long ago the dragons laid it waste, and it has never recovered.\n";
+    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -13,3 +13,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room168", "west",
     });
 }
+
+void init() {
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -13,3 +13,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room184", "west",
     });
 }
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -14,3 +14,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room738", "north",
     });
 }
+
+void init() {
+    add_action("block_structure", "north");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Splintered Rapier Way";
-    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room194", "east",
         "domain/original/area/vesla/room137", "west",

--- a/domain/original/area/vesla/room194.c
+++ b/domain/original/area/vesla/room194.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Splintered Rapier Way";
-    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room195", "east",
         "domain/original/area/vesla/room193", "west",

--- a/domain/original/area/vesla/room195.c
+++ b/domain/original/area/vesla/room195.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Splintered Rapier Way";
-    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "east",
         "domain/original/area/vesla/room194", "west",

--- a/domain/original/area/vesla/room196.c
+++ b/domain/original/area/vesla/room196.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Splintered Rapier Way";
-    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. The dragons' assault left this way broken and lifeless.\n";
+    long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room197", "east",
         "domain/original/area/vesla/room195", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Broken End of East River Street";
-    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar from the dragons' wrath.\n";
+    long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Desecrated Crossing of Via Sacra and River Street";
-    long_desc = "The sacred road meets the river street in a churn of broken stone and ash. The dragons left the junction desecrated and silent.\n";
+    long_desc = "The sacred road meets the river street in a churn of broken stone and ash. The junction is desecrated and silent, marked by talon-scores and old bone piles.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -15,3 +15,13 @@ void reset(int arg) {
         "domain/original/area/vesla/room215", "north",
     });
 }
+
+void init() {
+    add_action("block_structure", "west");
+    add_action("block_structure", "east");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -15,3 +15,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room217", "north",
     });
 }
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -14,3 +14,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room218", "north",
     });
 }
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -14,3 +14,12 @@ void reset(int arg) {
         "domain/original/area/vesla/room220", "north",
     });
 }
+
+void init() {
+    add_action("block_structure", "west");
+}
+
+int block_structure() {
+    write("Only rubble remains there; the way is impassable.\n");
+    return 1;
+}

--- a/domain/original/area/vesla/room419.c
+++ b/domain/original/area/vesla/room419.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Lightless Ruined Alleyway";
-    long_desc = "No light reaches this narrow cut between ruins, only soot and broken masonry. The place feels abandoned even by the dragons.\n";
+    long_desc = "No light reaches this narrow cut between ruins, only soot and broken masonry. The place feels abandoned even by whatever once nested here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "north",
     });

--- a/obj/living.c
+++ b/obj/living.c
@@ -196,10 +196,20 @@ void move_player(string dir_dest, object optional_dest_ob) {
         return;
     }
     ob = environment(this_object());
-    if (brief)
+    if (brief) {
         write(ob->short() + "\n");
-    else
+    } else {
+        string room_short;
+        string *room_lines;
+
+        room_short = ob->short();
+        if (room_short) {
+            room_lines = explode(room_short, "\n");
+            if (sizeof(room_lines))
+                write(room_lines[0] + "\n");
+        }
         ob->long();
+    }
     for (i = 0, ob = first_inventory(ob); ob; ob = next_inventory(ob)) {
         if (ob != this_object()) {
             string short_str;

--- a/obj/player.c
+++ b/obj/player.c
@@ -627,10 +627,20 @@ int teleport(string dest) {
         move_object(myself, ob);
         if (!is_invis)
             say(cap_name + " " + mmsgin + ".\n");
-        if (brief)
+        if (brief) {
             write(ob->short() + "\n");
-        else
+        } else {
+            string room_short;
+            string *room_lines;
+
+            room_short = ob->short();
+            if (room_short) {
+                room_lines = explode(room_short, "\n");
+                if (sizeof(room_lines))
+                    write(room_lines[0] + "\n");
+            }
             ob->long();
+        }
         ob = first_inventory(ob);
         while (ob) {
             if (ob != this_object()) {


### PR DESCRIPTION
### Motivation

- Rework Vesla city rooms to imply a long-ago, massive destruction and later nesting activity without explicitly naming dragons. 
- Prevent players from traversing collapsed single-exit rooms that open onto ruined thoroughfares by intercepting movement with `init`/`add_action` handlers. 
- Block access to the Wilderness through ruined gates by making those `exit` commands impassable. 
- Change mudlib display so when `brief == false` the room `short()` is shown on its own line before `long()` and exits.

### Description

- Rewrote many Vesla room `long_desc` texts to replace explicit references with visual imagery (searing heat, talon-like scars, gouges, bone shards); changes are in the `domain/original/area/vesla` files. 
- Added `init`/`add_action` handlers and `block_structure`/`block_wilderness` functions to affected rooms (examples: `room115.c`, `room134.c`, `room129.c`, `room214.c`, and many thoroughfare rooms) to intercept and block travel with a message. 
- Updated the mudlib display logic in `obj/living.c` and `obj/player.c` so that when detailed mode is used the first line of `short()` is printed on its own line and then `long()` is invoked. 
- Changes span the Vesla area and the two core files above to ensure consistent behavior and messaging across the ruined district.

### Testing

- Ran a Python scanner that finds single-exit rooms and verifies the corresponding thoroughfare rooms have blocking handlers, which reported no missing handlers (`missing thoroughfare 0`). 
- Performed a search for the explicit keyword `dragon` in the Vesla area and confirmed no remaining direct matches. 
- Inspected updated room source files (e.g. `domain/original/area/vesla/room115.c`, `room134.c`, `room214.c`) to confirm `add_action` blocks and messages were added. 
- Verified `obj/living.c` and `obj/player.c` now output the room short line before calling `long()` in non-brief mode by examining the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e981bd8a483278430c05ab4a1abd1)