### PR TITLE
Revise Vesla ruin descriptions and reopen blocked exits

### DIFF
--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Portal Room";
-    long_desc = "Portal Room.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "up",
         "domain/original/area/island/room605", "island",

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("Rubble blocks the way; the structure has long since fallen.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Only rubble remains there; the way is impassable.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Only shattered remains mark the spot; the building caved in long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("There is only debris; the structure collapsed years ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("There is only debris; the structure collapsed years ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Only shattered remains mark the spot; the building caved in long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("Rubble blocks the way; the structure has long since fallen.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("A long-collapsed structure leaves only rubble there.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Only shattered remains mark the spot; the building caved in long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("The way ends in collapsed ruins; only debris remains.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -14,12 +14,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("The exit is buried under debris and can't be used.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room184.c
+++ b/domain/original/area/vesla/room184.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Breached Wall Road";
-    long_desc = "The city wall is broken here, its stones strewn across the street. The wall-side street is a rubble-strewn trench running along the shattered defenses.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room183", "east",
     });

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("Rubble fills the exit, leaving no route forward.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -16,12 +16,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Nothing but rubble lies beyond; the building fell ages ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Rubble blocks the way; the structure has long since fallen.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -15,12 +15,3 @@ void reset(int arg) {
     });
 }
 
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("A long-collapsed structure leaves only rubble there.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Collapsed Structure";
-    long_desc = "Collapsed Structure.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "west",
         "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rubble-Choked Shell";
-    long_desc = "Rubble-Choked Shell.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room223", "west",
         "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Crumbling Wreck";
-    long_desc = "Crumbling Wreck.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "west",
         "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered Remains";
-    long_desc = "Shattered Remains.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "west",
         "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room225.c
+++ b/domain/original/area/vesla/room225.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Brimstone";
-    long_desc = "Brimstone.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "east",
         "domain/original/area/vesla/room122", "north",

--- a/domain/original/area/vesla/room226.c
+++ b/domain/original/area/vesla/room226.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room117", "south",
         "domain/original/area/vesla/room228", "west",

--- a/domain/original/area/vesla/room227.c
+++ b/domain/original/area/vesla/room227.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "north",
         "domain/original/area/vesla/room118", "south",

--- a/domain/original/area/vesla/room228.c
+++ b/domain/original/area/vesla/room228.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc  = "A peaceful park.\n";
+    short_desc = "Shattered Walk";
+    long_desc  = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
 
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "north",

--- a/domain/original/area/vesla/room230.c
+++ b/domain/original/area/vesla/room230.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room119", "south",
         "domain/original/area/vesla/room815", "west",

--- a/domain/original/area/vesla/room231.c
+++ b/domain/original/area/vesla/room231.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "south",
         "domain/original/area/vesla/room796", "west",

--- a/domain/original/area/vesla/room232.c
+++ b/domain/original/area/vesla/room232.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room226", "south",
         "domain/original/area/vesla/room227", "west",

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Edifice";
-    long_desc = "Broken Edifice.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "west",
         "domain/original/area/vesla/room116", "north",

--- a/domain/original/area/vesla/room234.c
+++ b/domain/original/area/vesla/room234.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Andre's Clothing";
-    long_desc = "Andre's Clothing.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room232", "south",
     });

--- a/domain/original/area/vesla/room394.c
+++ b/domain/original/area/vesla/room394.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Smoke House";
-    long_desc = "Smoke House.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room210", "south",
     });

--- a/domain/original/area/vesla/room395.c
+++ b/domain/original/area/vesla/room395.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Lathe";
-    long_desc = "The Lathe.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "south",
     });

--- a/domain/original/area/vesla/room396.c
+++ b/domain/original/area/vesla/room396.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Antique Shop";
-    long_desc = "Antique Shop.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "south",
     });

--- a/domain/original/area/vesla/room397.c
+++ b/domain/original/area/vesla/room397.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Mage's House";
-    long_desc = "Mage's House.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room398", "east",
         "domain/original/area/vesla/room206", "south",

--- a/domain/original/area/vesla/room398.c
+++ b/domain/original/area/vesla/room398.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Mage's Apprentice House";
-    long_desc = "Mage's Apprentice House.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room397", "west",
     });

