### PR TITLE
Vesla: block missing north exits and age PHASE0 rooms

### DIFF
--- a/domain/original/area/vesla/room128.c
+++ b/domain/original/area/vesla/room128.c
@@ -13,6 +13,5 @@ void reset(int arg) {
   dest_dir = ({
     "domain/original/area/vesla/room129", "west",
     "domain/original/area/vesla/room127", "east",
-    "domain/original/area/vesla/room881", "north",
   });
 }

--- a/domain/original/area/vesla/room131.c
+++ b/domain/original/area/vesla/room131.c
@@ -13,6 +13,5 @@ void reset(int arg) {
   dest_dir = ({
     "domain/original/area/vesla/room132", "west",
     "domain/original/area/vesla/room130", "east",
-    "domain/original/area/vesla/room858", "north",
   });
 }

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Shadowed Anvil";
-    long_desc = "PHASE0: a player-owned weapons shop";
-    dest_dir = ({
-        "domain/original/area/vesla/room220", "west",
-        "domain/original/area/vesla/room116", "north",
-    });
+  short_desc = "Iron Alcove";
+  long_desc = "Rust flakes from a split rack, and the floor is filmed\n"
+              + "with dust and old grit. A warped counter and dull iron\n"
+              + "hooks suggest where blades once hung, now left to mildew\n"
+              + "and silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room220", "west",
+    "domain/original/area/vesla/room116", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room234.c
+++ b/domain/original/area/vesla/room234.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Andre's Clothing";
-    long_desc = "PHASE0: a player-owned armor shop";
-    dest_dir = ({
-        "domain/original/area/vesla/room232", "south",
-    });
+  short_desc = "Stitch Loft";
+  long_desc = "Rot-softened padding slumps in a heap, and dust clogs\n"
+              + "the seams of a collapsed frame. A few dull buckles\n"
+              + "and a cracked mannequin hint at fittings once done\n"
+              + "here, now lost to mildew.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room232", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room411.c
+++ b/domain/original/area/vesla/room411.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Vesla Times Press Office";
-    long_desc = "PHASE0: NPC-owned newspaper printer";
-    dest_dir = ({
-        "domain/original/area/vesla/room410", "east",
-        "domain/original/area/vesla/room123", "south",
-    });
+  short_desc = "Ink Room";
+  long_desc = "The room is silent under a crust of paper dust, with broken\n"
+              + "rollers and a sagging frame. Ink stains still darken the\n"
+              + "boards, and warped trays rot in the damp.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room410", "east",
+    "domain/original/area/vesla/room123", "south",
+  });
 }
-
-

--- a/domain/original/area/vesla/room412.c
+++ b/domain/original/area/vesla/room412.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Smithy";
-    long_desc = "PHASE0: NPC-owned smithy";
-    dest_dir = ({
-        "domain/original/area/vesla/room160", "west",
-        "domain/original/area/vesla/room124", "south",
-    });
+  short_desc = "Cinder Bay";
+  long_desc = "Cold ash and rusted tools lie scattered across a cracked stone\n"
+              + "floor. A collapsed bellows and a soot-blackened hearth hint\n"
+              + "at heat that has not lived here for centuries.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room160", "west",
+    "domain/original/area/vesla/room124", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room419.c
+++ b/domain/original/area/vesla/room419.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A dark alleyway";
-    long_desc = "PHASE0: a couple low-level NPC thugs here";
-    dest_dir = ({
-        "domain/original/area/vesla/room129", "north",
-    });
+  short_desc = "Shadow Cut";
+  long_desc = "This narrow cut between walls is choked with grit and\n"
+              + "damp rot. Mildew climbs the stones, and a broken crate\n"
+              + "hints at rough dealings that once hid here.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room129", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room420.c
+++ b/domain/original/area/vesla/room420.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Old Temple";
-    long_desc = "PHASE0: players came here for healing if no player healers were available";
-    dest_dir = ({
-        "domain/original/area/vesla/room130", "north",
-    });
+  short_desc = "Quiet Nave";
+  long_desc = "The nave stands in silence, its benches split and furred with\n"
+              + "mildew. A broken basin and a faded sigil suggest solace once\n"
+              + "offered here, now left to dust.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room130", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room421.c
+++ b/domain/original/area/vesla/room421.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Mage's Guild";
-    long_desc = "PHASE0: Mage class guild";
-    dest_dir = ({
-        "domain/original/area/vesla/room132", "north",
-    });
+  short_desc = "Sigil Hall";
+  long_desc = "Dust lies thick over a ring of cracked tiles, and the\n"
+              + "air tastes of damp stone. Chipped shelves and a\n"
+              + "tarnished inlay hint at study and rite, now abandoned.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room132", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room794.c
+++ b/domain/original/area/vesla/room794.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A small building.";
-    long_desc = "PHASE0: formerly a sewer entrance (exit down)";
-    dest_dir = ({
-        "domain/original/area/vesla/room792", "south",
-    });
+  short_desc = "Grate Shed";
+  long_desc = "A low shed sags over a grated stone lip, its boards\n"
+              + "soft with rot. Mildew and silt stain the edges,\n"
+              + "hinting at a passage once kept clear below.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room792", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room804.c
+++ b/domain/original/area/vesla/room804.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Fish Mongery";
-    long_desc = "PHASE0: an NPC-owned shop";
-    dest_dir = ({
-        "domain/original/area/vesla/room803", "north",
-    });
+  short_desc = "Brine Stall";
+  long_desc = "Brine has long dried into a crust, leaving the stall rank and\n"
+              + "silent. Splintered tables and a rusted hook hint at trade in\n"
+              + "flesh that has since rotted away.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room803", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room805.c
+++ b/domain/original/area/vesla/room805.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Crazy Habib's Fertilizer";
-    long_desc = "PHASE0: an NPC-owned shop";
-    dest_dir = ({
-        "domain/original/area/vesla/room802", "north",
-    });
+  short_desc = "Sour Shed";
+  long_desc = "The shed reeks of damp earth and rot, with sacks\n"
+              + "collapsed into dark pulp. A battered scoop and\n"
+              + "stained planks hint at soil and dung once bartered\n"
+              + "here.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room802", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room807.c
+++ b/domain/original/area/vesla/room807.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Pornographers Den";
-    long_desc = "PHASE0: pornography den with an aggressive NPC";
-    dest_dir = ({
-        "domain/original/area/vesla/room802", "south",
-    });
+  short_desc = "Faded Curtain";
+  long_desc = "Torn curtains hang in tatters, and dust mats the warped floor\n"
+              + "boards. A low dais and broken screens hint at a private vice\n"
+              + "now drowned in mildew.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room802", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room813.c
+++ b/domain/original/area/vesla/room813.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "PHASE0: vacant player-owned business lot (available for rent)";
-    dest_dir = ({
-        "domain/original/area/vesla/room795", "north",
-    });
+  short_desc = "Silent Stall";
+  long_desc = "An empty shell of a room stands with a cracked lintel\n"
+              + "and dusted floor. Rotted beams and a few iron\n"
+              + "brackets suggest a trade space that never returned.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room795", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room878.c
+++ b/domain/original/area/vesla/room878.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "PHASE0: vacant player-owned business lot (available for rent)";
-    dest_dir = ({
-        "domain/original/area/vesla/room127", "south",
-    });
+  short_desc = "Empty Stall";
+  long_desc = "The vacant room is quiet, its plaster flaking and the\n"
+              + "air damp. Rotten joists and old fittings hint at a\n"
+              + "stall once meant for lease.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room127", "south",
+  });
 }
