### PR TITLE
Format Candera room descriptions

### DIFF
--- a/domain/original/area/candera/room1.c
+++ b/domain/original/area/candera/room1.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room57", "south",
         "domain/original/area/candera/room2", "east",

--- a/domain/original/area/candera/room10.c
+++ b/domain/original/area/candera/room10.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room9", "north",
         "domain/original/area/candera/room11", "south",

--- a/domain/original/area/candera/room100.c
+++ b/domain/original/area/candera/room100.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room99", "north",
         "domain/original/area/candera/room101", "south",

--- a/domain/original/area/candera/room101.c
+++ b/domain/original/area/candera/room101.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room100", "north",
         "domain/original/area/candera/room102", "south",

--- a/domain/original/area/candera/room1015.c
+++ b/domain/original/area/candera/room1015.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room65", "west",
     });

--- a/domain/original/area/candera/room1016.c
+++ b/domain/original/area/candera/room1016.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room73", "north",
     });

--- a/domain/original/area/candera/room1017.c
+++ b/domain/original/area/candera/room1017.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room73", "south",
         "domain/original/area/candera/room1018", "west",

--- a/domain/original/area/candera/room1019.c
+++ b/domain/original/area/candera/room1019.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room74", "north",
     });

--- a/domain/original/area/candera/room102.c
+++ b/domain/original/area/candera/room102.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room101", "north",
         "domain/original/area/candera/room103", "south",

--- a/domain/original/area/candera/room103.c
+++ b/domain/original/area/candera/room103.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room102", "north",
         "domain/original/area/candera/room104", "south",

--- a/domain/original/area/candera/room1030.c
+++ b/domain/original/area/candera/room1030.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room29", "north",
         "domain/original/area/candera/room1032", "east",

--- a/domain/original/area/candera/room1031.c
+++ b/domain/original/area/candera/room1031.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room1030", "east",
     });

--- a/domain/original/area/candera/room1032.c
+++ b/domain/original/area/candera/room1032.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room1030", "west",
     });

--- a/domain/original/area/candera/room1033.c
+++ b/domain/original/area/candera/room1033.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room1035", "north",
         "domain/original/area/candera/room1034", "south",

--- a/domain/original/area/candera/room1034.c
+++ b/domain/original/area/candera/room1034.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room1033", "north",
     });

--- a/domain/original/area/candera/room1035.c
+++ b/domain/original/area/candera/room1035.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room1033", "south",
     });

--- a/domain/original/area/candera/room104.c
+++ b/domain/original/area/candera/room104.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room103", "north",
         "domain/original/area/candera/room106", "east",

--- a/domain/original/area/candera/room105.c
+++ b/domain/original/area/candera/room105.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room104", "east",
         "domain/original/area/candera/room1127", "up",

--- a/domain/original/area/candera/room106.c
+++ b/domain/original/area/candera/room106.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room104", "west",
         "domain/original/area/candera/room1126", "up",

--- a/domain/original/area/candera/room107.c
+++ b/domain/original/area/candera/room107.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room108", "north",
         "domain/original/area/candera/room98", "south",

--- a/domain/original/area/candera/room108.c
+++ b/domain/original/area/candera/room108.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room109", "north",
         "domain/original/area/candera/room107", "south",

--- a/domain/original/area/candera/room109.c
+++ b/domain/original/area/candera/room109.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room110", "north",
         "domain/original/area/candera/room108", "south",

--- a/domain/original/area/candera/room1093.c
+++ b/domain/original/area/candera/room1093.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room90", "east",
     });

--- a/domain/original/area/candera/room1094.c
+++ b/domain/original/area/candera/room1094.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room90", "west",
     });

--- a/domain/original/area/candera/room1095.c
+++ b/domain/original/area/candera/room1095.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room75", "north",
     });

--- a/domain/original/area/candera/room1096.c
+++ b/domain/original/area/candera/room1096.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room79", "west",
     });

