### PR TITLE
Age Vesla west–east corridor rooms

### DIFF
--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -1,29 +1,33 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Gate to the Wilderness";
-    long_desc = "The Gate to the Wilderness\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room116", "west",
-	"domain/original/area/roadway/room14", "exit",
-    });
+  short_desc = "Ruined Gate";
+  long_desc = "A broken stone arch leans over the road, its timbers split and\n"
+              + "sagging. Crumbled masonry seals the passage, and old iron\n"
+              + "fittings lie rusted in the weeds.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room116", "west",
+    "domain/original/area/roadway/room14", "exit",
+  });
 }
 
 /*
 void init() {
-    ::init();
+  ::init();
 
-    add_action("block_exit", "exit");
+  add_action("block_exit", "exit");
 }
 
 int block_exit() {
-    write("The ruined gate has collapsed; the way to the wilderness is impassable.\n");
+  write("The ruined gate has collapsed; the way to the wilderness is\n"
+        + "impassable.\n");
 
-    return 1;
+  return 1;
 }
 */

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Park Street and Caravan Road";
-    long_desc = "Intersection of Park Street and Caravan Road\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room233", "south",
-        "domain/original/area/vesla/room117", "west",
-        "domain/original/area/vesla/room115", "east",
-        "domain/original/area/vesla/room172", "north",
-    });
+  short_desc = "Park Crossroads";
+  long_desc = "The crossing is choked with gravel and dead leaves where a\n"
+              + "broad street meets a narrower lane. Fallen posts and a\n"
+              + "tilted sign hold a silence settled over long neglect.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room233", "south",
+    "domain/original/area/vesla/room117", "west",
+    "domain/original/area/vesla/room115", "east",
+    "domain/original/area/vesla/room172", "north",
+  });
 }

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Park Street and Via Sacra";
-    long_desc = "Intersection of Park Street and Via Sacra\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room220", "south",
-        "domain/original/area/vesla/room118", "west",
-        "domain/original/area/vesla/room116", "east",
-        "domain/original/area/vesla/room226", "north",
-    });
+  short_desc = "Sacra Crossing";
+  long_desc = "Weathered stones mark the meeting of two old streets, their\n"
+              + "lines softened by drifted grit. A broken post leans over\n"
+              + "the junction, and no track has passed in generations.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room220", "south",
+    "domain/original/area/vesla/room118", "west",
+    "domain/original/area/vesla/room116", "east",
+    "domain/original/area/vesla/room226", "north",
+  });
 }

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room227", "north",
-        "domain/original/area/vesla/room221", "south",
-        "domain/original/area/vesla/room119", "west",
-        "domain/original/area/vesla/room117", "east",
-    });
+  short_desc = "Dim Walk";
+  long_desc = "A narrow walk runs beneath slumped beams and the last remains\n"
+              + "of a shaded trellis. Motes of dust cling to the air, and the\n"
+              + "stones are slick with old rot.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room227", "north",
+    "domain/original/area/vesla/room221", "south",
+    "domain/original/area/vesla/room119", "west",
+    "domain/original/area/vesla/room117", "east",
+  });
 }

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room222", "south",
-        "domain/original/area/vesla/room120", "west",
-        "domain/original/area/vesla/room118", "east",
-        "domain/original/area/vesla/room230", "north",
-    });
+  short_desc = "Shattered Walk";
+  long_desc = "The covered path is broken here, its ribs split and scattered\n"
+              + "across the paving. Wind drifts through the gaps, stirring\n"
+              + "leaves that have gathered in the hollows.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room222", "south",
+    "domain/original/area/vesla/room120", "west",
+    "domain/original/area/vesla/room118", "east",
+    "domain/original/area/vesla/room230", "north",
+  });
 }

