### PR TITLE
Ensure `::init()` runs first and remove historic place names in Vesla rooms

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -15,6 +15,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_wilderness", "exit");
 }
 

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Crossing of Park Street and Caravan Road";
-    long_desc = "Burned trees and shattered paving meet here where Park Street once touched Caravan Road. The air is stale with old smoke and drifting ash.\n";
+    short_desc = "Cindered Crossing of Two Ruined Roads";
+    long_desc = "Burned trees and shattered paving meet here where two ruined roads converge. The air is stale with old smoke and drifting ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room233", "south",
         "domain/original/area/vesla/room117", "west",

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Crossing of Park Street and Via Sacra";
-    long_desc = "Charred trunks and broken stones frame the junction of Park Street and the Via Sacra. Ash and rubble lie in wind-swept drifts, and the stone bears long talon-like scars.\n";
+    short_desc = "Cindered Crossing of Two Ruined Streets";
+    long_desc = "Charred trunks and broken stones frame the junction of two ruined streets. Ash and rubble lie in wind-swept drifts, and the stone bears long talon-like scars.\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "south",
         "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room227", "north",

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "south",

--- a/domain/original/area/vesla/room120.c
+++ b/domain/original/area/vesla/room120.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "west",

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room122.c
+++ b/domain/original/area/vesla/room122.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "south",

