### PR TITLE
Vesla: convert PHASE0 room texts to Phase 1 aged, abandoned prose

### DIFF
--- a/domain/original/area/vesla/room181.c
+++ b/domain/original/area/vesla/room181.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Eastern End of Wall Street";
-    long_desc = "PHASE0: a cobble-stone street below and interior to the exterior city wall";
+    short_desc = "Wallside Way";
+    long_desc = "The lane hugs the inner wall, its cobbles cracked and uneven beneath\n"
+                + "drifts of grit. Moss climbs the cold stone blocks, and a broken\n"
+                + "drainage channel runs dark and still.\n";
     dest_dir = ({
         "domain/original/area/vesla/room180", "east",
         "domain/original/area/vesla/room182", "west",

--- a/domain/original/area/vesla/room182.c
+++ b/domain/original/area/vesla/room182.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "PHASE0: a cobble-stone street below and interior to the exterior city wall";
+    short_desc = "Inner Walk";
+    long_desc = "A narrow run of cobbles skirts the wall, sunk and slick with damp.\n"
+                + "The high masonry is stained with mildew, and fallen stones crowd the\n"
+                + "edge of the path.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "east",
         "domain/original/area/vesla/room183", "west",

--- a/domain/original/area/vesla/room183.c
+++ b/domain/original/area/vesla/room183.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "PHASE0: a cobble-stone street below and interior to the exterior city wall";
+    short_desc = "Cobbled Run";
+    long_desc = "Cobbles press against the wall here, split by frost and buckling in\n"
+                + "the soil. Weeds and dark lichen gather where the stonework weeps,\n"
+                + "muting any echo.\n";
     dest_dir = ({
         "domain/original/area/vesla/room182", "east",
         "domain/original/area/vesla/room184", "west",

--- a/domain/original/area/vesla/room184.c
+++ b/domain/original/area/vesla/room184.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "PHASE0: a cobble-stone street below and interior to the exterior city wall";
+    short_desc = "Stone Passage";
+    long_desc = "The wall looms close over a cramped passage of worn stone, the gaps\n"
+                + "filled with dust. Rusty brackets jut from the masonry, and the air\n"
+                + "carries the chill of old damp.\n";
     dest_dir = ({
         "domain/original/area/vesla/room183", "east",
     });

--- a/domain/original/area/vesla/room425.c
+++ b/domain/original/area/vesla/room425.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Omar's Oils II";
-    long_desc = "PHASE0: This was an NPC-owned torch and lamp merchant";
+    short_desc = "Sooted Shop";
+    long_desc = "Soot smears the walls above a narrow counter, and empty hooks line the\n"
+                + "back. A crust of old oil darkens the floorboards, now gritty with dust\n"
+                + "and ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room121", "south",
     });

--- a/domain/original/area/vesla/room737.c
+++ b/domain/original/area/vesla/room737.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Chamber of Commerce";
-    long_desc = "PHASE0: this was a municipal building of some sort";
+    short_desc = "Quiet Office";
+    long_desc = "A low hall of stone desks and alcoves sits gutted and still. Mildew\n"
+                + "darkens the plaster, and empty niches line the walls where records once\n"
+                + "rested.\n";
     dest_dir = ({
         "domain/original/area/vesla/room187", "south",
     });

--- a/domain/original/area/vesla/room738.c
+++ b/domain/original/area/vesla/room738.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Alley";
-    long_desc = "PHASE0: a dead-end alley";
+    short_desc = "Blind Alley";
+    long_desc = "The alley narrows to a blind wall, its cobbles slick with grime and\n"
+                + "decay. Rotten beams lean overhead, and a stale dampness pools where the\n"
+                + "light dies.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "south",
     });

--- a/domain/original/area/vesla/room739.c
+++ b/domain/original/area/vesla/room739.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The School of Guild Skills";
-    long_desc = "PHASE0: this room allowed players to train and level up their skills related to player-owned businesses (taverns, distillers, armorers, weapons makers, banks, stables, smelters, corpse embalmers)";
+    short_desc = "Practice Hall";
+    long_desc = "Scuffed boards and long tables fill a wide room, now gray with dust.\n"
+                + "Faded tally marks and peg holes linger on the walls, hinting at lessons\n"
+                + "once kept here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "north",
     });

