### PR TITLE
Age Vesla PHASE0 rooms with subtle names and abandoned prose

### DIFF
--- a/domain/original/area/vesla/room394.c
+++ b/domain/original/area/vesla/room394.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Smoke House";
-    long_desc = "PHASE0: NPC workers labored here";
-    dest_dir = ({
-        "domain/original/area/vesla/room210", "south",
-    });
+  short_desc = "Cold Smoke";
+  long_desc = "Soot clings to the stone, and rusted hooks hang in a silence of dust and\n"
+        + "mildew. Rotting tubs and ash-stained gutters hint at preserved fare in\n"
+        + "dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room210", "south",
+  });
 }
 

--- a/domain/original/area/vesla/room395.c
+++ b/domain/original/area/vesla/room395.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Lathe";
-    long_desc = "PHASE0: an NPC woodworker was here";
-    dest_dir = ({
-        "domain/original/area/vesla/room209", "south",
-    });
+  short_desc = "Turner's Bench";
+  long_desc = "A cracked lathe stands in the corner, silent and dilapidated beneath dust and\n"
+        + "mildew. Spilled shavings and dulled tools sit in rot, hinting at careful\n"
+        + "turning left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room209", "south",
+  });
 }
 

--- a/domain/original/area/vesla/room400.c
+++ b/domain/original/area/vesla/room400.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Bell maker's shop";
-    long_desc = "PHASE0: NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room214", "east",
-    });
+  short_desc = "Dull Chime";
+  long_desc = "Broken molds and a rusted frame lie in silent dust, the shop dilapidated. Rot\n"
+        + "and mildew stain the stone, hinting at chimes once shaped here in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room214", "east",
+  });
 }
 

--- a/domain/original/area/vesla/room401.c
+++ b/domain/original/area/vesla/room401.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Candle Shop";
-    long_desc = "PHASE0: NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room214", "west",
-    });
+  short_desc = "Wax Shelf";
+  long_desc = "Hardened wax pools on a sagging table, silent beneath dust and mildew. Empty\n"
+        + "molds and a stale tallow smell linger in rot, hinting at candlework in\n"
+        + "dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room214", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room402.c
+++ b/domain/original/area/vesla/room402.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Do-it-Yourself Distiller";
-    long_desc = "PHASE0: NPC-owned distillery";
-    dest_dir = ({
-        "domain/original/area/vesla/room216", "east",
-    });
+  short_desc = "Cold Still";
+  long_desc = "A copper coil lies split on the floor, silent and dilapidated under dust and\n"
+        + "mildew. Dry barrels and a stained hearth sit in rot, hinting at spirits once\n"
+        + "made here in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room216", "east",
+  });
 }
 

--- a/domain/original/area/vesla/room409.c
+++ b/domain/original/area/vesla/room409.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Bounty Room";
-    long_desc = "PHASE0: players could place and collect bounties on other players here";
-    dest_dir = ({
-        "domain/original/area/vesla/room219", "east",
-    });
+  short_desc = "Nailed Notices";
+  long_desc = "A warped board is riddled with rusted nails, silent under dust and mildew.\n"
+        + "Faded names and tally marks sit in rot, hinting at claims once posted in\n"
+        + "dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room219", "east",
+  });
 }
 

--- a/domain/original/area/vesla/room736.c
+++ b/domain/original/area/vesla/room736.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "PHASE0: vacant player-owned mercantile guild lot";
-    dest_dir = ({
-        "domain/original/area/vesla/room173", "west",
-    });
+  short_desc = "Market Lot";
+  long_desc = "Low foundations ring a vacant patch, silent beneath dust, mildew, and rot. A\n"
+        + "broken sign frame hints at trade, the lot dilapidated and in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room173", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room816.c
+++ b/domain/original/area/vesla/room816.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Castle Bridge";
-    long_desc = "PHASE0: A high-level NPC castle guard blocked the way south";
-    dest_dir = ({
-        "domain/original/area/vesla/room151", "north",
-    });
+  short_desc = "Stone Span";
+  long_desc = "The bridge stones are slick with moss, the span silent and dilapidated. Rust\n"
+        + "marks the grooves of an old gate, and dust and mildew cling to the guard\n"
+        + "alcove in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room151", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room840.c
+++ b/domain/original/area/vesla/room840.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room841", "west",
-        "domain/original/area/vesla/room148", "south",
-    });
+  short_desc = "Ashen Way";
+  long_desc = "Charred stone and blackened beams mark this stretch, now silent and\n"
+        + "dilapidated. Ash lies under drifted dust, and mildewed rubble clogs the broken\n"
+        + "curb where small fronts once opened in rot and disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room841", "west",
+    "domain/original/area/vesla/room148", "south",
+  });
 }
 