--- a/domain/original/area/vesla/room399.c
+++ b/domain/original/area/vesla/room399.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Retired Warrior's House";
-    long_desc = "Retired Warrior's House.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room734", "up",
         "domain/original/area/vesla/room213", "west",

--- a/domain/original/area/vesla/room400.c
+++ b/domain/original/area/vesla/room400.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Bell maker's shop";
-    long_desc = "Bell maker's shop.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "east",
     });

--- a/domain/original/area/vesla/room401.c
+++ b/domain/original/area/vesla/room401.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Candle Shop";
-    long_desc = "Candle Shop.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "west",
     });

--- a/domain/original/area/vesla/room402.c
+++ b/domain/original/area/vesla/room402.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Do-it-Yourself Distiller";
-    long_desc = "Do-it-Yourself Distiller.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room216", "east",
     });

--- a/domain/original/area/vesla/room403.c
+++ b/domain/original/area/vesla/room403.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Entrance to a temple";
-    long_desc = "Entrance to a temple.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room404", "east",
         "domain/original/area/vesla/room216", "west",

--- a/domain/original/area/vesla/room404.c
+++ b/domain/original/area/vesla/room404.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Temple of Amaterasu";
-    long_desc = "Temple of Amaterasu.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "east",
         "domain/original/area/vesla/room403", "west",

--- a/domain/original/area/vesla/room405.c
+++ b/domain/original/area/vesla/room405.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Temple of Amaterasu";
-    long_desc = "Temple of Amaterasu.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room404", "west",
         "domain/original/area/vesla/room407", "south",

--- a/domain/original/area/vesla/room406.c
+++ b/domain/original/area/vesla/room406.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Candle Room";
-    long_desc = "Candle Room.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "south",
     });

--- a/domain/original/area/vesla/room407.c
+++ b/domain/original/area/vesla/room407.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Quiet Room";
-    long_desc = "Quiet Room.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "north",
     });

--- a/domain/original/area/vesla/room408.c
+++ b/domain/original/area/vesla/room408.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Sundered Hall";
-    long_desc = "Sundered Hall.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "east",
     });

--- a/domain/original/area/vesla/room409.c
+++ b/domain/original/area/vesla/room409.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Bounty Room";
-    long_desc = "Bounty Room.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "east",
     });

--- a/domain/original/area/vesla/room411.c
+++ b/domain/original/area/vesla/room411.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Vesla Times Press Office";
-    long_desc = "Vesla Times Press Office.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room410", "east",
         "domain/original/area/vesla/room123", "south",

--- a/domain/original/area/vesla/room412.c
+++ b/domain/original/area/vesla/room412.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Smithy";
-    long_desc = "Smithy.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "west",
         "domain/original/area/vesla/room124", "south",

--- a/domain/original/area/vesla/room419.c
+++ b/domain/original/area/vesla/room419.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Lightless Ruined Alleyway";
-    long_desc = "No light reaches this narrow cut between ruins, only soot and broken masonry. The place feels abandoned even by whatever once nested here.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "north",
     });

--- a/domain/original/area/vesla/room420.c
+++ b/domain/original/area/vesla/room420.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Old Temple";
-    long_desc = "The Old Temple.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "north",
     });

--- a/domain/original/area/vesla/room421.c
+++ b/domain/original/area/vesla/room421.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Mage's Guild";
-    long_desc = "Mage's Guild.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "north",
     });

--- a/domain/original/area/vesla/room422.c
+++ b/domain/original/area/vesla/room422.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Mercantile Guild Office";
-    long_desc = "Mercantile Guild Office.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room837", "east",
         "domain/original/area/vesla/room155", "west",

--- a/domain/original/area/vesla/room423.c
+++ b/domain/original/area/vesla/room423.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Glassblower";
-    long_desc = "Glassblower.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "east",
     });

--- a/domain/original/area/vesla/room424.c
+++ b/domain/original/area/vesla/room424.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Fighter's Guild";
-    long_desc = "Fighter's Guild.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "west",
     });

--- a/domain/original/area/vesla/room425.c
+++ b/domain/original/area/vesla/room425.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Omar's Oils II";
-    long_desc = "Omar's Oils II.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "south",
     });

--- a/domain/original/area/vesla/room426.c
+++ b/domain/original/area/vesla/room426.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Deora's Outfitters";
-    long_desc = "Deora's Outfitters.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room231", "south",
     });

