### PR TITLE
Standardize Vesla blocked-exit handlers to `block_exit`

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -16,10 +16,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_wilderness", "exit");
+    add_action("block_exit", "exit");
 }
 
-int block_wilderness() {
+int block_exit() {
     write("The ruined gate has collapsed; the way to the wilderness is impassable.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
-    add_action("block_structure", "north");
+    add_action("block_exit", "south");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the structure collapsed long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the way is impassable.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -16,10 +16,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_wilderness", "exit");
+    add_action("block_exit", "exit");
 }
 
-int block_wilderness() {
+int block_exit() {
     write("The ruined gate is choked with stone; the wilderness beyond is impassable.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
-    add_action("block_structure", "east");
+    add_action("block_exit", "west");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
-    add_action("block_structure", "east");
+    add_action("block_exit", "west");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the structure collapsed long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
-    add_action("block_structure", "east");
+    add_action("block_exit", "west");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -16,10 +16,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but fallen masonry lies there; it's impassable.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -16,10 +16,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("The exit is buried under debris and can't be used.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Rubble fills the exit, leaving no route forward.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the structure collapsed long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Nothing but rubble lies beyond; the building fell ages ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
-    add_action("block_structure", "north");
+    add_action("block_exit", "south");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Rubble blocks the way; the structure has long since fallen.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "east");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the structure collapsed long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("A long-collapsed structure leaves only rubble there.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
-    add_action("block_structure", "east");
+    add_action("block_exit", "west");
+    add_action("block_exit", "east");
 }
 
-int block_structure() {
+int block_exit() {
     write("A heap of collapsed stone blocks the way.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("The passage is choked with debris; you cannot pass.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("The way is blocked by a wall of broken stone.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "west");
+    add_action("block_exit", "west");
 }
 
-int block_structure() {
+int block_exit() {
     write("Crumbling ruins bar that direction completely.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -18,10 +18,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only rubble remains there; the structure collapsed long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
-    add_action("block_structure", "north");
+    add_action("block_exit", "south");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("The way ends in collapsed ruins; only debris remains.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -17,10 +17,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "north");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("Only shattered remains mark the spot; the building caved in long ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -18,11 +18,11 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
-    add_action("block_structure", "north");
+    add_action("block_exit", "south");
+    add_action("block_exit", "north");
 }
 
-int block_structure() {
+int block_exit() {
     write("There is only debris; the structure collapsed years ago.\n");
     return 1;
 }

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -16,10 +16,10 @@ void reset(int arg) {
 
 void init() {
     ::init();
-    add_action("block_structure", "south");
+    add_action("block_exit", "south");
 }
 
-int block_structure() {
+int block_exit() {
     write("Just ruins and broken stone remain; the structure gave out long ago.\n");
     return 1;
 }


### PR DESCRIPTION
### Motivation

- Consolidate exit-blocking logic across Vesla rooms by standardizing handler names to `block_exit` for consistency.
- Replace legacy handler names `block_structure` and `block_wilderness` which were used inconsistently across the area.
- Make `add_action` targets and function names match to reduce confusion and simplify future refactors.

### Description

- Renamed handler functions from `block_structure` and `block_wilderness` to `block_exit` and updated the corresponding `add_action` calls in `domain/original/area/vesla/*.c` files.
- Applied a bulk search-and-replace over the Vesla room files and preserved the original written messages and behavior.
- Multiple blocked directions in a room now register multiple `add_action("block_exit", "<dir>")` calls as before.
- Changes span 44 files and the commit shows "44 files changed, 96 insertions(+), 96 deletions(-)".

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee7ad59788327b44a2ba462672227)