### PR TITLE
Age Vesla PHASE0 rooms: replace placeholders with abandoned prose and subtler names

### DIFF
--- a/domain/original/area/vesla/room222.c
+++ b/domain/original/area/vesla/room222.c
@@ -6,13 +6,14 @@ void reset(int arg) {
   }
 
   set_light(1);
-  short_desc = "Stilled Hall";
-  long_desc = "PHASE0: a tavern";
-              + "walls in thin curls, and silence gathers in corners.\n";
+
+  short_desc = "Empty Taproom";
+  long_desc = "Rot-softened beams sag over a long counter gone gray with dust and mildew.\n"
+              + "Benches lie broken in the hush, and a sour stain clings where drink once\n"
+              + "spilled. The hearth is cold, its iron hooks rusted and half-buried in grit.\n";
   dest_dir = ({
     "domain/original/area/vesla/room223", "west",
     "domain/original/area/vesla/room221", "east",
     "domain/original/area/vesla/room119", "north",
   });
 }
-

--- a/domain/original/area/vesla/room396.c
+++ b/domain/original/area/vesla/room396.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Antique Shop";
-    long_desc = "PHASE0: antique shop";
-    dest_dir = ({
-        "domain/original/area/vesla/room208", "south",
-    });
+  short_desc = "Faded Curios";
+  long_desc = "Narrow shelves sag under warped boxes and tarnished curios, all buried in dust.\n"
+              + "The air is sweet with mildew, and the floorboards have bowed around a\n"
+              + "collapsed display case. A cracked mirror leans in back, its gilt peeling away.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room208", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room397.c
+++ b/domain/original/area/vesla/room397.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Mage's House";
-    long_desc = "PHASE0: a wizard's home";
-    dest_dir = ({
-        "domain/original/area/vesla/room398", "east",
-        "domain/original/area/vesla/room206", "south",
-    });
+  short_desc = "Sooted Study";
+  long_desc = "Soot stains the stone around a slumped hearth, and chalky rings fade on the\n"
+              + "floor beneath a crust of dust. Shelves of warped wood hold scattered vials and\n"
+              + "stiffened pages, their ink bled by damp and mildew.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room398", "east",
+    "domain/original/area/vesla/room206", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room398.c
+++ b/domain/original/area/vesla/room398.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Mage's Apprentice House";
-    long_desc = "PHASE0: a wizard's home";
-    dest_dir = ({
-        "domain/original/area/vesla/room397", "west",
-    });
+  short_desc = "Chalked Loft";
+  long_desc = "A narrow stair ends in a loft where a worktable sits split and furred with\n"
+              + "mildew. Blackened candle stubs and cracked lenses lie in drifts of dust, hinting\n"
+              + "at old study now drowned in silence and rot.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room397", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room399.c
+++ b/domain/original/area/vesla/room399.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Retired Warrior's House";
-    long_desc = "PHASE0: a humble home";
-    dest_dir = ({
-        "domain/original/area/vesla/room734", "up",
-        "domain/original/area/vesla/room213", "west",
-    });
+  short_desc = "Low Hearth";
+  long_desc = "The low room smells of damp stone, its beams soft with rot and its floor hidden\n"
+              + "beneath dust. A simple table has collapsed beside a cold hearth, and a notched\n"
+              + "post stands where some small training once took place.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room734", "up",
+    "domain/original/area/vesla/room213", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room403.c
+++ b/domain/original/area/vesla/room403.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Entrance to a temple";
-    long_desc = "PHASE0: a temple of worship";
-    dest_dir = ({
-        "domain/original/area/vesla/room404", "east",
-        "domain/original/area/vesla/room216", "west",
-    });
+  short_desc = "Broken Threshold";
+  long_desc = "A wide threshold of cracked stone leads into a cavernous hall, its pillars\n"
+              + "pocked and green with mildew. Shattered bowls lie at the base of a raised dais,\n"
+              + "and ash-dark banners hang in ragged silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room404", "east",
+    "domain/original/area/vesla/room216", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room404.c
+++ b/domain/original/area/vesla/room404.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Temple of Amaterasu";
-    long_desc = "PHASE0: a temple of worship";
-    dest_dir = ({
-        "domain/original/area/vesla/room405", "east",
-        "domain/original/area/vesla/room403", "west",
-    });
+  short_desc = "Dusty Nave";
+  long_desc = "Tall columns loom over a nave littered with fallen tiles and windblown dust.\n"
+              + "A cracked altar slab sits beneath a roof opened to rain, and the air carries\n"
+              + "mildew from sodden tapestries curled against the walls.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room405", "east",
+    "domain/original/area/vesla/room403", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room405.c
+++ b/domain/original/area/vesla/room405.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Temple of Amaterasu";
-    long_desc = "PHASE0: a temple of worship";
-    dest_dir = ({
-        "domain/original/area/vesla/room404", "west",
-        "domain/original/area/vesla/room407", "south",
-        "domain/original/area/vesla/room406", "north",
-    });
+  short_desc = "Fallen Shrine";
+  long_desc = "Stone benches sit in crooked rows, their edges rounded by damp and rot.\n"
+              + "A shallow brazier lies overturned near the front, its iron scaled with rust and\n"
+              + "its embers long gone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room404", "west",
+    "domain/original/area/vesla/room407", "south",
+    "domain/original/area/vesla/room406", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room406.c
+++ b/domain/original/area/vesla/room406.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Candle Room";
-    long_desc = "PHASE0: a temple of worship";
-    dest_dir = ({
-        "domain/original/area/vesla/room405", "south",
-    });
+  short_desc = "Wax Alcove";
+  long_desc = "A side chamber is lined with niche shelves, now empty and gray with dust.\n"
+              + "Wax drips have hardened on the floor, their puddles greened by mildew and\n"
+              + "tracked with grit from a door that no longer shuts.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room405", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room407.c
+++ b/domain/original/area/vesla/room407.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Quiet Room";
-    long_desc = "PHASE0: a temple of worship";
-    dest_dir = ({
-        "domain/original/area/vesla/room405", "north",
-    });
+  short_desc = "Silent Choir";
+  long_desc = "A narrow gallery runs above the main hall, its railings split and softened by\n"
+              + "rot. Torn cloth once bright hangs in strips, and the air is still but for the\n"
+              + "dry rattle of loose tiles.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room405", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room422.c
+++ b/domain/original/area/vesla/room422.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Mercantile Guild Office";
-    long_desc = "PHASE0: a business office";
-    dest_dir = ({
-        "domain/original/area/vesla/room837", "east",
-        "domain/original/area/vesla/room155", "west",
-    });
+  short_desc = "Ledger Room";
+  long_desc = "Desks sit in crooked ranks, their drawers swollen and stuck with damp.\n"
+              + "Mold frets at the corners of scattered ledgers, and a rusted seal lies half\n"
+              + "buried in dust where clerks once tallied.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room837", "east",
+    "domain/original/area/vesla/room155", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room423.c
+++ b/domain/original/area/vesla/room423.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Glassblower";
-    long_desc = "PHASE0: a merchant";
-    dest_dir = ({
-        "domain/original/area/vesla/room155", "east",
-    });
+  short_desc = "Cold Kiln";
+  long_desc = "A soot-black kiln squats against the wall, its mouth choked with ash and dust.\n"
+              + "Fused beads and curled shards glitter faintly amid rot and mildew, and a\n"
+              + "workbench has split under the weight of silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room155", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room424.c
+++ b/domain/original/area/vesla/room424.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Fighter's Guild";
-    long_desc = "PHASE0: a combat-training guild";
-    dest_dir = ({
-        "domain/original/area/vesla/room156", "west",
-    });
+  short_desc = "Silent Yard";
+  long_desc = "Practice posts lean at odd angles, their tops splintered and gray with rot.\n"
+              + "Racks of rusted gear line the walls, and dust has buried the scuffed floor\n"
+              + "where drills once rang.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room156", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room734.c
+++ b/domain/original/area/vesla/room734.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Weapon Master's Bedroom";
-    long_desc = "PHASE0: a humble home";
-    dest_dir = ({
-        "domain/original/area/vesla/room399", "down",
-    });
+  short_desc = "Bare Chamber";
+  long_desc = "A narrow bedframe sags against the wall, its straw long moldered into dust.\n"
+              + "A cracked chest sits open, and a single practice rail leans nearby, dulled by\n"
+              + "mildew and time.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room399", "down",
+  });
 }
