### PR TITLE
Rename abandoned thoroughfares to condition-based names

### DIFF
--- a/domain/original/area/exedoria/room287.c
+++ b/domain/original/area/exedoria/room287.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room286", "west",
         "domain/original/area/exedoria/room288", "east",

--- a/domain/original/area/exedoria/room288.c
+++ b/domain/original/area/exedoria/room288.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room368", "south",
         "domain/original/area/exedoria/room287", "west",

--- a/domain/original/area/exedoria/room289.c
+++ b/domain/original/area/exedoria/room289.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room288", "west",
         "domain/original/area/exedoria/room290", "east",

--- a/domain/original/area/exedoria/room290.c
+++ b/domain/original/area/exedoria/room290.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Monument Circle, Main Street";
-    long_desc = "Monument Circle, Main Street.\n";
+    short_desc = "Monument Circle, Rutted Street";
+    long_desc = "Monument Circle, Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room299", "south",
         "domain/original/area/exedoria/room289", "west",

--- a/domain/original/area/exedoria/room291.c
+++ b/domain/original/area/exedoria/room291.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room298", "south",
         "domain/original/area/exedoria/room290", "west",

--- a/domain/original/area/exedoria/room292.c
+++ b/domain/original/area/exedoria/room292.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room291", "west",
         "domain/original/area/exedoria/room293", "east",

--- a/domain/original/area/exedoria/room293.c
+++ b/domain/original/area/exedoria/room293.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room294", "east",
         "domain/original/area/exedoria/room292", "west",

--- a/domain/original/area/exedoria/room294.c
+++ b/domain/original/area/exedoria/room294.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room295", "east",
         "domain/original/area/exedoria/room293", "west",

--- a/domain/original/area/exedoria/room295.c
+++ b/domain/original/area/exedoria/room295.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room296", "east",
         "domain/original/area/exedoria/room294", "west",

--- a/domain/original/area/exedoria/room296.c
+++ b/domain/original/area/exedoria/room296.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Main Street";
-    long_desc = "Main Street.\n";
+    short_desc = "Rutted Street";
+    long_desc = "Rutted Street.\n";
     dest_dir = ({
         "domain/original/area/exedoria/room297", "east",
         "domain/original/area/exedoria/room295", "west",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "The westward river road is split by frost and root, the\n"
                 + "stones heaved uneven.\n"
                 + "A dry gutter runs alongside, packed with silt and curled\n"

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "Moss clings to the low curb here, and the road narrows\n"
                 + "between leaning facades.\n"
                 + "Rusted rings jut from the masonry, their purpose long\n"

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "Flat stones lie loose underfoot, some tipped into a\n"
                 + "shallow rut.\n"
                 + "A broken lintel rests against a wall, half buried in\n"

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "The river road bends past a slumped doorway, its\n"
                 + "threshold choked with debris.\n"
                 + "Pale lichen maps the stone, and no tracks disturb the\n"

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "A line of cracked flagstones stretches west, fractured\n"
                 + "by roots.\n"
                 + "A low parapet crumbles toward a silent channel, its edge\n"

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "Weeds crowd the seams of the paving, softening the road\n"
                 + "into a green ribbon.\n"
                 + "The air is damp and still along the empty course.\n";

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "West River Road";
+    short_desc = "West River Track";
     long_desc = "Here the stones are stained dark, as if by old floods\n"
                 + "that never returned.\n"
                 + "A toppled iron post lies in the gutter, rusted through.\n";

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "The eastern stretch runs straight and hollow, its stones\n"
                 + "slick with moss.\n"
                 + "A low wall beside it is buckled and split.\n";

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "Silt lies in shallow drifts along the edge of the road.\n"
                 + "A fallen shutter leans against the stone, water-dark and\n"
                 + "warped.\n";

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "Patches of grass push through the joints in the paving\n"
                 + "here.\n"
                 + "The river channel beside the road is choked with debris\n"

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "The road narrows between blank fronts, their doors\n"
                 + "hanging askew.\n"
                 + "Wind has swept the stones clean in thin streaks.\n";
@@ -15,4 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room396", "north",
     });
 }
-

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "A shallow rut marks the center line, worn deep before\n"
                 + "the silence.\n"
                 + "Small piles of gravel gather against the curb.\n";

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "East River Road";
+    short_desc = "East River Track";
     long_desc = "Cracked stones and broken mortar leave the roadway\n"
                 + "ragged.\n"
                 + "A rusted chain lies half sunk in the silt.\n";

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "River Road End";
+    short_desc = "River Track End";
     long_desc = "The road ends at a tumbled edge of stone, dropping to a\n"
                 + "dry, weeded bank.\n"
                 + "Broken posts stand like stumps along the rim.\n";

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Southern Sacra Way";
+    short_desc = "Southern Cracked Way";
     long_desc = "Wide paving slabs lie buckled and parted by grass.\n"
                 + "A line of soot-streaked stone posts leans in slow\n"
                 + "collapse.\n";

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Sacra Way";
+    short_desc = "Cracked Way";
     long_desc = "The sacra way runs quiet between squat walls, its stones\n"
                 + "dulled and uneven.\n"
                 + "Old carvings are worn to nubs, nearly erased by weather.\n";

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Sacra Way";
+    short_desc = "Cracked Way";
     long_desc = "A shallow channel cuts along the path, filled with grit\n"
                 + "and broken tile.\n"
                 + "The air is cool and still between the close walls.\n";

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Sacra Way";
+    short_desc = "Cracked Way";
     long_desc = "The paving here is split by roots, forming a jagged\n"
                 + "seam.\n"
                 + "A toppled arch stone blocks part of the way.\n";

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Sacra Way";
+    short_desc = "Cracked Way";
     long_desc = "Loose stones crunch under a thin coat of dust.\n"
                 + "A rusted bracket clings to the wall, its mate long gone.\n";
     dest_dir = ({

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -5,7 +5,7 @@ void reset(int arg) {
         return;
 
     set_light(1);
-    short_desc = "Sacra Way";
+    short_desc = "Cracked Way";
     long_desc = "The street opens slightly, revealing pale stone flecked\n"
                 + "with lichen.\n"
                 + "A shallow depression holds rain-dark stains.\n";


### PR DESCRIPTION
### Motivation
- Remove legacy, pre-abandonment street names such as "Sacra Way", "River Road", and "Main Street" which imply knowledge a new arrival would not have.
- Reflect the Phase 1 setting of an abandoned, weathered world as described in `OVERVIEW.md`.
- Use concise, condition-based room names in line with `PROSE.md` guidance (describe present condition rather than historical names).
- Apply consistent naming across affected areas to avoid mixed legacy/condition labels.

### Description
- Updated `short_desc` values in Vesla rooms to condition-based names: replaced occurrences of "Sacra Way" with "Cracked Way", "West/East River Road" with "West/East River Track", and "River Road End" with "River Track End".
- Updated Exedoria rooms that used "Main Street" to `short_desc`/`long_desc` = "Rutted Street", and changed the Monument Circle title to "Monument Circle, Rutted Street".
- Changes are limited to room title/description text in files under `domain/original/area/vesla` and `domain/original/area/exedoria` and do not alter room logic or exit behavior.
- Affected set includes ~30 files updated to maintain consistent, present-tense naming.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e3e6a23c8327a1f01970f1866885)