### PR TITLE
Age Vesla parks and major streets for Phase 1 decay

### DIFF
--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Corner of Basalt Avenue and West River Street";
-    long_desc = "Corner of Basalt Avenue and West River Street\n";
+    short_desc = "Basalt River Corner";
+    long_desc = "Cracked basalt paving meets the river road, its stones\n"
+                + "slick with old stains.\n"
+                + "A collapsed wall spills rubble into the corner, and\n"
+                + "weeds root in the gaps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",
         "domain/original/area/vesla/room142", "north",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River Street";
-    long_desc = "West River Street\n";
+    short_desc = "West River Road";
+    long_desc = "The westward river road is split by frost and root, the\n"
+                + "stones heaved uneven.\n"
+                + "A dry gutter runs alongside, packed with silt and curled\n"
+                + "leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River Street";
-    long_desc = "West River Street\n";
+    short_desc = "West River Road";
+    long_desc = "Moss clings to the low curb here, and the road narrows\n"
+                + "between leaning facades.\n"
+                + "Rusted rings jut from the masonry, their purpose long\n"
+                + "gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River Street";
-    long_desc = "West River Street\n";
+    short_desc = "West River Road";
+    long_desc = "Flat stones lie loose underfoot, some tipped into a\n"
+                + "shallow rut.\n"
+                + "A broken lintel rests against a wall, half buried in\n"
+                + "grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River Street";
-    long_desc = "West River Street\n";
+    short_desc = "West River Road";
+    long_desc = "The river road bends past a slumped doorway, its\n"
+                + "threshold choked with debris.\n"
+                + "Pale lichen maps the stone, and no tracks disturb the\n"
+                + "dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River Street";
-    long_desc = "West River Street\n";
+    short_desc = "West River Road";
+    long_desc = "A line of cracked flagstones stretches west, fractured\n"
+                + "by roots.\n"
+                + "A low parapet crumbles toward a silent channel, its edge\n"
+                + "washed bare.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River street";
-    long_desc = "West River street\n";
+    short_desc = "West River Road";
+    long_desc = "Weeds crowd the seams of the paving, softening the road\n"
+                + "into a green ribbon.\n"
+                + "The air is damp and still along the empty course.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "West River street";
-    long_desc = "West River street\n";
+    short_desc = "West River Road";
+    long_desc = "Here the stones are stained dark, as if by old floods\n"
+                + "that never returned.\n"
+                + "A toppled iron post lies in the gutter, rusted through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "River Street and South Main";
-    long_desc = "River Street and South Main\n";
+    short_desc = "River-Main Junction";
+    long_desc = "Two dead roads cross in a scatter of broken cobbles.\n"
+                + "A fractured drain grate sits at the center, packed with\n"
+                + "mud and leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main street";
-    long_desc = "South Main street\n";
+    short_desc = "South Main Road";
+    long_desc = "The southern main road is rutted and split, its stones\n"
+                + "tipped at odd angles.\n"
+                + "A fallen signboard lies half buried in dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
         "domain/original/area/vesla/room819", "west",

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main Street";
-    long_desc = "South Main Street\n";
+    short_desc = "South Main Road";
+    long_desc = "A broad stretch of paving runs north and south, worn\n"
+                + "smooth in places.\n"
+                + "The bases of old walls sit empty, their timbers long\n"
+                + "gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",
         "domain/original/area/vesla/room152", "south",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main Street";
