### PR TITLE
Replace named rooms with generic ruined descriptors

### DIFF
--- a/domain/original/area/anshelm/room1192.c
+++ b/domain/original/area/anshelm/room1192.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Second Bank of Anshelm";
-    long_desc = "Second Bank of Anshelm.\n";
+    short_desc = "Collapsed Chamber";
+    long_desc = "Collapsed Chamber.\n";
     dest_dir = ({
         "domain/original/area/anshelm/room240", "west",
     });

--- a/domain/original/area/anshelm/room1193.c
+++ b/domain/original/area/anshelm/room1193.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Anshelmish General Store";
-    long_desc = "The Anshelmish General Store.\n";
+    short_desc = "Ruined Passage";
+    long_desc = "Ruined Passage.\n";
     dest_dir = ({
         "domain/original/area/anshelm/room251", "west",
     });

--- a/domain/original/area/exedoria/room354.c
+++ b/domain/original/area/exedoria/room354.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Mom's General Store";
-    long_desc = "Mom's General Store.\n";
+    short_desc = "Fragmented Walls";
+    long_desc = "Fragmented Walls.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room312", "east",
     });

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "General Store";
-    long_desc = "General Store.\n";
+    short_desc = "Collapsed Structure";
+    long_desc = "Collapsed Structure.\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "west",
         "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Comfortably Numb";
-    long_desc = "Comfortably Numb.\n";
+    short_desc = "Rubble-Choked Shell";
+    long_desc = "Rubble-Choked Shell.\n";
     dest_dir = ({
         "domain/original/area/vesla/room223", "west",
         "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Medieval Mounts";
-    long_desc = "Medieval Mounts.\n";
+    short_desc = "Crumbling Wreck";
+    long_desc = "Crumbling Wreck.\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "west",
         "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Big Hole Banking";
-    long_desc = "Big Hole Banking.\n";
+    short_desc = "Shattered Remains";
+    long_desc = "Shattered Remains.\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "west",
         "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Shadowed Anvil";
-    long_desc = "The Shadowed Anvil.\n";
+    short_desc = "Broken Edifice";
+    long_desc = "Broken Edifice.\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "west",
         "domain/original/area/vesla/room116", "north",

--- a/domain/original/area/vesla/room408.c
+++ b/domain/original/area/vesla/room408.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "MD Banking";
-    long_desc = "MD Banking.\n";
+    short_desc = "Sundered Hall";
+    long_desc = "Sundered Hall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "east",
     });

--- a/domain/original/area/vesla/room740.c
+++ b/domain/original/area/vesla/room740.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stationery Store";
-    long_desc = "Stationery Store.\n";
+    short_desc = "Fallen Annex";
+    long_desc = "Fallen Annex.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "north",
     });

--- a/domain/original/area/vesla/room746.c
+++ b/domain/original/area/vesla/room746.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Store Room";
-    long_desc = "Store Room.\n";
+    short_desc = "Dusty Ruins";
+    long_desc = "Dusty Ruins.\n";
     dest_dir = ({
         "domain/original/area/vesla/room745", "west",
     });

--- a/domain/original/area/vesla/room811.c
+++ b/domain/original/area/vesla/room811.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Hardware Store";
-    long_desc = "Hardware Store.\n";
+    short_desc = "Splintered Shell";
+    long_desc = "Splintered Shell.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "west",
     });

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Abandoned Store";
-    long_desc = "Abandoned Store.\n";
+    short_desc = "Buried Wreckage";
+    long_desc = "Buried Wreckage.\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "west",
     });

--- a/maps/anshelm.json
+++ b/maps/anshelm.json
@@ -365,11 +365,11 @@
       "exits": { "east": 1190, "south": 1185 }
     },
     {
-      "id": 1192, "name": "Second Bank of Anshelm",
+      "id": 1192, "name": "Collapsed Chamber",
       "exits": { "west": 240 }
     },
     {
-      "id": 1193, "name": "The Anshelmish General Store",
+      "id": 1193, "name": "Ruined Passage",
       "exits": { "west": 251 }
     },
     {

--- a/maps/exedoria.json
+++ b/maps/exedoria.json
@@ -273,7 +273,7 @@
       "exits": { "south": 352 }
     },
     {
-      "id": 354, "name": "Mom's General Store",
+      "id": 354, "name": "Fragmented Walls",
       "exits": { "east": 312 }
     },
     {

--- a/maps/moraldecay.json
+++ b/maps/moraldecay.json
@@ -1101,22 +1101,22 @@
       "area": {"id": 2}
     },
     {
-      "id": 221, "name": "General Store",
+      "id": 221, "name": "Collapsed Structure",
       "exits": { "west": 222, "east": 220, "north": 118 },
       "area": {"id": 2}
     },
     {
-      "id": 222, "name": "Comfortably Numb",
+      "id": 222, "name": "Rubble-Choked Shell",
       "exits": { "west": 223, "east": 221, "north": 119 },
       "area": {"id": 2}
     },
     {
-      "id": 223, "name": "Medieval Mounts",
+      "id": 223, "name": "Crumbling Wreck",
       "exits": { "west": 224, "east": 222, "north": 120 },
       "area": {"id": 2}
     },
     {
-      "id": 224, "name": "Big Hole Banking",
+      "id": 224, "name": "Shattered Remains",
       "exits": { "west": 225, "east": 223, "north": 121 },
       "area": {"id": 2}
     },