-

--- a/domain/original/area/vesla/room815.c
+++ b/domain/original/area/vesla/room815.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Back Room";
-    long_desc = "PHASE0: a weapons merchant";
-    dest_dir = ({
-        "domain/original/area/vesla/room230", "east",
-        "domain/original/area/vesla/room814", "north",
-    });
+  short_desc = "Rust Racks";
+  long_desc = "Empty racks line the walls, their iron pegs eaten with rust and rot.\n"
+              + "A counter has collapsed under dust-caked scraps, and the floor is littered with\n"
+              + "blunted fragments that hint at trade long ended.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room230", "east",
+    "domain/original/area/vesla/room814", "north",
+  });
 }
-
-

--- a/domain/original/area/vesla/room817.c
+++ b/domain/original/area/vesla/room817.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Manor House";
-    long_desc = "PHASE0: an ornate home";
-    dest_dir = ({
-        "domain/original/area/vesla/room818", "up",
-        "domain/original/area/vesla/room152", "west",
-    });
+  short_desc = "Faded Manor";
+  long_desc = "Carved pillars and a broad stair rise into shadow, their edges softened by rot.\n"
+              + "Mildewed drapes hang in tatters, and the air is heavy with dust.\n"
+              + "A broken crest above the hearth hints at a once-proud household.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room818", "up",
+    "domain/original/area/vesla/room152", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room818.c
+++ b/domain/original/area/vesla/room818.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Manor House";
-    long_desc = "PHASE0: an ornate home";
-    dest_dir = ({
-        "domain/original/area/vesla/room817", "down",
-    });
+  short_desc = "Gilded Ruin";
+  long_desc = "The high chamber is stripped to its bones, yet traces of gilt cling to cracked\n"
+              + "molding. Damp has streaked the walls, and a heap of sagged cushions lies in\n"
+              + "mildew and silence near a cold firepit.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room817", "down",
+  });
 }
