### PR TITLE
Age and refine Vesla room descriptions

### DIFF
--- a/domain/original/area/vesla/room394.c
+++ b/domain/original/area/vesla/room394.c
@@ -9,9 +9,8 @@ void reset(int arg) {
   short_desc = "Cold Smoke";
   long_desc = "Soot clings to the stone, and rusted hooks hang in a silence of dust and\n"
         + "mildew. Rotting tubs and ash-stained gutters hint at preserved fare in\n"
-        + "dilapidated disrepair.\n";
+        + "long-neglected ruin.\n";
   dest_dir = ({
     "domain/original/area/vesla/room210", "south",
   });
 }
-

--- a/domain/original/area/vesla/room395.c
+++ b/domain/original/area/vesla/room395.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Turner's Bench";
-  long_desc = "A cracked lathe stands in the corner, silent and dilapidated beneath dust and\n"
+  long_desc = "A cracked lathe stands in the corner, silent and ruined beneath dust and\n"
         + "mildew. Spilled shavings and dulled tools sit in rot, hinting at careful\n"
-        + "turning left in disrepair.\n";
+        + "turning left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room209", "south",
   });
 }
-

--- a/domain/original/area/vesla/room400.c
+++ b/domain/original/area/vesla/room400.c
@@ -7,10 +7,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Dull Chime";
-  long_desc = "Broken molds and a rusted frame lie in silent dust, the shop dilapidated. Rot\n"
-        + "and mildew stain the stone, hinting at chimes once shaped here in disrepair.\n";
+  long_desc = "Broken molds and a rusted frame lie in silent dust, the shop in ruin. Rot and\n"
+        + "mildew stain the stone, hinting at chimes once shaped here in neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room214", "east",
   });
 }
-

--- a/domain/original/area/vesla/room401.c
+++ b/domain/original/area/vesla/room401.c
@@ -8,10 +8,9 @@ void reset(int arg) {
 
   short_desc = "Wax Shelf";
   long_desc = "Hardened wax pools on a sagging table, silent beneath dust and mildew. Empty\n"
-        + "molds and a stale tallow smell linger in rot, hinting at candlework in\n"
-        + "dilapidated disrepair.\n";
+        + "molds and a stale tallow smell linger in rot, hinting at candlework long\n"
+        + "abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room214", "west",
   });
 }
-

--- a/domain/original/area/vesla/room402.c
+++ b/domain/original/area/vesla/room402.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Cold Still";
-  long_desc = "A copper coil lies split on the floor, silent and dilapidated under dust and\n"
+  long_desc = "A copper coil lies split on the floor, silent and wrecked under dust and\n"
         + "mildew. Dry barrels and a stained hearth sit in rot, hinting at spirits once\n"
-        + "made here in disrepair.\n";
+        + "made here and long forgotten.\n";
   dest_dir = ({
     "domain/original/area/vesla/room216", "east",
   });
 }
-

--- a/domain/original/area/vesla/room409.c
+++ b/domain/original/area/vesla/room409.c
@@ -8,10 +8,9 @@ void reset(int arg) {
 
   short_desc = "Nailed Notices";
   long_desc = "A warped board is riddled with rusted nails, silent under dust and mildew.\n"
-        + "Faded names and tally marks sit in rot, hinting at claims once posted in\n"
-        + "dilapidated disrepair.\n";
+        + "Faded names and tally marks sit in rot, hinting at claims once posted in a\n"
+        + "long-quiet hall.\n";
   dest_dir = ({
     "domain/original/area/vesla/room219", "east",
   });
 }
-

--- a/domain/original/area/vesla/room736.c
+++ b/domain/original/area/vesla/room736.c
@@ -8,9 +8,8 @@ void reset(int arg) {
 
   short_desc = "Market Lot";
   long_desc = "Low foundations ring a vacant patch, silent beneath dust, mildew, and rot. A\n"
-        + "broken sign frame hints at trade, the lot dilapidated and in disrepair.\n";
+        + "broken sign frame hints at trade, the lot left to crumble.\n";
   dest_dir = ({
     "domain/original/area/vesla/room173", "west",
   });
 }
-

--- a/domain/original/area/vesla/room816.c
+++ b/domain/original/area/vesla/room816.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Stone Span";
-  long_desc = "The bridge stones are slick with moss, the span silent and dilapidated. Rust\n"
+  long_desc = "The bridge stones are slick with moss, the span silent and weatherworn. Rust\n"
         + "marks the grooves of an old gate, and dust and mildew cling to the guard\n"
-        + "alcove in disrepair.\n";
+        + "alcove, now sagged and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room151", "north",
   });
 }