--- a/domain/original/area/vesla/room740.c
+++ b/domain/original/area/vesla/room740.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Stationery Store";
-    long_desc = "PHASE0: NPC owned business";
+    short_desc = "Dusty Stall";
+    long_desc = "A small room with a low counter sits abandoned, its shelves stripped\n"
+                + "clean. The air is stale with rot, and broken pegs show where trade once\n"
+                + "hung.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "north",
     });

--- a/domain/original/area/vesla/room741.c
+++ b/domain/original/area/vesla/room741.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Hallway";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Silent Bunks";
+    long_desc = "Rows of low frames line the walls, their slats warped and gray with\n"
+                + "dust. Mildew softens the plaster, and the floor is worn smooth by\n"
+                + "vanished footsteps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "up",
         "domain/original/area/vesla/room190", "south",

--- a/domain/original/area/vesla/room742.c
+++ b/domain/original/area/vesla/room742.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Magoo's Bookstore";
-    long_desc = "PHASE0: NPC-owned business";
+    short_desc = "Shuttered Front";
+    long_desc = "A narrow storefront opens to a room of bare shelves and a sagging\n"
+                + "counter. Dust heaps in the corners, and a faded sign fragment clings to\n"
+                + "the lintel.\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "north",
     });

--- a/domain/original/area/vesla/room743.c
+++ b/domain/original/area/vesla/room743.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Frenchie's Cafe";
-    long_desc = "PHASE0: NPC-owned business";
+    short_desc = "Hollow Counter";
+    long_desc = "A cracked counter stretches across the room, with empty racks behind it.\n"
+                + "Rot has crept into the floorboards, and mildew stains blur whatever\n"
+                + "goods once stood here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room191", "south",
     });

--- a/domain/original/area/vesla/room744.c
+++ b/domain/original/area/vesla/room744.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "An empty lot.";
-    long_desc = "PHASE0: empty lot";
+    short_desc = "Bare Plot";
+    long_desc = "A broad patch of bare earth interrupts the street, rimmed by broken\n"
+                + "foundations. Splintered posts and sunken stones hint at a lost structure\n"
+                + "beneath the weeds.\n";
     dest_dir = ({
         "domain/original/area/vesla/room192", "north",
     });

--- a/domain/original/area/vesla/room745.c
+++ b/domain/original/area/vesla/room745.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Kitchen";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Dusty Cots";
+    long_desc = "A tight room of empty pallets sits in silence, the straw long gone. Rot\n"
+                + "has crept up the posts, and the air is stale with old sweat and mildew.\n";
     dest_dir = ({
         "domain/original/area/vesla/room746", "east",
         "domain/original/area/vesla/room741", "south",

--- a/domain/original/area/vesla/room746.c
+++ b/domain/original/area/vesla/room746.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Store Room";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Quiet Racks";
+    long_desc = "Narrow sleeping frames stand in two lines, stripped to bare wood and\n"
+                + "cobweb. A boarded alcove gapes at the far end, and the boards sag with\n"
+                + "damp.\n";
     dest_dir = ({
         "domain/original/area/vesla/room745", "west",
     });

--- a/domain/original/area/vesla/room747.c
+++ b/domain/original/area/vesla/room747.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Administrator's Room";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Empty Hall";
+    long_desc = "A long chamber holds only the outline of former sleeping spaces, now\n"
+                + "dusted gray. Moisture streaks the walls, and the floorboards creak under\n"
+                + "a film of grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room741", "west",
     });

--- a/domain/original/area/vesla/room748.c
+++ b/domain/original/area/vesla/room748.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormitory Hallway";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Bare Bunks";
+    long_desc = "The room is divided by low rails where thin beds once rested in rows.\n"
+                + "Mildew and rot soften the timbers, and the air lies flat and stale.\n";
     dest_dir = ({
         "domain/original/area/vesla/room751", "west",
         "domain/original/area/vesla/room741", "down",

--- a/domain/original/area/vesla/room749.c
+++ b/domain/original/area/vesla/room749.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Rotted Racks";
+    long_desc = "Warped wooden frames cling to the walls, their joints loose and\n"
+                + "splintered. Cobwebs gather in the corners, and a sour dampness hangs over\n"
+                + "the floor.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "south",
     });

--- a/domain/original/area/vesla/room750.c
+++ b/domain/original/area/vesla/room750.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Faded Quarters";
+    long_desc = "A cramped chamber shows the shadow of old sleeping rows in the dust.\n"
+                + "Plaster has fallen in sheets, and the boards are dark with mildew.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "west",
     });