--- a/domain/original/area/candera/room1097.c
+++ b/domain/original/area/candera/room1097.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room82", "east",
     });

--- a/domain/original/area/candera/room1098.c
+++ b/domain/original/area/candera/room1098.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room82", "west",
         "domain/original/area/candera/room1099", "down",

--- a/domain/original/area/candera/room11.c
+++ b/domain/original/area/candera/room11.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room10", "north",
         "domain/original/area/candera/room12", "south",

--- a/domain/original/area/candera/room110.c
+++ b/domain/original/area/candera/room110.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room111", "north",
         "domain/original/area/candera/room109", "south",

--- a/domain/original/area/candera/room111.c
+++ b/domain/original/area/candera/room111.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room112", "north",
         "domain/original/area/candera/room110", "south",

--- a/domain/original/area/candera/room112.c
+++ b/domain/original/area/candera/room112.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room111", "south",
         "domain/original/area/candera/room114", "east",

--- a/domain/original/area/candera/room1125.c
+++ b/domain/original/area/candera/room1125.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room967", "south",
     });

--- a/domain/original/area/candera/room1126.c
+++ b/domain/original/area/candera/room1126.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room106", "down",
     });

--- a/domain/original/area/candera/room1127.c
+++ b/domain/original/area/candera/room1127.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room105", "down",
     });

--- a/domain/original/area/candera/room1128.c
+++ b/domain/original/area/candera/room1128.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room114", "down",
     });

--- a/domain/original/area/candera/room1129.c
+++ b/domain/original/area/candera/room1129.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room113", "down",
     });

--- a/domain/original/area/candera/room113.c
+++ b/domain/original/area/candera/room113.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room112", "east",
         "domain/original/area/candera/room1129", "up",

--- a/domain/original/area/candera/room1130.c
+++ b/domain/original/area/candera/room1130.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room84", "down",
     });

--- a/domain/original/area/candera/room1131.c
+++ b/domain/original/area/candera/room1131.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room85", "down",
     });

--- a/domain/original/area/candera/room1132.c
+++ b/domain/original/area/candera/room1132.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room92", "down",
     });

--- a/domain/original/area/candera/room1133.c
+++ b/domain/original/area/candera/room1133.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room93", "down",
     });

--- a/domain/original/area/candera/room1134.c
+++ b/domain/original/area/candera/room1134.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room69", "down",
     });

--- a/domain/original/area/candera/room114.c
+++ b/domain/original/area/candera/room114.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room112", "west",
         "domain/original/area/candera/room1128", "up",

--- a/domain/original/area/candera/room12.c
+++ b/domain/original/area/candera/room12.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room11", "north",
         "domain/original/area/candera/room13", "south",

--- a/domain/original/area/candera/room13.c
+++ b/domain/original/area/candera/room13.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room12", "north",
         "domain/original/area/candera/room14", "south",

--- a/domain/original/area/candera/room14.c
+++ b/domain/original/area/candera/room14.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room13", "north",
         "domain/original/area/candera/room15", "south",

--- a/domain/original/area/candera/room15.c
+++ b/domain/original/area/candera/room15.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room14", "north",
         "domain/original/area/candera/room16", "south",

--- a/domain/original/area/candera/room16.c
+++ b/domain/original/area/candera/room16.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room15", "north",
         "domain/original/area/candera/room17", "south",

--- a/domain/original/area/candera/room17.c
+++ b/domain/original/area/candera/room17.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room16", "north",
         "domain/original/area/candera/room18", "south",

--- a/domain/original/area/candera/room18.c
+++ b/domain/original/area/candera/room18.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room17", "north",
         "domain/original/area/candera/room19", "south",

--- a/domain/original/area/candera/room19.c
+++ b/domain/original/area/candera/room19.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room18", "north",
         "domain/original/area/candera/room20", "south",

--- a/domain/original/area/candera/room2.c
+++ b/domain/original/area/candera/room2.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room3", "east",
         "domain/original/area/candera/room1", "west",

