### PR TITLE
Wrap Vesla `long_desc` to 80-character lines

### DIFF
--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -7,9 +7,8 @@ void reset(int arg) {
     set_light(1);
 
     short_desc = "Portal Room";
-    long_desc = "This is the portal room.\n" +
-	        "As development continues, these areas will be removed from the portal room\n" +
-		"and linked to the full world.\n";
+    long_desc = "This is the portal room. As development continues, these areas will be removed\n"
+                + "from the portal room and linked to the full world.\n";
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "up",
         "domain/original/area/island/room605", "island",

--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Ruined Gate";
-  long_desc = "A broken stone arch leans over the road, its timbers split and\n"
-              + "sagging. Crumbled masonry seals the passage, and old iron\n"
-              + "fittings lie rusted in the weeds.\n";
+  long_desc = "A broken stone arch leans over the road, its timbers split and sagging. Crumbled\n"
+              + "masonry seals the passage, and old iron fittings lie rusted in the weeds.\n";
   dest_dir = ({
     "domain/original/area/vesla/room116", "west",
     "domain/original/area/roadway/room14", "exit",

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Park Crossroads";
-  long_desc = "The crossing is choked with gravel and dead leaves where a\n"
-              + "broad street meets a narrower lane. Fallen posts and a\n"
-              + "tilted sign hold a silence settled over long neglect.\n";
+  long_desc = "The crossing is choked with gravel and dead leaves where a broad street meets a\n"
+              + "narrower lane. Fallen posts and a tilted sign hold a silence settled over long\n"
+              + "neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room233", "south",
     "domain/original/area/vesla/room117", "west",

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Grit-Streaked Crossing";
-  long_desc = "Weathered stones mark the meeting of two old streets, their\n"
-              + "lines softened by drifted grit. A broken post leans over\n"
-              + "the junction, and no track has passed in generations.\n";
+  long_desc = "Weathered stones mark the meeting of two old streets, their lines softened by\n"
+              + "drifted grit. A broken post leans over the junction, and no track has passed in\n"
+              + "generations.\n";
   dest_dir = ({
     "domain/original/area/vesla/room220", "south",
     "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Dim Walk";
-  long_desc = "A narrow walk runs beneath slumped beams and the last remains\n"
-              + "of a shaded trellis. Motes of dust cling to the air, and the\n"
-              + "stones are slick with old rot.\n";
+  long_desc = "A narrow walk runs beneath slumped beams and the last remains of a shaded\n"
+              + "trellis. Motes of dust cling to the air, and the stones are slick with old rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room227", "north",
     "domain/original/area/vesla/room221", "south",

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Shattered Walk";
-  long_desc = "The covered path is broken here, its ribs split and scattered\n"
-              + "across the paving. Wind drifts through the gaps, stirring\n"
-              + "leaves that have gathered in the hollows.\n";
+  long_desc = "The covered path is broken here, its ribs split and scattered across the paving.\n"
+              + "Wind drifts through the gaps, stirring leaves that have gathered in the hollows.\n";
   dest_dir = ({
     "domain/original/area/vesla/room222", "south",
     "domain/original/area/vesla/room120", "west",

--- a/domain/original/area/vesla/room120.c
+++ b/domain/original/area/vesla/room120.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Hollow Walk";
-  long_desc = "A hollowed stretch of passage runs between damp stone walls.\n"
-              + "The roof timbers have fallen away, leaving the corridor open\n"
-              + "to dull light and slow rain.\n";
+  long_desc = "A hollowed stretch of passage runs between damp stone walls. The roof timbers\n"
+              + "have fallen away, leaving the corridor open to dull light and slow rain.\n";
   dest_dir = ({
     "domain/original/area/vesla/room121", "west",
     "domain/original/area/vesla/room119", "east",

--- a/domain/original/area/vesla/room121.c
+++ b/domain/original/area/vesla/room121.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Sunken Walk";
-  long_desc = "The walkway dips into a shallow trough where stones have\n"
-              + "settled unevenly. A thin film of moss trails along the\n"
-              + "seams, and the air sits heavy with damp.\n";
+  long_desc = "The walkway dips into a shallow trough where stones have settled unevenly. A\n"
+              + "thin film of moss trails along the seams, and the air sits heavy with damp.\n";
   dest_dir = ({
     "domain/original/area/vesla/room224", "south",
     "domain/original/area/vesla/room122", "west",

--- a/domain/original/area/vesla/room122.c
+++ b/domain/original/area/vesla/room122.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Withered Walk";
-  long_desc = "The path narrows beneath the remains of a withered canopy.\n"
-              + "Splintered slats litter the ground, and the walls are dark\n"
-              + "with rain stains and age.\n";
+  long_desc = "The path narrows beneath the remains of a withered canopy. Splintered slats\n"
+              + "litter the ground, and the walls are dark with rain stains and age.\n";
   dest_dir = ({
     "domain/original/area/vesla/room225", "south",
     "domain/original/area/vesla/room123", "west",

--- a/domain/original/area/vesla/room123.c
+++ b/domain/original/area/vesla/room123.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Silent Walk";
-  long_desc = "A quiet stretch of stone runs west, its seams filled with\n"
-              + "grit and grass. The remnants of a low railing sag along the\n"
-              + "edge, half buried in dust.\n";
+  long_desc = "A quiet stretch of stone runs west, its seams filled with grit and grass. The\n"
+              + "remnants of a low railing sag along the edge, half buried in dust.\n";
   dest_dir = ({
     "domain/original/area/vesla/room124", "west",
     "domain/original/area/vesla/room122", "east",

--- a/domain/original/area/vesla/room124.c
+++ b/domain/original/area/vesla/room124.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Broken Canopy";
-  long_desc = "The cover above the walk has failed, opening to a pale strip\n"
-              + "of sky. Loose stones and splintered wood lie scattered, and\n"
-              + "the ground shows long years of weathering.\n";
+  long_desc = "The cover above the walk has failed, opening to a pale strip of sky. Loose\n"
+              + "stones and splintered wood lie scattered, and the ground shows long years of\n"
+              + "weathering.\n";
   dest_dir = ({
     "domain/original/area/vesla/room125", "west",
     "domain/original/area/vesla/room123", "east",

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Empty Junction";
-  long_desc = "A wide junction opens where several streets once met. The\n"
-              + "stones are worn smooth, and scattered rubble marks where\n"
-              + "structures have slumped into the road.\n";
+  long_desc = "A wide junction opens where several streets once met. The stones are worn\n"
+              + "smooth, and scattered rubble marks where structures have slumped into the road.\n";
   dest_dir = ({
     "domain/original/area/vesla/room159", "south",
     "domain/original/area/vesla/room126", "west",

--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Park's End";
-  long_desc = "The walk widens before crumbling walls that once framed a\n"
-              + "corner of the city. Loose stone and soil have spilled over\n"
-              + "the paving, and the air hangs still.\n";
+  long_desc = "The walk widens before crumbling walls that once framed a corner of the city.\n"
+              + "Loose stone and soil have spilled over the paving, and the air hangs still.\n";
   dest_dir = ({
     "domain/original/area/vesla/room880", "south",
     "domain/original/area/vesla/room127", "west",

--- a/domain/original/area/vesla/room127.c
+++ b/domain/original/area/vesla/room127.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Old City Gate";
-  long_desc = "A battered gateway stands between worn walls, its lintel\n"
-              + "cracked and sagging. Dust gathers in the deep grooves of the\n"
-              + "threshold, and no sound follows the road beyond.\n";
+  long_desc = "A battered gateway stands between worn walls, its lintel cracked and sagging.\n"
+              + "Dust gathers in the deep grooves of the threshold, and no sound follows the road\n"
+              + "beyond.\n";
   dest_dir = ({
     "domain/original/area/vesla/room128", "west",
     "domain/original/area/vesla/room126", "east",

--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Threshold";
-  long_desc = "The road angles west through a narrowed gap between leaning\n"
-              + "stonework. Chipped blocks and pale grit mark a boundary that\n"
-              + "time has left without purpose.\n";
+  long_desc = "The road angles west through a narrowed gap between leaning stonework. Chipped\n"
+              + "blocks and pale grit mark a boundary that time has left without purpose.\n";
   dest_dir = ({
     "domain/original/area/vesla/room129", "west",
     "domain/original/area/vesla/room127", "east",

--- a/domain/original/area/vesla/room129.c
+++ b/domain/original/area/vesla/room129.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Ruins";
-  long_desc = "Westroad runs between low stone shells, their upper courses\n"
-              + "missing. Fallen blocks lie in the ruts, and a thin growth of\n"
-              + "grass softens the roadway.\n";
+  long_desc = "Westroad runs between low stone shells, their upper courses missing. Fallen\n"
+              + "blocks lie in the ruts, and a thin growth of grass softens the roadway.\n";
   dest_dir = ({
     "domain/original/area/vesla/room130", "west",
     "domain/original/area/vesla/room128", "east",

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Silence";
-  long_desc = "The road narrows into a quiet channel of stone and dust. A\n"
-              + "collapsed lintel lies across one wall, and the space beyond\n"
-              + "it is dark and empty.\n";
+  long_desc = "The road narrows into a quiet channel of stone and dust. A collapsed lintel lies\n"
+              + "across one wall, and the space beyond it is dark and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room131", "west",
     "domain/original/area/vesla/room129", "east",

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Drift";
-  long_desc = "Windblown grit has gathered in thin drifts along the road.\n"
-              + "The stonework is stained and pitted, and a few twisted iron\n"
-              + "bands cling to the wall.\n";
+  long_desc = "Windblown grit has gathered in thin drifts along the road. The stonework is\n"
+              + "stained and pitted, and a few twisted iron bands cling to the wall.\n";
   dest_dir = ({
     "domain/original/area/vesla/room132", "west",
     "domain/original/area/vesla/room130", "east",

--- a/domain/original/area/vesla/room132.c
+++ b/domain/original/area/vesla/room132.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Scar";
-  long_desc = "A long crack splits the paving, running the length of the\n"
-              + "road. The break is filled with rubble and silt, and the\n"
-              + "surrounding stones are polished dull by time.\n";
+  long_desc = "A long crack splits the paving, running the length of the road. The break is\n"
+              + "filled with rubble and silt, and the surrounding stones are polished dull by\n"
+              + "time.\n";
   dest_dir = ({
     "domain/original/area/vesla/room133", "west",
     "domain/original/area/vesla/room131", "east",

--- a/domain/original/area/vesla/room133.c
+++ b/domain/original/area/vesla/room133.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Basalt Corner";
-  long_desc = "The road turns beside a wall of dark basalt blocks, their\n"
-              + "faces chipped and rough. A scatter of broken stone marks\n"
-              + "where another street has slumped away.\n";
+  long_desc = "The road turns beside a wall of dark basalt blocks, their faces chipped and\n"
+              + "rough. A scatter of broken stone marks where another street has slumped away.\n";
   dest_dir = ({
     "domain/original/area/vesla/room134", "west",
     "domain/original/area/vesla/room132", "east",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -8,9 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Western Gate";
-  long_desc = "The western gate has collapsed into a heap of stone and\n"
-              + "splintered wood. Rusted fittings lie half buried, and the\n"
-              + "blocked passage holds a deep, unmoving quiet.\n";
+  long_desc = "The western gate has collapsed into a heap of stone and splintered wood. Rusted\n"
+              + "fittings lie half buried, and the blocked passage holds a deep, unmoving quiet.\n";
   dest_dir = ({
     "domain/original/area/vesla/room133", "east",
     "domain/original/area/roadway/room29", "exit",

--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Basalt River Corner";
-    long_desc = "Cracked basalt paving meets the river road, its stones\n"
-                + "slick with old stains.\n"
-                + "A collapsed wall spills rubble into the corner, and\n"
-                + "weeds root in the gaps.\n";
+    long_desc = "Cracked basalt paving meets the river road, its stones slick with old stains. A\n"
+                + "collapsed wall spills rubble into the corner, and weeds root in the gaps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",
         "domain/original/area/vesla/room142", "north",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "The westward river road is split by frost and root, the\n"
-                + "stones heaved uneven.\n"
-                + "A dry gutter runs alongside, packed with silt and curled\n"
-                + "leaves.\n";
+    long_desc = "The westward river road is split by frost and root, the stones heaved uneven. A\n"
+                + "dry gutter runs alongside, packed with silt and curled leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Moss clings to the low curb here, and the road narrows\n"
-                + "between leaning facades.\n"
-                + "Rusted rings jut from the masonry, their purpose long\n"
-                + "gone.\n";
+    long_desc = "Moss clings to the low curb here, and the road narrows between leaning facades.\n"
+                + "Rusted rings jut from the masonry, their purpose long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Flat stones lie loose underfoot, some tipped into a\n"
-                + "shallow rut.\n"
-                + "A broken lintel rests against a wall, half buried in\n"
-                + "grit.\n";
+    long_desc = "Flat stones lie loose underfoot, some tipped into a shallow rut. A broken lintel\n"
+                + "rests against a wall, half buried in grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "The river road bends past a slumped doorway, its\n"
-                + "threshold choked with debris.\n"
-                + "Pale lichen maps the stone, and no tracks disturb the\n"
-                + "dust.\n";
+    long_desc = "The river road bends past a slumped doorway, its threshold choked with debris.\n"
+                + "Pale lichen maps the stone, and no tracks disturb the dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "A line of cracked flagstones stretches west, fractured\n"
-                + "by roots.\n"
-                + "A low parapet crumbles toward a silent channel, its edge\n"
-                + "washed bare.\n";
+    long_desc = "A line of cracked flagstones stretches west, fractured by roots. A low parapet\n"
+                + "crumbles toward a silent channel, its edge washed bare.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Weeds crowd the seams of the paving, softening the road\n"
-                + "into a green ribbon.\n"
-                + "The air is damp and still along the empty course.\n";
+    long_desc = "Weeds crowd the seams of the paving, softening the road into a green ribbon. The\n"
+                + "air is damp and still along the empty course.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Here the stones are stained dark, as if by old floods\n"
-                + "that never returned.\n"
-                + "A toppled iron post lies in the gutter, rusted through.\n";
+    long_desc = "Here the stones are stained dark, as if by old floods that never returned. A\n"
+                + "toppled iron post lies in the gutter, rusted through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "River-Main Junction";
-    long_desc = "Two dead roads cross in a scatter of broken cobbles.\n"
-                + "A fractured drain grate sits at the center, packed with\n"
-                + "mud and leaves.\n";
+    long_desc = "Two dead roads cross in a scatter of broken cobbles. A fractured drain grate\n"
+                + "sits at the center, packed with mud and leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "The southern main road is rutted and split, its stones\n"
-                + "tipped at odd angles.\n"
-                + "A fallen signboard lies half buried in dust.\n";
+    long_desc = "The southern main road is rutted and split, its stones tipped at odd angles. A\n"
+                + "fallen signboard lies half buried in dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
         "domain/original/area/vesla/room819", "west",

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "A broad stretch of paving runs north and south, worn\n"
-                + "smooth in places.\n"
-                + "The bases of old walls sit empty, their timbers long\n"
-                + "gone.\n";
+    long_desc = "A broad stretch of paving runs north and south, worn smooth in places. The bases\n"
+                + "of old walls sit empty, their timbers long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",
         "domain/original/area/vesla/room152", "south",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "Thin weeds stripe the main road here, forcing a crooked\n"
-                + "path.\n"
-                + "A low curb has crumbled into the street, leaving a\n"
-                + "scatter of chips.\n";
+    long_desc = "Thin weeds stripe the main road here, forcing a crooked path. A low curb has\n"
+                + "crumbled into the street, leaving a scatter of chips.\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
         "domain/original/area/vesla/room821", "east",

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "The roadway dips slightly, holding a thin skin of damp\n"
-                + "grit.\n"
-                + "A sagging doorway yawns nearby, black with soot.\n";
+    long_desc = "The roadway dips slightly, holding a thin skin of damp grit. A sagging doorway\n"
+                + "yawns nearby, black with soot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
         "domain/original/area/vesla/room423", "west",

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "Broken cobbles gather near a collapsed stoop.\n"
-                + "The main road is silent, its centerline marked by a\n"
-                + "shallow rut.\n";
+    long_desc = "Broken cobbles gather near a collapsed stoop. The main road is silent, its\n"
+                + "centerline marked by a shallow rut.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
         "domain/original/area/vesla/room822", "west",

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "The southern road narrows between leaning walls.\n"
-                + "Loose slate and tile litter the paving.\n";
+    long_desc = "The southern road narrows between leaning walls. Loose slate and tile litter the\n"
+                + "paving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
         "domain/original/area/vesla/room823", "west",

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "Old cart ruts cut through the stones, softened by moss.\n"
-                + "A toppled beam rests across the gutter.\n";
+    long_desc = "Old cart ruts cut through the stones, softened by moss. A toppled beam rests\n"
+                + "across the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",
         "domain/original/area/vesla/room157", "south",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "The paving stones here are splintered and slick with\n"
-                + "lichen.\n"
-                + "Dust lies thick against the bases of the walls.\n";
+    long_desc = "The paving stones here are splintered and slick with lichen. Dust lies thick\n"
+                + "against the bases of the walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",
         "domain/original/area/vesla/room125", "north",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The northward main road rises slightly, its stones pale\n"
-                + "and chipped.\n"
-                + "A cold breeze funnels through the gap between empty\n"
-                + "facades.\n";
+    long_desc = "The northward main road rises slightly, its stones pale and chipped. A cold\n"
+                + "breeze funnels through the gap between empty facades.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "Here the main road is flanked by crumbling foundations.\n"
-                + "A patch of nettles spills across the center line.\n";
+    long_desc = "Here the main road is flanked by crumbling foundations. A patch of nettles\n"
+                + "spills across the center line.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The stones are cracked into a ragged mosaic, some sunk\n"
-                + "low.\n"
-                + "A rusted hinge hangs from a doorframe, unmoving.\n";
+    long_desc = "The stones are cracked into a ragged mosaic, some sunk low. A rusted hinge hangs\n"
+                + "from a doorframe, unmoving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -6,8 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "A narrow strip of sky opens above the north road, framed\n"
-                + "by broken rooflines.\n"
+    long_desc = "A narrow strip of sky opens above the north road, framed by broken rooflines.\n"
                 + "Shattered brick and mortar gather in drifts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The road passes a doorway choked with rubble and ivy.\n"
-                + "Small pools of rain-dark water stain the stones.\n";
+    long_desc = "The road passes a doorway choked with rubble and ivy. Small pools of rain-dark\n"
+                + "water stain the stones.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The north road levels out and grows quiet, its surface\n"
-                + "scabbed with grit.\n"
-                + "A cracked iron grate lies in the gutter.\n";
+    long_desc = "The north road levels out and grows quiet, its surface scabbed with grit. A\n"
+                + "cracked iron grate lies in the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Main Scholar Crossing";
-    long_desc = "Two streets cross in a square of uneven stone.\n"
-                + "The corners are piled with broken masonry and grit.\n";
+    long_desc = "Two streets cross in a square of uneven stone. The corners are piled with broken\n"
+                + "masonry and grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The main road bends toward the gate, its stones worn\n"
-                + "thin and pale.\n"
-                + "A line of old posts leans toward the center.\n";
+    long_desc = "The main road bends toward the gate, its stones worn thin and pale. A line of\n"
+                + "old posts leans toward the center.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Main Wall Crossing";
-    long_desc = "The crossing is wide and empty, marked by worn paving\n"
-                + "and shallow ruts.\n"
-                + "A broken curb rings the corner where the streets meet.\n";
+    long_desc = "The crossing is wide and empty, marked by worn paving and shallow ruts. A broken\n"
+                + "curb rings the corner where the streets meet.\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
         "domain/original/area/vesla/room793", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "The eastern stretch runs straight and hollow, its stones\n"
-                + "slick with moss.\n"
-                + "A low wall beside it is buckled and split.\n";
+    long_desc = "The eastern stretch runs straight and hollow, its stones slick with moss. A low\n"
+                + "wall beside it is buckled and split.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "Silt lies in shallow drifts along the edge of the road.\n"
-                + "A fallen shutter leans against the stone, water-dark and\n"
-                + "warped.\n";
+    long_desc = "Silt lies in shallow drifts along the edge of the road. A fallen shutter leans\n"
+                + "against the stone, water-dark and warped.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "Patches of grass push through the joints in the paving\n"
-                + "here.\n"
-                + "The river channel beside the road is choked with debris\n"
-                + "and still.\n";
+    long_desc = "Patches of grass push through the joints in the paving here. The river channel\n"
+                + "beside the road is choked with debris and still.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "The road narrows between blank fronts, their doors\n"
-                + "hanging askew.\n"
-                + "Wind has swept the stones clean in thin streaks.\n";
+    long_desc = "The road narrows between blank fronts, their doors hanging askew. Wind has swept\n"
+                + "the stones clean in thin streaks.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "A shallow rut marks the center line, worn deep before\n"
-                + "the silence.\n"
-                + "Small piles of gravel gather against the curb.\n";
+    long_desc = "A shallow rut marks the center line, worn deep before the silence. Small piles\n"
+                + "of gravel gather against the curb.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "Cracked stones and broken mortar leave the roadway\n"
-                + "ragged.\n"
-                + "A rusted chain lies half sunk in the silt.\n";
+    long_desc = "Cracked stones and broken mortar leave the roadway ragged. A rusted chain lies\n"
+                + "half sunk in the silt.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "River Track End";
-    long_desc = "The road ends at a tumbled edge of stone, dropping to a\n"
-                + "dry, weeded bank.\n"
-                + "Broken posts stand like stumps along the rim.\n";
+    long_desc = "The road ends at a tumbled edge of stone, dropping to a dry, weeded bank. Broken\n"
+                + "posts stand like stumps along the rim.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "River Crossing";
-    long_desc = "The crossing is a scatter of worn stones, their edges\n"
-                + "smoothed by time.\n"
-                + "The two ways meet in silence, framed by damp, crumbling\n"
-                + "walls.\n";
+    long_desc = "The crossing is a scatter of worn stones, their edges smoothed by time. The two\n"
+                + "ways meet in silence, framed by damp, crumbling walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Southern End";
-    long_desc = "The way thins into broken stones, the once-\n"
-                + "straight line sagging.\n"
-                + "Fallen trim and damp rubble gather at the end of the\n"
-                + "road.\n";
+    long_desc = "The way thins into broken stones, the once- straight line sagging. Fallen trim\n"
+                + "and damp rubble gather at the end of the road.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",
         "domain/original/area/vesla/room399", "east",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Southern Cracked Way";
-    long_desc = "Wide paving slabs lie buckled and parted by grass.\n"
-                + "A line of soot-streaked stone posts leans in slow\n"
-                + "collapse.\n";
+    long_desc = "Wide paving slabs lie buckled and parted by grass. A line of soot-streaked stone\n"
+                + "posts leans in slow collapse.\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
         "domain/original/area/vesla/room400", "west",

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "The way runs quiet between squat walls, its stones\n"
-                + "dulled and uneven.\n"
-                + "Old carvings are worn to nubs, nearly erased by weather.\n";
+    long_desc = "The way runs quiet between squat walls, its stones dulled and uneven. Old\n"
+                + "carvings are worn to nubs, nearly erased by weather.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",
         "domain/original/area/vesla/room216", "north",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "A shallow channel cuts along the path, filled with grit\n"
-                + "and broken tile.\n"
-                + "The air is cool and still between the close walls.\n";
+    long_desc = "A shallow channel cuts along the path, filled with grit and broken tile. The air\n"
+                + "is cool and still between the close walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
         "domain/original/area/vesla/room402", "west",

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "The paving here is split by roots, forming a jagged\n"
-                + "seam.\n"
-                + "A toppled arch stone blocks part of the way.\n";
+    long_desc = "The paving here is split by roots, forming a jagged seam. A toppled arch stone\n"
+                + "blocks part of the way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
         "domain/original/area/vesla/room216", "south",

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "Loose stones crunch under a thin coat of dust.\n"
-                + "A rusted bracket clings to the wall, its mate long gone.\n";
+    long_desc = "Loose stones crunch under a thin coat of dust. A rusted bracket clings to the\n"
+                + "wall, its mate long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",
         "domain/original/area/vesla/room219", "north",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "The street opens slightly, revealing pale stone flecked\n"
-                + "with lichen.\n"
-                + "A shallow depression holds rain-dark stains.\n";
+    long_desc = "The street opens slightly, revealing pale stone flecked with lichen. A shallow\n"
+                + "depression holds rain-dark stains.\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
         "domain/original/area/vesla/room218", "south",

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Northern End";
-    long_desc = "The way ends beneath a sagging lintel, the stones split\n"
-                + "and bowed.\n"
-                + "A scatter of fallen blocks marks the threshold into the\n"
-                + "north.\n";
+    long_desc = "The way ends beneath a sagging lintel, the stones split and bowed. A scatter of\n"
+                + "fallen blocks marks the threshold into the north.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",
         "domain/original/area/vesla/room221", "west",

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -7,10 +7,8 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Hollow Counter";
-  long_desc = "A long counter sags under its own weight, split and\n"
-              + "furred with dust.\n"
-              + "Behind it, shelves lie in heaps, and the air is stale\n"
-              + "and still.\n";
+  long_desc = "A long counter sags under its own weight, split and furred with dust. Behind it,\n"
+              + "shelves lie in heaps, and the air is stale and still.\n";
   dest_dir = ({
     "domain/original/area/vesla/room222", "west",
     "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -7,9 +7,8 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Stilled Hall";
-  long_desc = "A low hall stretches empty, its floor cold and bare.\n"
-              + "Plaster peels from the walls in thin curls, and silence\n"
-              + "gathers in corners.\n";
+  long_desc = "A low hall stretches empty, its floor cold and bare. Plaster peels from the\n"
+              + "walls in thin curls, and silence gathers in corners.\n";
   dest_dir = ({
     "domain/original/area/vesla/room223", "west",
     "domain/original/area/vesla/room221", "east",

--- a/domain/original/area/vesla/room223.c
+++ b/domain/original/area/vesla/room223.c
@@ -7,9 +7,8 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Rotted Stalls";
-  long_desc = "Stall frames lean inward, their rails splintered and\n"
-              + "gray.\n"
-              + "Dry straw rot and scattered nails litter the floor.\n";
+  long_desc = "Stall frames lean inward, their rails splintered and gray. Dry straw rot and\n"
+              + "scattered nails litter the floor.\n";
   dest_dir = ({
     "domain/original/area/vesla/room224", "west",
     "domain/original/area/vesla/room222", "east",

--- a/domain/original/area/vesla/room224.c
+++ b/domain/original/area/vesla/room224.c
@@ -7,10 +7,9 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Fallen Vault";
-  long_desc = "A heavy door hangs askew on broken hinges, opening into\n"
-              + "a chamber choked with rubble.\n"
-              + "Iron bands are rusted through, and the floor has sunk\n"
-              + "into a shallow pit.\n";
+  long_desc = "A heavy door hangs askew on broken hinges, opening into a chamber choked with\n"
+              + "rubble. Iron bands are rusted through, and the floor has sunk into a shallow\n"
+              + "pit.\n";
   dest_dir = ({
     "domain/original/area/vesla/room225", "west",
     "domain/original/area/vesla/room223", "east",

--- a/domain/original/area/vesla/room225.c
+++ b/domain/original/area/vesla/room225.c
@@ -7,9 +7,8 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Cold Hearth";
-  long_desc = "Soot-dark stone surrounds a dead hearth, its ash long\n"
-              + "blown away.\n"
-              + "Crumbling brick and damp stains mark the still chamber.\n";
+  long_desc = "Soot-dark stone surrounds a dead hearth, its ash long blown away. Crumbling\n"
+              + "brick and damp stains mark the still chamber.\n";
   dest_dir = ({
     "domain/original/area/vesla/room224", "east",
     "domain/original/area/vesla/room122", "north",

--- a/domain/original/area/vesla/room226.c
+++ b/domain/original/area/vesla/room226.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Desolate Park";
-    long_desc = "Stone paths fracture beneath a mat of low weeds and\n"
-                + "windblown soil.\n"
-                + "A dry fountain bowl sits cracked and empty under leaning\n"
-                + "trees.\n";
+    long_desc = "Stone paths fracture beneath a mat of low weeds and windblown soil. A dry\n"
+                + "fountain bowl sits cracked and empty under leaning trees.\n";
     dest_dir = ({
         "domain/original/area/vesla/room117", "south",
         "domain/original/area/vesla/room228", "west",

--- a/domain/original/area/vesla/room227.c
+++ b/domain/original/area/vesla/room227.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Overgrown Park";
-    long_desc = "Thick grass swallows old benches, leaving warped planks\n"
-                + "and rusted bolts.\n"
-                + "A sagging iron fence lists inward, half-buried in leaf\n"
-                + "mold.\n";
+    long_desc = "Thick grass swallows old benches, leaving warped planks and rusted bolts. A\n"
+                + "sagging iron fence lists inward, half-buried in leaf mold.\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "north",
         "domain/original/area/vesla/room118", "south",

--- a/domain/original/area/vesla/room228.c
+++ b/domain/original/area/vesla/room228.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Quiet Park";
-    long_desc = "A wide clearing lies mute, its stones scattered and\n"
-                + "moss-dark.\n"
-                + "Birdless branches arch over the space, their shadows\n"
-                + "unmoving.\n";
+    long_desc = "A wide clearing lies mute, its stones scattered and moss-dark. Birdless branches\n"
+                + "arch over the space, their shadows unmoving.\n";
 
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "north",

--- a/domain/original/area/vesla/room230.c
+++ b/domain/original/area/vesla/room230.c
@@ -6,9 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Abandoned Park";
-    long_desc = "A once-open lawn is now a tangle of thorn and nettle.\n"
-                + "Broken edging stones ring the growth like a half-lost\n"
-                + "border.\n";
+    long_desc = "A once-open lawn is now a tangle of thorn and nettle. Broken edging stones ring\n"
+                + "the growth like a half-lost border.\n";
     dest_dir = ({
         "domain/original/area/vesla/room119", "south",
         "domain/original/area/vesla/room815", "west",

--- a/domain/original/area/vesla/room231.c
+++ b/domain/original/area/vesla/room231.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Withered Park";
-    long_desc = "Dry shrubs crowd a cracked path, and pale trunks stand\n"
-                + "stripped of bark.\n"
-                + "Old lantern hooks hang crooked from a low wall, black\n"
-                + "with rust.\n";
+    long_desc = "Dry shrubs crowd a cracked path, and pale trunks stand stripped of bark. Old\n"
+                + "lantern hooks hang crooked from a low wall, black with rust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "south",
         "domain/original/area/vesla/room796", "west",

--- a/domain/original/area/vesla/room232.c
+++ b/domain/original/area/vesla/room232.c
@@ -6,10 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Hollow Park";
-    long_desc = "The ground dips where a pond once spread, now a dish of\n"
-                + "silt and weeds.\n"
-                + "Scattered paving stones and toppled posts mark the\n"
-                + "forgotten walkway.\n";
+    long_desc = "The ground dips where a pond once spread, now a dish of silt and weeds.\n"
+                + "Scattered paving stones and toppled posts mark the forgotten walkway.\n";
     dest_dir = ({
         "domain/original/area/vesla/room226", "south",
         "domain/original/area/vesla/room227", "west",


### PR DESCRIPTION
### Motivation
- Enforce the authoritative `CODE-STYLE.md` line-length rule for player-facing text so `long_desc` lines do not exceed 80 characters.
- Keep room prose consistent and readable while preserving existing wording and intent.
- Improve future maintainability by ensuring `long_desc` formatting is deterministic across the Vesla area.

### Description
- Rewrapped `long_desc` string literals in files under `domain/original/area/vesla` so each source line stays at or below ~80 characters. 
- The change touches the in-area room files (many `room*.c` files) and `portal.c`, preserving original sentences and semantics while adjusting string concatenation and line breaks. 
- The rewrap was performed by a scripted transformation to avoid manual drift and ensure consistent wrapping behavior.

### Testing
- Ran a verification script that scans `long_desc` values in `domain/original/area/vesla/*.c` and it reported no `long_desc` lines longer than 80 characters.
- No automated unit or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962eabb87c88327b6fed18893d90b43)