--- a/domain/original/area/vesla/room734.c
+++ b/domain/original/area/vesla/room734.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Weapon Master's Bedroom";
-    long_desc = "Weapon Master's Bedroom.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room399", "down",
     });

--- a/domain/original/area/vesla/room735.c
+++ b/domain/original/area/vesla/room735.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "west",
     });

--- a/domain/original/area/vesla/room736.c
+++ b/domain/original/area/vesla/room736.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "west",
     });

--- a/domain/original/area/vesla/room737.c
+++ b/domain/original/area/vesla/room737.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Chamber of Commerce";
-    long_desc = "Chamber of Commerce.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room187", "south",
     });

--- a/domain/original/area/vesla/room738.c
+++ b/domain/original/area/vesla/room738.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rubble-Choked Alley";
-    long_desc = "The alley is little more than a trench of shattered stone and collapsed timbers. Ash and rubble fill the cramped passage.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "south",
     });

--- a/domain/original/area/vesla/room739.c
+++ b/domain/original/area/vesla/room739.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The School of Guild Skills";
-    long_desc = "The School of Guild Skills.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "north",
     });

--- a/domain/original/area/vesla/room740.c
+++ b/domain/original/area/vesla/room740.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Fallen Annex";
-    long_desc = "Fallen Annex.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "north",
     });

--- a/domain/original/area/vesla/room741.c
+++ b/domain/original/area/vesla/room741.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Hallway";
-    long_desc = "Dormitory Hallway.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "up",
         "domain/original/area/vesla/room190", "south",

--- a/domain/original/area/vesla/room742.c
+++ b/domain/original/area/vesla/room742.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Magoo's Bookstore";
-    long_desc = "Magoo's Bookstore.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "north",
     });

--- a/domain/original/area/vesla/room743.c
+++ b/domain/original/area/vesla/room743.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Frenchie's Cafe";
-    long_desc = "Frenchie's Cafe.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "south",
     });

--- a/domain/original/area/vesla/room745.c
+++ b/domain/original/area/vesla/room745.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Kitchen";
-    long_desc = "Dormitory Kitchen.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room746", "east",
         "domain/original/area/vesla/room741", "south",

--- a/domain/original/area/vesla/room746.c
+++ b/domain/original/area/vesla/room746.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dusty Ruins";
-    long_desc = "Dusty Ruins.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room745", "west",
     });

--- a/domain/original/area/vesla/room747.c
+++ b/domain/original/area/vesla/room747.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Administrator's Room";
-    long_desc = "Dormitory Administrator's Room.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room741", "west",
     });

--- a/domain/original/area/vesla/room748.c
+++ b/domain/original/area/vesla/room748.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Hallway";
-    long_desc = "Dormitory Hallway.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room751", "west",
         "domain/original/area/vesla/room741", "down",

--- a/domain/original/area/vesla/room749.c
+++ b/domain/original/area/vesla/room749.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "Dormer.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "south",
     });

--- a/domain/original/area/vesla/room750.c
+++ b/domain/original/area/vesla/room750.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "Dormer.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "west",
     });

--- a/domain/original/area/vesla/room751.c
+++ b/domain/original/area/vesla/room751.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "Dormer.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "east",
     });

--- a/domain/original/area/vesla/room752.c
+++ b/domain/original/area/vesla/room752.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "Dormer.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "north",
     });

--- a/domain/original/area/vesla/room753.c
+++ b/domain/original/area/vesla/room753.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The drawbridge";
-    long_desc = "The drawbridge.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room169", "southwest",
         "domain/original/area/vesla/room754", "north",

--- a/domain/original/area/vesla/room754.c
+++ b/domain/original/area/vesla/room754.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Between the towers";
-    long_desc = "Between the towers.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room753", "south",
         "domain/original/area/vesla/room755", "north",

--- a/domain/original/area/vesla/room755.c
+++ b/domain/original/area/vesla/room755.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Between the towers";
-    long_desc = "Between the towers.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room754", "south",
         "domain/original/area/vesla/room756", "north",

--- a/domain/original/area/vesla/room756.c
+++ b/domain/original/area/vesla/room756.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room755", "south",
         "domain/original/area/vesla/room757", "north",