--- a/domain/original/area/candera/room20.c
+++ b/domain/original/area/candera/room20.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room19", "north",
         "domain/original/area/candera/room21", "south",

--- a/domain/original/area/candera/room21.c
+++ b/domain/original/area/candera/room21.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room20", "north",
         "domain/original/area/candera/room22", "south",

--- a/domain/original/area/candera/room22.c
+++ b/domain/original/area/candera/room22.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room21", "north",
         "domain/original/area/candera/room23", "west",

--- a/domain/original/area/candera/room23.c
+++ b/domain/original/area/candera/room23.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room22", "east",
         "domain/original/area/candera/room24", "west",

--- a/domain/original/area/candera/room24.c
+++ b/domain/original/area/candera/room24.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room23", "east",
         "domain/original/area/candera/room25", "west",

--- a/domain/original/area/candera/room25.c
+++ b/domain/original/area/candera/room25.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room24", "east",
         "domain/original/area/candera/room26", "west",

--- a/domain/original/area/candera/room26.c
+++ b/domain/original/area/candera/room26.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room25", "east",
         "domain/original/area/candera/room27", "west",

--- a/domain/original/area/candera/room27.c
+++ b/domain/original/area/candera/room27.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room26", "east",
         "domain/original/area/candera/room28", "west",

--- a/domain/original/area/candera/room28.c
+++ b/domain/original/area/candera/room28.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room27", "east",
         "domain/original/area/candera/room29", "west",

--- a/domain/original/area/candera/room29.c
+++ b/domain/original/area/candera/room29.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room1030", "south",
         "domain/original/area/candera/room28", "east",

--- a/domain/original/area/candera/room3.c
+++ b/domain/original/area/candera/room3.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room4", "east",
         "domain/original/area/candera/room2", "west",

--- a/domain/original/area/candera/room30.c
+++ b/domain/original/area/candera/room30.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room29", "east",
         "domain/original/area/candera/room31", "west",

--- a/domain/original/area/candera/room31.c
+++ b/domain/original/area/candera/room31.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room30", "east",
         "domain/original/area/candera/room32", "west",

--- a/domain/original/area/candera/room32.c
+++ b/domain/original/area/candera/room32.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room31", "east",
         "domain/original/area/candera/room33", "west",

--- a/domain/original/area/candera/room33.c
+++ b/domain/original/area/candera/room33.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room32", "east",
         "domain/original/area/candera/room34", "west",

--- a/domain/original/area/candera/room34.c
+++ b/domain/original/area/candera/room34.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room33", "east",
         "domain/original/area/candera/room35", "west",

--- a/domain/original/area/candera/room35.c
+++ b/domain/original/area/candera/room35.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room34", "east",
         "domain/original/area/candera/room36", "west",

--- a/domain/original/area/candera/room36.c
+++ b/domain/original/area/candera/room36.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room37", "north",
         "domain/original/area/candera/room35", "east",

--- a/domain/original/area/candera/room37.c
+++ b/domain/original/area/candera/room37.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room38", "north",
         "domain/original/area/candera/room36", "south",

--- a/domain/original/area/candera/room38.c
+++ b/domain/original/area/candera/room38.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room39", "north",
         "domain/original/area/candera/room37", "south",

--- a/domain/original/area/candera/room39.c
+++ b/domain/original/area/candera/room39.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room40", "north",
         "domain/original/area/candera/room38", "south",

--- a/domain/original/area/candera/room4.c
+++ b/domain/original/area/candera/room4.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room5", "east",
         "domain/original/area/candera/room3", "west",

--- a/domain/original/area/candera/room40.c
+++ b/domain/original/area/candera/room40.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room41", "north",
         "domain/original/area/candera/room39", "south",

--- a/domain/original/area/candera/room41.c
+++ b/domain/original/area/candera/room41.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room42", "north",
         "domain/original/area/candera/room40", "south",

--- a/domain/original/area/candera/room42.c
+++ b/domain/original/area/candera/room42.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room43", "north",
         "domain/original/area/candera/room41", "south",