-

--- a/domain/original/area/vesla/room840.c
+++ b/domain/original/area/vesla/room840.c
@@ -7,12 +7,11 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Ashen Way";
-  long_desc = "Charred stone and blackened beams mark this stretch, now silent and\n"
-        + "dilapidated. Ash lies under drifted dust, and mildewed rubble clogs the broken\n"
-        + "curb where small fronts once opened in rot and disrepair.\n";
+  long_desc = "Charred stone and blackened beams mark this stretch, now silent and ruined.\n"
+        + "Ash lies under drifted dust, and mildewed rubble clogs the broken curb where\n"
+        + "small fronts once opened in ash and rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room841", "west",
     "domain/original/area/vesla/room148", "south",
   });
 }
-

--- a/domain/original/area/vesla/room841.c
+++ b/domain/original/area/vesla/room841.c
@@ -9,7 +9,7 @@ void reset(int arg) {
   short_desc = "Sooted Row";
   long_desc = "Soot stains the surviving walls, and the lane sits in a hush of rot and dust.\n"
         + "Warped shutters and mildewed frames lean inward, the fire-scarred row left in\n"
-        + "dilapidated disrepair.\n";
+        + "collapse and silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room147", "south",
     "domain/original/area/vesla/room842", "west",
@@ -17,4 +17,3 @@ void reset(int arg) {
     "domain/original/area/vesla/room843", "north",
   });
 }
-

--- a/domain/original/area/vesla/room842.c
+++ b/domain/original/area/vesla/room842.c
@@ -8,12 +8,11 @@ void reset(int arg) {
 
   short_desc = "Charred Lane";
   long_desc = "Fire-split timbers jut from the stonework, soft with mildew and long silent in\n"
-        + "dilapidated ruin. Dust coats the old thresholds, and rot gnaws at doorframes\n"
-        + "that hint at narrow rooms now in disrepair.\n";
+        + "ruin. Dust coats the old thresholds, and rot gnaws at doorframes that hint at\n"
+        + "narrow rooms now fallen and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room146", "south",
     "domain/original/area/vesla/room841", "east",
     "domain/original/area/vesla/room844", "north",
   });
 }
-

--- a/domain/original/area/vesla/room843.c
+++ b/domain/original/area/vesla/room843.c
@@ -8,12 +8,11 @@ void reset(int arg) {
 
   short_desc = "Blackened Court";
   long_desc = "The court is a hollow of scorched brick and collapsed awnings, silent and\n"
-        + "dilapidated. Mildew blooms on low walls, and rot mixes with dust around broken\n"
-        + "stalls left in disrepair.\n";
+        + "ruined. Mildew blooms on low walls, and rot mixes with dust around broken\n"
+        + "stalls left to crumble.\n";
   dest_dir = ({
     "domain/original/area/vesla/room844", "west",
     "domain/original/area/vesla/room841", "south",
     "domain/original/area/vesla/room201", "north",
   });
 }
-

--- a/domain/original/area/vesla/room844.c
+++ b/domain/original/area/vesla/room844.c
@@ -8,12 +8,11 @@ void reset(int arg) {
 
   short_desc = "Cinder Walk";
   long_desc = "Cinder and gravel crunch over warped flagstones, the walk silent and\n"
-        + "dilapidated. Rusting hinges and charred lintels sag in rot and mildew, a dusty\n"
-        + "hint of shop doors left in disrepair.\n";
+        + "weathered. Rusting hinges and charred lintels sag in rot and mildew, a dusty\n"
+        + "hint of shop doors left to decay.\n";
   dest_dir = ({
     "domain/original/area/vesla/room842", "south",
     "domain/original/area/vesla/room843", "east",
     "domain/original/area/vesla/room202", "north",
   });
 }
-

--- a/domain/original/area/vesla/room845.c
+++ b/domain/original/area/vesla/room845.c
@@ -7,12 +7,11 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Scorched Pass";
-  long_desc = "Scorched boards lie half-buried in damp dust, the passage silent and\n"
-        + "dilapidated. A low sill and slumped counter are soft with rot and mildew,\n"
-        + "hinting at a trade stall in disrepair.\n";
+  long_desc = "Scorched boards lie half-buried in damp dust, the passage silent and ruined.\n"
+        + "A low sill and slumped counter are soft with rot and mildew, hinting at a\n"
+        + "trade stall left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room846", "east",
     "domain/original/area/vesla/room146", "north",
   });
 }
-

