### PR TITLE
Add wizard `ld` command to edit room long descriptions

### DIFF
--- a/room/room.c
+++ b/room/room.c
@@ -163,6 +163,11 @@ void set_short(string str) {
   return;
 }
 
+void set_long(string str) {
+  long_desc = str;
+  return;
+}
+
 string *query_dest_dir() {
     return dest_dir;
 }


### PR DESCRIPTION
### Motivation

- Provide a wizard-facing counterpart to the existing `sd` command so long room descriptions can be updated in source and in memory. 
- Allow wizards to patch `long_desc` consistently using the same workflow used for `short_desc` edits. 
- Ensure live rooms reflect source edits immediately without requiring a reload or manual change.

### Description

- Add `set_room_long` to `obj/player.c`, which locates the current room's source file, replaces the `long_desc =` line (escaping quotes/backslashes), writes the updated file, and calls `room->set_long(str)` to update the live object. 
- Register the new command as `ld` in the wizard command table via `add_action("set_room_long", "ld")` so it is available only to wizards. 
- Add a `set_long` setter to `room/room.c` to support live updates of the room's `long_desc`.

### Testing

- No automated tests were run on these changes.
- Basic repository operations (file edits and commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962fa92899c8327826fb6bd254c35a9)