### PR TITLE
Unblock Vesla room exits (remove block_exit handlers)

### DIFF
--- a/domain/original/area/vesla/room126.c
+++ b/domain/original/area/vesla/room126.c
@@ -17,14 +17,3 @@ void reset(int arg) {
     "domain/original/area/vesla/room879", "north",
   });
 }
-
-void init() {
-  ::init();
-  add_action("block_exit", "south");
-  add_action("block_exit", "north");
-}
-
-int block_exit() {
-  write("Only rubble remains there; the structure collapsed long ago.\n");
-  return 1;
-}

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room137", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("The way ends in collapsed ruins; only debris remains.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room138", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room158", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("A long-collapsed structure leaves only rubble there.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -13,13 +13,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room168", "west",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Nothing but fallen masonry lies there; it's impassable.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room743", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("Rubble blocks the way; the structure has long since fallen.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room744", "south",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room198", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room395", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("A long-collapsed structure leaves only rubble there.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room394", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("There is only debris; the structure collapsed years ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room215", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-    add_action("block_exit", "east");
-}
-
-int block_exit() {
-    write("A heap of collapsed stone blocks the way.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -15,13 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room217", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("The passage is choked with debris; you cannot pass.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room218", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("The way is blocked by a wall of broken stone.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room220", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "west");
-}
-
-int block_exit() {
-    write("Crumbling ruins bar that direction completely.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room792.c
+++ b/domain/original/area/vesla/room792.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room794", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("The way ends in collapsed ruins; only debris remains.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -15,13 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room797", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Only rubble remains there; the structure collapsed long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room961", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("The way ends in collapsed ruins; only debris remains.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -14,13 +14,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room806", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("Only shattered remains mark the spot; the building caved in long ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -15,14 +15,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room807", "north",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-    add_action("block_exit", "north");
-}
-
-int block_exit() {
-    write("There is only debris; the structure collapsed years ago.\n");
-    return 1;
-}

--- a/domain/original/area/vesla/room803.c
+++ b/domain/original/area/vesla/room803.c
@@ -13,13 +13,3 @@ void reset(int arg) {
         "domain/original/area/vesla/room804", "south",
     });
 }
-
-void init() {
-    ::init();
-    add_action("block_exit", "south");
-}
-
-int block_exit() {
-    write("Just ruins and broken stone remain; the structure gave out long ago.\n");
-    return 1;
-}


### PR DESCRIPTION
### Motivation
- Reopen internal pedestrian connections in the Vesla area by removing hard movement blockers created by `block_exit` handlers. 
- Preserve world-phase constraints by not introducing new items, NPCs, or mechanics, and by honoring exceptions for roadway exits and non-existent destination rooms. 

### Description
- Removed `add_action("block_exit", ...)` calls and their corresponding `block_exit()` functions from multiple Vesla room files so listed exits are no longer programmatically blocked. 
- Changes affect twenty Vesla room files under `domain/original/area/vesla/` and remove the blocking handlers without altering `dest_dir` entries. 
- Roadway-facing exits and any exits that would target missing rooms were intentionally left unchanged. 

### Testing
- Verified removal with repository searches using `rg -n "block_exit"` to confirm handlers were cleared. 
- Committed the changes successfully with `git commit` (commit message: "Unblock Vesla room exits"). 
- No automated unit or integration tests were executed against the mudlib as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cd322f1c83278f8f2ff43a0b6681)