-    long_desc = "South Main Street\n";
+    short_desc = "South Main Road";
+    long_desc = "Thin weeds stripe the main road here, forcing a crooked\n"
+                + "path.\n"
+                + "A low curb has crumbled into the street, leaving a\n"
+                + "scatter of chips.\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
         "domain/original/area/vesla/room821", "east",

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main Street";
-    long_desc = "South Main Street\n";
+    short_desc = "South Main Road";
+    long_desc = "The roadway dips slightly, holding a thin skin of damp\n"
+                + "grit.\n"
+                + "A sagging doorway yawns nearby, black with soot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
         "domain/original/area/vesla/room423", "west",

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main Street";
-    long_desc = "South Main Street\n";
+    short_desc = "South Main Road";
+    long_desc = "Broken cobbles gather near a collapsed stoop.\n"
+                + "The main road is silent, its centerline marked by a\n"
+                + "shallow rut.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
         "domain/original/area/vesla/room822", "west",

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main Street";
-    long_desc = "South Main Street\n";
+    short_desc = "South Main Road";
+    long_desc = "The southern road narrows between leaning walls.\n"
+                + "Loose slate and tile litter the paving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
         "domain/original/area/vesla/room823", "west",

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main street";
-    long_desc = "South Main street\n";
+    short_desc = "South Main Road";
+    long_desc = "Old cart ruts cut through the stones, softened by moss.\n"
+                + "A toppled beam rests across the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",
         "domain/original/area/vesla/room157", "south",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South Main street";
-    long_desc = "South Main street\n";
+    short_desc = "South Main Road";
+    long_desc = "The paving stones here are splintered and slick with\n"
+                + "lichen.\n"
+                + "Dust lies thick against the bases of the walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",
         "domain/original/area/vesla/room125", "north",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main";
-    long_desc = "Northern Main\n";
+    short_desc = "North Main Road";
+    long_desc = "The northward main road rises slightly, its stones pale\n"
+                + "and chipped.\n"
+                + "A cold breeze funnels through the gap between empty\n"
+                + "facades.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street\n";
+    short_desc = "North Main Road";
+    long_desc = "Here the main road is flanked by crumbling foundations.\n"
+                + "A patch of nettles spills across the center line.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street\n";
+    short_desc = "North Main Road";
+    long_desc = "The stones are cracked into a ragged mosaic, some sunk\n"
+                + "low.\n"
+                + "A rusted hinge hangs from a doorframe, unmoving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main Street";
-    long_desc = "Northern Main Street\n";
+    short_desc = "North Main Road";
+    long_desc = "A narrow strip of sky opens above the north road, framed\n"
+                + "by broken rooflines.\n"
+                + "Shattered brick and mortar gather in drifts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street\n";
+    short_desc = "North Main Road";
+    long_desc = "The road passes a doorway choked with rubble and ivy.\n"
+                + "Small pools of rain-dark water stain the stones.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street\n";
+    short_desc = "North Main Road";
+    long_desc = "The north road levels out and grows quiet, its surface\n"
+                + "scabbed with grit.\n"
+                + "A cracked iron grate lies in the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Intersection of North Main and Scholar's Way";
-    long_desc = "Intersection of North Main and Scholar's Way\n";
+    short_desc = "Main Scholar Crossing";
+    long_desc = "Two streets cross in a square of uneven stone.\n"
+                + "The corners are piled with broken masonry and grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern Main street";
-    long_desc = "Northern Main street\n";
+    short_desc = "North Main Road";
+    long_desc = "The main road bends toward the gate, its stones worn\n"
+                + "thin and pale.\n"
+                + "A line of old posts leans toward the center.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Intersection of North Main and Wall Street";
-    long_desc = "Intersection of North Main and Wall Street\n";
+    short_desc = "Main Wall Crossing";
+    long_desc = "The crossing is wide and empty, marked by worn paving\n"
+                + "and shallow ruts.\n"
+                + "A broken curb rings the corner where the streets meet.\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
         "domain/original/area/vesla/room793", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "The eastern stretch runs straight and hollow, its stones\n"
