### PR TITLE
Vary blocked-exit rubble messages in vesla rooms

### DIFF
--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -20,6 +20,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("Nothing but fallen masonry lies there; it's impassable.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -20,6 +20,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("The exit is buried under debris and can't be used.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("Rubble fills the exit, leaving no route forward.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("A heap of collapsed stone blocks the way.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("The passage is choked with debris; you cannot pass.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("The way is blocked by a wall of broken stone.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the way is impassable.\n");
+    write("Crumbling ruins bar that direction completely.\n");
     return 1;
 }


### PR DESCRIPTION
### Motivation
- The Vesla area contained many identical blocked-exit messages which reduced variety in player feedback.
- Introduce several alternate phrasings to make blocked exits more descriptive while preserving the same meaning.

### Description
- Replaced the `write()` string in `block_structure()` for seven rooms to use varied rubble/blocked-exit messages in `domain/original/area/vesla`: `room170.c`, `room183.c`, `room188.c`, `room214.c`, `room216.c`, `room217.c`, and `room219.c`.
- One matching location from the original search was intentionally left using the original message for consistency in `room129.c`.
- No logic or control flow was changed; only the literal strings passed to `write()` were updated.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee3d6f8d48327bfcf86192f62ca75)