### PR TITLE
Reset Vesla room short/long descriptions to map names

### DIFF
--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Collapsed Structure";
-    long_desc = "Collapsed Structure";
+    short_desc = "General Store";
+    long_desc = "General Store";
     dest_dir = ({
         "domain/original/area/vesla/room222", "west",
         "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Rubble-Choked Shell";
-    long_desc = "Rubble-Choked Shell";
+    short_desc = "Comfortably Numb";
+    long_desc = "Comfortably Numb";
     dest_dir = ({
         "domain/original/area/vesla/room223", "west",
         "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Crumbling Wreck";
-    long_desc = "Crumbling Wreck";
+    short_desc = "Medieval Mounts";
+    long_desc = "Medieval Mounts";
     dest_dir = ({
         "domain/original/area/vesla/room224", "west",
         "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Shattered Remains";
-    long_desc = "Shattered Remains";
+    short_desc = "Big Hole Banking";
+    long_desc = "Big Hole Banking";
     dest_dir = ({
         "domain/original/area/vesla/room225", "west",
         "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Broken Edifice";
-    long_desc = "Broken Edifice";
+    short_desc = "The Shadowed Anvil";
+    long_desc = "The Shadowed Anvil";
     dest_dir = ({
         "domain/original/area/vesla/room220", "west",
         "domain/original/area/vesla/room116", "north",

--- a/domain/original/area/vesla/room408.c
+++ b/domain/original/area/vesla/room408.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Sundered Hall";
-    long_desc = "Sundered Hall";
+    short_desc = "MD Banking";
+    long_desc = "MD Banking";
     dest_dir = ({
         "domain/original/area/vesla/room217", "east",
     });

--- a/domain/original/area/vesla/room740.c
+++ b/domain/original/area/vesla/room740.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Fallen Annex";
-    long_desc = "Fallen Annex";
+    short_desc = "Stationery Store";
+    long_desc = "Stationery Store";
     dest_dir = ({
         "domain/original/area/vesla/room190", "north",
     });

--- a/domain/original/area/vesla/room746.c
+++ b/domain/original/area/vesla/room746.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dusty Ruins";
-    long_desc = "Dusty Ruins";
+    short_desc = "Store Room";
+    long_desc = "Store Room";
     dest_dir = ({
         "domain/original/area/vesla/room745", "west",
     });

--- a/domain/original/area/vesla/room811.c
+++ b/domain/original/area/vesla/room811.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Splintered Shell";
-    long_desc = "Splintered Shell";
+    short_desc = "Hardware Store";
+    long_desc = "Hardware Store";
     dest_dir = ({
         "domain/original/area/vesla/room163", "west",
     });

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Buried Wreckage";
-    long_desc = "Buried Wreckage";
+    short_desc = "Abandoned Store";
+    long_desc = "Abandoned Store";
     dest_dir = ({
         "domain/original/area/vesla/room199", "west",
     });


### PR DESCRIPTION
### Motivation
- Restore Vesla area room names so each room's `short_desc` and `long_desc` match the `name` values defined in `maps/vesla.json`.
- Only adjust the two description fields per room and leave exits, light settings, and all other code unchanged.
- Respect exclusions for special files and do not modify `portal.c`, `sanctuary.c`, or `lounge.c`.
- Report any JSON entries that have no corresponding room file in the Vesla area.

### Description
- Updated `short_desc` and `long_desc` in 10 files to match the map: `room221.c`, `room222.c`, `room223.c`, `room224.c`, `room233.c`, `room408.c`, `room740.c`, `room746.c`, `room811.c`, and `room962.c`.
- Replacements were limited to the two description string assignments in each file and no other code was altered.
- Checked the mapping completeness and found one JSON entry with no corresponding room file: `id` 229 ("Sanctuary") which has no `room229.c` in the Vesla area.

### Testing
- Ran a Python verification script that compared `short_desc`/`long_desc` in `domain/original/area/vesla/room*.c` against `maps/vesla.json` and reported 10 mismatches prior to the update.
- Executed an automated update script that replaced the two description strings and reported `updated 10`.
- Re-inspected the modified files to confirm the new `short_desc`/`long_desc` values and that no other lines changed.
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b8ef4c5c83278867002977d47264)