-
-

--- a/domain/original/area/vesla/room879.c
+++ b/domain/original/area/vesla/room879.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Vesla Post Office";
-    long_desc = "PHASE0: \"post office\" for in-game player email";
-    dest_dir = ({
-        "domain/original/area/vesla/room126", "south",
-    });
+  short_desc = "Broken Desk";
+  long_desc = "A line of battered cubbies slumps against the wall,\n"
+              + "clogged with dust. A collapsed counter and scattered\n"
+              + "tags hint at messages once sorted here, now lost.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room126", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room880.c
+++ b/domain/original/area/vesla/room880.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Old Adventurer's Guild";
-    long_desc = "PHASE0: profession guild";
-    dest_dir = ({
-        "domain/original/area/vesla/room126", "north",
-    });
+  short_desc = "Worn Hall";
+  long_desc = "The hall is hollow, its banners reduced to rags and\n"
+              + "mildew. Worn planks and a stone dais hint at oaths\n"
+              + "and instruction that ended long ago.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room126", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room961.c
+++ b/domain/original/area/vesla/room961.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rising Phoenix";
-    long_desc = "PHASE0: a player-owned distillery";
-    dest_dir = ({
-        "domain/original/area/vesla/room796", "south",
-    });
+  short_desc = "Cask Room";
+  long_desc = "The air is stale and damp, with broken casks split and\n"
+              + "rotting. A soot-stained hearth and a copper coil left\n"
+              + "to tarnish hint at spirits once drawn here.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room796", "south",
+  });
 }
-


### PR DESCRIPTION
### Motivation

- Remove invalid exits that pointed to missing rooms and avoid broken navigation in the Vesla area.
- Bring PHASE0 placeholder rooms into Phase 1 tone by aging them ~200 years of abandonment and decay.
- Replace explicit, purpose-stating names with restrained, suggestive room titles that hint at prior use.
- Bring formatting for the modified rooms in line with the repository `CODE-STYLE.md` conventions.

### Description

- Removed the north exits from `domain/original/area/vesla/room128.c` and `domain/original/area/vesla/room131.c` to prevent links to missing rooms.
- Rewrote `short_desc` and `long_desc` for PHASE0 rooms under `domain/original/area/vesla/` (including `room233.c`, `room234.c`, `room411.c`, `room412.c`, `room419.c`, `room420.c`, `room421.c`, `room794.c`, `room804.c`, `room805.c`, `room807.c`, `room813.c`, `room878.c`, `room879.c`, `room880.c`, and `room961.c`) to convey two centuries of disuse with subtle hints of their original functions.
- Adjusted `reset` guard formatting and string concatenation to match the repository style (explicit `if (arg) { return; }` and wrapped description lines).
- No exits were otherwise added or rerouted; only prose and formatting changes plus the two exit removals were applied.

### Testing

- Ran a line-length check with `awk 'length($0) > 80'` against the modified files and it produced no failures, indicating wrapped player-facing lines respect the 80-character guideline.
- No unit or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d248ea9883279fefa6701249fe00)