--- a/domain/original/area/vesla/room751.c
+++ b/domain/original/area/vesla/room751.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Hushed Cots";
+    long_desc = "Low bed frames run along the sides, stripped to bare ribs and powdery\n"
+                + "with dust. The ceiling sags, and the stale air holds the hint of old\n"
+                + "bedding.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "east",
     });

--- a/domain/original/area/vesla/room752.c
+++ b/domain/original/area/vesla/room752.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Dormer";
-    long_desc = "PHASE0: dormitory where NPC students and athletes lived";
+    short_desc = "Dormant Rows";
+    long_desc = "Long lines of empty sleeping frames sit rigid in the gloom, their wood\n"
+                + "soft with rot. The floor is pitted and damp, and silence presses against\n"
+                + "the walls.\n";
     dest_dir = ({
         "domain/original/area/vesla/room748", "north",
     });

--- a/domain/original/area/vesla/room753.c
+++ b/domain/original/area/vesla/room753.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The drawbridge";
-    long_desc = "PHASE0: a drawbridge, left open";
+    short_desc = "Hinged Span";
+    long_desc = "A hinged span lies open over the gap, its timbers split and softened by\n"
+                + "rot. Rusty chains sag from the ruined fittings, and the stone landing is\n"
+                + "scoured bare.\n";
     dest_dir = ({
         "domain/original/area/vesla/room169", "southwest",
         "domain/original/area/vesla/room754", "north",

--- a/domain/original/area/vesla/room769.c
+++ b/domain/original/area/vesla/room769.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The well";
-    long_desc = "PHASE0: a well";
+    short_desc = "Stone Shaft";
+    long_desc = "A circular stone shaft yawns in the floor, its lip chipped and stained\n"
+                + "with lime. The old windlass is gone, leaving only rusted bolts and a\n"
+                + "stale breath of damp below.\n";
     dest_dir = ({
         "domain/original/area/vesla/room765", "southwest",
         "domain/original/area/vesla/room771", "east",

--- a/domain/original/area/vesla/room770.c
+++ b/domain/original/area/vesla/room770.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Broken Stalls";
+    long_desc = "Splintered stall walls lean inward, their rails slick with mildew. A\n"
+                + "cracked feeding trough sits dry, and dust lies thick where hooves once\n"
+                + "churned.\n";
     dest_dir = ({
         "domain/original/area/vesla/room790", "south",
         "domain/original/area/vesla/room765", "west",

--- a/domain/original/area/vesla/room771.c
+++ b/domain/original/area/vesla/room771.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The blacksmith";
-    long_desc = "PHASE0: a powerful NPC with valuable items, the Blacksmith, worked here";
+    short_desc = "Cold Hearth";
+    long_desc = "A broad stone hearth squats in the center, dark with soot and long\n"
+                + "without heat. An anvil stump and iron tools sit rusted among cinders and\n"
+                + "damp ash.\n";
     dest_dir = ({
         "domain/original/area/vesla/room772", "east",
         "domain/original/area/vesla/room769", "west",

--- a/domain/original/area/vesla/room772.c
+++ b/domain/original/area/vesla/room772.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "The storage room";
-    long_desc = "PHASE0: a storage room for the blacksmith to the west";
+    short_desc = "Ash Store";
+    long_desc = "Low shelves and bins crowd the room, warped and split from damp. Cinder\n"
+                + "stains and rusted nail heads hint at the forge work once stacked here.\n";
     dest_dir = ({
         "domain/original/area/vesla/room771", "west",
     });

--- a/domain/original/area/vesla/room773.c
+++ b/domain/original/area/vesla/room773.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Iron Rings";
+    long_desc = "Rusty ring bolts stud the posts, and the plank walls bow with age. Old\n"
+                + "straw dust clings to the floor, mixed with a sour, damp rot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room789", "south",
         "domain/original/area/vesla/room770", "west",

--- a/domain/original/area/vesla/room774.c
+++ b/domain/original/area/vesla/room774.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Tack Hooks";
+    long_desc = "Crooked hooks line the wall, empty but scarred by long use. The boards\n"
+                + "are warped and blackened with damp, and the air is still and rank.\n";
     dest_dir = ({
         "domain/original/area/vesla/room787", "south",
         "domain/original/area/vesla/room773", "west",

--- a/domain/original/area/vesla/room775.c
+++ b/domain/original/area/vesla/room775.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Silted Run";
+    long_desc = "A narrow run between stalls is choked with silt and crumbled wood. The\n"
+                + "rails are split, and the stone base is slick with moss.\n";
     dest_dir = ({
         "domain/original/area/vesla/room784", "south",
         "domain/original/area/vesla/room774", "west",

--- a/domain/original/area/vesla/room776.c
+++ b/domain/original/area/vesla/room776.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Castle stables";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Cracked Trough";
+    long_desc = "A stone trough is split down the middle, its basin crusted with lime.\n"
+                + "Rot has eaten the surrounding planks, leaving gaps filled with dust and\n"
+                + "mold.\n";
     dest_dir = ({
         "domain/original/area/vesla/room782", "south",
         "domain/original/area/vesla/room775", "west",

--- a/domain/original/area/vesla/room777.c
+++ b/domain/original/area/vesla/room777.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Low Pens";
+    long_desc = "Low pen walls barely stand, their joints loose and sagging. Mildew\n"
+                + "freckles the timbers, and a damp chill clings to the floor.\n";
     dest_dir = ({
         "domain/original/area/vesla/room779", "southeast",
         "domain/original/area/vesla/room783", "south",

--- a/domain/original/area/vesla/room778.c
+++ b/domain/original/area/vesla/room778.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Hay Loft";
+    long_desc = "A collapsed loft hangs above, its beams broken and draped in cobwebs.\n"
+                + "Dry chaff dust coats the ground, now darkened by years of damp.\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "southwest",
         "domain/original/area/vesla/room777", "west",

--- a/domain/original/area/vesla/room779.c
+++ b/domain/original/area/vesla/room779.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Empty Stalls";
+    long_desc = "Stall partitions linger as gray ribs, and rusted hinges hang from them.\n"
+                + "The floor is packed hard and bare, with only the stink of wet rot left.\n";
     dest_dir = ({
         "domain/original/area/vesla/room783", "west",
         "domain/original/area/vesla/room777", "northwest",

--- a/domain/original/area/vesla/room781.c
+++ b/domain/original/area/vesla/room781.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Guttered Bays";
+    long_desc = "A row of bays opens along the wall, their gates missing and frames\n"
+                + "twisted. Water stains creep up the stone base, and the air is heavy with\n"
+                + "mildew.\n";
     dest_dir = ({
         "domain/original/area/vesla/room776", "south",
     });

--- a/domain/original/area/vesla/room782.c
+++ b/domain/original/area/vesla/room782.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Moldy Loft";
+    long_desc = "A low loft space is sunk and split, its ladder gone. Mold spreads across\n"
+                + "the rafters, and a dull dampness fills the room.\n";
     dest_dir = ({
         "domain/original/area/vesla/room776", "north",
     });

--- a/domain/original/area/vesla/room783.c
+++ b/domain/original/area/vesla/room783.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Small paddock";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Saddle Racks";
+    long_desc = "Bare racks line one side, warped and splintered by time. Rust flakes\n"
+                + "from old fittings, and dust gathers in soft drifts.\n";
     dest_dir = ({
         "domain/original/area/vesla/room778", "northeast",
         "domain/original/area/vesla/room779", "east",

--- a/domain/original/area/vesla/room784.c
+++ b/domain/original/area/vesla/room784.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Split Rails";
+    long_desc = "Split rails mark the stall lines, some fallen flat into the dirt. The\n"
+                + "ground is rutted and cold, with a sour odor of rot.\n";
     dest_dir = ({
         "domain/original/area/vesla/room775", "north",
     });

--- a/domain/original/area/vesla/room785.c
+++ b/domain/original/area/vesla/room785.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Dusty Pens";
+    long_desc = "Pen walls stand in crooked rows, their boards gray and powdery. Cobwebs\n"
+                + "hang from the corners, and the floor is gritty with old straw dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room775", "south",
     });

--- a/domain/original/area/vesla/room786.c
+++ b/domain/original/area/vesla/room786.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Tack room";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Rotted Bays";
+    long_desc = "Wide bays open into shadow, their frames softened by decay. Dampness\n"
+                + "beads on the stone, and the silence is thick and close.\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "south",
     });

--- a/domain/original/area/vesla/room787.c
+++ b/domain/original/area/vesla/room787.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Feed room";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Saddling Corner";
+    long_desc = "A narrow corner holds a low block and scarred posts, now slick with\n"
+                + "mold. The surrounding boards are split, and the air is stale with wet\n"
+                + "wood.\n";
     dest_dir = ({
         "domain/original/area/vesla/room774", "north",
     });

--- a/domain/original/area/vesla/room788.c
+++ b/domain/original/area/vesla/room788.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Iron Post";
+    long_desc = "An iron post rises from the floor, its ring eaten with rust. Chaff and\n"
+                + "dust cake the ground, and the walls weep with damp.\n";
     dest_dir = ({
         "domain/original/area/vesla/room773", "south",
     });

--- a/domain/original/area/vesla/room789.c
+++ b/domain/original/area/vesla/room789.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Tether Line";
+    long_desc = "A line of rotted posts stands uneven, each marked by rust streaks. The\n"
+                + "floor is hard and bare, broken only by a drift of grit.\n";
     dest_dir = ({
         "domain/original/area/vesla/room773", "north",
     });

--- a/domain/original/area/vesla/room790.c
+++ b/domain/original/area/vesla/room790.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Sunk Stalls";
+    long_desc = "Stall floors have sunk into the earth, leaving the boards slanted and\n"
+                + "warped. Mildew climbs the posts, and a musty silence settles in the\n"
+                + "gaps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room770", "north",
     });

--- a/domain/original/area/vesla/room791.c
+++ b/domain/original/area/vesla/room791.c
@@ -6,8 +6,9 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "You swing open the wooden door and enter the stall.";
-    long_desc = "PHASE0: stables (hay, wood, horse-tending tools, etc.)";
+    short_desc = "Littered Pen";
+    long_desc = "A pen lies open and collapsed, its boards scattered and softened by\n"
+                + "rot. The stone base is stained dark, and the air hangs damp and still.\n";
     dest_dir = ({
         "domain/original/area/vesla/room770", "south",
     });

--- a/domain/original/area/vesla/room793.c
+++ b/domain/original/area/vesla/room793.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Effortlessly, you scale the brick wall and drop into a garden on the opposite";
-    long_desc = "PHASE0: a garden of a home to the west, which no longer exists";
+    short_desc = "Overgrown Beds";
+    long_desc = "Overgrown beds sag beneath nettles and mildew-dark leaves, their borders\n"
+                + "crumbled. A fallen trellis and a cracked basin suggest careful tending\n"
+                + "long since undone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room168", "east",
     });

--- a/domain/original/area/vesla/room814.c
+++ b/domain/original/area/vesla/room814.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Flea Market";
-    long_desc = "PHASE0: this was a player-owned weapons and armor shop";
+    short_desc = "Rusted Display";
+    long_desc = "Rusted brackets and weapon grooves scar the walls, with a sagging rack in\n"
+                + "front. The floor is littered with flakes of iron and rot, and the air\n"
+                + "carries the taste of cold metal.\n";
     dest_dir = ({
         "domain/original/area/vesla/room796", "north",
     });


### PR DESCRIPTION
### Motivation
- Present Vesla rooms as a world abandoned for centuries by applying Phase 1 aging guidance so descriptions evoke rot, dust, mildew, silence, and faded purpose.
- Remove explicit developer markers and functional labels so room names feel memory‑eroded and non‑prescriptive.
- Ensure player-facing text follows the repository's prose and code style constraints, including ~80‑character line breaks.

### Description
- Replaced `short_desc` and `long_desc` in 46 files under `domain/original/area/vesla/` to remove `PHASE0:` markers and provide aged, less-explicit names and descriptions consistent with `PHASE1.md` and `PROSE.md` guidance. (Commit shows `46 files changed, 166 insertions(+), 92 deletions(-)`.)
- Reformatted `long_desc` strings so each line is broken near 80 characters and concatenated with `+` per `CODE-STYLE.md` rules for player text.
- Renamed visible room titles to concise, evocative names (one or two words) that hint at original purpose without stating it explicitly.

### Testing
- Ran `rg -n "PHASE0:"` against the Vesla area to confirm no `PHASE0:` markers remain, which returned no matches (success).
- Executed a Python check to detect player-facing lines longer than 80 characters, which produced no violations (success).
- Staged and committed the changes with Git and created the PR metadata automatically (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968db7ad5a08327a3e3e8aac29b1185)