--- a/domain/original/area/candera/room427.c
+++ b/domain/original/area/candera/room427.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room94", "north",
         "domain/original/area/candera/room64", "west",

--- a/domain/original/area/candera/room428.c
+++ b/domain/original/area/candera/room428.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room97", "south",
         "domain/original/area/candera/room977", "west",

--- a/domain/original/area/candera/room429.c
+++ b/domain/original/area/candera/room429.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room72", "north",
         "domain/original/area/candera/room64", "east",

--- a/domain/original/area/candera/room43.c
+++ b/domain/original/area/candera/room43.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room44", "north",
         "domain/original/area/candera/room42", "south",

--- a/domain/original/area/candera/room430.c
+++ b/domain/original/area/candera/room430.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room65", "east",
     });

--- a/domain/original/area/candera/room431.c
+++ b/domain/original/area/candera/room431.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room68", "west",
     });

--- a/domain/original/area/candera/room44.c
+++ b/domain/original/area/candera/room44.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room45", "north",
         "domain/original/area/candera/room43", "south",

--- a/domain/original/area/candera/room45.c
+++ b/domain/original/area/candera/room45.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room46", "north",
         "domain/original/area/candera/room44", "south",

--- a/domain/original/area/candera/room46.c
+++ b/domain/original/area/candera/room46.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room47", "north",
         "domain/original/area/candera/room45", "south",

--- a/domain/original/area/candera/room47.c
+++ b/domain/original/area/candera/room47.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room48", "north",
         "domain/original/area/candera/room46", "south",

--- a/domain/original/area/candera/room48.c
+++ b/domain/original/area/candera/room48.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room49", "north",
         "domain/original/area/candera/room47", "south",

--- a/domain/original/area/candera/room49.c
+++ b/domain/original/area/candera/room49.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room50", "north",
         "domain/original/area/candera/room48", "south",

--- a/domain/original/area/candera/room5.c
+++ b/domain/original/area/candera/room5.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room6", "east",
         "domain/original/area/candera/room4", "west",

--- a/domain/original/area/candera/room50.c
+++ b/domain/original/area/candera/room50.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room49", "south",
         "domain/original/area/candera/room51", "east",

--- a/domain/original/area/candera/room505.c
+++ b/domain/original/area/candera/room505.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room100", "east",
     });

--- a/domain/original/area/candera/room51.c
+++ b/domain/original/area/candera/room51.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room52", "east",
         "domain/original/area/candera/room50", "west",

--- a/domain/original/area/candera/room52.c
+++ b/domain/original/area/candera/room52.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room53", "east",
         "domain/original/area/candera/room51", "west",

--- a/domain/original/area/candera/room53.c
+++ b/domain/original/area/candera/room53.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room54", "east",
         "domain/original/area/candera/room52", "west",

--- a/domain/original/area/candera/room54.c
+++ b/domain/original/area/candera/room54.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room55", "east",
         "domain/original/area/candera/room53", "west",

--- a/domain/original/area/candera/room55.c
+++ b/domain/original/area/candera/room55.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room56", "east",
         "domain/original/area/candera/room54", "west",

--- a/domain/original/area/candera/room56.c
+++ b/domain/original/area/candera/room56.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room1", "east",
         "domain/original/area/candera/room55", "west",

--- a/domain/original/area/candera/room57.c
+++ b/domain/original/area/candera/room57.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room1", "north",
         "domain/original/area/candera/room58", "south",

--- a/domain/original/area/candera/room58.c
+++ b/domain/original/area/candera/room58.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room57", "north",
         "domain/original/area/candera/room59", "south",

--- a/domain/original/area/candera/room59.c
+++ b/domain/original/area/candera/room59.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room58", "north",
         "domain/original/area/candera/room60", "south",

--- a/domain/original/area/candera/room6.c
+++ b/domain/original/area/candera/room6.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room7", "east",
         "domain/original/area/candera/room5", "west",