-

--- a/domain/original/area/vesla/room819.c
+++ b/domain/original/area/vesla/room819.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "PHASE0: a vacant commercial lot";
-    dest_dir = ({
-        "domain/original/area/vesla/room152", "east",
-    });
+  short_desc = "Empty Plot";
+  long_desc = "Low foundations break through the weeds, and a warped signpost lies in the dust.\n"
+              + "Rain has pooled in shallow pits, leaving rot and mildew along the stone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room152", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room820.c
+++ b/domain/original/area/vesla/room820.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cleric Guild";
-    long_desc = "PHASE0: a medicine-training guild";
-    dest_dir = ({
-        "domain/original/area/vesla/room839", "west",
-        "domain/original/area/vesla/room153", "east",
-        "domain/original/area/vesla/room838", "north",
-    });
+  short_desc = "Cold Ward";
+  long_desc = "Stone tables stand in a damp row, their surfaces stained and slick with mildew.\n"
+              + "Shelves of dried herbs have collapsed into dust, and a cracked basin gathers\n"
+              + "stale water beneath a ceiling gone soft with rot.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room839", "west",
+    "domain/original/area/vesla/room153", "east",
+    "domain/original/area/vesla/room838", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room821.c
+++ b/domain/original/area/vesla/room821.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Hall of the builders guild";
-    long_desc = "PHASE0: a business office";
-    dest_dir = ({
-        "domain/original/area/vesla/room154", "west",
-    });
+  short_desc = "Counting Hall";
+  long_desc = "A long table runs beneath a broken lintel, its surface coated in dust and rot.\n"
+              + "Empty cubbies and warped ledgers hint at old records, now blurred by mildew and\n"
+              + "silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room154", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room822.c
+++ b/domain/original/area/vesla/room822.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "City Hall";
-    long_desc = "PHASE0: a government building";
-    dest_dir = ({
-        "domain/original/area/vesla/room156", "east",
-        "domain/original/area/vesla/room831", "up",
-    });
+  short_desc = "Civic Hall";
+  long_desc = "Broad steps lead to a hall of cracked stone, where dust lies in deep drifts.\n"
+              + "A splintered dais and toppled benches suggest old gatherings, now muted by rot\n"
+              + "and mildew.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room156", "east",
+    "domain/original/area/vesla/room831", "up",
+  });
 }
