### PR TITLE
Normalize Vesla room `long_desc` strings to end with newline

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Gate to the Wilderness";
-    long_desc = "The Gate to the Wilderness";
+    long_desc = "The Gate to the Wilderness\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "west",
 	"domain/original/area/roadway/room14", "exit",

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Park Street and Caravan Road";
-    long_desc = "Intersection of Park Street and Caravan Road";
+    long_desc = "Intersection of Park Street and Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room233", "south",
         "domain/original/area/vesla/room117", "west",

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Park Street and Via Sacra";
-    long_desc = "Intersection of Park Street and Via Sacra";
+    long_desc = "Intersection of Park Street and Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "south",
         "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room227", "north",
         "domain/original/area/vesla/room221", "south",

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "south",
         "domain/original/area/vesla/room120", "west",

--- a/domain/original/area/vesla/room120.c
+++ b/domain/original/area/vesla/room120.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "west",
         "domain/original/area/vesla/room119", "east",

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "south",
         "domain/original/area/vesla/room122", "west",

--- a/domain/original/area/vesla/room122.c
+++ b/domain/original/area/vesla/room122.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "south",
         "domain/original/area/vesla/room123", "west",

--- a/domain/original/area/vesla/room123.c
+++ b/domain/original/area/vesla/room123.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A shaded walk";
-    long_desc = "A shaded walk";
+    long_desc = "A shaded walk\n";
     dest_dir = ({
         "domain/original/area/vesla/room124", "west",
         "domain/original/area/vesla/room122", "east",

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A break in the coverage";
-    long_desc = "A break in the coverage";
+    long_desc = "A break in the coverage\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "west",
         "domain/original/area/vesla/room123", "east",

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A busy intersection";
-    long_desc = "A busy intersection";
+    long_desc = "A busy intersection\n";
     dest_dir = ({
         "domain/original/area/vesla/room159", "south",
         "domain/original/area/vesla/room126", "west",

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The end of the park street";
-    long_desc = "The end of the park street";
+    long_desc = "The end of the park street\n";
     dest_dir = ({
         "domain/original/area/vesla/room880", "south",
         "domain/original/area/vesla/room127", "west",

--- a/domain/original/area/vesla/room127.c
+++ b/domain/original/area/vesla/room127.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Entrance to the Old City.";
-    long_desc = "Entrance to the Old City.";
+    long_desc = "Entrance to the Old City.\n";
     dest_dir = ({
         "domain/original/area/vesla/room128", "west",
         "domain/original/area/vesla/room126", "east",

--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Westroad, The Entrance to the Old City.";
-    long_desc = "Westroad, The Entrance to the Old City.";
+    long_desc = "Westroad, The Entrance to the Old City.\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "west",
         "domain/original/area/vesla/room127", "east",

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Westroad";
-    long_desc = "Westroad";
+    long_desc = "Westroad\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "west",
         "domain/original/area/vesla/room128", "east",

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Westroad";
-    long_desc = "Westroad";
+    long_desc = "Westroad\n";
     dest_dir = ({
         "domain/original/area/vesla/room131", "west",
         "domain/original/area/vesla/room129", "east",

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Westroad";
-    long_desc = "Westroad";
+    long_desc = "Westroad\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "west",
         "domain/original/area/vesla/room130", "east",

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Westroad";
-    long_desc = "Westroad";
+    long_desc = "Westroad\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "west",
         "domain/original/area/vesla/room131", "east",

--- a/domain/original/area/vesla/room133.c
+++ b/domain/original/area/vesla/room133.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The corner of Westroad and Basalt Avenue";
-    long_desc = "The corner of Westroad and Basalt Avenue";
+    long_desc = "The corner of Westroad and Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room134", "west",
         "domain/original/area/vesla/room132", "east",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Western Gate of Vesla";
-    long_desc = "Western Gate of Vesla";
+    long_desc = "Western Gate of Vesla\n";
     dest_dir = ({
         "domain/original/area/vesla/room133", "east",
         "domain/original/area/roadway/room29", "exit",

--- a/domain/original/area/vesla/room135.c
+++ b/domain/original/area/vesla/room135.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room136", "south",
         "domain/original/area/vesla/room133", "north",

--- a/domain/original/area/vesla/room136.c
+++ b/domain/original/area/vesla/room136.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room137", "south",
         "domain/original/area/vesla/room135", "north",

--- a/domain/original/area/vesla/room137.c
+++ b/domain/original/area/vesla/room137.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Basalt Avenue and Rapier Way";
-    long_desc = "Intersection of Basalt Avenue and Rapier Way";
+    long_desc = "Intersection of Basalt Avenue and Rapier Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "south",
         "domain/original/area/vesla/room193", "east",

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "south",
         "domain/original/area/vesla/room856", "west",

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room140", "south",
         "domain/original/area/vesla/room853", "west",

--- a/domain/original/area/vesla/room140.c
+++ b/domain/original/area/vesla/room140.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Basalt Avenue and Street of the Bells";
-    long_desc = "Intersection of Basalt Avenue and Street of the Bells";
+    long_desc = "Intersection of Basalt Avenue and Street of the Bells\n";
     dest_dir = ({
         "domain/original/area/vesla/room141", "south",
         "domain/original/area/vesla/room204", "east",

--- a/domain/original/area/vesla/room141.c
+++ b/domain/original/area/vesla/room141.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "south",
         "domain/original/area/vesla/room140", "north",

--- a/domain/original/area/vesla/room142.c
+++ b/domain/original/area/vesla/room142.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Basalt Avenue";
-    long_desc = "Basalt Avenue";
+    long_desc = "Basalt Avenue\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "south",
         "domain/original/area/vesla/room850", "east",

--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Corner of Basalt Avenue and West River Street";
-    long_desc = "Corner of Basalt Avenue and West River Street";
+    long_desc = "Corner of Basalt Avenue and West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",
         "domain/original/area/vesla/room142", "north",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River Street";
-    long_desc = "West River Street";
+    long_desc = "West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River Street";
-    long_desc = "West River Street";
+    long_desc = "West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River Street";
-    long_desc = "West River Street";
+    long_desc = "West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River Street";
-    long_desc = "West River Street";
+    long_desc = "West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River Street";
-    long_desc = "West River Street";
+    long_desc = "West River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River street";
-    long_desc = "West River street";
+    long_desc = "West River street\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "West River street";
-    long_desc = "West River street";
+    long_desc = "West River street\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "River Street and South Main";
-    long_desc = "River Street and South Main";
+    long_desc = "River Street and South Main\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main street";
-    long_desc = "South Main street";
+    long_desc = "South Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
         "domain/original/area/vesla/room819", "west",

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main Street";
-    long_desc = "South Main Street";
+    long_desc = "South Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",
         "domain/original/area/vesla/room152", "south",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main Street";
-    long_desc = "South Main Street";
+    long_desc = "South Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
         "domain/original/area/vesla/room821", "east",

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main Street";
-    long_desc = "South Main Street";
+    long_desc = "South Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
         "domain/original/area/vesla/room423", "west",

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main Street";
-    long_desc = "South Main Street";
+    long_desc = "South Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
         "domain/original/area/vesla/room822", "west",

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main Street";
-    long_desc = "South Main Street";
+    long_desc = "South Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
         "domain/original/area/vesla/room823", "west",

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main street";
-    long_desc = "South Main street";
+    long_desc = "South Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",
         "domain/original/area/vesla/room157", "south",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South Main street";
-    long_desc = "South Main street";
+    long_desc = "South Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",
         "domain/original/area/vesla/room125", "north",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main";
-    long_desc = "Northern Main";
+    long_desc = "Northern Main\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street";
+    long_desc = "Northern Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main street";
-    long_desc = "Northern Main street";
+    long_desc = "Northern Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street";
+    long_desc = "Northern Main Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main street";
-    long_desc = "Northern Main street";
+    long_desc = "Northern Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main street";
-    long_desc = "Northern Main street";
+    long_desc = "Northern Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of North Main and Scholar's Way";
-    long_desc = "Intersection of North Main and Scholar's Way";
+    long_desc = "Intersection of North Main and Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Main street";
-    long_desc = "Northern Main street";
+    long_desc = "Northern Main street\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of North Main and Wall Street";
-    long_desc = "Intersection of North Main and Wall Street";
+    long_desc = "Intersection of North Main and Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
         "domain/original/area/vesla/room793", "west",

--- a/domain/original/area/vesla/room169.c
+++ b/domain/original/area/vesla/room169.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern Gate";
-    long_desc = "Northern Gate";
+    long_desc = "Northern Gate\n";
     dest_dir = ({
         "domain/original/area/vesla/room168", "south",
         "domain/original/area/vesla/room753", "northeast",

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Western End of Wall Street";
-    long_desc = "Western End of Wall Street";
+    long_desc = "Western End of Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room171", "east",
         "domain/original/area/vesla/room168", "west",

--- a/domain/original/area/vesla/room171.c
+++ b/domain/original/area/vesla/room171.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Wall Street";
-    long_desc = "Wall Street";
+    long_desc = "Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room170", "west",
     });

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "south",
         "domain/original/area/vesla/room226", "west",

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "south",
         "domain/original/area/vesla/room232", "west",

--- a/domain/original/area/vesla/room174.c
+++ b/domain/original/area/vesla/room174.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "south",
         "domain/original/area/vesla/room175", "north",

--- a/domain/original/area/vesla/room175.c
+++ b/domain/original/area/vesla/room175.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room174", "south",
         "domain/original/area/vesla/room176", "north",

--- a/domain/original/area/vesla/room176.c
+++ b/domain/original/area/vesla/room176.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room175", "south",
         "domain/original/area/vesla/room177", "north",

--- a/domain/original/area/vesla/room177.c
+++ b/domain/original/area/vesla/room177.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room176", "south",
         "domain/original/area/vesla/room178", "north",

--- a/domain/original/area/vesla/room178.c
+++ b/domain/original/area/vesla/room178.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Scholar's Way and Caravan Road";
-    long_desc = "Intersection of Scholar's Way and Caravan Road";
+    long_desc = "Intersection of Scholar's Way and Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "west",
         "domain/original/area/vesla/room177", "south",

--- a/domain/original/area/vesla/room179.c
+++ b/domain/original/area/vesla/room179.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Caravan Road";
-    long_desc = "Caravan Road";
+    long_desc = "Caravan Road\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "south",
         "domain/original/area/vesla/room180", "north",

--- a/domain/original/area/vesla/room180.c
+++ b/domain/original/area/vesla/room180.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Caravan Road and Wall Street";
-    long_desc = "Intersection of Caravan Road and Wall Street";
+    long_desc = "Intersection of Caravan Road and Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "west",
         "domain/original/area/vesla/room179", "south",

--- a/domain/original/area/vesla/room181.c
+++ b/domain/original/area/vesla/room181.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Eastern End of Wall Street";
-    long_desc = "Eastern End of Wall Street";
+    long_desc = "Eastern End of Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room180", "east",
         "domain/original/area/vesla/room182", "west",

--- a/domain/original/area/vesla/room182.c
+++ b/domain/original/area/vesla/room182.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Wall Street";
-    long_desc = "Wall Street";
+    long_desc = "Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "east",
         "domain/original/area/vesla/room183", "west",

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Wall Street";
-    long_desc = "Wall Street";
+    long_desc = "Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room182", "east",
         "domain/original/area/vesla/room184", "west",

--- a/domain/original/area/vesla/room184.c
+++ b/domain/original/area/vesla/room184.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Wall Street";
-    long_desc = "Wall Street";
+    long_desc = "Wall Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room183", "east",
     });

--- a/domain/original/area/vesla/room185.c
+++ b/domain/original/area/vesla/room185.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "east",
         "domain/original/area/vesla/room186", "west",

--- a/domain/original/area/vesla/room186.c
+++ b/domain/original/area/vesla/room186.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "east",
         "domain/original/area/vesla/room187", "west",

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "west",
         "domain/original/area/vesla/room186", "east",

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "west",
         "domain/original/area/vesla/room187", "east",

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "west",
         "domain/original/area/vesla/room188", "east",

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room740", "south",
         "domain/original/area/vesla/room191", "west",

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room742", "south",
         "domain/original/area/vesla/room192", "west",

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way";
+    long_desc = "Scholar's Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "west",
         "domain/original/area/vesla/room191", "east",

--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rapier Way";
-    long_desc = "Rapier Way";
+    long_desc = "Rapier Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room194", "east",
         "domain/original/area/vesla/room137", "west",

--- a/domain/original/area/vesla/room194.c
+++ b/domain/original/area/vesla/room194.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rapier Way";
-    long_desc = "Rapier Way";
+    long_desc = "Rapier Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room195", "east",
         "domain/original/area/vesla/room193", "west",

--- a/domain/original/area/vesla/room195.c
+++ b/domain/original/area/vesla/room195.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rapier Way";
-    long_desc = "Rapier Way";
+    long_desc = "Rapier Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "east",
         "domain/original/area/vesla/room194", "west",

--- a/domain/original/area/vesla/room196.c
+++ b/domain/original/area/vesla/room196.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rapier Way";
-    long_desc = "Rapier Way";
+    long_desc = "Rapier Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room197", "east",
         "domain/original/area/vesla/room195", "west",

--- a/domain/original/area/vesla/room197.c
+++ b/domain/original/area/vesla/room197.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Rapier Way and Zand Boulevard";
-    long_desc = "Intersection of Rapier Way and Zand Boulevard";
+    long_desc = "Intersection of Rapier Way and Zand Boulevard\n";
     dest_dir = ({
         "domain/original/area/vesla/room196", "west",
         "domain/original/area/vesla/room198", "south",

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Zand Boulevard";
-    long_desc = "Zand Boulevard";
+    long_desc = "Zand Boulevard\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "south",
         "domain/original/area/vesla/room857", "east",

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Zand Boulevard";
-    long_desc = "Zand Boulevard";
+    long_desc = "Zand Boulevard\n";
     dest_dir = ({
         "domain/original/area/vesla/room200", "south",
         "domain/original/area/vesla/room962", "east",

--- a/domain/original/area/vesla/room200.c
+++ b/domain/original/area/vesla/room200.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Street of the Bells and Zand Boulevard";
-    long_desc = "Intersection of Street of the Bells and Zand Boulevard";
+    long_desc = "Intersection of Street of the Bells and Zand Boulevard\n";
     dest_dir = ({
         "domain/original/area/vesla/room201", "west",
         "domain/original/area/vesla/room199", "north",

--- a/domain/original/area/vesla/room201.c
+++ b/domain/original/area/vesla/room201.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells";
+    long_desc = "Street of the Bells\n";
     dest_dir = ({
         "domain/original/area/vesla/room843", "south",
         "domain/original/area/vesla/room202", "west",

--- a/domain/original/area/vesla/room202.c
+++ b/domain/original/area/vesla/room202.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells";
+    long_desc = "Street of the Bells\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "west",
         "domain/original/area/vesla/room201", "east",

--- a/domain/original/area/vesla/room203.c
+++ b/domain/original/area/vesla/room203.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells";
+    long_desc = "Street of the Bells\n";
     dest_dir = ({
         "domain/original/area/vesla/room202", "east",
         "domain/original/area/vesla/room204", "west",

--- a/domain/original/area/vesla/room204.c
+++ b/domain/original/area/vesla/room204.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Street of the Bells";
-    long_desc = "Street of the Bells";
+    long_desc = "Street of the Bells\n";
     dest_dir = ({
         "domain/original/area/vesla/room203", "east",
         "domain/original/area/vesla/room140", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "East River Street";
-    long_desc = "East River Street";
+    long_desc = "East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "End of East River Street";
-    long_desc = "End of East River Street";
+    long_desc = "End of East River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Intersection of Via Sacra and River Street";
-    long_desc = "Intersection of Via Sacra and River Street";
+    long_desc = "Intersection of Via Sacra and River Street\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "South End of Via Sacra";
-    long_desc = "South End of Via Sacra";
+    long_desc = "South End of Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",
         "domain/original/area/vesla/room399", "east",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Southern Via Sacra";
-    long_desc = "Southern Via Sacra";
+    long_desc = "Southern Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
         "domain/original/area/vesla/room400", "west",

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Via Sacra";
-    long_desc = "Via Sacra";
+    long_desc = "Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",
         "domain/original/area/vesla/room216", "north",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Via Sacra";
-    long_desc = "Via Sacra";
+    long_desc = "Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
         "domain/original/area/vesla/room402", "west",

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Via Sacra";
-    long_desc = "Via Sacra";
+    long_desc = "Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
         "domain/original/area/vesla/room216", "south",

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Via Sacra";
-    long_desc = "Via Sacra";
+    long_desc = "Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",
         "domain/original/area/vesla/room219", "north",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Via Sacra";
-    long_desc = "Via Sacra";
+    long_desc = "Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
         "domain/original/area/vesla/room218", "south",

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Northern End of Via Sacra";
-    long_desc = "Northern End of Via Sacra";
+    long_desc = "Northern End of Via Sacra\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",
         "domain/original/area/vesla/room221", "west",

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "General Store";
-    long_desc = "General Store";
+    long_desc = "General Store\n";
     dest_dir = ({
         "domain/original/area/vesla/room222", "west",
         "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Comfortably Numb";
-    long_desc = "Comfortably Numb";
+    long_desc = "Comfortably Numb\n";
     dest_dir = ({
         "domain/original/area/vesla/room223", "west",
         "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Medieval Mounts";
-    long_desc = "Medieval Mounts";
+    long_desc = "Medieval Mounts\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "west",
         "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Big Hole Banking";
-    long_desc = "Big Hole Banking";
+    long_desc = "Big Hole Banking\n";
     dest_dir = ({
         "domain/original/area/vesla/room225", "west",
         "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room225.c
+++ b/domain/original/area/vesla/room225.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Brimstone";
-    long_desc = "Brimstone";
+    long_desc = "Brimstone\n";
     dest_dir = ({
         "domain/original/area/vesla/room224", "east",
         "domain/original/area/vesla/room122", "north",

--- a/domain/original/area/vesla/room226.c
+++ b/domain/original/area/vesla/room226.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A peaceful park";
-    long_desc = "A peaceful park";
+    long_desc = "A peaceful park\n";
     dest_dir = ({
         "domain/original/area/vesla/room117", "south",
         "domain/original/area/vesla/room228", "west",

--- a/domain/original/area/vesla/room227.c
+++ b/domain/original/area/vesla/room227.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A peaceful park";
-    long_desc = "A peaceful park";
+    long_desc = "A peaceful park\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "north",
         "domain/original/area/vesla/room118", "south",

--- a/domain/original/area/vesla/room230.c
+++ b/domain/original/area/vesla/room230.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A peaceful park";
-    long_desc = "A peaceful park";
+    long_desc = "A peaceful park\n";
     dest_dir = ({
         "domain/original/area/vesla/room119", "south",
         "domain/original/area/vesla/room815", "west",

--- a/domain/original/area/vesla/room231.c
+++ b/domain/original/area/vesla/room231.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A peaceful park";
-    long_desc = "A peaceful park";
+    long_desc = "A peaceful park\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "south",
         "domain/original/area/vesla/room796", "west",

--- a/domain/original/area/vesla/room232.c
+++ b/domain/original/area/vesla/room232.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A peaceful park";
-    long_desc = "A peaceful park";
+    long_desc = "A peaceful park\n";
     dest_dir = ({
         "domain/original/area/vesla/room226", "south",
         "domain/original/area/vesla/room227", "west",

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Shadowed Anvil";
-    long_desc = "The Shadowed Anvil";
+    long_desc = "The Shadowed Anvil\n";
     dest_dir = ({
         "domain/original/area/vesla/room220", "west",
         "domain/original/area/vesla/room116", "north",

--- a/domain/original/area/vesla/room234.c
+++ b/domain/original/area/vesla/room234.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Andre's Clothing";
-    long_desc = "Andre's Clothing";
+    long_desc = "Andre's Clothing\n";
     dest_dir = ({
         "domain/original/area/vesla/room232", "south",
     });

--- a/domain/original/area/vesla/room394.c
+++ b/domain/original/area/vesla/room394.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Smoke House";
-    long_desc = "Smoke House";
+    long_desc = "Smoke House\n";
     dest_dir = ({
         "domain/original/area/vesla/room210", "south",
     });

--- a/domain/original/area/vesla/room395.c
+++ b/domain/original/area/vesla/room395.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Lathe";
-    long_desc = "The Lathe";
+    long_desc = "The Lathe\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "south",
     });

--- a/domain/original/area/vesla/room396.c
+++ b/domain/original/area/vesla/room396.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Antique Shop";
-    long_desc = "Antique Shop";
+    long_desc = "Antique Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "south",
     });

--- a/domain/original/area/vesla/room397.c
+++ b/domain/original/area/vesla/room397.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Mage's House";
-    long_desc = "Mage's House";
+    long_desc = "Mage's House\n";
     dest_dir = ({
         "domain/original/area/vesla/room398", "east",
         "domain/original/area/vesla/room206", "south",

--- a/domain/original/area/vesla/room398.c
+++ b/domain/original/area/vesla/room398.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Mage's Apprentice House";
-    long_desc = "Mage's Apprentice House";
+    long_desc = "Mage's Apprentice House\n";
     dest_dir = ({
         "domain/original/area/vesla/room397", "west",
     });

--- a/domain/original/area/vesla/room399.c
+++ b/domain/original/area/vesla/room399.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Retired Warrior's House";
-    long_desc = "Retired Warrior's House";
+    long_desc = "Retired Warrior's House\n";
     dest_dir = ({
         "domain/original/area/vesla/room734", "up",
         "domain/original/area/vesla/room213", "west",

--- a/domain/original/area/vesla/room400.c
+++ b/domain/original/area/vesla/room400.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Bell maker's shop";
-    long_desc = "Bell maker's shop";
+    long_desc = "Bell maker's shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "east",
     });

--- a/domain/original/area/vesla/room401.c
+++ b/domain/original/area/vesla/room401.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Candle Shop";
-    long_desc = "Candle Shop";
+    long_desc = "Candle Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "west",
     });

--- a/domain/original/area/vesla/room402.c
+++ b/domain/original/area/vesla/room402.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Do-it-Yourself Distiller";
-    long_desc = "Do-it-Yourself Distiller";
+    long_desc = "Do-it-Yourself Distiller\n";
     dest_dir = ({
         "domain/original/area/vesla/room216", "east",
     });

--- a/domain/original/area/vesla/room403.c
+++ b/domain/original/area/vesla/room403.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Entrance to a temple";
-    long_desc = "Entrance to a temple";
+    long_desc = "Entrance to a temple\n";
     dest_dir = ({
         "domain/original/area/vesla/room404", "east",
         "domain/original/area/vesla/room216", "west",

--- a/domain/original/area/vesla/room404.c
+++ b/domain/original/area/vesla/room404.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Temple of Amaterasu";
-    long_desc = "Temple of Amaterasu";
+    long_desc = "Temple of Amaterasu\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "east",
         "domain/original/area/vesla/room403", "west",

--- a/domain/original/area/vesla/room405.c
+++ b/domain/original/area/vesla/room405.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Temple of Amaterasu";
-    long_desc = "Temple of Amaterasu";
+    long_desc = "Temple of Amaterasu\n";
     dest_dir = ({
         "domain/original/area/vesla/room404", "west",
         "domain/original/area/vesla/room407", "south",

--- a/domain/original/area/vesla/room406.c
+++ b/domain/original/area/vesla/room406.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Candle Room";
-    long_desc = "Candle Room";
+    long_desc = "Candle Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "south",
     });

--- a/domain/original/area/vesla/room407.c
+++ b/domain/original/area/vesla/room407.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Quiet Room";
-    long_desc = "Quiet Room";
+    long_desc = "Quiet Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room405", "north",
     });

--- a/domain/original/area/vesla/room408.c
+++ b/domain/original/area/vesla/room408.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "MD Banking";
-    long_desc = "MD Banking";
+    long_desc = "MD Banking\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "east",
     });

--- a/domain/original/area/vesla/room409.c
+++ b/domain/original/area/vesla/room409.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Bounty Room";
-    long_desc = "Bounty Room";
+    long_desc = "Bounty Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "east",
     });

--- a/domain/original/area/vesla/room410.c
+++ b/domain/original/area/vesla/room410.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway";
+    long_desc = "A dingy alleyway\n";
     dest_dir = ({
         "domain/original/area/vesla/room411", "west",
         "domain/original/area/vesla/room122", "south",

--- a/domain/original/area/vesla/room411.c
+++ b/domain/original/area/vesla/room411.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Vesla Times Press Office";
-    long_desc = "Vesla Times Press Office";
+    long_desc = "Vesla Times Press Office\n";
     dest_dir = ({
         "domain/original/area/vesla/room410", "east",
         "domain/original/area/vesla/room123", "south",

--- a/domain/original/area/vesla/room412.c
+++ b/domain/original/area/vesla/room412.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Smithy";
-    long_desc = "Smithy";
+    long_desc = "Smithy\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "west",
         "domain/original/area/vesla/room124", "south",

--- a/domain/original/area/vesla/room419.c
+++ b/domain/original/area/vesla/room419.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A dark alleyway";
-    long_desc = "A dark alleyway";
+    long_desc = "A dark alleyway\n";
     dest_dir = ({
         "domain/original/area/vesla/room129", "north",
     });

--- a/domain/original/area/vesla/room420.c
+++ b/domain/original/area/vesla/room420.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Old Temple";
-    long_desc = "The Old Temple";
+    long_desc = "The Old Temple\n";
     dest_dir = ({
         "domain/original/area/vesla/room130", "north",
     });

--- a/domain/original/area/vesla/room421.c
+++ b/domain/original/area/vesla/room421.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Mage's Guild";
-    long_desc = "Mage's Guild";
+    long_desc = "Mage's Guild\n";
     dest_dir = ({
         "domain/original/area/vesla/room132", "north",
     });

--- a/domain/original/area/vesla/room422.c
+++ b/domain/original/area/vesla/room422.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Mercantile Guild Office";
-    long_desc = "Mercantile Guild Office";
+    long_desc = "Mercantile Guild Office\n";
     dest_dir = ({
         "domain/original/area/vesla/room837", "east",
         "domain/original/area/vesla/room155", "west",

--- a/domain/original/area/vesla/room423.c
+++ b/domain/original/area/vesla/room423.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Glassblower";
-    long_desc = "Glassblower";
+    long_desc = "Glassblower\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "east",
     });

--- a/domain/original/area/vesla/room424.c
+++ b/domain/original/area/vesla/room424.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Fighter's Guild";
-    long_desc = "Fighter's Guild";
+    long_desc = "Fighter's Guild\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "west",
     });

--- a/domain/original/area/vesla/room425.c
+++ b/domain/original/area/vesla/room425.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Omar's Oils II";
-    long_desc = "Omar's Oils II";
+    long_desc = "Omar's Oils II\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "south",
     });

--- a/domain/original/area/vesla/room426.c
+++ b/domain/original/area/vesla/room426.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Deora's Outfitters";
-    long_desc = "Deora's Outfitters";
+    long_desc = "Deora's Outfitters\n";
     dest_dir = ({
         "domain/original/area/vesla/room231", "south",
     });

--- a/domain/original/area/vesla/room734.c
+++ b/domain/original/area/vesla/room734.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Weapon Master's Bedroom";
-    long_desc = "Weapon Master's Bedroom";
+    long_desc = "Weapon Master's Bedroom\n";
     dest_dir = ({
         "domain/original/area/vesla/room399", "down",
     });

--- a/domain/original/area/vesla/room735.c
+++ b/domain/original/area/vesla/room735.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "west",
     });

--- a/domain/original/area/vesla/room736.c
+++ b/domain/original/area/vesla/room736.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "west",
     });

--- a/domain/original/area/vesla/room737.c
+++ b/domain/original/area/vesla/room737.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Chamber of Commerce";
-    long_desc = "Chamber of Commerce";
+    long_desc = "Chamber of Commerce\n";
     dest_dir = ({
         "domain/original/area/vesla/room187", "south",
     });

--- a/domain/original/area/vesla/room738.c
+++ b/domain/original/area/vesla/room738.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Alley";
-    long_desc = "Alley";
+    long_desc = "Alley\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "south",
     });

--- a/domain/original/area/vesla/room739.c
+++ b/domain/original/area/vesla/room739.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The School of Guild Skills";
-    long_desc = "The School of Guild Skills";
+    long_desc = "The School of Guild Skills\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "north",
     });

--- a/domain/original/area/vesla/room740.c
+++ b/domain/original/area/vesla/room740.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stationery Store";
-    long_desc = "Stationery Store";
+    long_desc = "Stationery Store\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "north",
     });

--- a/domain/original/area/vesla/room741.c
+++ b/domain/original/area/vesla/room741.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormitory Hallway";
-    long_desc = "Dormitory Hallway";
+    long_desc = "Dormitory Hallway\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "up",
         "domain/original/area/vesla/room190", "south",

--- a/domain/original/area/vesla/room742.c
+++ b/domain/original/area/vesla/room742.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Magoo's Bookstore";
-    long_desc = "Magoo's Bookstore";
+    long_desc = "Magoo's Bookstore\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "north",
     });

--- a/domain/original/area/vesla/room743.c
+++ b/domain/original/area/vesla/room743.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Frenchie's Cafe";
-    long_desc = "Frenchie's Cafe";
+    long_desc = "Frenchie's Cafe\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "south",
     });

--- a/domain/original/area/vesla/room744.c
+++ b/domain/original/area/vesla/room744.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "An empty lot.";
-    long_desc = "An empty lot.";
+    long_desc = "An empty lot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room192", "north",
     });

--- a/domain/original/area/vesla/room745.c
+++ b/domain/original/area/vesla/room745.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormitory Kitchen";
-    long_desc = "Dormitory Kitchen";
+    long_desc = "Dormitory Kitchen\n";
     dest_dir = ({
         "domain/original/area/vesla/room746", "east",
         "domain/original/area/vesla/room741", "south",

--- a/domain/original/area/vesla/room746.c
+++ b/domain/original/area/vesla/room746.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Store Room";
-    long_desc = "Store Room";
+    long_desc = "Store Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room745", "west",
     });

--- a/domain/original/area/vesla/room747.c
+++ b/domain/original/area/vesla/room747.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormitory Administrator's Room";
-    long_desc = "Dormitory Administrator's Room";
+    long_desc = "Dormitory Administrator's Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room741", "west",
     });

--- a/domain/original/area/vesla/room748.c
+++ b/domain/original/area/vesla/room748.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormitory Hallway";
-    long_desc = "Dormitory Hallway";
+    long_desc = "Dormitory Hallway\n";
     dest_dir = ({
         "domain/original/area/vesla/room751", "west",
         "domain/original/area/vesla/room741", "down",

--- a/domain/original/area/vesla/room749.c
+++ b/domain/original/area/vesla/room749.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormer";
-    long_desc = "Dormer";
+    long_desc = "Dormer\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "south",
     });

--- a/domain/original/area/vesla/room750.c
+++ b/domain/original/area/vesla/room750.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormer";
-    long_desc = "Dormer";
+    long_desc = "Dormer\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "west",
     });

--- a/domain/original/area/vesla/room751.c
+++ b/domain/original/area/vesla/room751.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormer";
-    long_desc = "Dormer";
+    long_desc = "Dormer\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "east",
     });

--- a/domain/original/area/vesla/room752.c
+++ b/domain/original/area/vesla/room752.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Dormer";
-    long_desc = "Dormer";
+    long_desc = "Dormer\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "north",
     });

--- a/domain/original/area/vesla/room753.c
+++ b/domain/original/area/vesla/room753.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The drawbridge";
-    long_desc = "The drawbridge";
+    long_desc = "The drawbridge\n";
     dest_dir = ({
         "domain/original/area/vesla/room169", "southwest",
         "domain/original/area/vesla/room754", "north",

--- a/domain/original/area/vesla/room754.c
+++ b/domain/original/area/vesla/room754.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Between the towers";
-    long_desc = "Between the towers";
+    long_desc = "Between the towers\n";
     dest_dir = ({
         "domain/original/area/vesla/room753", "south",
         "domain/original/area/vesla/room755", "north",

--- a/domain/original/area/vesla/room755.c
+++ b/domain/original/area/vesla/room755.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Between the towers";
-    long_desc = "Between the towers";
+    long_desc = "Between the towers\n";
     dest_dir = ({
         "domain/original/area/vesla/room754", "south",
         "domain/original/area/vesla/room756", "north",

--- a/domain/original/area/vesla/room756.c
+++ b/domain/original/area/vesla/room756.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room755", "south",
         "domain/original/area/vesla/room757", "north",

--- a/domain/original/area/vesla/room757.c
+++ b/domain/original/area/vesla/room757.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room756", "south",
         "domain/original/area/vesla/room765", "northeast",

--- a/domain/original/area/vesla/room758.c
+++ b/domain/original/area/vesla/room758.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room757", "west",
         "domain/original/area/vesla/room759", "south",

--- a/domain/original/area/vesla/room759.c
+++ b/domain/original/area/vesla/room759.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Eastern guard room";
-    long_desc = "Eastern guard room";
+    long_desc = "Eastern guard room\n";
     dest_dir = ({
         "domain/original/area/vesla/room760", "northeast",
         "domain/original/area/vesla/room758", "north",

--- a/domain/original/area/vesla/room760.c
+++ b/domain/original/area/vesla/room760.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Lower eastern stairwell";
-    long_desc = "Lower eastern stairwell";
+    long_desc = "Lower eastern stairwell\n";
     dest_dir = ({
         "domain/original/area/vesla/room759", "southwest",
         "domain/original/area/vesla/room761", "up",

--- a/domain/original/area/vesla/room761.c
+++ b/domain/original/area/vesla/room761.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Middle eastern stairwell";
-    long_desc = "Middle eastern stairwell";
+    long_desc = "Middle eastern stairwell\n";
     dest_dir = ({
         "domain/original/area/vesla/room762", "southwest",
         "domain/original/area/vesla/room760", "down",

--- a/domain/original/area/vesla/room762.c
+++ b/domain/original/area/vesla/room762.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Eastern guard quarters";
-    long_desc = "Eastern guard quarters";
+    long_desc = "Eastern guard quarters\n";
     dest_dir = ({
         "domain/original/area/vesla/room761", "northeast",
     });

--- a/domain/original/area/vesla/room763.c
+++ b/domain/original/area/vesla/room763.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Upper eastern stairwell";
-    long_desc = "Upper eastern stairwell";
+    long_desc = "Upper eastern stairwell\n";
     dest_dir = ({
         "domain/original/area/vesla/room764", "southwest",
         "domain/original/area/vesla/room761", "down",

--- a/domain/original/area/vesla/room764.c
+++ b/domain/original/area/vesla/room764.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Eastern tower observatory";
-    long_desc = "Eastern tower observatory";
+    long_desc = "Eastern tower observatory\n";
     dest_dir = ({
         "domain/original/area/vesla/room763", "northeast",
     });

--- a/domain/original/area/vesla/room765.c
+++ b/domain/original/area/vesla/room765.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room766", "west",
         "domain/original/area/vesla/room767", "northwest",

--- a/domain/original/area/vesla/room766.c
+++ b/domain/original/area/vesla/room766.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room758", "southeast",
         "domain/original/area/vesla/room757", "south",

--- a/domain/original/area/vesla/room767.c
+++ b/domain/original/area/vesla/room767.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room768", "east",
         "domain/original/area/vesla/room765", "southeast",

--- a/domain/original/area/vesla/room768.c
+++ b/domain/original/area/vesla/room768.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The inner ward";
-    long_desc = "The inner ward";
+    long_desc = "The inner ward\n";
     dest_dir = ({
         "domain/original/area/vesla/room766", "southwest",
         "domain/original/area/vesla/room767", "west",

--- a/domain/original/area/vesla/room769.c
+++ b/domain/original/area/vesla/room769.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The well";
-    long_desc = "The well";
+    long_desc = "The well\n";
     dest_dir = ({
         "domain/original/area/vesla/room765", "southwest",
         "domain/original/area/vesla/room771", "east",

--- a/domain/original/area/vesla/room770.c
+++ b/domain/original/area/vesla/room770.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle stables";
-    long_desc = "Castle stables";
+    long_desc = "Castle stables\n";
     dest_dir = ({
         "domain/original/area/vesla/room790", "south",
         "domain/original/area/vesla/room765", "west",

--- a/domain/original/area/vesla/room771.c
+++ b/domain/original/area/vesla/room771.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The blacksmith";
-    long_desc = "The blacksmith";
+    long_desc = "The blacksmith\n";
     dest_dir = ({
         "domain/original/area/vesla/room772", "east",
         "domain/original/area/vesla/room769", "west",

--- a/domain/original/area/vesla/room772.c
+++ b/domain/original/area/vesla/room772.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The storage room";
-    long_desc = "The storage room";
+    long_desc = "The storage room\n";
     dest_dir = ({
         "domain/original/area/vesla/room771", "west",
     });

--- a/domain/original/area/vesla/room773.c
+++ b/domain/original/area/vesla/room773.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle stables";
-    long_desc = "Castle stables";
+    long_desc = "Castle stables\n";
     dest_dir = ({
         "domain/original/area/vesla/room789", "south",
         "domain/original/area/vesla/room770", "west",

--- a/domain/original/area/vesla/room774.c
+++ b/domain/original/area/vesla/room774.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle stables";
-    long_desc = "Castle stables";
+    long_desc = "Castle stables\n";
     dest_dir = ({
         "domain/original/area/vesla/room787", "south",
         "domain/original/area/vesla/room773", "west",

--- a/domain/original/area/vesla/room775.c
+++ b/domain/original/area/vesla/room775.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle stables";
-    long_desc = "Castle stables";
+    long_desc = "Castle stables\n";
     dest_dir = ({
         "domain/original/area/vesla/room784", "south",
         "domain/original/area/vesla/room774", "west",

--- a/domain/original/area/vesla/room776.c
+++ b/domain/original/area/vesla/room776.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle stables";
-    long_desc = "Castle stables";
+    long_desc = "Castle stables\n";
     dest_dir = ({
         "domain/original/area/vesla/room782", "south",
         "domain/original/area/vesla/room775", "west",

--- a/domain/original/area/vesla/room777.c
+++ b/domain/original/area/vesla/room777.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Small paddock";
-    long_desc = "Small paddock";
+    long_desc = "Small paddock\n";
     dest_dir = ({
         "domain/original/area/vesla/room779", "southeast",
         "domain/original/area/vesla/room783", "south",

--- a/domain/original/area/vesla/room778.c
+++ b/domain/original/area/vesla/room778.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Small paddock";
-    long_desc = "Small paddock";
+    long_desc = "Small paddock\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "southwest",
         "domain/original/area/vesla/room777", "west",

--- a/domain/original/area/vesla/room779.c
+++ b/domain/original/area/vesla/room779.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Small paddock";
-    long_desc = "Small paddock";
+    long_desc = "Small paddock\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "west",
         "domain/original/area/vesla/room777", "northwest",

--- a/domain/original/area/vesla/room780.c
+++ b/domain/original/area/vesla/room780.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Wash area";
-    long_desc = "Wash area";
+    long_desc = "Wash area\n";
     dest_dir = ({
         "domain/original/area/vesla/room778", "southeast",
         "domain/original/area/vesla/room777", "south",

--- a/domain/original/area/vesla/room781.c
+++ b/domain/original/area/vesla/room781.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room776", "south",
     });

--- a/domain/original/area/vesla/room782.c
+++ b/domain/original/area/vesla/room782.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room776", "north",
     });

--- a/domain/original/area/vesla/room783.c
+++ b/domain/original/area/vesla/room783.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Small paddock";
-    long_desc = "Small paddock";
+    long_desc = "Small paddock\n";
     dest_dir = ({
         "domain/original/area/vesla/room778", "northeast",
         "domain/original/area/vesla/room779", "east",

--- a/domain/original/area/vesla/room784.c
+++ b/domain/original/area/vesla/room784.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room775", "north",
     });

--- a/domain/original/area/vesla/room785.c
+++ b/domain/original/area/vesla/room785.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room775", "south",
     });

--- a/domain/original/area/vesla/room786.c
+++ b/domain/original/area/vesla/room786.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Tack room";
-    long_desc = "Tack room";
+    long_desc = "Tack room\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "south",
     });

--- a/domain/original/area/vesla/room787.c
+++ b/domain/original/area/vesla/room787.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Feed room";
-    long_desc = "Feed room";
+    long_desc = "Feed room\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "north",
     });

--- a/domain/original/area/vesla/room788.c
+++ b/domain/original/area/vesla/room788.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room773", "south",
     });

--- a/domain/original/area/vesla/room789.c
+++ b/domain/original/area/vesla/room789.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room773", "north",
     });

--- a/domain/original/area/vesla/room790.c
+++ b/domain/original/area/vesla/room790.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room770", "north",
     });

--- a/domain/original/area/vesla/room791.c
+++ b/domain/original/area/vesla/room791.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "You swing open the wooden door and enter the stall.";
+    long_desc = "You swing open the wooden door and enter the stall.\n";
     dest_dir = ({
         "domain/original/area/vesla/room770", "south",
     });

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway";
+    long_desc = "A dingy alleyway\n";
     dest_dir = ({
         "domain/original/area/vesla/room410", "south",
         "domain/original/area/vesla/room795", "east",

--- a/domain/original/area/vesla/room793.c
+++ b/domain/original/area/vesla/room793.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite";
-    long_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite";
+    long_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite\n";
     dest_dir = ({
         "domain/original/area/vesla/room168", "east",
     });

--- a/domain/original/area/vesla/room794.c
+++ b/domain/original/area/vesla/room794.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A small building.";
-    long_desc = "A small building.";
+    long_desc = "A small building.\n";
     dest_dir = ({
         "domain/original/area/vesla/room792", "south",
     });

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A dingy alleyway";
-    long_desc = "A dingy alleyway";
+    long_desc = "A dingy alleyway\n";
     dest_dir = ({
         "domain/original/area/vesla/room813", "south",
         "domain/original/area/vesla/room792", "west",

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "An alley";
-    long_desc = "An alley";
+    long_desc = "An alley\n";
     dest_dir = ({
         "domain/original/area/vesla/room814", "south",
         "domain/original/area/vesla/room795", "west",

--- a/domain/original/area/vesla/room797.c
+++ b/domain/original/area/vesla/room797.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A dingy alley";
-    long_desc = "A dingy alley";
+    long_desc = "A dingy alley\n";
     dest_dir = ({
         "domain/original/area/vesla/room795", "south",
         "domain/original/area/vesla/room798", "north",

--- a/domain/original/area/vesla/room798.c
+++ b/domain/original/area/vesla/room798.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "A Dingy Alley";
-    long_desc = "A Dingy Alley";
+    long_desc = "A Dingy Alley\n";
     dest_dir = ({
         "domain/original/area/vesla/room797", "south",
         "domain/original/area/vesla/room799", "north",

--- a/domain/original/area/vesla/room799.c
+++ b/domain/original/area/vesla/room799.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way";
+    long_desc = "Stink Alley Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "west",
         "domain/original/area/vesla/room800", "east",

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way";
+    long_desc = "Stink Alley Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room799", "west",
         "domain/original/area/vesla/room801", "east",

--- a/domain/original/area/vesla/room801.c
+++ b/domain/original/area/vesla/room801.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way";
+    long_desc = "Stink Alley Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room800", "west",
     });

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way";
+    long_desc = "Stink Alley Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room805", "south",
         "domain/original/area/vesla/room803", "west",

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Stink Alley Way";
-    long_desc = "Stink Alley Way";
+    long_desc = "Stink Alley Way\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "east",
         "domain/original/area/vesla/room804", "south",

--- a/domain/original/area/vesla/room804.c
+++ b/domain/original/area/vesla/room804.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Fish Mongery";
-    long_desc = "Fish Mongery";
+    long_desc = "Fish Mongery\n";
     dest_dir = ({
         "domain/original/area/vesla/room803", "north",
     });

--- a/domain/original/area/vesla/room805.c
+++ b/domain/original/area/vesla/room805.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Crazy Habib's Fertilizer";
-    long_desc = "Crazy Habib's Fertilizer";
+    long_desc = "Crazy Habib's Fertilizer\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "north",
     });

--- a/domain/original/area/vesla/room806.c
+++ b/domain/original/area/vesla/room806.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Barber Shop";
-    long_desc = "Barber Shop";
+    long_desc = "Barber Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room800", "south",
     });

--- a/domain/original/area/vesla/room807.c
+++ b/domain/original/area/vesla/room807.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Pornographers Den";
-    long_desc = "Pornographers Den";
+    long_desc = "Pornographers Den\n";
     dest_dir = ({
         "domain/original/area/vesla/room802", "south",
     });

--- a/domain/original/area/vesla/room808.c
+++ b/domain/original/area/vesla/room808.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Livery";
-    long_desc = "Livery";
+    long_desc = "Livery\n";
     dest_dir = ({
         "domain/original/area/vesla/room809", "up",
         "domain/original/area/vesla/room161", "west",

--- a/domain/original/area/vesla/room809.c
+++ b/domain/original/area/vesla/room809.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Hayloft";
-    long_desc = "Hayloft";
+    long_desc = "Hayloft\n";
     dest_dir = ({
         "domain/original/area/vesla/room808", "down",
     });

--- a/domain/original/area/vesla/room810.c
+++ b/domain/original/area/vesla/room810.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Tailor's Shop";
-    long_desc = "Tailor's Shop";
+    long_desc = "Tailor's Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "west",
     });

--- a/domain/original/area/vesla/room811.c
+++ b/domain/original/area/vesla/room811.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Hardware Store";
-    long_desc = "Hardware Store";
+    long_desc = "Hardware Store\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "west",
     });

--- a/domain/original/area/vesla/room812.c
+++ b/domain/original/area/vesla/room812.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Haseltine Engravers";
-    long_desc = "Haseltine Engravers";
+    long_desc = "Haseltine Engravers\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "west",
     });

--- a/domain/original/area/vesla/room813.c
+++ b/domain/original/area/vesla/room813.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent\n";
     dest_dir = ({
         "domain/original/area/vesla/room795", "north",
     });

--- a/domain/original/area/vesla/room814.c
+++ b/domain/original/area/vesla/room814.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Flea Market";
-    long_desc = "Flea Market";
+    long_desc = "Flea Market\n";
     dest_dir = ({
         "domain/original/area/vesla/room796", "north",
     });

--- a/domain/original/area/vesla/room815.c
+++ b/domain/original/area/vesla/room815.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Back Room";
-    long_desc = "The Back Room";
+    long_desc = "The Back Room\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "east",
         "domain/original/area/vesla/room814", "north",

--- a/domain/original/area/vesla/room816.c
+++ b/domain/original/area/vesla/room816.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Castle Bridge";
-    long_desc = "Castle Bridge";
+    long_desc = "Castle Bridge\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "north",
     });

--- a/domain/original/area/vesla/room817.c
+++ b/domain/original/area/vesla/room817.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Manor House";
-    long_desc = "Manor House";
+    long_desc = "Manor House\n";
     dest_dir = ({
         "domain/original/area/vesla/room818", "up",
         "domain/original/area/vesla/room152", "west",

--- a/domain/original/area/vesla/room818.c
+++ b/domain/original/area/vesla/room818.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Manor House";
-    long_desc = "Manor House";
+    long_desc = "Manor House\n";
     dest_dir = ({
         "domain/original/area/vesla/room817", "down",
     });

--- a/domain/original/area/vesla/room819.c
+++ b/domain/original/area/vesla/room819.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent\n";
     dest_dir = ({
         "domain/original/area/vesla/room152", "east",
     });

--- a/domain/original/area/vesla/room820.c
+++ b/domain/original/area/vesla/room820.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Cleric Guild";
-    long_desc = "Cleric Guild";
+    long_desc = "Cleric Guild\n";
     dest_dir = ({
         "domain/original/area/vesla/room839", "west",
         "domain/original/area/vesla/room153", "east",

--- a/domain/original/area/vesla/room821.c
+++ b/domain/original/area/vesla/room821.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Hall of the builders guild";
-    long_desc = "Hall of the builders guild";
+    long_desc = "Hall of the builders guild\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "west",
     });

--- a/domain/original/area/vesla/room822.c
+++ b/domain/original/area/vesla/room822.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "City Hall";
-    long_desc = "City Hall";
+    long_desc = "City Hall\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "east",
         "domain/original/area/vesla/room831", "up",

--- a/domain/original/area/vesla/room823.c
+++ b/domain/original/area/vesla/room823.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Tea Shop";
-    long_desc = "Tea Shop";
+    long_desc = "Tea Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room157", "east",
     });

--- a/domain/original/area/vesla/room824.c
+++ b/domain/original/area/vesla/room824.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Whore House";
-    long_desc = "Whore House";
+    long_desc = "Whore House\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "east",
         "domain/original/area/vesla/room825", "up",

--- a/domain/original/area/vesla/room825.c
+++ b/domain/original/area/vesla/room825.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Second floor of whore house.";
-    long_desc = "Second floor of whore house.";
+    long_desc = "Second floor of whore house.\n";
     dest_dir = ({
         "domain/original/area/vesla/room828", "south",
         "domain/original/area/vesla/room826", "west",

--- a/domain/original/area/vesla/room826.c
+++ b/domain/original/area/vesla/room826.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Viking's room";
-    long_desc = "Viking's room";
+    long_desc = "Viking's room\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "east",
     });

--- a/domain/original/area/vesla/room827.c
+++ b/domain/original/area/vesla/room827.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Sandra's room";
-    long_desc = "Sandra's room";
+    long_desc = "Sandra's room\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "south",
     });

--- a/domain/original/area/vesla/room828.c
+++ b/domain/original/area/vesla/room828.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Kathy's room";
-    long_desc = "Kathy's room";
+    long_desc = "Kathy's room\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "north",
     });

--- a/domain/original/area/vesla/room829.c
+++ b/domain/original/area/vesla/room829.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Robert's room";
-    long_desc = "Robert's room";
+    long_desc = "Robert's room\n";
     dest_dir = ({
         "domain/original/area/vesla/room825", "down",
     });

--- a/domain/original/area/vesla/room830.c
+++ b/domain/original/area/vesla/room830.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Baker's Shop";
-    long_desc = "Baker's Shop";
+    long_desc = "Baker's Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room157", "west",
     });

--- a/domain/original/area/vesla/room831.c
+++ b/domain/original/area/vesla/room831.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "First Floor";
-    long_desc = "First Floor";
+    long_desc = "First Floor\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "up",
         "domain/original/area/vesla/room822", "down",

--- a/domain/original/area/vesla/room832.c
+++ b/domain/original/area/vesla/room832.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Chamber of Commerce";
-    long_desc = "Chamber of Commerce";
+    long_desc = "Chamber of Commerce\n";
     dest_dir = ({
         "domain/original/area/vesla/room831", "east",
     });

--- a/domain/original/area/vesla/room833.c
+++ b/domain/original/area/vesla/room833.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Second Floor";
-    long_desc = "Second Floor";
+    long_desc = "Second Floor\n";
     dest_dir = ({
         "domain/original/area/vesla/room835", "up",
         "domain/original/area/vesla/room831", "down",

--- a/domain/original/area/vesla/room834.c
+++ b/domain/original/area/vesla/room834.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Magistrate";
-    long_desc = "Magistrate";
+    long_desc = "Magistrate\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "east",
     });

--- a/domain/original/area/vesla/room835.c
+++ b/domain/original/area/vesla/room835.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "City Archives";
-    long_desc = "City Archives";
+    long_desc = "City Archives\n";
     dest_dir = ({
         "domain/original/area/vesla/room833", "down",
         "domain/original/area/vesla/room836", "west",

--- a/domain/original/area/vesla/room836.c
+++ b/domain/original/area/vesla/room836.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Inner Sanctum";
-    long_desc = "Inner Sanctum";
+    long_desc = "Inner Sanctum\n";
     dest_dir = ({
         "domain/original/area/vesla/room835", "east",
     });

--- a/domain/original/area/vesla/room837.c
+++ b/domain/original/area/vesla/room837.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Open Air Market:";
-    long_desc = "Open Air Market:";
+    long_desc = "Open Air Market:\n";
     dest_dir = ({
         "domain/original/area/vesla/room422", "west",
     });

--- a/domain/original/area/vesla/room838.c
+++ b/domain/original/area/vesla/room838.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Chapel of War";
-    long_desc = "Chapel of War";
+    long_desc = "Chapel of War\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "south",
     });

--- a/domain/original/area/vesla/room839.c
+++ b/domain/original/area/vesla/room839.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Reconciliation Chapel";
-    long_desc = "Reconciliation Chapel";
+    long_desc = "Reconciliation Chapel\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "east",
     });

--- a/domain/original/area/vesla/room840.c
+++ b/domain/original/area/vesla/room840.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room841", "west",
         "domain/original/area/vesla/room148", "south",

--- a/domain/original/area/vesla/room841.c
+++ b/domain/original/area/vesla/room841.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "south",
         "domain/original/area/vesla/room842", "west",

--- a/domain/original/area/vesla/room842.c
+++ b/domain/original/area/vesla/room842.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "south",
         "domain/original/area/vesla/room841", "east",

--- a/domain/original/area/vesla/room843.c
+++ b/domain/original/area/vesla/room843.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room844", "west",
         "domain/original/area/vesla/room841", "south",

--- a/domain/original/area/vesla/room844.c
+++ b/domain/original/area/vesla/room844.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room842", "south",
         "domain/original/area/vesla/room843", "east",

--- a/domain/original/area/vesla/room845.c
+++ b/domain/original/area/vesla/room845.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "east",
         "domain/original/area/vesla/room146", "north",

--- a/domain/original/area/vesla/room846.c
+++ b/domain/original/area/vesla/room846.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Burned Area";
-    long_desc = "Burned Area";
+    long_desc = "Burned Area\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "west",
         "domain/original/area/vesla/room147", "north",

--- a/domain/original/area/vesla/room847.c
+++ b/domain/original/area/vesla/room847.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Old City Offices";
-    long_desc = "Old City Offices";
+    long_desc = "Old City Offices\n";
     dest_dir = ({
         "domain/original/area/vesla/room849", "west",
         "domain/original/area/vesla/room848", "east",

--- a/domain/original/area/vesla/room848.c
+++ b/domain/original/area/vesla/room848.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Old Office";
-    long_desc = "Old Office";
+    long_desc = "Old Office\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "west",
     });

--- a/domain/original/area/vesla/room849.c
+++ b/domain/original/area/vesla/room849.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Old Office";
-    long_desc = "Old Office";
+    long_desc = "Old Office\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "east",
     });

--- a/domain/original/area/vesla/room850.c
+++ b/domain/original/area/vesla/room850.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn";
+    long_desc = "Howling Wolf Inn\n";
     dest_dir = ({
         "domain/original/area/vesla/room142", "west",
         "domain/original/area/vesla/room852", "east",

--- a/domain/original/area/vesla/room851.c
+++ b/domain/original/area/vesla/room851.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn";
+    long_desc = "Howling Wolf Inn\n";
     dest_dir = ({
         "domain/original/area/vesla/room850", "south",
     });

--- a/domain/original/area/vesla/room852.c
+++ b/domain/original/area/vesla/room852.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Howling Wolf Inn";
-    long_desc = "Howling Wolf Inn";
+    long_desc = "Howling Wolf Inn\n";
     dest_dir = ({
         "domain/original/area/vesla/room850", "west",
     });

--- a/domain/original/area/vesla/room853.c
+++ b/domain/original/area/vesla/room853.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Abandoned Building";
-    long_desc = "Abandoned Building";
+    long_desc = "Abandoned Building\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "east",
     });

--- a/domain/original/area/vesla/room854.c
+++ b/domain/original/area/vesla/room854.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Spice Merchant";
-    long_desc = "Spice Merchant";
+    long_desc = "Spice Merchant\n";
     dest_dir = ({
         "domain/original/area/vesla/room139", "west",
     });

--- a/domain/original/area/vesla/room855.c
+++ b/domain/original/area/vesla/room855.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Abandoned Building";
-    long_desc = "Abandoned Building";
+    long_desc = "Abandoned Building\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "west",
     });

--- a/domain/original/area/vesla/room856.c
+++ b/domain/original/area/vesla/room856.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Carvings Shop";
-    long_desc = "Carvings Shop";
+    long_desc = "Carvings Shop\n";
     dest_dir = ({
         "domain/original/area/vesla/room138", "east",
     });

--- a/domain/original/area/vesla/room857.c
+++ b/domain/original/area/vesla/room857.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Abandoned Warehouse";
-    long_desc = "Abandoned Warehouse";
+    long_desc = "Abandoned Warehouse\n";
     dest_dir = ({
         "domain/original/area/vesla/room198", "west",
     });

--- a/domain/original/area/vesla/room870.c
+++ b/domain/original/area/vesla/room870.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "In Rohan's bedroom";
-    long_desc = "In Rohan's bedroom";
+    long_desc = "In Rohan's bedroom\n";
     dest_dir = ({
         "domain/original/area/vesla/room869", "down",
         "domain/original/area/vesla/room871", "up",

--- a/domain/original/area/vesla/room871.c
+++ b/domain/original/area/vesla/room871.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "In Gwyneth's bedroom";
-    long_desc = "In Gwyneth's bedroom";
+    long_desc = "In Gwyneth's bedroom\n";
     dest_dir = ({
         "domain/original/area/vesla/room873", "down",
         "domain/original/area/vesla/room872", "up",

--- a/domain/original/area/vesla/room872.c
+++ b/domain/original/area/vesla/room872.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "In Vella's bedroom";
-    long_desc = "In Vella's bedroom";
+    long_desc = "In Vella's bedroom\n";
     dest_dir = ({
         "domain/original/area/vesla/room871", "down",
     });

--- a/domain/original/area/vesla/room873.c
+++ b/domain/original/area/vesla/room873.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "<> Aladrin escapes reality and falls into Moral Decay. <>";
-    long_desc = "<> Aladrin escapes reality and falls into Moral Decay. <>";
+    long_desc = "<> Aladrin escapes reality and falls into Moral Decay. <>\n";
     dest_dir = ({
         "domain/original/area/vesla/room874", "down",
         "domain/original/area/vesla/room871", "up",

--- a/domain/original/area/vesla/room874.c
+++ b/domain/original/area/vesla/room874.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Bottom floor of the silo";
-    long_desc = "Bottom floor of the silo";
+    long_desc = "Bottom floor of the silo\n";
     dest_dir = ({
         "domain/original/area/vesla/room873", "up",
     });

--- a/domain/original/area/vesla/room878.c
+++ b/domain/original/area/vesla/room878.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Guild/Shop Space for rent";
-    long_desc = "Guild/Shop Space for rent";
+    long_desc = "Guild/Shop Space for rent\n";
     dest_dir = ({
         "domain/original/area/vesla/room127", "south",
     });

--- a/domain/original/area/vesla/room879.c
+++ b/domain/original/area/vesla/room879.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Vesla Post Office";
-    long_desc = "Vesla Post Office";
+    long_desc = "Vesla Post Office\n";
     dest_dir = ({
         "domain/original/area/vesla/room126", "south",
     });

--- a/domain/original/area/vesla/room880.c
+++ b/domain/original/area/vesla/room880.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Old Adventurer's Guild";
-    long_desc = "Old Adventurer's Guild";
+    long_desc = "Old Adventurer's Guild\n";
     dest_dir = ({
         "domain/original/area/vesla/room126", "north",
     });

--- a/domain/original/area/vesla/room893.c
+++ b/domain/original/area/vesla/room893.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "The Players' lounge";
-    long_desc = "The Players' lounge";
+    long_desc = "The Players' lounge\n";
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "down",
     });

--- a/domain/original/area/vesla/room961.c
+++ b/domain/original/area/vesla/room961.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Rising Phoenix";
-    long_desc = "Rising Phoenix";
+    long_desc = "Rising Phoenix\n";
     dest_dir = ({
         "domain/original/area/vesla/room796", "south",
     });

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Abandoned Store";
-    long_desc = "Abandoned Store";
+    long_desc = "Abandoned Store\n";
     dest_dir = ({
         "domain/original/area/vesla/room199", "west",
     });


### PR DESCRIPTION
### Motivation
- Room presentation should be consistent: `long_desc` strings in the Vesla area must end with a trailing newline to match the formatting in `room228.c`. 
- Ensure player-facing text follows the repository's prose and formatting expectations so rendering is predictable.

### Description
- Appended a trailing `\n` to the `long_desc` string literal in each `domain/original/area/vesla/room*.c` file where it was missing. 
- The change was applied across 280 Vesla room files and no other logic or text content was modified. 
- Files were updated in-place with a small Python script that matches `long_desc = "...";` and appends `\n` when absent. 
- Changes were committed with a single commit containing the 280 file updates.

### Testing
- Ran a detection script (`python` regex check) that initially reported 280 `long_desc` entries missing a trailing newline. 
- Executed the bulk update script which modified 280 files to append `\n` to `long_desc` literals. 
- Re-ran the detection script and verified it reported 0 remaining files missing the trailing newline. 
- Confirmed the repository status and commit recorded 280 files changed in the single commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c74079f08327852096fc81f2769e)