--- a/domain/original/area/vesla/room841.c
+++ b/domain/original/area/vesla/room841.c
@@ -1,18 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room147", "south",
-        "domain/original/area/vesla/room842", "west",
-        "domain/original/area/vesla/room840", "east",
-        "domain/original/area/vesla/room843", "north",
-    });
+  short_desc = "Sooted Row";
+  long_desc = "Soot stains the surviving walls, and the lane sits in a hush of rot and dust.\n"
+        + "Warped shutters and mildewed frames lean inward, the fire-scarred row left in\n"
+        + "dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room147", "south",
+    "domain/original/area/vesla/room842", "west",
+    "domain/original/area/vesla/room840", "east",
+    "domain/original/area/vesla/room843", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room842.c
+++ b/domain/original/area/vesla/room842.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room146", "south",
-        "domain/original/area/vesla/room841", "east",
-        "domain/original/area/vesla/room844", "north",
-    });
+  short_desc = "Charred Lane";
+  long_desc = "Fire-split timbers jut from the stonework, soft with mildew and long silent in\n"
+        + "dilapidated ruin. Dust coats the old thresholds, and rot gnaws at doorframes\n"
+        + "that hint at narrow rooms now in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room146", "south",
+    "domain/original/area/vesla/room841", "east",
+    "domain/original/area/vesla/room844", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room843.c
+++ b/domain/original/area/vesla/room843.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room844", "west",
-        "domain/original/area/vesla/room841", "south",
-        "domain/original/area/vesla/room201", "north",
-    });
+  short_desc = "Blackened Court";
+  long_desc = "The court is a hollow of scorched brick and collapsed awnings, silent and\n"
+        + "dilapidated. Mildew blooms on low walls, and rot mixes with dust around broken\n"
+        + "stalls left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room844", "west",
+    "domain/original/area/vesla/room841", "south",
+    "domain/original/area/vesla/room201", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room844.c
+++ b/domain/original/area/vesla/room844.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room842", "south",
-        "domain/original/area/vesla/room843", "east",
-        "domain/original/area/vesla/room202", "north",
-    });
+  short_desc = "Cinder Walk";
+  long_desc = "Cinder and gravel crunch over warped flagstones, the walk silent and\n"
+        + "dilapidated. Rusting hinges and charred lintels sag in rot and mildew, a dusty\n"
+        + "hint of shop doors left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room842", "south",
+    "domain/original/area/vesla/room843", "east",
+    "domain/original/area/vesla/room202", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room845.c
+++ b/domain/original/area/vesla/room845.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room846", "east",
-        "domain/original/area/vesla/room146", "north",
-    });
+  short_desc = "Scorched Pass";
+  long_desc = "Scorched boards lie half-buried in damp dust, the passage silent and\n"
+        + "dilapidated. A low sill and slumped counter are soft with rot and mildew,\n"
+        + "hinting at a trade stall in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room846", "east",
+    "domain/original/area/vesla/room146", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room846.c
+++ b/domain/original/area/vesla/room846.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Burned Area";
-    long_desc = "PHASE0: this area suffered a fire before the city was abandoned";
-    dest_dir = ({
-        "domain/original/area/vesla/room845", "west",
-        "domain/original/area/vesla/room147", "north",
-    });
+  short_desc = "Cinder Row";
+  long_desc = "Charcoal streaks still mark the stones, now silent and dilapidated beneath\n"
+        + "lichen and mildew. Collapsed rafters and dusted crockery sit in rot, hinting\n"
+        + "at a small shop left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room845", "west",
+    "domain/original/area/vesla/room147", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room850.c
+++ b/domain/original/area/vesla/room850.c
@@ -1,17 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "PHASE0: inn";
-    dest_dir = ({
-        "domain/original/area/vesla/room142", "west",
-        "domain/original/area/vesla/room852", "east",
-        "domain/original/area/vesla/room851", "north",
-    });
+  short_desc = "Silent Hearth";
+  long_desc = "A wide, cold hearth sits beneath a soot-dark mantle, the room silent and\n"
+        + "dilapidated. Rotted tables lean in dust and mildew, and the common space is\n"
+        + "left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room142", "west",
+    "domain/original/area/vesla/room852", "east",
+    "domain/original/area/vesla/room851", "north",
+  });
 }
 

--- a/domain/original/area/vesla/room851.c
+++ b/domain/original/area/vesla/room851.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "PHASE0: inn";
-    dest_dir = ({
-        "domain/original/area/vesla/room850", "south",
-    });
+  short_desc = "Quiet Bunks";
+  long_desc = "Rough bunks sag against the walls, silent in dust, rot, and mildew. Hooks and\n"
+        + "pegs hang over a dilapidated floor, hinting at lodging left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room850", "south",
+  });
 }
 