+                + "slick with moss.\n"
+                + "A low wall beside it is buckled and split.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "Silt lies in shallow drifts along the edge of the road.\n"
+                + "A fallen shutter leans against the stone, water-dark and\n"
+                + "warped.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "Patches of grass push through the joints in the paving\n"
+                + "here.\n"
+                + "The river channel beside the road is choked with debris\n"
+                + "and still.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "The road narrows between blank fronts, their doors\n"
+                + "hanging askew.\n"
+                + "Wind has swept the stones clean in thin streaks.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "A shallow rut marks the center line, worn deep before\n"
+                + "the silence.\n"
+                + "Small piles of gravel gather against the curb.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "East River Street";
-    long_desc = "East River Street\n";
+    short_desc = "East River Road";
+    long_desc = "Cracked stones and broken mortar leave the roadway\n"
+                + "ragged.\n"
+                + "A rusted chain lies half sunk in the silt.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "End of East River Street";
-    long_desc = "End of East River Street\n";
+    short_desc = "River Road End";
+    long_desc = "The road ends at a tumbled edge of stone, dropping to a\n"
+                + "dry, weeded bank.\n"
+                + "Broken posts stand like stumps along the rim.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Intersection of Via Sacra and River Street";
-    long_desc = "Intersection of Via Sacra and River Street\n";
+    short_desc = "Sacra River Crossing";
+    long_desc = "The crossing is a scatter of worn stones, their edges\n"
+                + "smoothed by time.\n"
+                + "The two ways meet in silence, framed by damp, crumbling\n"
+                + "walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "South End of Via Sacra";
-    long_desc = "South End of Via Sacra\n";
+    short_desc = "Southern Sacra End";
+    long_desc = "The sacra way thins into broken stones, the once-\n"
+                + "straight line sagging.\n"
+                + "Fallen trim and damp rubble gather at the end of the\n"
+                + "road.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",
         "domain/original/area/vesla/room399", "east",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Southern Via Sacra";
-    long_desc = "Southern Via Sacra\n";
+    short_desc = "Southern Sacra Way";
+    long_desc = "Wide paving slabs lie buckled and parted by grass.\n"
+                + "A line of soot-streaked stone posts leans in slow\n"
+                + "collapse.\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
         "domain/original/area/vesla/room400", "west",

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra\n";
+    short_desc = "Sacra Way";
+    long_desc = "The sacra way runs quiet between squat walls, its stones\n"
+                + "dulled and uneven.\n"
+                + "Old carvings are worn to nubs, nearly erased by weather.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",
         "domain/original/area/vesla/room216", "north",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra\n";
+    short_desc = "Sacra Way";
+    long_desc = "A shallow channel cuts along the path, filled with grit\n"
+                + "and broken tile.\n"
+                + "The air is cool and still between the close walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
         "domain/original/area/vesla/room402", "west",

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra\n";
+    short_desc = "Sacra Way";
+    long_desc = "The paving here is split by roots, forming a jagged\n"
+                + "seam.\n"
+                + "A toppled arch stone blocks part of the way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
         "domain/original/area/vesla/room216", "south",

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -5,9 +5,9 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra\n";
+    short_desc = "Sacra Way";
+    long_desc = "Loose stones crunch under a thin coat of dust.\n"
+                + "A rusted bracket clings to the wall, its mate long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",
         "domain/original/area/vesla/room219", "north",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Via Sacra";
-    long_desc = "Via Sacra\n";
+    short_desc = "Sacra Way";
+    long_desc = "The street opens slightly, revealing pale stone flecked\n"
+                + "with lichen.\n"
+                + "A shallow depression holds rain-dark stains.\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
         "domain/original/area/vesla/room218", "south",

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "Northern End of Via Sacra";
-    long_desc = "Northern End of Via Sacra\n";
+    short_desc = "Northern Sacra End";
+    long_desc = "The way ends beneath a sagging lintel, the stones split\n"
+                + "and bowed.\n"
+                + "A scatter of fallen blocks marks the threshold into the\n"
+                + "north.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",
         "domain/original/area/vesla/room221", "west",

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -6,11 +6,11 @@ void reset(int arg) {
   }
 
   set_light(1);