--- a/domain/original/area/candera/room60.c
+++ b/domain/original/area/candera/room60.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room59", "north",
         "domain/original/area/candera/room61", "south",

--- a/domain/original/area/candera/room61.c
+++ b/domain/original/area/candera/room61.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room60", "north",
         "domain/original/area/candera/room62", "south",

--- a/domain/original/area/candera/room62.c
+++ b/domain/original/area/candera/room62.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room61", "north",
         "domain/original/area/candera/room63", "south",

--- a/domain/original/area/candera/room63.c
+++ b/domain/original/area/candera/room63.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room62", "north",
         "domain/original/area/candera/room64", "south",

--- a/domain/original/area/candera/room64.c
+++ b/domain/original/area/candera/room64.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room63", "north",
         "domain/original/area/candera/room65", "south",

--- a/domain/original/area/candera/room65.c
+++ b/domain/original/area/candera/room65.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room64", "north",
         "domain/original/area/candera/room66", "south",

--- a/domain/original/area/candera/room66.c
+++ b/domain/original/area/candera/room66.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room65", "north",
         "domain/original/area/candera/room67", "south",

--- a/domain/original/area/candera/room67.c
+++ b/domain/original/area/candera/room67.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room66", "north",
         "domain/original/area/candera/room68", "south",

--- a/domain/original/area/candera/room68.c
+++ b/domain/original/area/candera/room68.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room67", "north",
         "domain/original/area/candera/room69", "south",

--- a/domain/original/area/candera/room69.c
+++ b/domain/original/area/candera/room69.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room68", "north",
         "domain/original/area/candera/room71", "east",

--- a/domain/original/area/candera/room7.c
+++ b/domain/original/area/candera/room7.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room8", "east",
         "domain/original/area/candera/room6", "west",

--- a/domain/original/area/candera/room70.c
+++ b/domain/original/area/candera/room70.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room69", "east",
     });

--- a/domain/original/area/candera/room71.c
+++ b/domain/original/area/candera/room71.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room69", "west",
     });

--- a/domain/original/area/candera/room72.c
+++ b/domain/original/area/candera/room72.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room429", "south",
         "domain/original/area/candera/room63", "east",

--- a/domain/original/area/candera/room73.c
+++ b/domain/original/area/candera/room73.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room1017", "north",
         "domain/original/area/candera/room1016", "south",

--- a/domain/original/area/candera/room74.c
+++ b/domain/original/area/candera/room74.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room1018", "north",
         "domain/original/area/candera/room1019", "south",

--- a/domain/original/area/candera/room75.c
+++ b/domain/original/area/candera/room75.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room1095", "south",
         "domain/original/area/candera/room74", "east",

--- a/domain/original/area/candera/room76.c
+++ b/domain/original/area/candera/room76.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room86", "north",
         "domain/original/area/candera/room78", "south",

--- a/domain/original/area/candera/room78.c
+++ b/domain/original/area/candera/room78.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room76", "north",
         "domain/original/area/candera/room79", "south",

--- a/domain/original/area/candera/room79.c
+++ b/domain/original/area/candera/room79.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room78", "north",
         "domain/original/area/candera/room80", "south",

--- a/domain/original/area/candera/room8.c
+++ b/domain/original/area/candera/room8.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room9", "south",
         "domain/original/area/candera/room7", "west",

--- a/domain/original/area/candera/room80.c
+++ b/domain/original/area/candera/room80.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room79", "north",
         "domain/original/area/candera/room81", "south",

--- a/domain/original/area/candera/room81.c
+++ b/domain/original/area/candera/room81.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room80", "north",
         "domain/original/area/candera/room82", "south",

--- a/domain/original/area/candera/room82.c
+++ b/domain/original/area/candera/room82.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room81", "north",
         "domain/original/area/candera/room83", "south",

--- a/domain/original/area/candera/room83.c
+++ b/domain/original/area/candera/room83.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room82", "north",
         "domain/original/area/candera/room85", "east",