-

--- a/domain/original/area/vesla/room824.c
+++ b/domain/original/area/vesla/room824.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Whore House";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room158", "east",
-        "domain/original/area/vesla/room825", "up",
-    });
+  short_desc = "Shuttered House";
+  long_desc = "Heavy curtains hang in strips, their fabric stiff with dust and mildew.\n"
+              + "Low couches have collapsed into rot, and a faint sweetness lingers where\n"
+              + "perfume once clung to the air.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room158", "east",
+    "domain/original/area/vesla/room825", "up",
+  });
 }
-

--- a/domain/original/area/vesla/room825.c
+++ b/domain/original/area/vesla/room825.c
@@ -1,19 +1,21 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Second floor of whore house.";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room828", "south",
-        "domain/original/area/vesla/room826", "west",
-        "domain/original/area/vesla/room829", "up",
-        "domain/original/area/vesla/room824", "down",
-        "domain/original/area/vesla/room827", "north",
-    });
+  short_desc = "Quiet Landing";
+  long_desc = "The upper landing is choked with dust, its rail warped and soft with rot.\n"
+              + "Closed doors lean inward, and a cracked mirror keeps a dim memory of bright\n"
+              + "rooms now gone to mildew.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room828", "south",
+    "domain/original/area/vesla/room826", "west",
+    "domain/original/area/vesla/room829", "up",
+    "domain/original/area/vesla/room824", "down",
+    "domain/original/area/vesla/room827", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room826.c
+++ b/domain/original/area/vesla/room826.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Viking's room";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room825", "east",
-    });
+  short_desc = "Veiled Room";
+  long_desc = "A narrow chamber holds a sagging bedframe and a tangle of torn veil cloth.\n"
+              + "Mildew creeps along the walls, and the floorboards sag under layers of dust and\n"
+              + "silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room825", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room827.c
+++ b/domain/original/area/vesla/room827.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Sandra's room";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room825", "south",
-    });
+  short_desc = "Faded Chamber";
+  long_desc = "Pale plaster peels from the walls, revealing dark stains of damp and rot.\n"
+              + "A small table has split in two, and a stub of candle wax sits in dust where\n"
+              + "soft music once played.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room825", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room828.c
+++ b/domain/original/area/vesla/room828.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kathy's room";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room825", "north",
-    });
+  short_desc = "Curtained Room";
+  long_desc = "A ragged curtain droops from a rusted rod, its hem greened with mildew.\n"
+              + "The bedstead is bare and cracked, and dust has drifted into the corners like\n"
+              + "ash.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room825", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room829.c
+++ b/domain/original/area/vesla/room829.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Robert's room";
-    long_desc = "PHASE0: a brothel";
-    dest_dir = ({
-        "domain/original/area/vesla/room825", "down",
-    });
+  short_desc = "Quiet Parlor";
+  long_desc = "This back room is heavy with stale air, its cushions reduced to moldy husks.\n"
+              + "A low screen has fallen across the floor, and the only scent left is damp wood\n"
+              + "and dust.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room825", "down",
+  });
 }
-