-
-  short_desc = "Forgotten Counter";
-  long_desc = "A long counter lies warped and split, its surface powdered\n"
-              + "with dust. Fallen shelves clutter the walls, and the air\n"
-              + "hangs stale and undisturbed.\n";
+  short_desc = "Hollow Counter";
+  long_desc = "A long counter sags under its own weight, split and\n"
+              + "furred with dust.\n"
+              + "Behind it, shelves lie in heaps, and the air is stale\n"
+              + "and still.\n";
   dest_dir = ({
     "domain/original/area/vesla/room222", "west",
     "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -6,10 +6,10 @@ void reset(int arg) {
   }
 
   set_light(1);
-
-  short_desc = "Numb Hall";
-  long_desc = "A low hall sits empty, its stone floor cold and bare. Faded\n"
-              + "trim peels from the walls, and the quiet is deep.\n";
+  short_desc = "Stilled Hall";
+  long_desc = "A low hall stretches empty, its floor cold and bare.\n"
+              + "Plaster peels from the walls in thin curls, and silence\n"
+              + "gathers in corners.\n";
   dest_dir = ({
     "domain/original/area/vesla/room223", "west",
     "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -6,10 +6,10 @@ void reset(int arg) {
   }
 
   set_light(1);
-
-  short_desc = "Empty Stalls";
-  long_desc = "Stall frames lean inward, their rails broken and dulled by\n"
-              + "age. Dry straw rot and scattered nails cling to the floor.\n";
+  short_desc = "Rotted Stalls";
+  long_desc = "Stall frames lean inward, their rails splintered and\n"
+              + "gray.\n"
+              + "Dry straw rot and scattered nails litter the floor.\n";
   dest_dir = ({
     "domain/original/area/vesla/room224", "west",
     "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -6,11 +6,11 @@ void reset(int arg) {
   }
 
   set_light(1);
-
-  short_desc = "Collapsed Vault";
-  long_desc = "A heavy doorway hangs open on broken hinges, leading to a\n"
-              + "chamber choked with debris. Iron bands are rusted through,\n"
-              + "and the floor has buckled into a shallow pit.\n";
+  short_desc = "Fallen Vault";
+  long_desc = "A heavy door hangs askew on broken hinges, opening into\n"
+              + "a chamber choked with rubble.\n"
+              + "Iron bands are rusted through, and the floor has sunk\n"
+              + "into a shallow pit.\n";
   dest_dir = ({
     "domain/original/area/vesla/room225", "west",
     "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room225.c
+++ b/domain/original/area/vesla/room225.c
@@ -6,11 +6,10 @@ void reset(int arg) {
   }
 
   set_light(1);
-
-  short_desc = "Scorched Hearth";
-  long_desc = "Soot-dark stone surrounds a dead hearth, the ash long gone.\n"
-              + "Crumbling brick and damp stains are all that remain in the\n"
-              + "still, cool chamber.\n";
+  short_desc = "Cold Hearth";
+  long_desc = "Soot-dark stone surrounds a dead hearth, its ash long\n"
+              + "blown away.\n"
+              + "Crumbling brick and damp stains mark the still chamber.\n";
   dest_dir = ({
     "domain/original/area/vesla/room224", "east",
     "domain/original/area/vesla/room122", "north",

--- a/domain/original/area/vesla/room226.c
+++ b/domain/original/area/vesla/room226.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Desolate Park";
+    long_desc = "Stone paths fracture beneath a mat of low weeds and\n"
+                + "windblown soil.\n"
+                + "A dry fountain bowl sits cracked and empty under leaning\n"
+                + "trees.\n";
     dest_dir = ({
         "domain/original/area/vesla/room117", "south",
         "domain/original/area/vesla/room228", "west",

--- a/domain/original/area/vesla/room227.c
+++ b/domain/original/area/vesla/room227.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Overgrown Park";
+    long_desc = "Thick grass swallows old benches, leaving warped planks\n"
+                + "and rusted bolts.\n"
+                + "A sagging iron fence lists inward, half-buried in leaf\n"
+                + "mold.\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "north",
         "domain/original/area/vesla/room118", "south",

--- a/domain/original/area/vesla/room228.c
+++ b/domain/original/area/vesla/room228.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Quiet Park";
+    long_desc = "A wide clearing lies mute, its stones scattered and\n"
+                + "moss-dark.\n"
+                + "Birdless branches arch over the space, their shadows\n"
+                + "unmoving.\n";
 
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "north",

--- a/domain/original/area/vesla/room230.c
+++ b/domain/original/area/vesla/room230.c
@@ -5,9 +5,10 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Abandoned Park";
+    long_desc = "A once-open lawn is now a tangle of thorn and nettle.\n"
+                + "Broken edging stones ring the growth like a half-lost\n"
+                + "border.\n";
     dest_dir = ({
         "domain/original/area/vesla/room119", "south",
         "domain/original/area/vesla/room815", "west",

--- a/domain/original/area/vesla/room231.c
+++ b/domain/original/area/vesla/room231.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Withered Park";
+    long_desc = "Dry shrubs crowd a cracked path, and pale trunks stand\n"
+                + "stripped of bark.\n"
+                + "Old lantern hooks hang crooked from a low wall, black\n"
+                + "with rust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "south",
         "domain/original/area/vesla/room796", "west",

--- a/domain/original/area/vesla/room232.c
+++ b/domain/original/area/vesla/room232.c
@@ -5,9 +5,11 @@ void reset(int arg) {
         return;
 
     set_light(1);
-
-    short_desc = "A peaceful park";
-    long_desc = "A peaceful park\n";
+    short_desc = "Hollow Park";
+    long_desc = "The ground dips where a pond once spread, now a dish of\n"
+                + "silt and weeds.\n"
+                + "Scattered paving stones and toppled posts mark the\n"
+                + "forgotten walkway.\n";
     dest_dir = ({
         "domain/original/area/vesla/room226", "south",
         "domain/original/area/vesla/room227", "west",


### PR DESCRIPTION
### Motivation
- Bring Vesla rooms into the Phase 1 abandoned state described in `OVERVIEW.md` by translating terse names into aged, evocative anchors.  
- Make River Street, Via Sacra, Main Street, and park spaces read as places empty for ~200 years, emphasizing material decay and silence.  
- Ensure nearby interior rooms (`room221`–`room225`) share the same tonal treatment so adjacent navigation feels coherent.  
- Follow the repository prose and style rules in `PROSE.md` and `CODE-STYLE.md` so descriptions remain concise and line-wrapped.

### Description
- Rewrote short and long descriptions in 53 room files under `domain/original/area/vesla`, replacing generic names like `A peaceful park` with aged titles (e.g. `Desolate Park`) and adding multi-sentence, Phase 1–appropriate `long_desc` text.  
- Updated River Street segments (files such as `room205.c`–`room211.c` and `room206.c` etc.) to `East/West River Road` styles and added decay details.  
- Updated Via Sacra segments (files such as `room212.c`–`room220.c`, `room215.c`, etc.) to `Sacra Way` variants with worn-stone and rubble imagery.  
- Revised Main Street segments (files such as `room152.c`–`room160.c`, `room160.c`–`room167.c`, etc.) and rooms `room221.c`–`room225.c` to consistent abandoned short_descs and refreshed `long_desc` blocks.

### Testing
- No automated runtime tests were executed because the changes are text-only.  
- Ran automated line-length/wrapping checks and adjusted `long_desc` string wrapping to respect the 80-character guideline from `CODE-STYLE.md`.  
- Verified the modified room files parse and contain the new `short_desc` / `long_desc` blocks via local scripts.  
- Committed the changes as a single update titled "Age Vesla parks and roadways" (53 files changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db3f9384832781d5ff2ba6883a35)