--- a/domain/original/area/vesla/room120.c
+++ b/domain/original/area/vesla/room120.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room121", "west",
-        "domain/original/area/vesla/room119", "east",
-        "domain/original/area/vesla/room223", "south",
-    });
+  short_desc = "Hollow Walk";
+  long_desc = "A hollowed stretch of passage runs between damp stone walls.\n"
+              + "The roof timbers have fallen away, leaving the corridor open\n"
+              + "to dull light and slow rain.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room121", "west",
+    "domain/original/area/vesla/room119", "east",
+    "domain/original/area/vesla/room223", "south",
+  });
 }

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -1,18 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room224", "south",
-        "domain/original/area/vesla/room122", "west",
-        "domain/original/area/vesla/room120", "east",
-        "domain/original/area/vesla/room425", "north",
-    });
+  short_desc = "Sunken Walk";
+  long_desc = "The walkway dips into a shallow trough where stones have\n"
+              + "settled unevenly. A thin film of moss trails along the\n"
+              + "seams, and the air sits heavy with damp.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room224", "south",
+    "domain/original/area/vesla/room122", "west",
+    "domain/original/area/vesla/room120", "east",
+    "domain/original/area/vesla/room425", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room122.c
+++ b/domain/original/area/vesla/room122.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room225", "south",
-        "domain/original/area/vesla/room123", "west",
-        "domain/original/area/vesla/room121", "east",
-        "domain/original/area/vesla/room410", "north",
-    });
+  short_desc = "Withered Walk";
+  long_desc = "The path narrows beneath the remains of a withered canopy.\n"
+              + "Splintered slats litter the ground, and the walls are dark\n"
+              + "with rain stains and age.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room225", "south",
+    "domain/original/area/vesla/room123", "west",
+    "domain/original/area/vesla/room121", "east",
+    "domain/original/area/vesla/room410", "north",
+  });
 }

--- a/domain/original/area/vesla/room123.c
+++ b/domain/original/area/vesla/room123.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A shaded walk";
-    long_desc = "A shaded walk\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room124", "west",
-        "domain/original/area/vesla/room122", "east",
-        "domain/original/area/vesla/room411", "north",
-    });
+  short_desc = "Silent Walk";
+  long_desc = "A quiet stretch of stone runs west, its seams filled with\n"
+              + "grit and grass. The remnants of a low railing sag along the\n"
+              + "edge, half buried in dust.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room124", "west",
+    "domain/original/area/vesla/room122", "east",
+    "domain/original/area/vesla/room411", "north",
+  });
 }

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A break in the coverage";
-    long_desc = "A break in the coverage\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room125", "west",
-        "domain/original/area/vesla/room123", "east",
-        "domain/original/area/vesla/room412", "north",
-    });
+  short_desc = "Broken Canopy";
+  long_desc = "The cover above the walk has failed, opening to a pale strip\n"
+              + "of sky. Loose stones and splintered wood lie scattered, and\n"
+              + "the ground shows long years of weathering.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room125", "west",
+    "domain/original/area/vesla/room123", "east",
+    "domain/original/area/vesla/room412", "north",
+  });
 }

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A busy intersection";
-    long_desc = "A busy intersection\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room159", "south",
-        "domain/original/area/vesla/room126", "west",
-        "domain/original/area/vesla/room124", "east",
-        "domain/original/area/vesla/room160", "north",
-    });
+  short_desc = "Empty Junction";
+  long_desc = "A wide junction opens where several streets once met. The\n"
+              + "stones are worn smooth, and scattered rubble marks where\n"
+              + "structures have slumped into the road.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room159", "south",
+    "domain/original/area/vesla/room126", "west",
+    "domain/original/area/vesla/room124", "east",
+    "domain/original/area/vesla/room160", "north",
+  });
 }

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -1,28 +1,31 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The end of the park street";
-    long_desc = "The end of the park street\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room880", "south",
-        "domain/original/area/vesla/room127", "west",
-        "domain/original/area/vesla/room125", "east",
-        "domain/original/area/vesla/room879", "north",
-    });
+  short_desc = "Park's End";
+  long_desc = "The walk widens before crumbling walls that once framed a\n"
+              + "corner of the city. Loose stone and soil have spilled over\n"
+              + "the paving, and the air hangs still.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room880", "south",
+    "domain/original/area/vesla/room127", "west",
+    "domain/original/area/vesla/room125", "east",
+    "domain/original/area/vesla/room879", "north",
+  });
 }
 
 void init() {
-    ::init();
-    add_action("block_exit", "south");
-    add_action("block_exit", "north");
+  ::init();
+  add_action("block_exit", "south");
+  add_action("block_exit", "north");
 }
 
 int block_exit() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
-    return 1;
+  write("Only rubble remains there; the structure collapsed long ago.\n");
+  return 1;
 }