--- a/domain/original/area/vesla/room846.c
+++ b/domain/original/area/vesla/room846.c
@@ -7,12 +7,11 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Cinder Row";
-  long_desc = "Charcoal streaks still mark the stones, now silent and dilapidated beneath\n"
+  long_desc = "Charcoal streaks still mark the stones, now silent and weatherworn beneath\n"
         + "lichen and mildew. Collapsed rafters and dusted crockery sit in rot, hinting\n"
-        + "at a small shop left in disrepair.\n";
+        + "at a small shop long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room845", "west",
     "domain/original/area/vesla/room147", "north",
   });
 }
-

--- a/domain/original/area/vesla/room847.c
+++ b/domain/original/area/vesla/room847.c
@@ -6,12 +6,13 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old City Offices";
-    long_desc = "PHASE0: municipal offices";
+    short_desc = "Record Hall";
+    long_desc = "A long chamber sits in silence, its ceiling sagged and its floor layered in\n"
+        + "dust and mildew. Split desks and fallen stools crowd the room, and a rusted\n"
+        + "rail still divides a row of mildewed pigeonholes.\n";
     dest_dir = ({
         "domain/original/area/vesla/room849", "west",
         "domain/original/area/vesla/room848", "east",
         "domain/original/area/vesla/room144", "north",
     });
 }
-

--- a/domain/original/area/vesla/room848.c
+++ b/domain/original/area/vesla/room848.c
@@ -6,10 +6,11 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old Office";
-    long_desc = "PHASE0: municipal offices";
+    short_desc = "Worn Annex";
+    long_desc = "A narrow side room lies under a crust of dust, its shelves bowed and the air\n"
+        + "stale with mildew. A dry ink smell clings to cracked boxes and a toppled\n"
+        + "writing stand, the place long empty.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "west",
     });
 }
-

--- a/domain/original/area/vesla/room849.c
+++ b/domain/original/area/vesla/room849.c
@@ -6,10 +6,11 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Old Office";
-    long_desc = "PHASE0: municipal offices";
+    short_desc = "Dusty Alcove";
+    long_desc = "The chamber is tight and dim, its stone sweating with damp and the floor\n"
+        + "cluttered with scraps of paper turned to pulp. A broken cabinet and a rusted\n"
+        + "lockbox lean together in the quiet of long neglect.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "east",
     });
 }
-

--- a/domain/original/area/vesla/room850.c
+++ b/domain/original/area/vesla/room850.c
@@ -8,12 +8,11 @@ void reset(int arg) {
 
   short_desc = "Silent Hearth";
   long_desc = "A wide, cold hearth sits beneath a soot-dark mantle, the room silent and\n"
-        + "dilapidated. Rotted tables lean in dust and mildew, and the common space is\n"
-        + "left in disrepair.\n";
+        + "ruined. Rotted tables lean in dust and mildew, and the common space is left to\n"
+        + "sag.\n";
   dest_dir = ({
     "domain/original/area/vesla/room142", "west",
     "domain/original/area/vesla/room852", "east",
     "domain/original/area/vesla/room851", "north",
   });
 }
-

--- a/domain/original/area/vesla/room851.c
+++ b/domain/original/area/vesla/room851.c
@@ -8,9 +8,8 @@ void reset(int arg) {
 
   short_desc = "Quiet Bunks";
   long_desc = "Rough bunks sag against the walls, silent in dust, rot, and mildew. Hooks and\n"
-        + "pegs hang over a dilapidated floor, hinting at lodging left in disrepair.\n";
+        + "pegs hang over a sagging floor, hinting at lodging long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room850", "south",
   });
 }
-

--- a/domain/original/area/vesla/room852.c
+++ b/domain/original/area/vesla/room852.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Dry Tap";
-  long_desc = "A cracked counter and dry cask stand in silence, the space dilapidated and\n"
-        + "dim. Dust, mildew, and rot cling to the shelves, hinting at a taproom left in\n"
-        + "disrepair.\n";
+  long_desc = "A cracked counter and dry cask stand in silence, the space dim and neglected.\n"
+        + "Dust, mildew, and rot cling to the shelves, hinting at a taproom left to\n"
+        + "fade.\n";
   dest_dir = ({
     "domain/original/area/vesla/room850", "west",
   });
 }
-

--- a/domain/original/area/vesla/room853.c
+++ b/domain/original/area/vesla/room853.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Quiet Rooms";
-  long_desc = "Two small rooms sit open to the street, silent, dusty, and dilapidated. A cold\n"
+  long_desc = "Two small rooms sit open to the street, silent, dusty, and ruined. A cold\n"
         + "hearth and broken bedframe are soft with mildew and rot, hinting at cramped\n"