--- a/domain/original/area/candera/room84.c
+++ b/domain/original/area/candera/room84.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room83", "east",
         "domain/original/area/candera/room1130", "up",

--- a/domain/original/area/candera/room85.c
+++ b/domain/original/area/candera/room85.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room83", "west",
         "domain/original/area/candera/room1131", "up",

--- a/domain/original/area/candera/room86.c
+++ b/domain/original/area/candera/room86.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room87", "north",
         "domain/original/area/candera/room76", "south",

--- a/domain/original/area/candera/room87.c
+++ b/domain/original/area/candera/room87.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room88", "north",
         "domain/original/area/candera/room86", "south",

--- a/domain/original/area/candera/room88.c
+++ b/domain/original/area/candera/room88.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room89", "north",
         "domain/original/area/candera/room87", "south",

--- a/domain/original/area/candera/room89.c
+++ b/domain/original/area/candera/room89.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room90", "north",
         "domain/original/area/candera/room88", "south",

--- a/domain/original/area/candera/room9.c
+++ b/domain/original/area/candera/room9.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room8", "north",
         "domain/original/area/candera/room10", "south",

--- a/domain/original/area/candera/room90.c
+++ b/domain/original/area/candera/room90.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room91", "north",
         "domain/original/area/candera/room89", "south",

--- a/domain/original/area/candera/room91.c
+++ b/domain/original/area/candera/room91.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room90", "south",
         "domain/original/area/candera/room93", "east",

--- a/domain/original/area/candera/room92.c
+++ b/domain/original/area/candera/room92.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room91", "east",
         "domain/original/area/candera/room1132", "up",

--- a/domain/original/area/candera/room93.c
+++ b/domain/original/area/candera/room93.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room91", "west",
         "domain/original/area/candera/room1133", "up",

--- a/domain/original/area/candera/room94.c
+++ b/domain/original/area/candera/room94.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room972", "north",
         "domain/original/area/candera/room427", "south",

--- a/domain/original/area/candera/room95.c
+++ b/domain/original/area/candera/room95.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room975", "south",
         "domain/original/area/candera/room96", "east",

--- a/domain/original/area/candera/room96.c
+++ b/domain/original/area/candera/room96.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room977", "north",
         "domain/original/area/candera/room976", "south",

--- a/domain/original/area/candera/room963.c
+++ b/domain/original/area/candera/room963.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room57", "east",
         "domain/original/area/candera/room1027", "west",

--- a/domain/original/area/candera/room964.c
+++ b/domain/original/area/candera/room964.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room57", "west",
     });

--- a/domain/original/area/candera/room965.c
+++ b/domain/original/area/candera/room965.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "burned run";
-    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones shift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
+    short_desc = "Burned Run";
+    long_desc = "A crooked passage threads between leaning fragments of masonry. Loose stones\nshift with each step, exposing darker layers below.\n\nThe place feels picked clean, stripped of timber and metal.\n";
     dest_dir = ({
         "domain/original/area/candera/room58", "east",
     });

--- a/domain/original/area/candera/room966.c
+++ b/domain/original/area/candera/room966.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "wind-scoured reach";
-    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Wind-Scoured Reach";
+    long_desc = "The way pinches tight, then opens again into scattered foundations. Ash and grit\ncollect in corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room989", "east",
         "domain/original/area/candera/room58", "west",

--- a/domain/original/area/candera/room967.c
+++ b/domain/original/area/candera/room967.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "rubble-strewn walk";
-    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines. Splintered tiles crunch underfoot, mixed with crushed brick.\n";
+    short_desc = "Rubble-Strewn Walk";
+    long_desc = "An open stretch of hard-packed grit marks a crossing of several lines.\nSplintered tiles crunch underfoot, mixed with crushed brick.\n";
     dest_dir = ({
         "domain/original/area/candera/room1125", "north",
         "domain/original/area/candera/room59", "east",

--- a/domain/original/area/candera/room968.c
+++ b/domain/original/area/candera/room968.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "broken passage";
-    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Broken Passage";
+    long_desc = "A long strip of stonework drifts under dunes, only a spine still visible. Fire-\nblackened patches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room60", "east",
     });