--- a/domain/original/area/vesla/room757.c
+++ b/domain/original/area/vesla/room757.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room756", "south",
         "domain/original/area/vesla/room765", "northeast",

--- a/domain/original/area/vesla/room758.c
+++ b/domain/original/area/vesla/room758.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room757", "west",
         "domain/original/area/vesla/room759", "south",

--- a/domain/original/area/vesla/room759.c
+++ b/domain/original/area/vesla/room759.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Eastern guard room";
-    long_desc = "Eastern guard room.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room760", "northeast",
         "domain/original/area/vesla/room758", "north",

--- a/domain/original/area/vesla/room760.c
+++ b/domain/original/area/vesla/room760.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Lower eastern stairwell";
-    long_desc = "Lower eastern stairwell.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room759", "southwest",
         "domain/original/area/vesla/room761", "up",

--- a/domain/original/area/vesla/room761.c
+++ b/domain/original/area/vesla/room761.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Middle eastern stairwell";
-    long_desc = "Middle eastern stairwell.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room762", "southwest",
         "domain/original/area/vesla/room760", "down",

--- a/domain/original/area/vesla/room762.c
+++ b/domain/original/area/vesla/room762.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Eastern guard quarters";
-    long_desc = "Eastern guard quarters.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room761", "northeast",
     });

--- a/domain/original/area/vesla/room763.c
+++ b/domain/original/area/vesla/room763.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Upper eastern stairwell";
-    long_desc = "Upper eastern stairwell.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room764", "southwest",
         "domain/original/area/vesla/room761", "down",

--- a/domain/original/area/vesla/room764.c
+++ b/domain/original/area/vesla/room764.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Eastern tower observatory";
-    long_desc = "Eastern tower observatory.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room763", "northeast",
     });

--- a/domain/original/area/vesla/room765.c
+++ b/domain/original/area/vesla/room765.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room766", "west",
         "domain/original/area/vesla/room767", "northwest",

--- a/domain/original/area/vesla/room766.c
+++ b/domain/original/area/vesla/room766.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room758", "southeast",
         "domain/original/area/vesla/room757", "south",

--- a/domain/original/area/vesla/room767.c
+++ b/domain/original/area/vesla/room767.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room768", "east",
         "domain/original/area/vesla/room765", "southeast",

--- a/domain/original/area/vesla/room768.c
+++ b/domain/original/area/vesla/room768.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "The inner ward.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room766", "southwest",
         "domain/original/area/vesla/room767", "west",

--- a/domain/original/area/vesla/room769.c
+++ b/domain/original/area/vesla/room769.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The well";
-    long_desc = "The well.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room765", "southwest",
         "domain/original/area/vesla/room771", "east",

--- a/domain/original/area/vesla/room770.c
+++ b/domain/original/area/vesla/room770.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "Castle stables.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room790", "south",
         "domain/original/area/vesla/room765", "west",

--- a/domain/original/area/vesla/room771.c
+++ b/domain/original/area/vesla/room771.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The blacksmith";
-    long_desc = "The blacksmith.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room772", "east",
         "domain/original/area/vesla/room769", "west",

--- a/domain/original/area/vesla/room772.c
+++ b/domain/original/area/vesla/room772.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The storage room";
-    long_desc = "The storage room.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room771", "west",
     });

--- a/domain/original/area/vesla/room773.c
+++ b/domain/original/area/vesla/room773.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "Castle stables.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room789", "south",
         "domain/original/area/vesla/room770", "west",

--- a/domain/original/area/vesla/room774.c
+++ b/domain/original/area/vesla/room774.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "Castle stables.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room787", "south",
         "domain/original/area/vesla/room773", "west",

--- a/domain/original/area/vesla/room775.c
+++ b/domain/original/area/vesla/room775.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "Castle stables.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room784", "south",
         "domain/original/area/vesla/room774", "west",

--- a/domain/original/area/vesla/room776.c
+++ b/domain/original/area/vesla/room776.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "Castle stables.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room782", "south",
         "domain/original/area/vesla/room775", "west",

--- a/domain/original/area/vesla/room777.c
+++ b/domain/original/area/vesla/room777.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "Small paddock.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room779", "southeast",
         "domain/original/area/vesla/room783", "south",