-        + "living in disrepair.\n";
+        + "living left behind.\n";
   dest_dir = ({
     "domain/original/area/vesla/room139", "east",
   });
 }
-

--- a/domain/original/area/vesla/room854.c
+++ b/domain/original/area/vesla/room854.c
@@ -9,9 +9,8 @@ void reset(int arg) {
   short_desc = "Scented Stall";
   long_desc = "Rusted tins and cracked jars sit on sagging shelves, silent beneath dust and\n"
         + "mildew. A faint, stale sweetness clings to the rot, hinting at spice trade in\n"
-        + "dilapidated disrepair.\n";
+        + "quiet neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room139", "west",
   });
 }
-

--- a/domain/original/area/vesla/room855.c
+++ b/domain/original/area/vesla/room855.c
@@ -8,10 +8,9 @@ void reset(int arg) {
 
   short_desc = "Rear Rooms";
   long_desc = "A narrow back room lies in silence, its shelves sagging with dust and mildew.\n"
-        + "Rot has taken the warped counter, hinting at storage and trade in dilapidated\n"
-        + "disrepair.\n";
+        + "Rot has taken the warped counter, hinting at storage and trade long\n"
+        + "abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room138", "west",
   });
 }
-

--- a/domain/original/area/vesla/room856.c
+++ b/domain/original/area/vesla/room856.c
@@ -7,11 +7,10 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Shaving Shed";
-  long_desc = "The floor is buried in old shavings turned to pulp, silent and dilapidated.\n"
-        + "Dulled chisels and a chipped mallet lie in dust, mildew, and rot, hinting at\n"
-        + "carved work in disrepair.\n";
+  long_desc = "The floor is buried in old shavings turned to pulp, silent and ruined. Dulled\n"
+        + "chisels and a chipped mallet lie in dust, mildew, and rot, hinting at carved\n"
+        + "work left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room138", "east",
   });
 }
-

--- a/domain/original/area/vesla/room857.c
+++ b/domain/original/area/vesla/room857.c
@@ -7,10 +7,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Hollow Hall";
-  long_desc = "A wide hall yawns under sagging beams, silent and dilapidated. Dust, mildew,\n"
-        + "and rot swallow splintered crates, hinting at bulk storage left in disrepair.\n";
+  long_desc = "A wide hall yawns under sagging beams, silent and ruined. Dust, mildew, and\n"
+        + "rot swallow splintered crates, hinting at bulk storage long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room198", "west",
   });
 }
-

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -8,9 +8,8 @@ void reset(int arg) {
 
   short_desc = "Shuttered Front";
   long_desc = "A warped counter blocks the entry, silent under dust and mildew. Bare shelves\n"
-        + "and a torn awning sit in rot, hinting at trade in dilapidated disrepair.\n";
+        + "and a torn awning sit in rot, hinting at trade long faded.\n";
   dest_dir = ({
     "domain/original/area/vesla/room199", "west",
   });
 }
-


### PR DESCRIPTION
### Motivation

- Update Vesla rooms that were left as `PHASE0:` placeholders so they read as long‑abandoned and vacant rather than explicit municipal offices.
- Replace explicit room names with subtler, one‑to‑two word titles that hint at original function without stating it.
- Reduce repetitive phrasing (notably "dilapidated" and "in disrepair") to increase variety while preserving the abandoned, rot‑and‑mildew atmosphere.
- Ensure player‑facing text follows `CODE-STYLE.md` and `PROSE.md` constraints on line length and restrained tone.

### Description

- Replaced the `PHASE0: municipal offices` placeholders in `room847.c`, `room848.c`, and `room849.c` with aged, ambiguous short descriptions and multi‑line long descriptions that connote long neglect.
- Varied abandonment wording across the Vesla area, replacing repeated "dilapidated"/"in disrepair" uses with alternatives like "ruin", "long abandoned", "left to crumble", and "left to waste".
- Updated a total of 27 room files under `domain/original/area/vesla` to apply these prose changes and keep descriptions concise and evocative.
- Formatted long descriptions to respect the repository's line‑wrapping rules and committed the changes.

### Testing

- Ran `rg -n "PHASE0:"` to locate the placeholders prior to edits and confirmed the targeted files were updated.
- Ran `rg -n "dilapidated|in disrepair"` after edits and received no matches, indicating repetitive phrases were removed.
- Executed a Python check that parses `long_desc` strings and verified there are zero lines over ~80 characters.
- Performed `git commit` which succeeded with the message "Update Vesla room descriptions" and recorded 27 files changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640e598e948327b9d236b6408d6736)