--- a/domain/original/area/vesla/room127.c
+++ b/domain/original/area/vesla/room127.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Entrance to the Old City.";
-    long_desc = "Entrance to the Old City.\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room128", "west",
-        "domain/original/area/vesla/room126", "east",
-        "domain/original/area/vesla/room878", "north",
-    });
+  short_desc = "Old City Gate";
+  long_desc = "A battered gateway stands between worn walls, its lintel\n"
+              + "cracked and sagging. Dust gathers in the deep grooves of the\n"
+              + "threshold, and no sound follows the road beyond.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room128", "west",
+    "domain/original/area/vesla/room126", "east",
+    "domain/original/area/vesla/room878", "north",
+  });
 }

--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Westroad, The Entrance to the Old City.";
-    long_desc = "Westroad, The Entrance to the Old City.\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room129", "west",
-        "domain/original/area/vesla/room127", "east",
-        "domain/original/area/vesla/room881", "north",
-    });
+  short_desc = "Westroad Threshold";
+  long_desc = "The road angles west through a narrowed gap between leaning\n"
+              + "stonework. Chipped blocks and pale grit mark a boundary that\n"
+              + "time has left without purpose.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room129", "west",
+    "domain/original/area/vesla/room127", "east",
+    "domain/original/area/vesla/room881", "north",
+  });
 }

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room130", "west",
-        "domain/original/area/vesla/room128", "east",
-        "domain/original/area/vesla/room419", "south",
-    });
+  short_desc = "Westroad Ruins";
+  long_desc = "Westroad runs between low stone shells, their upper courses\n"
+              + "missing. Fallen blocks lie in the ruts, and a thin growth of\n"
+              + "grass softens the roadway.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room130", "west",
+    "domain/original/area/vesla/room128", "east",
+    "domain/original/area/vesla/room419", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room131", "west",
-        "domain/original/area/vesla/room129", "east",
-        "domain/original/area/vesla/room420", "south",
-    });
+  short_desc = "Westroad Silence";
+  long_desc = "The road narrows into a quiet channel of stone and dust. A\n"
+              + "collapsed lintel lies across one wall, and the space beyond\n"
+              + "it is dark and empty.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room131", "west",
+    "domain/original/area/vesla/room129", "east",
+    "domain/original/area/vesla/room420", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room132", "west",
-        "domain/original/area/vesla/room130", "east",
-        "domain/original/area/vesla/room858", "north",
-    });
+  short_desc = "Westroad Drift";
+  long_desc = "Windblown grit has gathered in thin drifts along the road.\n"
+              + "The stonework is stained and pitted, and a few twisted iron\n"
+              + "bands cling to the wall.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room132", "west",
+    "domain/original/area/vesla/room130", "east",
+    "domain/original/area/vesla/room858", "north",
+  });
 }

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Westroad";
-    long_desc = "Westroad\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room133", "west",
-        "domain/original/area/vesla/room131", "east",
-        "domain/original/area/vesla/room421", "south",
-    });
+  short_desc = "Westroad Scar";
+  long_desc = "A long crack splits the paving, running the length of the\n"
+              + "road. The break is filled with rubble and silt, and the\n"
+              + "surrounding stones are polished dull by time.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room133", "west",
+    "domain/original/area/vesla/room131", "east",
+    "domain/original/area/vesla/room421", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room133.c
+++ b/domain/original/area/vesla/room133.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The corner of Westroad and Basalt Avenue";
-    long_desc = "The corner of Westroad and Basalt Avenue\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room134", "west",
-        "domain/original/area/vesla/room132", "east",
-        "domain/original/area/vesla/room135", "south",
-    });
+  short_desc = "Basalt Corner";
+  long_desc = "The road turns beside a wall of dark basalt blocks, their\n"
+              + "faces chipped and rough. A scatter of broken stone marks\n"
+              + "where another street has slumped away.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room134", "west",
+    "domain/original/area/vesla/room132", "east",
+    "domain/original/area/vesla/room135", "south",
+  });
 }

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -1,25 +1,29 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western Gate of Vesla";
-    long_desc = "Western Gate of Vesla\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room133", "east",
-        "domain/original/area/roadway/room29", "exit",
-    });
+  short_desc = "Western Gate";
+  long_desc = "The western gate has collapsed into a heap of stone and\n"
+              + "splintered wood. Rusted fittings lie half buried, and the\n"
+              + "blocked passage holds a deep, unmoving quiet.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room133", "east",
+    "domain/original/area/roadway/room29", "exit",
+  });
 }
 
 void init() {
-    ::init();
-    add_action("block_exit", "exit");
+  ::init();
+  add_action("block_exit", "exit");
 }
 
 int block_exit() {
-    write("The ruined gate is choked with stone; the wilderness beyond is impassable.\n");
-    return 1;
+  write("The ruined gate is choked with stone; the wilderness beyond is\n"
+        + "impassable.\n");
+  return 1;
 }

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "General Store";
-    long_desc = "General Store\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room222", "west",
-        "domain/original/area/vesla/room220", "east",
-        "domain/original/area/vesla/room118", "north",
-    });
+  short_desc = "Forgotten Counter";
+  long_desc = "A long counter lies warped and split, its surface powdered\n"
+              + "with dust. Fallen shelves clutter the walls, and the air\n"
+              + "hangs stale and undisturbed.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room222", "west",
+    "domain/original/area/vesla/room220", "east",
+    "domain/original/area/vesla/room118", "north",
+  });
 }

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Comfortably Numb";
-    long_desc = "Comfortably Numb\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room223", "west",
-        "domain/original/area/vesla/room221", "east",
-        "domain/original/area/vesla/room119", "north",
-    });
+  short_desc = "Numb Hall";
+  long_desc = "A low hall sits empty, its stone floor cold and bare. Faded\n"
+              + "trim peels from the walls, and the quiet is deep.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room223", "west",
+    "domain/original/area/vesla/room221", "east",
+    "domain/original/area/vesla/room119", "north",
+  });
 }

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Medieval Mounts";
-    long_desc = "Medieval Mounts\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room224", "west",
-        "domain/original/area/vesla/room222", "east",
-        "domain/original/area/vesla/room120", "north",
-    });
+  short_desc = "Empty Stalls";
+  long_desc = "Stall frames lean inward, their rails broken and dulled by\n"
+              + "age. Dry straw rot and scattered nails cling to the floor.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room224", "west",
+    "domain/original/area/vesla/room222", "east",
+    "domain/original/area/vesla/room120", "north",
+  });
 }

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Big Hole Banking";
-    long_desc = "Big Hole Banking\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room225", "west",
-        "domain/original/area/vesla/room223", "east",
-        "domain/original/area/vesla/room121", "north",
-    });
+  short_desc = "Collapsed Vault";
+  long_desc = "A heavy doorway hangs open on broken hinges, leading to a\n"
+              + "chamber choked with debris. Iron bands are rusted through,\n"
+              + "and the floor has buckled into a shallow pit.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room225", "west",
+    "domain/original/area/vesla/room223", "east",
+    "domain/original/area/vesla/room121", "north",
+  });
 }