--- a/domain/original/area/vesla/room778.c
+++ b/domain/original/area/vesla/room778.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "Small paddock.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "southwest",
         "domain/original/area/vesla/room777", "west",

--- a/domain/original/area/vesla/room779.c
+++ b/domain/original/area/vesla/room779.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "Small paddock.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "west",
         "domain/original/area/vesla/room777", "northwest",

--- a/domain/original/area/vesla/room780.c
+++ b/domain/original/area/vesla/room780.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wash area";
-    long_desc = "Wash area.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room778", "southeast",
         "domain/original/area/vesla/room777", "south",

--- a/domain/original/area/vesla/room783.c
+++ b/domain/original/area/vesla/room783.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "Small paddock.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room778", "northeast",
         "domain/original/area/vesla/room779", "east",

--- a/domain/original/area/vesla/room786.c
+++ b/domain/original/area/vesla/room786.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Tack room";
-    long_desc = "Tack room.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "south",
     });

--- a/domain/original/area/vesla/room787.c
+++ b/domain/original/area/vesla/room787.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Feed room";
-    long_desc = "Feed room.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "north",
     });

--- a/domain/original/area/vesla/room793.c
+++ b/domain/original/area/vesla/room793.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite";
-    long_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room168", "east",
     });

--- a/domain/original/area/vesla/room804.c
+++ b/domain/original/area/vesla/room804.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Fish Mongery";
-    long_desc = "Fish Mongery.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room803", "north",
     });

--- a/domain/original/area/vesla/room805.c
+++ b/domain/original/area/vesla/room805.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Crazy Habib's Fertilizer";
-    long_desc = "Crazy Habib's Fertilizer.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "north",
     });

--- a/domain/original/area/vesla/room806.c
+++ b/domain/original/area/vesla/room806.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Barber Shop";
-    long_desc = "Barber Shop.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room800", "south",
     });

--- a/domain/original/area/vesla/room807.c
+++ b/domain/original/area/vesla/room807.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Pornographers Den";
-    long_desc = "Pornographers Den.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "south",
     });

--- a/domain/original/area/vesla/room808.c
+++ b/domain/original/area/vesla/room808.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Livery";
-    long_desc = "Livery.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room809", "up",
         "domain/original/area/vesla/room161", "west",

--- a/domain/original/area/vesla/room809.c
+++ b/domain/original/area/vesla/room809.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Hayloft";
-    long_desc = "Hayloft.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room808", "down",
     });

--- a/domain/original/area/vesla/room810.c
+++ b/domain/original/area/vesla/room810.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Tailor's Shop";
-    long_desc = "Tailor's Shop.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "west",
     });

--- a/domain/original/area/vesla/room811.c
+++ b/domain/original/area/vesla/room811.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Shell";
-    long_desc = "Splintered Shell.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "west",
     });

--- a/domain/original/area/vesla/room812.c
+++ b/domain/original/area/vesla/room812.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Haseltine Engravers";
-    long_desc = "Haseltine Engravers.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "west",
     });

--- a/domain/original/area/vesla/room813.c
+++ b/domain/original/area/vesla/room813.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room795", "north",
     });

--- a/domain/original/area/vesla/room814.c
+++ b/domain/original/area/vesla/room814.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Flea Market";
-    long_desc = "Flea Market.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room796", "north",
     });

--- a/domain/original/area/vesla/room815.c
+++ b/domain/original/area/vesla/room815.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Back Room";
-    long_desc = "The Back Room.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "east",
         "domain/original/area/vesla/room814", "north",

--- a/domain/original/area/vesla/room816.c
+++ b/domain/original/area/vesla/room816.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle Bridge";
-    long_desc = "Castle Bridge.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "north",
     });

--- a/domain/original/area/vesla/room817.c
+++ b/domain/original/area/vesla/room817.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Manor House";
-    long_desc = "Manor House.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room818", "up",
         "domain/original/area/vesla/room152", "west",

--- a/domain/original/area/vesla/room818.c
+++ b/domain/original/area/vesla/room818.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Manor House";
-    long_desc = "Manor House.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room817", "down",
     });

--- a/domain/original/area/vesla/room819.c
+++ b/domain/original/area/vesla/room819.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room152", "east",
     });

--- a/domain/original/area/vesla/room820.c
+++ b/domain/original/area/vesla/room820.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Cleric Guild";
-    long_desc = "Cleric Guild.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room839", "west",
         "domain/original/area/vesla/room153", "east",

