### PR TITLE
Reflow Vesla room descriptions to ~80 columns

### DIFF
--- a/domain/original/area/vesla/portal.c
+++ b/domain/original/area/vesla/portal.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
     short_desc = "Portal Room";
     long_desc = "This is the portal room. As development continues, these areas will be removed\n"
-                + "from the portal room and linked to the full world.\n";
+              + "from the portal room and linked to the full world.\n";
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "up",
         "domain/original/area/island/room605", "island",

--- a/domain/original/area/vesla/room115.c
+++ b/domain/original/area/vesla/room115.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Ruined Gate";
-  long_desc = "A broken stone arch leans over the road, its timbers split and sagging. Crumbled\n"
-              + "masonry seals the passage, and old iron fittings lie rusted in the weeds.\n";
+  long_desc = "A broken stone arch leans over the road, its timbers split and sagging.\n"
+              + "Crumbled masonry seals the passage, and old iron fittings lie rusted in the\n"
+              + "weeds.\n";
   dest_dir = ({
     "domain/original/area/vesla/room116", "west",
     "domain/original/area/roadway/room14", "exit",

--- a/domain/original/area/vesla/room116.c
+++ b/domain/original/area/vesla/room116.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Park Crossroads";
-  long_desc = "The crossing is choked with gravel and dead leaves where a broad street meets a\n"
-              + "narrower lane. Fallen posts and a tilted sign hold a silence settled over long\n"
-              + "neglect.\n";
+  long_desc = "The crossing is choked with gravel and dead leaves where a broad street meets\n"
+              + "a narrower lane. Fallen posts and a tilted sign hold a silence settled over\n"
+              + "long neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room233", "south",
     "domain/original/area/vesla/room117", "west",

--- a/domain/original/area/vesla/room117.c
+++ b/domain/original/area/vesla/room117.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Grit-Streaked Crossing";
   long_desc = "Weathered stones mark the meeting of two old streets, their lines softened by\n"
-              + "drifted grit. A broken post leans over the junction, and no track has passed in\n"
-              + "generations.\n";
+              + "drifted grit. A broken post leans over the junction, and no track has passed\n"
+              + "in generations.\n";
   dest_dir = ({
     "domain/original/area/vesla/room220", "south",
     "domain/original/area/vesla/room118", "west",

--- a/domain/original/area/vesla/room118.c
+++ b/domain/original/area/vesla/room118.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Dim Walk";
   long_desc = "A narrow walk runs beneath slumped beams and the last remains of a shaded\n"
-              + "trellis. Motes of dust cling to the air, and the stones are slick with old rot.\n";
+              + "trellis. Motes of dust cling to the air, and the stones are slick with old\n"
+              + "rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room227", "north",
     "domain/original/area/vesla/room221", "south",

--- a/domain/original/area/vesla/room119.c
+++ b/domain/original/area/vesla/room119.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Shattered Walk";
-  long_desc = "The covered path is broken here, its ribs split and scattered across the paving.\n"
-              + "Wind drifts through the gaps, stirring leaves that have gathered in the hollows.\n";
+  long_desc = "The covered path is broken here, its ribs split and scattered across the\n"
+              + "paving. Wind drifts through the gaps, stirring leaves that have gathered in\n"
+              + "the hollows.\n";
   dest_dir = ({
     "domain/original/area/vesla/room222", "south",
     "domain/original/area/vesla/room120", "west",

--- a/domain/original/area/vesla/room125.c
+++ b/domain/original/area/vesla/room125.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Empty Junction";
   long_desc = "A wide junction opens where several streets once met. The stones are worn\n"
-              + "smooth, and scattered rubble marks where structures have slumped into the road.\n";
+              + "smooth, and scattered rubble marks where structures have slumped into the\n"
+              + "road.\n";
   dest_dir = ({
     "domain/original/area/vesla/room159", "south",
     "domain/original/area/vesla/room126", "west",

--- a/domain/original/area/vesla/room127.c
+++ b/domain/original/area/vesla/room127.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Old City Gate";
   long_desc = "A battered gateway stands between worn walls, its lintel cracked and sagging.\n"
-              + "Dust gathers in the deep grooves of the threshold, and no sound follows the road\n"
-              + "beyond.\n";
+              + "Dust gathers in the deep grooves of the threshold, and no sound follows the\n"
+              + "road beyond.\n";
   dest_dir = ({
     "domain/original/area/vesla/room128", "west",
     "domain/original/area/vesla/room126", "east",

--- a/domain/original/area/vesla/room130.c
+++ b/domain/original/area/vesla/room130.c
@@ -8,8 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Westroad Silence";
-  long_desc = "The road narrows into a quiet channel of stone and dust. A collapsed lintel lies\n"
-              + "across one wall, and the space beyond it is dark and empty.\n";
+  long_desc = "The road narrows into a quiet channel of stone and dust. A collapsed lintel\n"
+              + "lies across one wall, and the space beyond it is dark and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room131", "west",
     "domain/original/area/vesla/room129", "east",

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Western Gate";
-  long_desc = "The western gate has collapsed into a heap of stone and splintered wood. Rusted\n"
-              + "fittings lie half buried, and the blocked passage holds a deep, unmoving quiet.\n";
+  long_desc = "The western gate has collapsed into a heap of stone and splintered wood.\n"
+              + "Rusted fittings lie half buried, and the blocked passage holds a deep,\n"
+              + "unmoving quiet.\n";
   dest_dir = ({
     "domain/original/area/vesla/room133", "east",
     "domain/original/area/roadway/room29", "exit",

--- a/domain/original/area/vesla/room135.c
+++ b/domain/original/area/vesla/room135.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Basalt Avenue";
-  long_desc = "Basalt paving runs between dark stone walls, the joints split by weeds and grit.\n"
-              + "A low drift of broken tile lies where slow runoff has carved shallow channels.\n";
+  long_desc = "Basalt paving runs between dark stone walls, the joints split by weeds and\n"
+              + "grit. A low drift of broken tile lies where slow runoff has carved shallow\n"
+              + "channels.\n";
   dest_dir = ({
     "domain/original/area/vesla/room136", "south",
     "domain/original/area/vesla/room133", "north",

--- a/domain/original/area/vesla/room136.c
+++ b/domain/original/area/vesla/room136.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Basalt Avenue";
   long_desc = "The avenue narrows here, basalt stones dulled to slate by grit and weather.\n"
-              + "Rust-stained runoff traces the gutter, and a fallen lintel lies along the wall.\n";
+              + "Rust-stained runoff traces the gutter, and a fallen lintel lies along the\n"
+              + "wall.\n";
   dest_dir = ({
     "domain/original/area/vesla/room137", "south",
     "domain/original/area/vesla/room135", "north",

--- a/domain/original/area/vesla/room137.c
+++ b/domain/original/area/vesla/room137.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Intersection of Basalt Avenue and Rapier Way";
-  long_desc = "Two worn streets cross on uneven basalt, their corners softened by age and grit.\n"
-              + "The stones are cracked and slumped, leaving shallow puddles and windblown grit.\n";
+  long_desc = "Two worn streets cross on uneven basalt, their corners softened by age and\n"
+              + "grit. The stones are cracked and slumped, leaving shallow puddles and\n"
+              + "windblown grit.\n";
   dest_dir = ({
     "domain/original/area/vesla/room138", "south",
     "domain/original/area/vesla/room193", "east",

--- a/domain/original/area/vesla/room138.c
+++ b/domain/original/area/vesla/room138.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Basalt Avenue";
   long_desc = "Basalt blocks crowd the street, their faces chipped and dark with thick soot.\n"
-              + "Doorways gape into shadow, and the avenue is filmed with fine dust and leaf rot.\n";
+              + "Doorways gape into shadow, and the avenue is filmed with fine dust and leaf\n"
+              + "rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room139", "south",
     "domain/original/area/vesla/room856", "west",

--- a/domain/original/area/vesla/room139.c
+++ b/domain/original/area/vesla/room139.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Basalt Avenue";
   long_desc = "The avenue bends around sagging walls, the basalt setts uneven and underfoot.\n"
-              + "Moss clings in the seams, and broken steps lead into silent, collapsed doorways.\n";
+              + "Moss clings in the seams, and broken steps lead into silent, collapsed\n"
+              + "doorways.\n";
   dest_dir = ({
     "domain/original/area/vesla/room140", "south",
     "domain/original/area/vesla/room853", "west",

--- a/domain/original/area/vesla/room140.c
+++ b/domain/original/area/vesla/room140.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Intersection of Basalt Avenue and Street of the Bells";
-  long_desc = "A wider crossing opens where the paving is deeply scored by cart ruts and rain.\n"
-              + "The basalt is cracked into plates, and iron rings lie rusted into the stones.\n";
+  long_desc = "A wider crossing opens where the paving is deeply scored by cart ruts and\n"
+              + "rain. The basalt is cracked into plates, and iron rings lie rusted into the\n"
+              + "stones.\n";
   dest_dir = ({
     "domain/original/area/vesla/room141", "south",
     "domain/original/area/vesla/room204", "east",

--- a/domain/original/area/vesla/room141.c
+++ b/domain/original/area/vesla/room141.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Basalt Avenue";
   long_desc = "Basalt Avenue runs between low facades, their lintels split and worn with age.\n"
-              + "Thin grass pushes through the cracks, and loose stones have slid into the road.\n";
+              + "Thin grass pushes through the cracks, and loose stones have slid into the\n"
+              + "road.\n";
   dest_dir = ({
     "domain/original/area/vesla/room142", "south",
     "domain/original/area/vesla/room140", "north",

--- a/domain/original/area/vesla/room143.c
+++ b/domain/original/area/vesla/room143.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Basalt River Corner";
-    long_desc = "Cracked basalt paving meets the river road, its stones slick with old stains. A\n"
-                + "collapsed wall spills rubble into the corner, and weeds root in the gaps.\n";
+    long_desc = "Cracked basalt paving meets the river road, its stones slick with old stains.\n"
+              + "A collapsed wall spills rubble into the corner, and weeds root in the gaps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room144", "east",
         "domain/original/area/vesla/room142", "north",

--- a/domain/original/area/vesla/room144.c
+++ b/domain/original/area/vesla/room144.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "The westward river road is split by frost and root, the stones heaved uneven. A\n"
-                + "dry gutter runs alongside, packed with silt and curled leaves.\n";
+    long_desc = "The westward river road is split by frost and root, the stones heaved uneven.\n"
+              + "A dry gutter runs alongside, packed with silt and curled leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room143", "west",
         "domain/original/area/vesla/room145", "east",

--- a/domain/original/area/vesla/room145.c
+++ b/domain/original/area/vesla/room145.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Moss clings to the low curb here, and the road narrows between leaning facades.\n"
-                + "Rusted rings jut from the masonry, their purpose long gone.\n";
+    long_desc = "Moss clings to the low curb here, and the road narrows between leaning\n"
+              + "facades. Rusted rings jut from the masonry, their purpose long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room146", "east",
         "domain/original/area/vesla/room144", "west",

--- a/domain/original/area/vesla/room146.c
+++ b/domain/original/area/vesla/room146.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Flat stones lie loose underfoot, some tipped into a shallow rut. A broken lintel\n"
-                + "rests against a wall, half buried in grit.\n";
+    long_desc = "Flat stones lie loose underfoot, some tipped into a shallow rut. A broken\n"
+              + "lintel rests against a wall, half buried in grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room845", "south",
         "domain/original/area/vesla/room145", "west",

--- a/domain/original/area/vesla/room147.c
+++ b/domain/original/area/vesla/room147.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "West River Track";
     long_desc = "The river road bends past a slumped doorway, its threshold choked with debris.\n"
-                + "Pale lichen maps the stone, and no tracks disturb the dust.\n";
+              + "Pale lichen maps the stone, and no tracks disturb the dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room846", "south",
         "domain/original/area/vesla/room146", "west",

--- a/domain/original/area/vesla/room148.c
+++ b/domain/original/area/vesla/room148.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "West River Track";
     long_desc = "A line of cracked flagstones stretches west, fractured by roots. A low parapet\n"
-                + "crumbles toward a silent channel, its edge washed bare.\n";
+              + "crumbles toward a silent channel, its edge washed bare.\n";
     dest_dir = ({
         "domain/original/area/vesla/room147", "west",
         "domain/original/area/vesla/room149", "east",

--- a/domain/original/area/vesla/room149.c
+++ b/domain/original/area/vesla/room149.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "West River Track";
-    long_desc = "Weeds crowd the seams of the paving, softening the road into a green ribbon. The\n"
-                + "air is damp and still along the empty course.\n";
+    long_desc = "Weeds crowd the seams of the paving, softening the road into a green ribbon.\n"
+              + "The air is damp and still along the empty course.\n";
     dest_dir = ({
         "domain/original/area/vesla/room150", "east",
         "domain/original/area/vesla/room148", "west",

--- a/domain/original/area/vesla/room150.c
+++ b/domain/original/area/vesla/room150.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "West River Track";
     long_desc = "Here the stones are stained dark, as if by old floods that never returned. A\n"
-                + "toppled iron post lies in the gutter, rusted through.\n";
+              + "toppled iron post lies in the gutter, rusted through.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "east",
         "domain/original/area/vesla/room149", "west",

--- a/domain/original/area/vesla/room151.c
+++ b/domain/original/area/vesla/room151.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "River-Main Junction";
     long_desc = "Two dead roads cross in a scatter of broken cobbles. A fractured drain grate\n"
-                + "sits at the center, packed with mud and leaves.\n";
+              + "sits at the center, packed with mud and leaves.\n";
     dest_dir = ({
         "domain/original/area/vesla/room816", "south",
         "domain/original/area/vesla/room150", "west",

--- a/domain/original/area/vesla/room152.c
+++ b/domain/original/area/vesla/room152.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "The southern main road is rutted and split, its stones tipped at odd angles. A\n"
-                + "fallen signboard lies half buried in dust.\n";
+              + "fallen signboard lies half buried in dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room151", "south",
         "domain/original/area/vesla/room819", "west",

--- a/domain/original/area/vesla/room153.c
+++ b/domain/original/area/vesla/room153.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "A broad stretch of paving runs north and south, worn smooth in places. The bases\n"
-                + "of old walls sit empty, their timbers long gone.\n";
+    long_desc = "A broad stretch of paving runs north and south, worn smooth in places. The\n"
+              + "bases of old walls sit empty, their timbers long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room820", "west",
         "domain/original/area/vesla/room152", "south",

--- a/domain/original/area/vesla/room154.c
+++ b/domain/original/area/vesla/room154.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "Thin weeds stripe the main road here, forcing a crooked path. A low curb has\n"
-                + "crumbled into the street, leaving a scatter of chips.\n";
+              + "crumbled into the street, leaving a scatter of chips.\n";
     dest_dir = ({
         "domain/original/area/vesla/room153", "south",
         "domain/original/area/vesla/room821", "east",

--- a/domain/original/area/vesla/room155.c
+++ b/domain/original/area/vesla/room155.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "The roadway dips slightly, holding a thin skin of damp grit. A sagging doorway\n"
-                + "yawns nearby, black with soot.\n";
+              + "yawns nearby, black with soot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room154", "south",
         "domain/original/area/vesla/room423", "west",

--- a/domain/original/area/vesla/room156.c
+++ b/domain/original/area/vesla/room156.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "Broken cobbles gather near a collapsed stoop. The main road is silent, its\n"
-                + "centerline marked by a shallow rut.\n";
+              + "centerline marked by a shallow rut.\n";
     dest_dir = ({
         "domain/original/area/vesla/room155", "south",
         "domain/original/area/vesla/room822", "west",

--- a/domain/original/area/vesla/room157.c
+++ b/domain/original/area/vesla/room157.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "South Main Road";
-    long_desc = "The southern road narrows between leaning walls. Loose slate and tile litter the\n"
-                + "paving.\n";
+    long_desc = "The southern road narrows between leaning walls. Loose slate and tile litter\n"
+              + "the paving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room156", "south",
         "domain/original/area/vesla/room823", "west",

--- a/domain/original/area/vesla/room158.c
+++ b/domain/original/area/vesla/room158.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "Old cart ruts cut through the stones, softened by moss. A toppled beam rests\n"
-                + "across the gutter.\n";
+              + "across the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room824", "west",
         "domain/original/area/vesla/room157", "south",

--- a/domain/original/area/vesla/room159.c
+++ b/domain/original/area/vesla/room159.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "South Main Road";
     long_desc = "The paving stones here are splintered and slick with lichen. Dust lies thick\n"
-                + "against the bases of the walls.\n";
+              + "against the bases of the walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room158", "south",
         "domain/original/area/vesla/room125", "north",

--- a/domain/original/area/vesla/room160.c
+++ b/domain/original/area/vesla/room160.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "The northward main road rises slightly, its stones pale and chipped. A cold\n"
-                + "breeze funnels through the gap between empty facades.\n";
+              + "breeze funnels through the gap between empty facades.\n";
     dest_dir = ({
         "domain/original/area/vesla/room125", "south",
         "domain/original/area/vesla/room412", "east",

--- a/domain/original/area/vesla/room161.c
+++ b/domain/original/area/vesla/room161.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "Here the main road is flanked by crumbling foundations. A patch of nettles\n"
-                + "spills across the center line.\n";
+              + "spills across the center line.\n";
     dest_dir = ({
         "domain/original/area/vesla/room160", "south",
         "domain/original/area/vesla/room808", "east",

--- a/domain/original/area/vesla/room162.c
+++ b/domain/original/area/vesla/room162.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "North Main Road";
-    long_desc = "The stones are cracked into a ragged mosaic, some sunk low. A rusted hinge hangs\n"
-                + "from a doorframe, unmoving.\n";
+    long_desc = "The stones are cracked into a ragged mosaic, some sunk low. A rusted hinge\n"
+              + "hangs from a doorframe, unmoving.\n";
     dest_dir = ({
         "domain/original/area/vesla/room161", "south",
         "domain/original/area/vesla/room810", "east",

--- a/domain/original/area/vesla/room163.c
+++ b/domain/original/area/vesla/room163.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "A narrow strip of sky opens above the north road, framed by broken rooflines.\n"
-                + "Shattered brick and mortar gather in drifts.\n";
+              + "Shattered brick and mortar gather in drifts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room162", "south",
         "domain/original/area/vesla/room811", "east",

--- a/domain/original/area/vesla/room164.c
+++ b/domain/original/area/vesla/room164.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "The road passes a doorway choked with rubble and ivy. Small pools of rain-dark\n"
-                + "water stain the stones.\n";
+              + "water stain the stones.\n";
     dest_dir = ({
         "domain/original/area/vesla/room163", "south",
         "domain/original/area/vesla/room812", "east",

--- a/domain/original/area/vesla/room165.c
+++ b/domain/original/area/vesla/room165.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "The north road levels out and grows quiet, its surface scabbed with grit. A\n"
-                + "cracked iron grate lies in the gutter.\n";
+              + "cracked iron grate lies in the gutter.\n";
     dest_dir = ({
         "domain/original/area/vesla/room164", "south",
         "domain/original/area/vesla/room166", "north",

--- a/domain/original/area/vesla/room166.c
+++ b/domain/original/area/vesla/room166.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Main Scholar Crossing";
-    long_desc = "Two streets cross in a square of uneven stone. The corners are piled with broken\n"
-                + "masonry and grit.\n";
+    long_desc = "Two streets cross in a square of uneven stone. The corners are piled with\n"
+              + "broken masonry and grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room165", "south",
         "domain/original/area/vesla/room192", "east",

--- a/domain/original/area/vesla/room167.c
+++ b/domain/original/area/vesla/room167.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "North Main Road";
     long_desc = "The main road bends toward the gate, its stones worn thin and pale. A line of\n"
-                + "old posts leans toward the center.\n";
+              + "old posts leans toward the center.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "south",
         "domain/original/area/vesla/room168", "north",

--- a/domain/original/area/vesla/room168.c
+++ b/domain/original/area/vesla/room168.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Main Wall Crossing";
-    long_desc = "The crossing is wide and empty, marked by worn paving and shallow ruts. A broken\n"
-                + "curb rings the corner where the streets meet.\n";
+    long_desc = "The crossing is wide and empty, marked by worn paving and shallow ruts. A\n"
+              + "broken curb rings the corner where the streets meet.\n";
     dest_dir = ({
         "domain/original/area/vesla/room167", "south",
         "domain/original/area/vesla/room793", "west",

--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Rapier Way";
   long_desc = "Rapier Way begins between tight stone walls, its paving set in narrow strips.\n"
-              + "The stones are chipped and uneven, and dark dust has gathered deep in the seams.\n";
+              + "The stones are chipped and uneven, and dark dust has gathered deep in the\n"
+              + "seams.\n";
   dest_dir = ({
     "domain/original/area/vesla/room194", "east",
     "domain/original/area/vesla/room137", "west",

--- a/domain/original/area/vesla/room196.c
+++ b/domain/original/area/vesla/room196.c
@@ -9,7 +9,8 @@ void reset(int arg) {
 
   short_desc = "Rapier Way";
   long_desc = "The paving breaks into small islands, the gaps filled with dark soil and rot.\n"
-              + "The street narrows toward a wider crossing ahead, where the stones dip slightly.\n";
+              + "The street narrows toward a wider crossing ahead, where the stones dip\n"
+              + "slightly.\n";
   dest_dir = ({
     "domain/original/area/vesla/room197", "east",
     "domain/original/area/vesla/room195", "west",

--- a/domain/original/area/vesla/room205.c
+++ b/domain/original/area/vesla/room205.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "The eastern stretch runs straight and hollow, its stones slick with moss. A low\n"
-                + "wall beside it is buckled and split.\n";
+    long_desc = "The eastern stretch runs straight and hollow, its stones slick with moss. A\n"
+              + "low wall beside it is buckled and split.\n";
     dest_dir = ({
         "domain/original/area/vesla/room206", "east",
         "domain/original/area/vesla/room151", "west",

--- a/domain/original/area/vesla/room206.c
+++ b/domain/original/area/vesla/room206.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "East River Track";
     long_desc = "Silt lies in shallow drifts along the edge of the road. A fallen shutter leans\n"
-                + "against the stone, water-dark and warped.\n";
+              + "against the stone, water-dark and warped.\n";
     dest_dir = ({
         "domain/original/area/vesla/room205", "west",
         "domain/original/area/vesla/room207", "east",

--- a/domain/original/area/vesla/room207.c
+++ b/domain/original/area/vesla/room207.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "East River Track";
     long_desc = "Patches of grass push through the joints in the paving here. The river channel\n"
-                + "beside the road is choked with debris and still.\n";
+              + "beside the road is choked with debris and still.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "east",
         "domain/original/area/vesla/room206", "west",

--- a/domain/original/area/vesla/room208.c
+++ b/domain/original/area/vesla/room208.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "East River Track";
-    long_desc = "The road narrows between blank fronts, their doors hanging askew. Wind has swept\n"
-                + "the stones clean in thin streaks.\n";
+    long_desc = "The road narrows between blank fronts, their doors hanging askew. Wind has\n"
+              + "swept the stones clean in thin streaks.\n";
     dest_dir = ({
         "domain/original/area/vesla/room207", "west",
         "domain/original/area/vesla/room209", "east",

--- a/domain/original/area/vesla/room209.c
+++ b/domain/original/area/vesla/room209.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "East River Track";
     long_desc = "A shallow rut marks the center line, worn deep before the silence. Small piles\n"
-                + "of gravel gather against the curb.\n";
+              + "of gravel gather against the curb.\n";
     dest_dir = ({
         "domain/original/area/vesla/room208", "west",
         "domain/original/area/vesla/room210", "east",

--- a/domain/original/area/vesla/room210.c
+++ b/domain/original/area/vesla/room210.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "East River Track";
     long_desc = "Cracked stones and broken mortar leave the roadway ragged. A rusted chain lies\n"
-                + "half sunk in the silt.\n";
+              + "half sunk in the silt.\n";
     dest_dir = ({
         "domain/original/area/vesla/room209", "west",
         "domain/original/area/vesla/room211", "east",

--- a/domain/original/area/vesla/room211.c
+++ b/domain/original/area/vesla/room211.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "River Track End";
-    long_desc = "The road ends at a tumbled edge of stone, dropping to a dry, weeded bank. Broken\n"
-                + "posts stand like stumps along the rim.\n";
+    long_desc = "The road ends at a tumbled edge of stone, dropping to a dry, weeded bank.\n"
+              + "Broken posts stand like stumps along the rim.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "east",
         "domain/original/area/vesla/room210", "west",

--- a/domain/original/area/vesla/room212.c
+++ b/domain/original/area/vesla/room212.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "River Crossing";
-    long_desc = "The crossing is a scatter of worn stones, their edges smoothed by time. The two\n"
-                + "ways meet in silence, framed by damp, crumbling walls.\n";
+    long_desc = "The crossing is a scatter of worn stones, their edges smoothed by time. The\n"
+              + "two ways meet in silence, framed by damp, crumbling walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room211", "west",
         "domain/original/area/vesla/room213", "north",

--- a/domain/original/area/vesla/room213.c
+++ b/domain/original/area/vesla/room213.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Southern End";
     long_desc = "The way thins into broken stones, the once- straight line sagging. Fallen trim\n"
-                + "and damp rubble gather at the end of the road.\n";
+              + "and damp rubble gather at the end of the road.\n";
     dest_dir = ({
         "domain/original/area/vesla/room212", "south",
         "domain/original/area/vesla/room399", "east",

--- a/domain/original/area/vesla/room214.c
+++ b/domain/original/area/vesla/room214.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Southern Cracked Way";
-    long_desc = "Wide paving slabs lie buckled and parted by grass. A line of soot-streaked stone\n"
-                + "posts leans in slow collapse.\n";
+    long_desc = "Wide paving slabs lie buckled and parted by grass. A line of soot-streaked\n"
+              + "stone posts leans in slow collapse.\n";
     dest_dir = ({
         "domain/original/area/vesla/room213", "south",
         "domain/original/area/vesla/room400", "west",

--- a/domain/original/area/vesla/room215.c
+++ b/domain/original/area/vesla/room215.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Cracked Way";
     long_desc = "The way runs quiet between squat walls, its stones dulled and uneven. Old\n"
-                + "carvings are worn to nubs, nearly erased by weather.\n";
+              + "carvings are worn to nubs, nearly erased by weather.\n";
     dest_dir = ({
         "domain/original/area/vesla/room214", "south",
         "domain/original/area/vesla/room216", "north",

--- a/domain/original/area/vesla/room216.c
+++ b/domain/original/area/vesla/room216.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Way";
-    long_desc = "A shallow channel cuts along the path, filled with grit and broken tile. The air\n"
-                + "is cool and still between the close walls.\n";
+    long_desc = "A shallow channel cuts along the path, filled with grit and broken tile. The\n"
+              + "air is cool and still between the close walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room215", "south",
         "domain/original/area/vesla/room402", "west",

--- a/domain/original/area/vesla/room217.c
+++ b/domain/original/area/vesla/room217.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Cracked Way";
     long_desc = "The paving here is split by roots, forming a jagged seam. A toppled arch stone\n"
-                + "blocks part of the way.\n";
+              + "blocks part of the way.\n";
     dest_dir = ({
         "domain/original/area/vesla/room408", "west",
         "domain/original/area/vesla/room216", "south",

--- a/domain/original/area/vesla/room218.c
+++ b/domain/original/area/vesla/room218.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Cracked Way";
     long_desc = "Loose stones crunch under a thin coat of dust. A rusted bracket clings to the\n"
-                + "wall, its mate long gone.\n";
+              + "wall, its mate long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room217", "south",
         "domain/original/area/vesla/room219", "north",

--- a/domain/original/area/vesla/room219.c
+++ b/domain/original/area/vesla/room219.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Cracked Way";
     long_desc = "The street opens slightly, revealing pale stone flecked with lichen. A shallow\n"
-                + "depression holds rain-dark stains.\n";
+              + "depression holds rain-dark stains.\n";
     dest_dir = ({
         "domain/original/area/vesla/room409", "west",
         "domain/original/area/vesla/room218", "south",

--- a/domain/original/area/vesla/room220.c
+++ b/domain/original/area/vesla/room220.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Northern End";
-    long_desc = "The way ends beneath a sagging lintel, the stones split and bowed. A scatter of\n"
-                + "fallen blocks marks the threshold into the north.\n";
+    long_desc = "The way ends beneath a sagging lintel, the stones split and bowed. A scatter\n"
+              + "of fallen blocks marks the threshold into the north.\n";
     dest_dir = ({
         "domain/original/area/vesla/room219", "south",
         "domain/original/area/vesla/room221", "west",

--- a/domain/original/area/vesla/room221.c
+++ b/domain/original/area/vesla/room221.c
@@ -7,8 +7,8 @@ void reset(int arg) {
 
   set_light(1);
   short_desc = "Hollow Counter";
-  long_desc = "A long counter sags under its own weight, split and furred with dust. Behind it,\n"
-              + "shelves lie in heaps, and the air is stale and still.\n";
+  long_desc = "A long counter sags under its own weight, split and furred with dust. Behind\n"
+              + "it, shelves lie in heaps, and the air is stale and still.\n";
   dest_dir = ({
     "domain/original/area/vesla/room222", "west",
     "domain/original/area/vesla/room220", "east",

--- a/domain/original/area/vesla/room226.c
+++ b/domain/original/area/vesla/room226.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Desolate Park";
     long_desc = "Stone paths fracture beneath a mat of low weeds and windblown soil. A dry\n"
-                + "fountain bowl sits cracked and empty under leaning trees.\n";
+              + "fountain bowl sits cracked and empty under leaning trees.\n";
     dest_dir = ({
         "domain/original/area/vesla/room117", "south",
         "domain/original/area/vesla/room228", "west",

--- a/domain/original/area/vesla/room227.c
+++ b/domain/original/area/vesla/room227.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Overgrown Park";
     long_desc = "Thick grass swallows old benches, leaving warped planks and rusted bolts. A\n"
-                + "sagging iron fence lists inward, half-buried in leaf mold.\n";
+              + "sagging iron fence lists inward, half-buried in leaf mold.\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "north",
         "domain/original/area/vesla/room118", "south",

--- a/domain/original/area/vesla/room228.c
+++ b/domain/original/area/vesla/room228.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Quiet Park";
-    long_desc = "A wide clearing lies mute, its stones scattered and moss-dark. Birdless branches\n"
-                + "arch over the space, their shadows unmoving.\n";
+    long_desc = "A wide clearing lies mute, its stones scattered and moss-dark. Birdless\n"
+              + "branches arch over the space, their shadows unmoving.\n";
 
     dest_dir = ({
         "domain/original/area/vesla/sanctuary", "north",

--- a/domain/original/area/vesla/room230.c
+++ b/domain/original/area/vesla/room230.c
@@ -6,8 +6,8 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Abandoned Park";
-    long_desc = "A once-open lawn is now a tangle of thorn and nettle. Broken edging stones ring\n"
-                + "the growth like a half-lost border.\n";
+    long_desc = "A once-open lawn is now a tangle of thorn and nettle. Broken edging stones\n"
+              + "ring the growth like a half-lost border.\n";
     dest_dir = ({
         "domain/original/area/vesla/room119", "south",
         "domain/original/area/vesla/room815", "west",

--- a/domain/original/area/vesla/room231.c
+++ b/domain/original/area/vesla/room231.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Withered Park";
     long_desc = "Dry shrubs crowd a cracked path, and pale trunks stand stripped of bark. Old\n"
-                + "lantern hooks hang crooked from a low wall, black with rust.\n";
+              + "lantern hooks hang crooked from a low wall, black with rust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room230", "south",
         "domain/original/area/vesla/room796", "west",

--- a/domain/original/area/vesla/room232.c
+++ b/domain/original/area/vesla/room232.c
@@ -7,7 +7,7 @@ void reset(int arg) {
     set_light(1);
     short_desc = "Hollow Park";
     long_desc = "The ground dips where a pond once spread, now a dish of silt and weeds.\n"
-                + "Scattered paving stones and toppled posts mark the forgotten walkway.\n";
+              + "Scattered paving stones and toppled posts mark the forgotten walkway.\n";
     dest_dir = ({
         "domain/original/area/vesla/room226", "south",
         "domain/original/area/vesla/room227", "west",

--- a/domain/original/area/vesla/room233.c
+++ b/domain/original/area/vesla/room233.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Iron Alcove";
-  long_desc = "Rust flakes from a split rack, and the floor is filmed with dust and old grit. A\n"
-              + "warped counter and dull iron hooks suggest where blades once hung, now left to\n"
-              + "mildew and silence.\n";
+  long_desc = "Rust flakes from a split rack, and the floor is filmed with dust and old grit.\n"
+              + "A warped counter and dull iron hooks suggest where blades once hung, now left\n"
+              + "to mildew and silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room220", "west",
     "domain/original/area/vesla/room116", "north",

--- a/domain/original/area/vesla/room394.c
+++ b/domain/original/area/vesla/room394.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Cold Smoke";
   long_desc = "Soot clings to the stone, and rusted hooks hang in a silence of dust and\n"
-        + "mildew. Rotting tubs and ash-stained gutters hint at preserved fare in\n"
-        + "long-neglected ruin.\n";
+              + "mildew. Rotting tubs and ash-stained gutters hint at preserved fare in\n"
+              + "long-neglected ruin.\n";
   dest_dir = ({
     "domain/original/area/vesla/room210", "south",
   });

--- a/domain/original/area/vesla/room395.c
+++ b/domain/original/area/vesla/room395.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Turner's Bench";
   long_desc = "A cracked lathe stands in the corner, silent and ruined beneath dust and\n"
-        + "mildew. Spilled shavings and dulled tools sit in rot, hinting at careful\n"
-        + "turning left to waste.\n";
+              + "mildew. Spilled shavings and dulled tools sit in rot, hinting at careful\n"
+              + "turning left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room209", "south",
   });

--- a/domain/original/area/vesla/room396.c
+++ b/domain/original/area/vesla/room396.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Faded Curios";
-  long_desc = "Narrow shelves sag under warped boxes and tarnished curios, all buried in dust.\n"
-              + "The air is sweet with mildew, and the floorboards have bowed around a collapsed\n"
-              + "display case. A cracked mirror leans in back, its gilt peeling away.\n";
+  long_desc = "Narrow shelves sag under warped boxes and tarnished curios, all buried in\n"
+              + "dust. The air is sweet with mildew, and the floorboards have bowed around a\n"
+              + "collapsed display case. A cracked mirror leans in back, its gilt peeling away.\n";
   dest_dir = ({
     "domain/original/area/vesla/room208", "south",
   });

--- a/domain/original/area/vesla/room398.c
+++ b/domain/original/area/vesla/room398.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Chalked Loft";
   long_desc = "A narrow stair ends in a loft where a worktable sits split and furred with\n"
-              + "mildew. Blackened candle stubs and cracked lenses lie in drifts of dust, hinting\n"
-              + "at old study now drowned in silence and rot.\n";
+              + "mildew. Blackened candle stubs and cracked lenses lie in drifts of dust,\n"
+              + "hinting at old study now drowned in silence and rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room397", "west",
   });

--- a/domain/original/area/vesla/room399.c
+++ b/domain/original/area/vesla/room399.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Low Hearth";
-  long_desc = "The low room smells of damp stone, its beams soft with rot and its floor hidden\n"
-              + "beneath dust. A simple table has collapsed beside a cold hearth, and a notched\n"
-              + "post stands where some small training once took place.\n";
+  long_desc = "The low room smells of damp stone, its beams soft with rot and its floor\n"
+              + "hidden beneath dust. A simple table has collapsed beside a cold hearth, and a\n"
+              + "notched post stands where some small training once took place.\n";
   dest_dir = ({
     "domain/original/area/vesla/room734", "up",
     "domain/original/area/vesla/room213", "west",

--- a/domain/original/area/vesla/room400.c
+++ b/domain/original/area/vesla/room400.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
   short_desc = "Dull Chime";
   long_desc = "Broken molds and a rusted frame lie in silent dust, the shop in ruin. Rot and\n"
-        + "mildew stain the stone, hinting at chimes once shaped here in neglect.\n";
+              + "mildew stain the stone, hinting at chimes once shaped here in neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room214", "east",
   });

--- a/domain/original/area/vesla/room401.c
+++ b/domain/original/area/vesla/room401.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Wax Shelf";
   long_desc = "Hardened wax pools on a sagging table, silent beneath dust and mildew. Empty\n"
-        + "molds and a stale tallow smell linger in rot, hinting at candlework long\n"
-        + "abandoned.\n";
+              + "molds and a stale tallow smell linger in rot, hinting at candlework long\n"
+              + "abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room214", "west",
   });

--- a/domain/original/area/vesla/room402.c
+++ b/domain/original/area/vesla/room402.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Cold Still";
   long_desc = "A copper coil lies split on the floor, silent and wrecked under dust and\n"
-        + "mildew. Dry barrels and a stained hearth sit in rot, hinting at spirits once\n"
-        + "made here and long forgotten.\n";
+              + "mildew. Dry barrels and a stained hearth sit in rot, hinting at spirits once\n"
+              + "made here and long forgotten.\n";
   dest_dir = ({
     "domain/original/area/vesla/room216", "east",
   });

--- a/domain/original/area/vesla/room403.c
+++ b/domain/original/area/vesla/room403.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Broken Threshold";
   long_desc = "A wide threshold of cracked stone leads into a cavernous hall, its pillars\n"
-              + "pocked and green with mildew. Shattered bowls lie at the base of a raised dais,\n"
-              + "and ash-dark banners hang in ragged silence.\n";
+              + "pocked and green with mildew. Shattered bowls lie at the base of a raised\n"
+              + "dais, and ash-dark banners hang in ragged silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room404", "east",
     "domain/original/area/vesla/room216", "west",

--- a/domain/original/area/vesla/room409.c
+++ b/domain/original/area/vesla/room409.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Nailed Notices";
   long_desc = "A warped board is riddled with rusted nails, silent under dust and mildew.\n"
-        + "Faded names and tally marks sit in rot, hinting at claims once posted in a\n"
-        + "long-quiet hall.\n";
+              + "Faded names and tally marks sit in rot, hinting at claims once posted in a\n"
+              + "long-quiet hall.\n";
   dest_dir = ({
     "domain/original/area/vesla/room219", "east",
   });

--- a/domain/original/area/vesla/room421.c
+++ b/domain/original/area/vesla/room421.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Sigil Hall";
-  long_desc = "Dust lies thick over a ring of cracked tiles, and the air tastes of damp stone.\n"
-              + "Chipped shelves and a tarnished inlay hint at study and rite, now abandoned.\n";
+  long_desc = "Dust lies thick over a ring of cracked tiles, and the air tastes of damp\n"
+              + "stone. Chipped shelves and a tarnished inlay hint at study and rite, now\n"
+              + "abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room132", "north",
   });

--- a/domain/original/area/vesla/room422.c
+++ b/domain/original/area/vesla/room422.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Ledger Room";
   long_desc = "Desks sit in crooked ranks, their drawers swollen and stuck with damp. Mold\n"
-              + "frets at the corners of scattered ledgers, and a rusted seal lies half buried in\n"
-              + "dust where clerks once tallied.\n";
+              + "frets at the corners of scattered ledgers, and a rusted seal lies half buried\n"
+              + "in dust where clerks once tallied.\n";
   dest_dir = ({
     "domain/original/area/vesla/room837", "east",
     "domain/original/area/vesla/room155", "west",

--- a/domain/original/area/vesla/room424.c
+++ b/domain/original/area/vesla/room424.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Silent Yard";
   long_desc = "Practice posts lean at odd angles, their tops splintered and gray with rot.\n"
-              + "Racks of rusted gear line the walls, and dust has buried the scuffed floor where\n"
-              + "drills once rang.\n";
+              + "Racks of rusted gear line the walls, and dust has buried the scuffed floor\n"
+              + "where drills once rang.\n";
   dest_dir = ({
     "domain/original/area/vesla/room156", "west",
   });

--- a/domain/original/area/vesla/room736.c
+++ b/domain/original/area/vesla/room736.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
   short_desc = "Market Lot";
   long_desc = "Low foundations ring a vacant patch, silent beneath dust, mildew, and rot. A\n"
-        + "broken sign frame hints at trade, the lot left to crumble.\n";
+              + "broken sign frame hints at trade, the lot left to crumble.\n";
   dest_dir = ({
     "domain/original/area/vesla/room173", "west",
   });

--- a/domain/original/area/vesla/room804.c
+++ b/domain/original/area/vesla/room804.c
@@ -8,8 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Brine Stall";
-  long_desc = "Brine has long dried into a crust, leaving the stall rank and silent. Splintered\n"
-              + "tables and a rusted hook hint at trade in flesh that has since rotted away.\n";
+  long_desc = "Brine has long dried into a crust, leaving the stall rank and silent.\n"
+              + "Splintered tables and a rusted hook hint at trade in flesh that has since\n"
+              + "rotted away.\n";
   dest_dir = ({
     "domain/original/area/vesla/room803", "north",
   });

--- a/domain/original/area/vesla/room807.c
+++ b/domain/original/area/vesla/room807.c
@@ -8,8 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Faded Curtain";
-  long_desc = "Torn curtains hang in tatters, and dust mats the warped floor boards. A low dais\n"
-              + "and broken screens hint at a private vice now drowned in mildew.\n";
+  long_desc = "Torn curtains hang in tatters, and dust mats the warped floor boards. A low\n"
+              + "dais and broken screens hint at a private vice now drowned in mildew.\n";
   dest_dir = ({
     "domain/original/area/vesla/room802", "south",
   });

--- a/domain/original/area/vesla/room816.c
+++ b/domain/original/area/vesla/room816.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Stone Span";
   long_desc = "The bridge stones are slick with moss, the span silent and weatherworn. Rust\n"
-        + "marks the grooves of an old gate, and dust and mildew cling to the guard\n"
-        + "alcove, now sagged and empty.\n";
+              + "marks the grooves of an old gate, and dust and mildew cling to the guard\n"
+              + "alcove, now sagged and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room151", "north",
   });

--- a/domain/original/area/vesla/room817.c
+++ b/domain/original/area/vesla/room817.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Faded Manor";
-  long_desc = "Carved pillars and a broad stair rise into shadow, their edges softened by rot.\n"
-              + "Mildewed drapes hang in tatters, and the air is heavy with dust. A broken crest\n"
-              + "above the hearth hints at a once-proud household.\n";
+  long_desc = "Carved pillars and a broad stair rise into shadow, their edges softened by\n"
+              + "rot. Mildewed drapes hang in tatters, and the air is heavy with dust. A broken\n"
+              + "crest above the hearth hints at a once-proud household.\n";
   dest_dir = ({
     "domain/original/area/vesla/room818", "up",
     "domain/original/area/vesla/room152", "west",

--- a/domain/original/area/vesla/room819.c
+++ b/domain/original/area/vesla/room819.c
@@ -8,8 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Empty Plot";
-  long_desc = "Low foundations break through the weeds, and a warped signpost lies in the dust.\n"
-              + "Rain has pooled in shallow pits, leaving rot and mildew along the stone.\n";
+  long_desc = "Low foundations break through the weeds, and a warped signpost lies in the\n"
+              + "dust. Rain has pooled in shallow pits, leaving rot and mildew along the stone.\n";
   dest_dir = ({
     "domain/original/area/vesla/room152", "east",
   });

--- a/domain/original/area/vesla/room820.c
+++ b/domain/original/area/vesla/room820.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Cold Ward";
-  long_desc = "Stone tables stand in a damp row, their surfaces stained and slick with mildew.\n"
-              + "Shelves of dried herbs have collapsed into dust, and a cracked basin gathers\n"
-              + "stale water beneath a ceiling gone soft with rot.\n";
+  long_desc = "Stone tables stand in a damp row, their surfaces stained and slick with\n"
+              + "mildew. Shelves of dried herbs have collapsed into dust, and a cracked basin\n"
+              + "gathers stale water beneath a ceiling gone soft with rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room839", "west",
     "domain/original/area/vesla/room153", "east",

--- a/domain/original/area/vesla/room821.c
+++ b/domain/original/area/vesla/room821.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Counting Hall";
   long_desc = "A long table runs beneath a broken lintel, its surface coated in dust and rot.\n"
-              + "Empty cubbies and warped ledgers hint at old records, now blurred by mildew and\n"
-              + "silence.\n";
+              + "Empty cubbies and warped ledgers hint at old records, now blurred by mildew\n"
+              + "and silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room154", "west",
   });

--- a/domain/original/area/vesla/room822.c
+++ b/domain/original/area/vesla/room822.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Civic Hall";
   long_desc = "Broad steps lead to a hall of cracked stone, where dust lies in deep drifts. A\n"
-              + "splintered dais and toppled benches suggest old gatherings, now muted by rot and\n"
-              + "mildew.\n";
+              + "splintered dais and toppled benches suggest old gatherings, now muted by rot\n"
+              + "and mildew.\n";
   dest_dir = ({
     "domain/original/area/vesla/room156", "east",
     "domain/original/area/vesla/room831", "up",

--- a/domain/original/area/vesla/room825.c
+++ b/domain/original/area/vesla/room825.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Quiet Landing";
-  long_desc = "The upper landing is choked with dust, its rail warped and soft with rot. Closed\n"
-              + "doors lean inward, and a cracked mirror keeps a dim memory of bright rooms now\n"
-              + "gone to mildew.\n";
+  long_desc = "The upper landing is choked with dust, its rail warped and soft with rot.\n"
+              + "Closed doors lean inward, and a cracked mirror keeps a dim memory of bright\n"
+              + "rooms now gone to mildew.\n";
   dest_dir = ({
     "domain/original/area/vesla/room828", "south",
     "domain/original/area/vesla/room826", "west",

--- a/domain/original/area/vesla/room826.c
+++ b/domain/original/area/vesla/room826.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Veiled Room";
   long_desc = "A narrow chamber holds a sagging bedframe and a tangle of torn veil cloth.\n"
-              + "Mildew creeps along the walls, and the floorboards sag under layers of dust and\n"
-              + "silence.\n";
+              + "Mildew creeps along the walls, and the floorboards sag under layers of dust\n"
+              + "and silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room825", "east",
   });

--- a/domain/original/area/vesla/room829.c
+++ b/domain/original/area/vesla/room829.c
@@ -9,8 +9,8 @@ void reset(int arg) {
 
   short_desc = "Quiet Parlor";
   long_desc = "This back room is heavy with stale air, its cushions reduced to moldy husks. A\n"
-              + "low screen has fallen across the floor, and the only scent left is damp wood and\n"
-              + "dust.\n";
+              + "low screen has fallen across the floor, and the only scent left is damp wood\n"
+              + "and dust.\n";
   dest_dir = ({
     "domain/original/area/vesla/room825", "down",
   });

--- a/domain/original/area/vesla/room831.c
+++ b/domain/original/area/vesla/room831.c
@@ -8,8 +8,8 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Lower Office";
-  long_desc = "Long desks sit in a row, their legs sunk into a drift of dust. A rusted bell and\n"
-              + "cracked inkwells remain, and mildew has spread along the baseboards.\n";
+  long_desc = "Long desks sit in a row, their legs sunk into a drift of dust. A rusted bell\n"
+              + "and cracked inkwells remain, and mildew has spread along the baseboards.\n";
   dest_dir = ({
     "domain/original/area/vesla/room833", "up",
     "domain/original/area/vesla/room822", "down",

--- a/domain/original/area/vesla/room832.c
+++ b/domain/original/area/vesla/room832.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Trade Hall";
-  long_desc = "The chamber is wide and bare, its tiled floor split by damp and weeds. A set of\n"
-              + "warped benches faces a crumbling stand, with rotted placards scattered in the\n"
-              + "dust.\n";
+  long_desc = "The chamber is wide and bare, its tiled floor split by damp and weeds. A set\n"
+              + "of warped benches faces a crumbling stand, with rotted placards scattered in\n"
+              + "the dust.\n";
   dest_dir = ({
     "domain/original/area/vesla/room831", "east",
   });

--- a/domain/original/area/vesla/room839.c
+++ b/domain/original/area/vesla/room839.c
@@ -8,9 +8,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Fallen Choir";
-  long_desc = "A narrow nave ends at a cracked lectern, its wood softened by rot. Faded murals\n"
-              + "curl from the damp walls, and a line of benches sits in dust and mildew, facing\n"
-              + "a silence that never lifts.\n";
+  long_desc = "A narrow nave ends at a cracked lectern, its wood softened by rot. Faded\n"
+              + "murals curl from the damp walls, and a line of benches sits in dust and\n"
+              + "mildew, facing a silence that never lifts.\n";
   dest_dir = ({
     "domain/original/area/vesla/room820", "east",
   });

--- a/domain/original/area/vesla/room840.c
+++ b/domain/original/area/vesla/room840.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Ashen Way";
   long_desc = "Charred stone and blackened beams mark this stretch, now silent and ruined.\n"
-        + "Ash lies under drifted dust, and mildewed rubble clogs the broken curb where\n"
-        + "small fronts once opened in ash and rot.\n";
+              + "Ash lies under drifted dust, and mildewed rubble clogs the broken curb where\n"
+              + "small fronts once opened in ash and rot.\n";
   dest_dir = ({
     "domain/original/area/vesla/room841", "west",
     "domain/original/area/vesla/room148", "south",

--- a/domain/original/area/vesla/room841.c
+++ b/domain/original/area/vesla/room841.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Sooted Row";
   long_desc = "Soot stains the surviving walls, and the lane sits in a hush of rot and dust.\n"
-        + "Warped shutters and mildewed frames lean inward, the fire-scarred row left in\n"
-        + "collapse and silence.\n";
+              + "Warped shutters and mildewed frames lean inward, the fire-scarred row left in\n"
+              + "collapse and silence.\n";
   dest_dir = ({
     "domain/original/area/vesla/room147", "south",
     "domain/original/area/vesla/room842", "west",

--- a/domain/original/area/vesla/room842.c
+++ b/domain/original/area/vesla/room842.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Charred Lane";
   long_desc = "Fire-split timbers jut from the stonework, soft with mildew and long silent in\n"
-        + "ruin. Dust coats the old thresholds, and rot gnaws at doorframes that hint at\n"
-        + "narrow rooms now fallen and empty.\n";
+              + "ruin. Dust coats the old thresholds, and rot gnaws at doorframes that hint at\n"
+              + "narrow rooms now fallen and empty.\n";
   dest_dir = ({
     "domain/original/area/vesla/room146", "south",
     "domain/original/area/vesla/room841", "east",

--- a/domain/original/area/vesla/room843.c
+++ b/domain/original/area/vesla/room843.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Blackened Court";
   long_desc = "The court is a hollow of scorched brick and collapsed awnings, silent and\n"
-        + "ruined. Mildew blooms on low walls, and rot mixes with dust around broken\n"
-        + "stalls left to crumble.\n";
+              + "ruined. Mildew blooms on low walls, and rot mixes with dust around broken\n"
+              + "stalls left to crumble.\n";
   dest_dir = ({
     "domain/original/area/vesla/room844", "west",
     "domain/original/area/vesla/room841", "south",

--- a/domain/original/area/vesla/room844.c
+++ b/domain/original/area/vesla/room844.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Cinder Walk";
   long_desc = "Cinder and gravel crunch over warped flagstones, the walk silent and\n"
-        + "weathered. Rusting hinges and charred lintels sag in rot and mildew, a dusty\n"
-        + "hint of shop doors left to decay.\n";
+              + "weathered. Rusting hinges and charred lintels sag in rot and mildew, a dusty\n"
+              + "hint of shop doors left to decay.\n";
   dest_dir = ({
     "domain/original/area/vesla/room842", "south",
     "domain/original/area/vesla/room843", "east",

--- a/domain/original/area/vesla/room845.c
+++ b/domain/original/area/vesla/room845.c
@@ -7,9 +7,9 @@ void reset(int arg) {
   set_light(1);
 
   short_desc = "Scorched Pass";
-  long_desc = "Scorched boards lie half-buried in damp dust, the passage silent and ruined.\n"
-        + "A low sill and slumped counter are soft with rot and mildew, hinting at a\n"
-        + "trade stall left to waste.\n";
+  long_desc = "Scorched boards lie half-buried in damp dust, the passage silent and ruined. A\n"
+              + "low sill and slumped counter are soft with rot and mildew, hinting at a trade\n"
+              + "stall left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room846", "east",
     "domain/original/area/vesla/room146", "north",

--- a/domain/original/area/vesla/room846.c
+++ b/domain/original/area/vesla/room846.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Cinder Row";
   long_desc = "Charcoal streaks still mark the stones, now silent and weatherworn beneath\n"
-        + "lichen and mildew. Collapsed rafters and dusted crockery sit in rot, hinting\n"
-        + "at a small shop long abandoned.\n";
+              + "lichen and mildew. Collapsed rafters and dusted crockery sit in rot, hinting\n"
+              + "at a small shop long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room845", "west",
     "domain/original/area/vesla/room147", "north",

--- a/domain/original/area/vesla/room847.c
+++ b/domain/original/area/vesla/room847.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
     short_desc = "Record Hall";
     long_desc = "A long chamber sits in silence, its ceiling sagged and its floor layered in\n"
-        + "dust and mildew. Split desks and fallen stools crowd the room, and a rusted\n"
-        + "rail still divides a row of mildewed pigeonholes.\n";
+              + "dust and mildew. Split desks and fallen stools crowd the room, and a rusted\n"
+              + "rail still divides a row of mildewed pigeonholes.\n";
     dest_dir = ({
         "domain/original/area/vesla/room849", "west",
         "domain/original/area/vesla/room848", "east",

--- a/domain/original/area/vesla/room848.c
+++ b/domain/original/area/vesla/room848.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
     short_desc = "Worn Annex";
     long_desc = "A narrow side room lies under a crust of dust, its shelves bowed and the air\n"
-        + "stale with mildew. A dry ink smell clings to cracked boxes and a toppled\n"
-        + "writing stand, the place long empty.\n";
+              + "stale with mildew. A dry ink smell clings to cracked boxes and a toppled\n"
+              + "writing stand, the place long empty.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "west",
     });

--- a/domain/original/area/vesla/room849.c
+++ b/domain/original/area/vesla/room849.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
     short_desc = "Dusty Alcove";
     long_desc = "The chamber is tight and dim, its stone sweating with damp and the floor\n"
-        + "cluttered with scraps of paper turned to pulp. A broken cabinet and a rusted\n"
-        + "lockbox lean together in the quiet of long neglect.\n";
+              + "cluttered with scraps of paper turned to pulp. A broken cabinet and a rusted\n"
+              + "lockbox lean together in the quiet of long neglect.\n";
     dest_dir = ({
         "domain/original/area/vesla/room847", "east",
     });

--- a/domain/original/area/vesla/room850.c
+++ b/domain/original/area/vesla/room850.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Silent Hearth";
   long_desc = "A wide, cold hearth sits beneath a soot-dark mantle, the room silent and\n"
-        + "ruined. Rotted tables lean in dust and mildew, and the common space is left to\n"
-        + "sag.\n";
+              + "ruined. Rotted tables lean in dust and mildew, and the common space is left to\n"
+              + "sag.\n";
   dest_dir = ({
     "domain/original/area/vesla/room142", "west",
     "domain/original/area/vesla/room852", "east",

--- a/domain/original/area/vesla/room851.c
+++ b/domain/original/area/vesla/room851.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
   short_desc = "Quiet Bunks";
   long_desc = "Rough bunks sag against the walls, silent in dust, rot, and mildew. Hooks and\n"
-        + "pegs hang over a sagging floor, hinting at lodging long abandoned.\n";
+              + "pegs hang over a sagging floor, hinting at lodging long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room850", "south",
   });

--- a/domain/original/area/vesla/room852.c
+++ b/domain/original/area/vesla/room852.c
@@ -8,8 +8,7 @@ void reset(int arg) {
 
   short_desc = "Dry Tap";
   long_desc = "A cracked counter and dry cask stand in silence, the space dim and neglected.\n"
-        + "Dust, mildew, and rot cling to the shelves, hinting at a taproom left to\n"
-        + "fade.\n";
+              + "Dust, mildew, and rot cling to the shelves, hinting at a taproom left to fade.\n";
   dest_dir = ({
     "domain/original/area/vesla/room850", "west",
   });

--- a/domain/original/area/vesla/room853.c
+++ b/domain/original/area/vesla/room853.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Quiet Rooms";
   long_desc = "Two small rooms sit open to the street, silent, dusty, and ruined. A cold\n"
-        + "hearth and broken bedframe are soft with mildew and rot, hinting at cramped\n"
-        + "living left behind.\n";
+              + "hearth and broken bedframe are soft with mildew and rot, hinting at cramped\n"
+              + "living left behind.\n";
   dest_dir = ({
     "domain/original/area/vesla/room139", "east",
   });

--- a/domain/original/area/vesla/room854.c
+++ b/domain/original/area/vesla/room854.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Scented Stall";
   long_desc = "Rusted tins and cracked jars sit on sagging shelves, silent beneath dust and\n"
-        + "mildew. A faint, stale sweetness clings to the rot, hinting at spice trade in\n"
-        + "quiet neglect.\n";
+              + "mildew. A faint, stale sweetness clings to the rot, hinting at spice trade in\n"
+              + "quiet neglect.\n";
   dest_dir = ({
     "domain/original/area/vesla/room139", "west",
   });

--- a/domain/original/area/vesla/room855.c
+++ b/domain/original/area/vesla/room855.c
@@ -8,8 +8,7 @@ void reset(int arg) {
 
   short_desc = "Rear Rooms";
   long_desc = "A narrow back room lies in silence, its shelves sagging with dust and mildew.\n"
-        + "Rot has taken the warped counter, hinting at storage and trade long\n"
-        + "abandoned.\n";
+              + "Rot has taken the warped counter, hinting at storage and trade long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room138", "west",
   });

--- a/domain/original/area/vesla/room856.c
+++ b/domain/original/area/vesla/room856.c
@@ -8,8 +8,8 @@ void reset(int arg) {
 
   short_desc = "Shaving Shed";
   long_desc = "The floor is buried in old shavings turned to pulp, silent and ruined. Dulled\n"
-        + "chisels and a chipped mallet lie in dust, mildew, and rot, hinting at carved\n"
-        + "work left to waste.\n";
+              + "chisels and a chipped mallet lie in dust, mildew, and rot, hinting at carved\n"
+              + "work left to waste.\n";
   dest_dir = ({
     "domain/original/area/vesla/room138", "east",
   });

--- a/domain/original/area/vesla/room857.c
+++ b/domain/original/area/vesla/room857.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
   short_desc = "Hollow Hall";
   long_desc = "A wide hall yawns under sagging beams, silent and ruined. Dust, mildew, and\n"
-        + "rot swallow splintered crates, hinting at bulk storage long abandoned.\n";
+              + "rot swallow splintered crates, hinting at bulk storage long abandoned.\n";
   dest_dir = ({
     "domain/original/area/vesla/room198", "west",
   });

--- a/domain/original/area/vesla/room962.c
+++ b/domain/original/area/vesla/room962.c
@@ -8,7 +8,7 @@ void reset(int arg) {
 
   short_desc = "Shuttered Front";
   long_desc = "A warped counter blocks the entry, silent under dust and mildew. Bare shelves\n"
-        + "and a torn awning sit in rot, hinting at trade long faded.\n";
+              + "and a torn awning sit in rot, hinting at trade long faded.\n";
   dest_dir = ({
     "domain/original/area/vesla/room199", "west",
   });

--- a/domain/original/area/vesla/sanctuary.c
+++ b/domain/original/area/vesla/sanctuary.c
@@ -16,8 +16,7 @@ void reset(int arg) {
 
     reboot_time = time();
     short_desc = "Sanctuary";
-    long_desc = "A refuge from what lies beyond.\n" +
-                "You feel a STRONG urge to... you can't recall?\n";
+    long_desc = "A refuge from what lies beyond. You feel a STRONG urge to... you can't recall?\n";
     dest_dir = ({
         "domain/original/area/vesla/room228", "south",
         "domain/original/area/vesla/room893", "up",


### PR DESCRIPTION
### Motivation
- Enforce the `CODE-STYLE.md` line-length rule for player-facing text so `long_desc` lines use grammatical breaks near 80 columns.
- Improve consistency and readability of room descriptions in the Vesla area without changing their intended atmosphere or content.

### Description
- Reflowed `long_desc` string literals across the Vesla area files under `domain/original/area/vesla/` so each line is wrapped near 78–80 columns.
- Normalized multi-line `long_desc` concatenation and indentation, including explicit formatting fixes in `portal.c` and `sanctuary.c`.
- No semantic changes to prose or room behavior were made; this is strictly a formatting/whitespace pass on room descriptions.
- The changes touch the Vesla room files (many `room*.c` files) to keep presentation consistent.

### Testing
- Ran a verification script that checked `long_desc` lines and reported a maximum line length of 78 characters, with no lines exceeding 80, and the check passed.
- Treated the change as text-only so no runtime unit tests were executed against game logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968d6f6706c8327bb8fccb7661d60a7)