--- a/domain/original/area/vesla/room225.c
+++ b/domain/original/area/vesla/room225.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brimstone";
-    long_desc = "Brimstone\n";
-    dest_dir = ({
-        "domain/original/area/vesla/room224", "east",
-        "domain/original/area/vesla/room122", "north",
-    });
+  short_desc = "Scorched Hearth";
+  long_desc = "Soot-dark stone surrounds a dead hearth, the ash long gone.\n"
+              + "Crumbling brick and damp stains are all that remain in the\n"
+              + "still, cool chamber.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room224", "east",
+    "domain/original/area/vesla/room122", "north",
+  });
 }


### PR DESCRIPTION
### Motivation
- Bring the west–east corridor of Vesla into the Phase 1 abandoned state described in `VESLA.md` and `OVERVIEW.md` by aging nearby rooms.
- Align room prose with the project's `PROSE.md` constraints: concise, evocative, and materially grounded descriptions of decay and stillness.
- Ensure code follows `CODE-STYLE.md` line-length rules for player-facing text.

### Description
- Updated rooms `domain/original/area/vesla/room115.c` through `room134.c` with new `short_desc` values and revised `long_desc` text that evokes ~200 years of abandonment and decay.
- Aged interior rooms `domain/original/area/vesla/room221.c` through `room225.c` with new `short_desc` and `long_desc` to match the abandoned tone.
- Wrapped and reformatted long string literals in gate block messages (notably in `room115.c` and `room134.c`) to comply with the 80-character line-length rule.
- Committed the changes (25 files modified) and staged the updated room files for inclusion in the PR.

### Testing
- Ran an automated line-length scan across the modified files and corrected violations, leaving no lingering >80-character player-facing lines (scan succeeded).
- No unit or integration test suite was executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d7eea2bc83279cb28cab1ef481a3)