--- a/domain/original/area/vesla/room831.c
+++ b/domain/original/area/vesla/room831.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "First Floor";
-    long_desc = "PHASE0: a government building";
-    dest_dir = ({
-        "domain/original/area/vesla/room833", "up",
-        "domain/original/area/vesla/room822", "down",
-        "domain/original/area/vesla/room832", "west",
-    });
+  short_desc = "Lower Office";
+  long_desc = "Long desks sit in a row, their legs sunk into a drift of dust.\n"
+              + "A rusted bell and cracked inkwells remain, and mildew has spread along the\n"
+              + "baseboards.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room833", "up",
+    "domain/original/area/vesla/room822", "down",
+    "domain/original/area/vesla/room832", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room832.c
+++ b/domain/original/area/vesla/room832.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Chamber of Commerce";
-    long_desc = "PHASE0: a government building";
-    dest_dir = ({
-        "domain/original/area/vesla/room831", "east",
-    });
+  short_desc = "Trade Hall";
+  long_desc = "The chamber is wide and bare, its tiled floor split by damp and weeds.\n"
+              + "A set of warped benches faces a crumbling stand, with rotted placards scattered\n"
+              + "in the dust.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room831", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room833.c
+++ b/domain/original/area/vesla/room833.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Second Floor";
-    long_desc = "PHASE0: a government building";
-    dest_dir = ({
-        "domain/original/area/vesla/room835", "up",
-        "domain/original/area/vesla/room831", "down",
-        "domain/original/area/vesla/room834", "west",
-    });
+  short_desc = "Upper Hall";
+  long_desc = "Steps lead to a high room where rain has pooled, leaving dark rings on the\n"
+              + "stone. Torn ledgers and mildewed banners cling to the walls, and the air is\n"
+              + "still.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room835", "up",
+    "domain/original/area/vesla/room831", "down",
+    "domain/original/area/vesla/room834", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room834.c
+++ b/domain/original/area/vesla/room834.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Magistrate";
-    long_desc = "PHASE0: a government building";
-    dest_dir = ({
-        "domain/original/area/vesla/room833", "east",
-    });
+  short_desc = "Stone Office";
+  long_desc = "A heavy chair sits askew behind a broad desk, both softened by rot and damp.\n"
+              + "Dust mounds around a broken seal press, and mildew climbs the cracked plaster.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room833", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room837.c
+++ b/domain/original/area/vesla/room837.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Open Air Market:";
-    long_desc = "PHASE0: a small market";
-    dest_dir = ({
-        "domain/original/area/vesla/room422", "west",
-    });
+  short_desc = "Stalled Row";
+  long_desc = "Rotted awnings sag over empty stalls, their poles splintered and gray.\n"
+              + "Scales and shallow trays lie scattered in dust, and mildew darkens the stone\n"
+              + "where trade once clustered.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room422", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room839.c
+++ b/domain/original/area/vesla/room839.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Reconciliation Chapel";
-    long_desc = "PHASE0: a chapel";
-    dest_dir = ({
-        "domain/original/area/vesla/room820", "east",
-    });
+  short_desc = "Fallen Choir";
+  long_desc = "A narrow nave ends at a cracked lectern, its wood softened by rot.\n"
+              + "Faded murals curl from the damp walls, and a line of benches sits in dust and\n"
+              + "mildew, facing a silence that never lifts.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room820", "east",
+  });
 }
-


### PR DESCRIPTION
### Motivation
- Bring Vesla interiors into the Phase‑1 setting by aging rooms ~200 years of vacancy and decay. 
- Replace terse `PHASE0:` placeholders with restrained, evocative prose that implies abandonment, rot, mildew, and silence. 
- Make `short_desc` values less explicit so names hint at former function rather than stating it directly. 
- Follow repository guidelines for prose and code form (see `PROSE.md` and `CODE-STYLE.md`).

### Description
- Rewrote the `long_desc` for 33 rooms under `domain/original/area/vesla` to remove `PHASE0:` markers and add 2–3 sentence descriptions connoting disrepair and subtle hints of prior use. 
- Updated the corresponding `short_desc` values to more suggestive, less-explicit room names. 
- Normalized `reset` function formatting to use explicit block-style `if (arg) { return; }` and consistent indentation per `CODE-STYLE.md`. 
- All changes were staged and committed together (33 files changed). 

### Testing
- Searched the area with `rg` to locate `PHASE0:` occurrences and confirmed the targeted files were updated. 
- Ran Python scripts used to generate and inject the new descriptions and to check line-lengths, and reviewed their output. 
- Verified repository state with `git status` and created a commit with message `Age Vesla PHASE0 rooms`. 
- No automated unit or runtime tests were executed as these are content-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962fdb9a82c83278051094d450f426e)