--- a/domain/original/area/vesla/room821.c
+++ b/domain/original/area/vesla/room821.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Hall of the builders guild";
-    long_desc = "Hall of the builders guild.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "west",
     });

--- a/domain/original/area/vesla/room822.c
+++ b/domain/original/area/vesla/room822.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "City Hall";
-    long_desc = "City Hall.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "east",
         "domain/original/area/vesla/room831", "up",

--- a/domain/original/area/vesla/room823.c
+++ b/domain/original/area/vesla/room823.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Tea Shop";
-    long_desc = "Tea Shop.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room157", "east",
     });

--- a/domain/original/area/vesla/room824.c
+++ b/domain/original/area/vesla/room824.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Whore House";
-    long_desc = "Whore House.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "east",
         "domain/original/area/vesla/room825", "up",

--- a/domain/original/area/vesla/room826.c
+++ b/domain/original/area/vesla/room826.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Viking's room";
-    long_desc = "Viking's room.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "east",
     });

--- a/domain/original/area/vesla/room827.c
+++ b/domain/original/area/vesla/room827.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Sandra's room";
-    long_desc = "Sandra's room.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "south",
     });

--- a/domain/original/area/vesla/room828.c
+++ b/domain/original/area/vesla/room828.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Kathy's room";
-    long_desc = "Kathy's room.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "north",
     });

--- a/domain/original/area/vesla/room829.c
+++ b/domain/original/area/vesla/room829.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Robert's room";
-    long_desc = "Robert's room.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "down",
     });

--- a/domain/original/area/vesla/room830.c
+++ b/domain/original/area/vesla/room830.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Baker's Shop";
-    long_desc = "Baker's Shop.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room157", "west",
     });

--- a/domain/original/area/vesla/room831.c
+++ b/domain/original/area/vesla/room831.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "First Floor";
-    long_desc = "First Floor.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "up",
         "domain/original/area/vesla/room822", "down",

--- a/domain/original/area/vesla/room832.c
+++ b/domain/original/area/vesla/room832.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Chamber of Commerce";
-    long_desc = "Chamber of Commerce.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room831", "east",
     });

--- a/domain/original/area/vesla/room833.c
+++ b/domain/original/area/vesla/room833.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Second Floor";
-    long_desc = "Second Floor.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room835", "up",
         "domain/original/area/vesla/room831", "down",

--- a/domain/original/area/vesla/room834.c
+++ b/domain/original/area/vesla/room834.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Magistrate";
-    long_desc = "Magistrate.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "east",
     });

--- a/domain/original/area/vesla/room835.c
+++ b/domain/original/area/vesla/room835.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "City Archives";
-    long_desc = "City Archives.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "down",
         "domain/original/area/vesla/room836", "west",

--- a/domain/original/area/vesla/room836.c
+++ b/domain/original/area/vesla/room836.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Inner Sanctum";
-    long_desc = "Inner Sanctum.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room835", "east",
     });

--- a/domain/original/area/vesla/room837.c
+++ b/domain/original/area/vesla/room837.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Open Air Market:";
-    long_desc = "Open Air Market:.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room422", "west",
     });

--- a/domain/original/area/vesla/room838.c
+++ b/domain/original/area/vesla/room838.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Chapel of War";
-    long_desc = "Chapel of War.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "south",
     });

--- a/domain/original/area/vesla/room839.c
+++ b/domain/original/area/vesla/room839.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Reconciliation Chapel";
-    long_desc = "Reconciliation Chapel.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "east",
     });

--- a/domain/original/area/vesla/room840.c
+++ b/domain/original/area/vesla/room840.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room841", "west",
         "domain/original/area/vesla/room148", "south",

--- a/domain/original/area/vesla/room841.c
+++ b/domain/original/area/vesla/room841.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "south",
         "domain/original/area/vesla/room842", "west",

--- a/domain/original/area/vesla/room842.c
+++ b/domain/original/area/vesla/room842.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "south",
         "domain/original/area/vesla/room841", "east",

--- a/domain/original/area/vesla/room843.c
+++ b/domain/original/area/vesla/room843.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room844", "west",
         "domain/original/area/vesla/room841", "south",