@@ -1161,7 +1161,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 233, "name": "The Shadowed Anvil",
+      "id": 233, "name": "Broken Edifice",
       "exits": { "west": 220, "north": 116 },
       "area": {"id": 2}
     },
@@ -1766,7 +1766,7 @@
       "area": {"id": 4}
     },
     {
-      "id": 354, "name": "Mom's General Store",
+      "id": 354, "name": "Fragmented Walls",
       "exits": { "east": 312 },
       "area": {"id": 4}
     },
@@ -2036,7 +2036,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 408, "name": "MD Banking",
+      "id": 408, "name": "Sundered Hall",
       "exits": { "east": 217 },
       "area": {"id": 2}
     },
@@ -3692,7 +3692,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 740, "name": "Stationery Store",
+      "id": 740, "name": "Fallen Annex",
       "exits": { "north": 190 },
       "area": {"id": 2}
     },
@@ -3722,7 +3722,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 746, "name": "Store Room",
+      "id": 746, "name": "Dusty Ruins",
       "exits": { "west": 745 },
       "area": {"id": 2}
     },
@@ -4047,7 +4047,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 811, "name": "Hardware Store",
+      "id": 811, "name": "Splintered Shell",
       "exits": { "west": 163 },
       "area": {"id": 2}
     },
@@ -4802,7 +4802,7 @@
       "area": {"id": 2}
     },
     {
-      "id": 962, "name": "Abandoned Store",
+      "id": 962, "name": "Buried Wreckage",
       "exits": { "west": 199 },
       "area": {"id": 2}
     },
@@ -5950,12 +5950,12 @@
       "area": {"id": 3}
     },
     {
-      "id": 1192, "name": "Second Bank of Anshelm",
+      "id": 1192, "name": "Collapsed Chamber",
       "exits": { "west": 240 },
       "area": {"id": 3}
     },
     {
-      "id": 1193, "name": "The Anshelmish General Store",
+      "id": 1193, "name": "Ruined Passage",
       "exits": { "west": 251 },
       "area": {"id": 3}
     },

--- a/maps/vesla.json
+++ b/maps/vesla.json
@@ -425,19 +425,19 @@
       "exits": { "south": 219, "west": 221, "east": 233, "north": 117 }
     },
     {
-      "id": 221, "name": "General Store",
+      "id": 221, "name": "Collapsed Structure",
       "exits": { "west": 222, "east": 220, "north": 118 }
     },
     {
-      "id": 222, "name": "Comfortably Numb",
+      "id": 222, "name": "Rubble-Choked Shell",
       "exits": { "west": 223, "east": 221, "north": 119 }
     },
     {
-      "id": 223, "name": "Medieval Mounts",
+      "id": 223, "name": "Crumbling Wreck",
       "exits": { "west": 224, "east": 222, "north": 120 }
     },
     {
-      "id": 224, "name": "Big Hole Banking",
+      "id": 224, "name": "Shattered Remains",
       "exits": { "west": 225, "east": 223, "north": 121 }
     },
     {
@@ -473,7 +473,7 @@
       "exits": { "south": 226, "west": 228, "east": 173, "north": 234 }
     },
     {
-      "id": 233, "name": "The Shadowed Anvil",
+      "id": 233, "name": "Broken Edifice",
       "exits": { "west": 220, "north": 116 }
     },
     {
@@ -537,7 +537,7 @@
       "exits": { "north": 405 }
     },
     {
-      "id": 408, "name": "MD Banking",
+      "id": 408, "name": "Sundered Hall",
       "exits": { "east": 217 }
     },
     {
@@ -613,7 +613,7 @@
       "exits": { "north": 189 }
     },
     {
-      "id": 740, "name": "Stationery Store",
+      "id": 740, "name": "Fallen Annex",
       "exits": { "north": 190 }
     },
     {
@@ -637,7 +637,7 @@
       "exits": { "east": 746, "south": 741 }
     },
     {
-      "id": 746, "name": "Store Room",
+      "id": 746, "name": "Dusty Ruins",
       "exits": { "west": 745 }
     },
     {
@@ -897,7 +897,7 @@
       "exits": { "west": 162 }
     },
     {
-      "id": 811, "name": "Hardware Store",
+      "id": 811, "name": "Splintered Shell",
       "exits": { "west": 163 }
     },
     {
@@ -1125,7 +1125,7 @@
       "exits": { "south": 796 }
     },
     {
-      "id": 962, "name": "Abandoned Store",
+      "id": 962, "name": "Buried Wreckage",
       "exits": { "west": 199 }
     }
   ]


### PR DESCRIPTION
### Motivation

- Obscure the original, specific purposes of several one-room locations by replacing their names and descriptions with generic ruin-themed text so their prior function cannot be deduced.
- Apply the change consistently across room sources and the map metadata so in-game displays and map exports remain in sync.

### Description

- Replaced `short_desc` and `long_desc` values in multiple room files under `domain/original/area/*` to generic ruined descriptors (e.g. `General Store` → `Collapsed Structure`, `Comfortably Numb` → `Rubble-Choked Shell`).
- Updated corresponding entries in `maps/vesla.json`, `maps/moraldecay.json`, `maps/anshelm.json`, and `maps/exedoria.json` to match the new room names.
- A total of 17 files were modified (room source files and map JSONs) to keep names and map data consistent.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee152ac4c832792d5dd0747711119)