### PR TITLE
Add variety to Vesla blocked-exit messages

### DIFF
--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -22,6 +22,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -21,6 +21,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -23,6 +23,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -20,6 +20,6 @@ void init() {
 }
 
 int block_structure() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
+    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }


### PR DESCRIPTION
### Motivation
- Reduce repetition of the same blocked-exit text in the Vesla area to improve room flavor.
- Replace the single hardcoded rubble message with a small set of variants so nearby rooms feel less repetitive.
- Preserve the original sentence as one of the possible messages.

### Description
- Replace the `write("Only rubble remains there; the structure collapsed long ago.\n")` call in multiple `domain/original/area/vesla/*.c` room files with one of eight alternate rubble messages.
- Applied changes across the Vesla area room files (29 files were committed) to rotate through the message variants.
- Changes were applied using a short Python script that selects from the eight prepared strings and writes the updated files.
- The original message is kept as one of the eight variants to retain the original wording in some rooms.

### Testing
- Used `rg` to locate the original occurrences before and after the change, which verified replacements completed as expected.
- Ran the Python replacement script (it reported `updated 34` during execution) and then re-checked with `rg`, which confirmed the new messages were present.
- Ran `git status`/`git commit` to record the changes and the commit completed showing `29 files changed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee6ddebcc832787dec74720f60be3)