--- a/domain/original/area/vesla/room844.c
+++ b/domain/original/area/vesla/room844.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room842", "south",
         "domain/original/area/vesla/room843", "east",

--- a/domain/original/area/vesla/room845.c
+++ b/domain/original/area/vesla/room845.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "east",
         "domain/original/area/vesla/room146", "north",

--- a/domain/original/area/vesla/room846.c
+++ b/domain/original/area/vesla/room846.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "Burned Area.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "west",
         "domain/original/area/vesla/room147", "north",

--- a/domain/original/area/vesla/room847.c
+++ b/domain/original/area/vesla/room847.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old City Offices";
-    long_desc = "Old City Offices.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room849", "west",
         "domain/original/area/vesla/room848", "east",

--- a/domain/original/area/vesla/room848.c
+++ b/domain/original/area/vesla/room848.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old Office";
-    long_desc = "Old Office.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "west",
     });

--- a/domain/original/area/vesla/room849.c
+++ b/domain/original/area/vesla/room849.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old Office";
-    long_desc = "Old Office.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "east",
     });

--- a/domain/original/area/vesla/room850.c
+++ b/domain/original/area/vesla/room850.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "west",
         "domain/original/area/vesla/room852", "east",

--- a/domain/original/area/vesla/room851.c
+++ b/domain/original/area/vesla/room851.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room850", "south",
     });

--- a/domain/original/area/vesla/room852.c
+++ b/domain/original/area/vesla/room852.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room850", "west",
     });

--- a/domain/original/area/vesla/room853.c
+++ b/domain/original/area/vesla/room853.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Abandoned Building";
-    long_desc = "Abandoned Building.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "east",
     });

--- a/domain/original/area/vesla/room854.c
+++ b/domain/original/area/vesla/room854.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Spice Merchant";
-    long_desc = "Spice Merchant.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "west",
     });

--- a/domain/original/area/vesla/room855.c
+++ b/domain/original/area/vesla/room855.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Abandoned Building";
-    long_desc = "Abandoned Building.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "west",
     });

--- a/domain/original/area/vesla/room856.c
+++ b/domain/original/area/vesla/room856.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Carvings Shop";
-    long_desc = "Carvings Shop.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "east",
     });

--- a/domain/original/area/vesla/room857.c
+++ b/domain/original/area/vesla/room857.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Abandoned Warehouse";
-    long_desc = "Abandoned Warehouse.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room198", "west",
     });

--- a/domain/original/area/vesla/room870.c
+++ b/domain/original/area/vesla/room870.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "In Rohan's bedroom";
-    long_desc = "In Rohan's bedroom.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room869", "down",
         "domain/original/area/vesla/room871", "up",

--- a/domain/original/area/vesla/room871.c
+++ b/domain/original/area/vesla/room871.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "In Gwyneth's bedroom";
-    long_desc = "In Gwyneth's bedroom.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room873", "down",
         "domain/original/area/vesla/room872", "up",

--- a/domain/original/area/vesla/room872.c
+++ b/domain/original/area/vesla/room872.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "In Vella's bedroom";
-    long_desc = "In Vella's bedroom.\n";
+    short_desc = "Collapsed Vault";
+    long_desc = "A cold hush hangs over the wreckage. Scorched beams and soot-blackened stone suggest flames that once raged here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room871", "down",
     });

--- a/domain/original/area/vesla/room873.c
+++ b/domain/original/area/vesla/room873.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "<> Aladrin escapes reality and falls into Moral Decay. <>";
-    long_desc = "<> Aladrin escapes reality and falls into Moral Decay. <>.\n";
+    short_desc = "Cinder-Laden Court";
+    long_desc = "The ceiling has partially collapsed, leaving jagged stone and ash. The destruction feels deliberate, as if wrought by enormous, fire-breathing beasts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room874", "down",
         "domain/original/area/vesla/room871", "up",

--- a/domain/original/area/vesla/room874.c
+++ b/domain/original/area/vesla/room874.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Bottom floor of the silo";
-    long_desc = "Bottom floor of the silo.\n";
+    short_desc = "Soot-Stained Interior";
+    long_desc = "Soot and dust drift in the stale air. The floor is split and buckled, as though immense weight and heat pressed down at once.\n";
     dest_dir = ({
         "domain/original/area/vesla/room873", "up",
     });