--- a/domain/original/area/vesla/room123.c
+++ b/domain/original/area/vesla/room123.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Walk";
+    short_desc = "Cindered Walk by a Dead Park";
     long_desc = "Blackened branches arch over a walkway of cracked flagstones, their shade long burned away. The path is quiet, littered with ash and broken masonry.\n";
     dest_dir = ({
         "domain/original/area/vesla/room124", "west",

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Ruptured Park Walk";
+    short_desc = "Ruptured Walk by a Dead Park";
     long_desc = "The ruined canopy opens to a gap of fallen trees and collapsed paving. Ash swirls where blistering heat tore the park apart, and bone shards lie in the loam.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "west",

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered Park Junction";
+    short_desc = "Cindered Junction by a Dead Park";
     long_desc = "Broken flagstones and scorched roots mark a junction that once bustled with traffic. Only rubble and silence connect the dead streets.\n";
     dest_dir = ({
         "domain/original/area/vesla/room159", "south",

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cindered End of Park Street";
-    long_desc = "Park Street ends in a jumble of shattered stones and charred stumps. The road lies broken and dead, gouged by something enormous.\n";
+    short_desc = "Cindered End of a Ruined Street";
+    long_desc = "The ruined street ends in a jumble of shattered stones and charred stumps. The road lies broken and dead, gouged by something enormous.\n";
     dest_dir = ({
         "domain/original/area/vesla/room880", "south",
         "domain/original/area/vesla/room127", "west",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
     add_action("block_structure", "north");
 }

--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Westroad, Entrance to the Old City";
-    long_desc = "Westroad begins here amid collapsed paving and scattered masonry. The way into the old city lies ruined and abandoned.\n";
+    short_desc = "Broken Western Road, Entrance to the Old City";
+    long_desc = "A western road begins here amid collapsed paving and scattered masonry. The way into the old city lies ruined and abandoned.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "west",
         "domain/original/area/vesla/room127", "east",

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
+    short_desc = "Broken Western Road";
+    long_desc = "The western road is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "west",
         "domain/original/area/vesla/room128", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
+    short_desc = "Broken Western Road";
+    long_desc = "The western road is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room131", "west",
         "domain/original/area/vesla/room129", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
+    short_desc = "Broken Western Road";
+    long_desc = "The western road is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "west",
         "domain/original/area/vesla/room130", "east",

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Westroad";
-    long_desc = "Westroad is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
+    short_desc = "Broken Western Road";
+    long_desc = "The western road is split by deep cracks and littered with shattered stone. The abandoned street bears the scars of searing heat and talon-scores.\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "west",
         "domain/original/area/vesla/room131", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room133.c
+++ b/domain/original/area/vesla/room133.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Corner of Westroad and Basalt Avenue";
+    short_desc = "Broken Corner of a Western Road and a Stone Avenue";
     long_desc = "Two ruined streets meet among rubble and scorched debris. The corner is choked with broken stone and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room134", "west",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -15,6 +15,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_wilderness", "exit");
 }
 

--- a/domain/original/area/vesla/room135.c
+++ b/domain/original/area/vesla/room135.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room136", "south",

--- a/domain/original/area/vesla/room136.c
+++ b/domain/original/area/vesla/room136.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room137", "south",

--- a/domain/original/area/vesla/room137.c
+++ b/domain/original/area/vesla/room137.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Crossing of Basalt Avenue and Rapier Way";
+    short_desc = "Scorched Crossing of a Stone Avenue and a Narrow Way";
     long_desc = "Melted basalt and splintered cobbles meet where the avenues cross. The junction is a smear of slag and rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "south",

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
     add_action("block_structure", "east");
 }

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room140", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
     add_action("block_structure", "east");
 }

--- a/domain/original/area/vesla/room140.c
+++ b/domain/original/area/vesla/room140.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Crossing of Basalt Avenue and Street of the Bells";
+    short_desc = "Scorched Crossing of a Stone Avenue and a Silent Street";
     long_desc = "Shattered paving and vitrified basalt mark this ruined crossing. The bells are long silent, and ash coats the stones.\n";
     dest_dir = ({
         "domain/original/area/vesla/room141", "south",

--- a/domain/original/area/vesla/room141.c
+++ b/domain/original/area/vesla/room141.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "south",

--- a/domain/original/area/vesla/room142.c
+++ b/domain/original/area/vesla/room142.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Basalt Avenue";
+    short_desc = "Scorched Stone Avenue";
     long_desc = "Basalt blocks are cracked and glassy, fused by searing heat. The avenue runs like a blackened scar through the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "south",

--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scorched Corner of Basalt Avenue and West River Street";
+    short_desc = "Scorched Corner of a Stone Avenue and the West Riverside Street";
     long_desc = "The corner is buried under fused basalt and broken river stones. Dragonfire has left the ground warped and cracked.\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silt-Choked West River Street";
+    short_desc = "Silt-Choked West Riverside Street";
     long_desc = "The river street is cracked and half-buried beneath silt and rubble. Broken embankments, ash, and long gouges show where something enormous tore through and wallowed amid the ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rubble-Choked River Street and Broken South Main";
+    short_desc = "Rubble-Choked Riverside Street and Broken Main Road";
     long_desc = "Two ruined streets meet in a heap of collapsed stone and shattered timbers. The crossing is quiet, the stones glazed by ancient heat.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
     add_action("block_structure", "east");
 }

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken South Main Street";
+    short_desc = "Broken Southern Main Road";
     long_desc = "The main road is split and collapsed, its stones scattered among ruined foundations. The silence of the dead city hangs over the broken way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered Crossing of North Main and Scholar's Way";
-    long_desc = "Cracked paving and toppled stones mark where North Main once met Scholar's Way. The junction is choked with rubble and ash.\n";
+    short_desc = "Shattered Crossing of the Northern Main Road and a Quiet Lane";
+    long_desc = "Cracked paving and toppled stones mark where the northern main road met a quiet lane. The junction is choked with rubble and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered North Main Street";
-    long_desc = "North Main is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
+    short_desc = "Shattered Northern Main Road";
+    long_desc = "The northern main road is cracked and heaved, with chunks of masonry strewn across it. Heat-blistered stone and deep gouges linger like the passage of something vast. Grease-dark stains and splintered bones collect in sheltered corners.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered Crossing of North Main and Wall Street";
+    short_desc = "Shattered Crossing of the Northern Main Road and the Wall Road";
     long_desc = "The crossing is a churn of broken stone where the wall once stood strong. It is quiet now, a ruin of intersecting streets.\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Western End of Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Western End of the Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room171", "east",
         "domain/original/area/vesla/room168", "west",
@@ -15,6 +15,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room171.c
+++ b/domain/original/area/vesla/room171.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room170", "west",
     });

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room174.c
+++ b/domain/original/area/vesla/room174.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "south",

--- a/domain/original/area/vesla/room175.c
+++ b/domain/original/area/vesla/room175.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room174", "south",

--- a/domain/original/area/vesla/room176.c
+++ b/domain/original/area/vesla/room176.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room175", "south",

--- a/domain/original/area/vesla/room177.c
+++ b/domain/original/area/vesla/room177.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room176", "south",

--- a/domain/original/area/vesla/room178.c
+++ b/domain/original/area/vesla/room178.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Crossing of Scholar's Way and Caravan Road";
-    long_desc = "Broken paving and gouged stone meet where the caravan route crosses Scholar's Way. The junction is littered with debris and ash.\n";
+    short_desc = "Rutted Crossing of a Quiet Lane and the Trade Road";
+    long_desc = "Broken paving and gouged stone meet where a trade route crosses a quiet lane. The junction is littered with debris and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "west",
         "domain/original/area/vesla/room177", "south",

--- a/domain/original/area/vesla/room179.c
+++ b/domain/original/area/vesla/room179.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Caravan Road";
+    short_desc = "Rutted Trade Road";
     long_desc = "Deep ruts and gouges cut through the roadway, as if something massive scraped along it. Ash and shattered stone choke the old caravan path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "south",

--- a/domain/original/area/vesla/room180.c
+++ b/domain/original/area/vesla/room180.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rutted Crossing of Caravan Road and Breached Wall Street";
-    long_desc = "Rutted Caravan Road meets the shattered wall here, the stones broken into a mound of debris. Ash and rubble choke the crossing.\n";
+    short_desc = "Rutted Crossing of the Trade Road and the Wall Road";
+    long_desc = "A rutted trade road meets the shattered wall here, the stones broken into a mound of debris. Ash and rubble choke the crossing.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "west",
         "domain/original/area/vesla/room179", "south",

--- a/domain/original/area/vesla/room181.c
+++ b/domain/original/area/vesla/room181.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Eastern End of Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Eastern End of the Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room180", "east",
         "domain/original/area/vesla/room182", "west",

--- a/domain/original/area/vesla/room182.c
+++ b/domain/original/area/vesla/room182.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "east",
         "domain/original/area/vesla/room183", "west",

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room182", "east",
         "domain/original/area/vesla/room184", "west",
@@ -15,6 +15,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room184.c
+++ b/domain/original/area/vesla/room184.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Wall Street";
-    long_desc = "The city wall is broken here, its stones strewn across the street. Wall Street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Breached Wall Road";
+    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
     dest_dir = ({
         "domain/original/area/vesla/room183", "east",
     });

--- a/domain/original/area/vesla/room185.c
+++ b/domain/original/area/vesla/room185.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "east",

--- a/domain/original/area/vesla/room186.c
+++ b/domain/original/area/vesla/room186.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "east",

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room740", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room742", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
     add_action("block_structure", "north");
 }

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Forsaken Scholar's Way";
+    short_desc = "Forsaken Broken Lane";
     long_desc = "Broken plaques and toppled markers line the way, their inscriptions lost beneath soot. The street lies deserted, a ruin of learning.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Rapier Way";