--- a/domain/original/area/candera/room969.c
+++ b/domain/original/area/candera/room969.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "dusty stretch";
-    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow window frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
+    short_desc = "Dusty Stretch";
+    long_desc = "The path angles around a heap of fallen blocks, forcing a slow turn. Hollow\nwindow frames stare out, their ledges buried in dust.\n\nThe wind slides through with a dry hiss.\n";
     dest_dir = ({
         "domain/original/area/candera/room60", "west",
     });

--- a/domain/original/area/candera/room97.c
+++ b/domain/original/area/candera/room97.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "pitted turn";
-    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Pitted Turn";
+    long_desc = "A low basin of ash and grit sits where the ground once stood higher. Wind has\npiled sand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room428", "north",
         "domain/original/area/candera/room98", "east",

--- a/domain/original/area/candera/room970.c
+++ b/domain/original/area/candera/room970.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sunken span";
-    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains cling to the stone, and the air tastes of old smoke.\n";
+    short_desc = "Sunken Span";
+    long_desc = "A gap between toppled arches forms a narrow throat in the route. Soot stains\ncling to the stone, and the air tastes of old smoke.\n";
     dest_dir = ({
         "domain/original/area/candera/room61", "east",
     });

--- a/domain/original/area/candera/room971.c
+++ b/domain/original/area/candera/room971.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "bleached bend";
-    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Bleached Bend";
+    long_desc = "Broken steps climb to a terrace of shattered stone, then fall away. Char marks\nstripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room62", "east",
     });

--- a/domain/original/area/candera/room972.c
+++ b/domain/original/area/candera/room972.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "tumbled slope";
-    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks mark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
+    short_desc = "Tumbled Slope";
+    long_desc = "A short rise of uneven paving leads to a wind-carved platform. Rust-red streaks\nmark where metal once lay, now long gone.\n\nThe ground bears the weight of repeated collapse.\n";
     dest_dir = ({
         "domain/original/area/candera/room94", "south",
         "domain/original/area/candera/room62", "west",

--- a/domain/original/area/candera/room973.c
+++ b/domain/original/area/candera/room973.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "shattered cut";
-    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Shattered Cut";
+    long_desc = "The ground levels out into a broad, empty spread of fractured flagstone. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room986", "north",
         "domain/original/area/candera/room974", "south",

--- a/domain/original/area/candera/room974.c
+++ b/domain/original/area/candera/room974.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "leaning way";
-    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones shift with each step, exposing darker layers below.\n";
+    short_desc = "Leaning Way";
+    long_desc = "Two aligned walls hint at a corridor now filled with drifted sand. Loose stones\nshift with each step, exposing darker layers below.\n";
     dest_dir = ({
         "domain/original/area/candera/room973", "north",
     });

--- a/domain/original/area/candera/room975.c
+++ b/domain/original/area/candera/room975.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "eroded rise";
-    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect in corners, damped by occasional trickles.\n";
+    short_desc = "Eroded Rise";
+    long_desc = "A jagged seam in the paving marks the line of a sunken run. Ash and grit collect\nin corners, damped by occasional trickles.\n";
     dest_dir = ({
         "domain/original/area/candera/room95", "north",
     });

--- a/domain/original/area/candera/room976.c
+++ b/domain/original/area/candera/room976.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "hollow gap";
-    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered tiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
+    short_desc = "Hollow Gap";
+    long_desc = "A stub of wall creates a blind corner before the way slips onward. Splintered\ntiles crunch underfoot, mixed with crushed brick.\n\nThe silence presses close between the broken walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room96", "north",
     });