--- a/domain/original/area/vesla/room852.c
+++ b/domain/original/area/vesla/room852.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Howling Wolf Inn";
-    long_desc = "PHASE0: inn";
-    dest_dir = ({
-        "domain/original/area/vesla/room850", "west",
-    });
+  short_desc = "Dry Tap";
+  long_desc = "A cracked counter and dry cask stand in silence, the space dilapidated and\n"
+        + "dim. Dust, mildew, and rot cling to the shelves, hinting at a taproom left in\n"
+        + "disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room850", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room853.c
+++ b/domain/original/area/vesla/room853.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Abandoned Building";
-    long_desc = "PHASE0: abandoned building";
-    dest_dir = ({
-        "domain/original/area/vesla/room139", "east",
-    });
+  short_desc = "Quiet Rooms";
+  long_desc = "Two small rooms sit open to the street, silent, dusty, and dilapidated. A cold\n"
+        + "hearth and broken bedframe are soft with mildew and rot, hinting at cramped\n"
+        + "living in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room139", "east",
+  });
 }
 

--- a/domain/original/area/vesla/room854.c
+++ b/domain/original/area/vesla/room854.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Spice Merchant";
-    long_desc = "PHASE0: NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room139", "west",
-    });
+  short_desc = "Scented Stall";
+  long_desc = "Rusted tins and cracked jars sit on sagging shelves, silent beneath dust and\n"
+        + "mildew. A faint, stale sweetness clings to the rot, hinting at spice trade in\n"
+        + "dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room139", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room855.c
+++ b/domain/original/area/vesla/room855.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Abandoned Building";
-    long_desc = "PHASE0: abandoned building";
-    dest_dir = ({
-        "domain/original/area/vesla/room138", "west",
-    });
+  short_desc = "Rear Rooms";
+  long_desc = "A narrow back room lies in silence, its shelves sagging with dust and mildew.\n"
+        + "Rot has taken the warped counter, hinting at storage and trade in dilapidated\n"
+        + "disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room138", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room856.c
+++ b/domain/original/area/vesla/room856.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Carvings Shop";
-    long_desc = "PHASE0: NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room138", "east",
-    });
+  short_desc = "Shaving Shed";
+  long_desc = "The floor is buried in old shavings turned to pulp, silent and dilapidated.\n"
+        + "Dulled chisels and a chipped mallet lie in dust, mildew, and rot, hinting at\n"
+        + "carved work in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room138", "east",
+  });
 }
 

--- a/domain/original/area/vesla/room857.c
+++ b/domain/original/area/vesla/room857.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Abandoned Warehouse";
-    long_desc = "PHASE0: abandoned warehouse";
-    dest_dir = ({
-        "domain/original/area/vesla/room198", "west",
-    });
+  short_desc = "Hollow Hall";
+  long_desc = "A wide hall yawns under sagging beams, silent and dilapidated. Dust, mildew,\n"
+        + "and rot swallow splintered crates, hinting at bulk storage left in disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room198", "west",
+  });
 }
 

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Abandoned Store";
-    long_desc = "PHASE0: abandoned store";
-    dest_dir = ({
-        "domain/original/area/vesla/room199", "west",
-    });
+  short_desc = "Shuttered Front";
+  long_desc = "A warped counter blocks the entry, silent under dust and mildew. Bare shelves\n"
+        + "and a torn awning sit in rot, hinting at trade in dilapidated disrepair.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room199", "west",
+  });
 }
 


### PR DESCRIPTION
### Motivation
- Replace terse `PHASE0:` markers with atmospheric, aged descriptions in keeping with the project's Phase 1 abandoned-world intent.
- Give room names a subtler, hinting tone that implies former purpose without stating it explicitly.
- Convey abandonment (rot, dust, mildew, silence, dilapidation) while following the restraint mandated by `PROSE.md`.
- Ensure player-facing text follows `CODE-STYLE.md` line-length rules with grammatically correct line breaks near 80 characters.

### Description
- Updated `short_desc` and `long_desc` in 24 files under `domain/original/area/vesla` to less-explicit names and aged, abandoned prose.
- Replaced `PHASE0:` placeholder lines with full multi-sentence `long_desc` values that hint at original room purpose without explicit statements.
- Reflowed `long_desc` strings using a ~78-character wrap and converted them to concatenated literal lines ending with `\n` to match the codebase formatting conventions.
- Adjusted indentation and formatting of the edited room files to the repository style and committed the changes with the message `Update Vesla room descriptions`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696407cef2bc8327b417b374a47406d3)