+    short_desc = "Splintered Narrow Way";
     long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room194", "east",

--- a/domain/original/area/vesla/room194.c
+++ b/domain/original/area/vesla/room194.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Rapier Way";
+    short_desc = "Splintered Narrow Way";
     long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room195", "east",

--- a/domain/original/area/vesla/room195.c
+++ b/domain/original/area/vesla/room195.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Rapier Way";
+    short_desc = "Splintered Narrow Way";
     long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "east",

--- a/domain/original/area/vesla/room196.c
+++ b/domain/original/area/vesla/room196.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Rapier Way";
+    short_desc = "Splintered Narrow Way";
     long_desc = "The paving is slashed and splintered, as if a blade had carved through stone. Scorched ruts and scattered bones leave the way broken and lifeless.\n";
     dest_dir = ({
         "domain/original/area/vesla/room197", "east",

--- a/domain/original/area/vesla/room197.c
+++ b/domain/original/area/vesla/room197.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Ash-Choked Crossing of Rapier Way and Zand Boulevard";
+    short_desc = "Ash-Choked Crossing of Two Ruined Boulevards";
     long_desc = "Ash drifts over the crossing, softening the edges of shattered cobbles. The ruined streets meet in a haze of gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "west",

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Ash-Choked Zand Boulevard";
+    short_desc = "Ash-Choked Ruined Boulevard";
     long_desc = "Fine ash has settled in drifts along the boulevard, muffling the crunch of broken stone. The road is deserted and choked with gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "south",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Ash-Choked Zand Boulevard";
+    short_desc = "Ash-Choked Ruined Boulevard";
     long_desc = "Fine ash has settled in drifts along the boulevard, muffling the crunch of broken stone. The road is deserted and choked with gray dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room200", "south",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "east");
 }
 