--- a/domain/original/area/candera/room98.c
+++ b/domain/original/area/candera/room98.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "faded corridor";
-    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened patches run along the base of the walls.\n";
+    short_desc = "Faded Corridor";
+    long_desc = "A shallow slope of debris leads down into a widened passage. Fire-blackened\npatches run along the base of the walls.\n";
     dest_dir = ({
         "domain/original/area/candera/room107", "north",
         "domain/original/area/candera/room99", "south",

--- a/domain/original/area/candera/room986.c
+++ b/domain/original/area/candera/room986.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "scarred hollow";
-    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window frames stare out, their ledges buried in dust.\n";
+    short_desc = "Scarred Hollow";
+    long_desc = "The route skirts a collapsed chamber, its edge cut clean by fire. Hollow window\nframes stare out, their ledges buried in dust.\n";
     dest_dir = ({
         "domain/original/area/candera/room973", "south",
     });

--- a/domain/original/area/candera/room99.c
+++ b/domain/original/area/candera/room99.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "drifted platform";
-    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled sand against one side, leaving the other scoured bare.\n";
+    short_desc = "Drifted Platform";
+    long_desc = "Scattered piers suggest a once-long span, now broken into bays. Wind has piled\nsand against one side, leaving the other scoured bare.\n";
     dest_dir = ({
         "domain/original/area/candera/room98", "north",
         "domain/original/area/candera/room100", "south",

--- a/domain/original/area/candera/room996.c
+++ b/domain/original/area/candera/room996.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "sand-choked lane";
-    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to dust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
+    short_desc = "Sand-Choked Lane";
+    long_desc = "A wide run of cracked stone stretches north and south, its center scoured to\ndust. Soot stains cling to the stone, and the air tastes of old smoke.\n\nNo footprints remain; only layered grit records the years.\n";
     dest_dir = ({
         "domain/original/area/candera/room111", "west",
     });

--- a/domain/original/area/candera/room997.c
+++ b/domain/original/area/candera/room997.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "ash-streaked crossing";
-    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char marks stripe the walls, and fine ash mixes with grit underfoot.\n";
+    short_desc = "Ash-Streaked Crossing";
+    long_desc = "A narrow lane bends between broken walls, the ground uneven and gritty. Char\nmarks stripe the walls, and fine ash mixes with grit underfoot.\n";
     dest_dir = ({
         "domain/original/area/candera/room100", "west",
     });

--- a/domain/original/area/candera/room998.c
+++ b/domain/original/area/candera/room998.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "cracked drop";
-    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red streaks mark where metal once lay, now long gone.\n";
+    short_desc = "Cracked Drop";
+    long_desc = "The space broadens into a shallow, rubble-filled bowl where paths meet. Rust-red\nstreaks mark where metal once lay, now long gone.\n";
     dest_dir = ({
         "domain/original/area/candera/room103", "east",
     });

--- a/domain/original/area/candera/room999.c
+++ b/domain/original/area/candera/room999.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "collapsed approach";
-    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small pits and cracks show where repeated blows split the surface.\n";
+    short_desc = "Collapsed Approach";
+    long_desc = "A straight corridor of paving is split by collapsed slabs and sinkholes. Small\npits and cracks show where repeated blows split the surface.\n";
     dest_dir = ({
         "domain/original/area/candera/room103", "west",
     });


### PR DESCRIPTION
### Motivation
- Normalize room text for the Candera area to improve consistency and readability.
- Ensure `short_desc` values follow a title-case style for UI consistency.
- Keep `long_desc` lines within 80 characters to avoid wrapped output problems in clients.

### Description
- Title-cased every `short_desc` in files under `domain/original/area/candera`.
- Reflowed `long_desc` paragraphs to wrap at 80 characters while preserving blank-line paragraph breaks.
- Changes applied across the Candera area (164 files modified, multiple rooms updated).
- Kept all other room code and destinations unchanged.

### Testing
- Ran an automated check that verified no `long_desc` line exceeds 80 characters and it reported zero violations.
- Ran an automated check that verified `short_desc` values are title-cased and it reported zero violations.
- Verified repository status and successfully committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69605ff85f3c8327a7dc8d68d36174c6)