--- a/domain/original/area/vesla/room878.c
+++ b/domain/original/area/vesla/room878.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent.\n";
+    short_desc = "Rubble-Strewn Ground";
+    long_desc = "Charred fragments litter the ground, and the walls are blistered by heat. Long gouges and melted slag mark the passing of something huge.\n";
     dest_dir = ({
         "domain/original/area/vesla/room127", "south",
     });

--- a/domain/original/area/vesla/room879.c
+++ b/domain/original/area/vesla/room879.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Vesla Post Office";
-    long_desc = "Vesla Post Office.\n";
+    short_desc = "Burned-Out Space";
+    long_desc = "Rubble forms uneven mounds where structures once stood. The scorched surfaces and clawed stone speak of a violent, fiery ruin.\n";
     dest_dir = ({
         "domain/original/area/vesla/room126", "south",
     });

--- a/domain/original/area/vesla/room880.c
+++ b/domain/original/area/vesla/room880.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old Adventurer's Guild";
-    long_desc = "Old Adventurer's Guild.\n";
+    short_desc = "Shattered Walk";
+    long_desc = "A brittle silence fills this ruined space. Burnt stone and warped metal gleam faintly, scarred by intense flames.\n";
     dest_dir = ({
         "domain/original/area/vesla/room126", "north",
     });

--- a/domain/original/area/vesla/room893.c
+++ b/domain/original/area/vesla/room893.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The Players' lounge";
-    long_desc = "The Players' lounge.\n";
+    short_desc = "Blistered Stonework";
+    long_desc = "Cracked flagstones and soot-smeared walls frame a hollow ruin. Signs of tremendous heat and raking talons remain.\n";
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "down",
     });

--- a/domain/original/area/vesla/room961.c
+++ b/domain/original/area/vesla/room961.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rising Phoenix";
-    long_desc = "Rising Phoenix.\n";
+    short_desc = "Ashen Ruins";
+    long_desc = "Ash lies thick over cracked stone and splintered timbers. The air smells of old smoke, and deep gouges show where something massive tore through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room796", "south",
     });

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Buried Wreckage";
-    long_desc = "Buried Wreckage.\n";
+    short_desc = "Scorched Chamber";
+    long_desc = "Char marks crawl across the walls, and fused debris crunches underfoot. Heat-scarred stone and warped metal hint at a terrible blaze.\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "west",
     });

--- a/domain/original/area/vesla/sanctuary.c
+++ b/domain/original/area/vesla/sanctuary.c
@@ -15,8 +15,8 @@ void reset(int arg) {
     set_light(1);
 
     reboot_time = time();
-    short_desc = "Sanctuary";
-    long_desc = "Sanctuary.\n";
+    short_desc = "Blackened Passage";
+    long_desc = "Broken masonry and cinders blanket the floor. Melted fixtures cling to the walls, and clawed furrows cut through the rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "south",
 	"domain/original/area/vesla/room893", "up",


### PR DESCRIPTION
### Motivation
- Make the Vesla area read as a coherent, dragon-ravaged ruin rather than a set of rooms with duplicated short/long text. 
- Replace rooms where `short_desc` matched the (trivial) `long_desc` with plausible, setting-appropriate short descriptions. 
- Update `long_desc` fields to concise, theme-appropriate sentences evoking devastation and fire-breathing attackers. 
- Reopen a selection of previously-blocked exits to restore navigability across the Vesla map.

### Description
- Replaced duplicated/placeholder short and long descriptions in many `domain/original/area/vesla/*.c` rooms with curated ruin-themed text (about 153 rooms updated). 
- Updated the area portal and sanctuary (`portal.c`, `sanctuary.c`) to match the new ruin theme and wording. 
- Removed `block_exit` handlers from a set of rooms (22 rooms) to reopen previously-blocked directions and restored the corresponding `dest_dir` connections so exits are traversable. 
- Bulk edits applied via scripted search/replace and per-room patches; overall change set touched 178 files with insertions and deletions to refresh descriptions and unblock routes.

### Testing
- No automated tests were executed for this change set.
- Basic scripted checks were used to locate rooms with duplicated descriptions before applying edits, and the same scripts were used to apply replacements (no test harness run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eec9c4c1883279c47481a47fdfa59)