--- a/domain/original/area/vesla/room200.c
+++ b/domain/original/area/vesla/room200.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silent Crossing of the Bells and Zand Boulevard";
+    short_desc = "Silent Crossing of a Bell-Haunted Street and a Ruined Boulevard";
     long_desc = "The crossing is quiet, its stones cracked and coated in ash. No bells ring here now, only the hush of ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room201", "west",

--- a/domain/original/area/vesla/room201.c
+++ b/domain/original/area/vesla/room201.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silent Street of the Bells";
+    short_desc = "Silent Bell-Haunted Street";
     long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room843", "south",

--- a/domain/original/area/vesla/room202.c
+++ b/domain/original/area/vesla/room202.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silent Street of the Bells";
+    short_desc = "Silent Bell-Haunted Street";
     long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "west",

--- a/domain/original/area/vesla/room203.c
+++ b/domain/original/area/vesla/room203.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silent Street of the Bells";
+    short_desc = "Silent Bell-Haunted Street";
     long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room202", "east",

--- a/domain/original/area/vesla/room204.c
+++ b/domain/original/area/vesla/room204.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Silent Street of the Bells";
+    short_desc = "Silent Bell-Haunted Street";
     long_desc = "Bell towers have fallen and their stones lie strewn across the street. The way is silent, its paving cracked and blackened.\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "east",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken East River Street";
+    short_desc = "Broken East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken End of East River Street";
+    short_desc = "Broken End of the East Riverside Street";
     long_desc = "The roadway along the river is split and sagging, choked with rubble. The embankment is broken, a scar of blistered stone and claw-scraped concrete.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Crossing of Via Sacra and River Street";
+    short_desc = "Desecrated Crossing of Two Ruined Streets";
     long_desc = "The sacred road meets the river street in a churn of broken stone and ash. The junction is desecrated and silent, marked by talon-scores and old bone piles.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated South End of Via Sacra";
+    short_desc = "Desecrated Southern End of the Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Southern Via Sacra";
+    short_desc = "Desecrated Southern Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
     add_action("block_structure", "east");
 }

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Via Sacra";
+    short_desc = "Desecrated Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Via Sacra";
+    short_desc = "Desecrated Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Via Sacra";
+    short_desc = "Desecrated Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Via Sacra";
+    short_desc = "Desecrated Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Via Sacra";
+    short_desc = "Desecrated Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "west");
 }
 

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Desecrated Northern End of Via Sacra";
+    short_desc = "Desecrated Northern End of the Ruined Avenue";
     long_desc = "Charred pillars and shattered altars line the once-holy way. The stones are cracked and cold, abandoned for two centuries.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
     add_action("block_structure", "north");
 }

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -16,6 +16,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "north");
 }
 

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -17,6 +17,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
     add_action("block_structure", "north");
 }

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -15,6 +15,7 @@ void reset(int arg) {
 }
 
 void init() {
+    ::init();
     add_action("block_structure", "south");
 }
 


### PR DESCRIPTION
### Motivation
- Ensure room initialization hooks call the inherited initializer before registering actions so parent setup runs reliably. 
- Remove use of historical/proper place names (e.g. "Park Street", "Via Sacra") so descriptions present the ruined city to new arrivals without prior local knowledge. 
- Preserve the ruined, atmospheric tone while making names generic and descriptive for newcomers.

### Description
- Inserted `::init();` as the first statement inside `void init()` across Vesla room files that define `init()` so inherited initialization runs before `add_action` calls. 
- Rewrote numerous `short_desc` and selected `long_desc` strings to replace specific historical road/place names with generic descriptors (for example, "Park Street" → "a ruined street" and "Via Sacra" → "ruined avenue").
- Applied a deterministic find-and-replace script to normalize related phrases (crossings, avenues, roads, lanes, boulevards) and updated files under `domain/original/area/vesla/*.c`. 
- Committed the changes with the message `Update Vesla room init order and descriptions`.

### Testing
- Ran `rg` searches to locate `init()` definitions and verify `::init()` insertion, which showed the updated files. 
- Executed a Python validation script that checks `::init();` is the first non-empty statement in each `init()` and it reported no missing occurrences (success). 
- Ran `rg` searches to detect remaining historic place names and confirmed replacements (no matches for the targeted names). 
- No runtime or unit tests were executed against the MUD server code in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed863ff8c8327874f848d19cb085c)