### PR TITLE
Age Vesla roads and crossings

### DIFF
--- a/domain/original/area/vesla/room170.c
+++ b/domain/original/area/vesla/room170.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Western End of Wall Street";
-    long_desc = "Western End of Wall Street\n";
+    short_desc = "Wall Road West";
+    long_desc = "The road ends against the inner wall, where the paving breaks into\n"
+              + "rubble and a shallow drift of sand. The wall looms close, its\n"
+              + "lower stones stained dark by old runoff and moss.\n";
     dest_dir = ({
         "domain/original/area/vesla/room171", "east",
         "domain/original/area/vesla/room168", "west",

--- a/domain/original/area/vesla/room171.c
+++ b/domain/original/area/vesla/room171.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Wall Street";
-    long_desc = "Wall Street\n";
+    short_desc = "Wall Road";
+    long_desc = "The wall runs north and south beside a straight stretch of empty\n"
+              + "road, its cobbles split by weeds and grit. The silence here is\n"
+              + "only broken by a faint, steady draft along the stone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room170", "west",
     });

--- a/domain/original/area/vesla/room172.c
+++ b/domain/original/area/vesla/room172.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "A broad road runs north and south, its surface worn into shallow\n"
+              + "ruts that hold dust and rain marks. Collapsed storefronts sag\n"
+              + "along the edges, their doorways open to the air.\n";
     dest_dir = ({
         "domain/original/area/vesla/room116", "south",
         "domain/original/area/vesla/room226", "west",

--- a/domain/original/area/vesla/room173.c
+++ b/domain/original/area/vesla/room173.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "The road narrows between low heaps of stone, the old curbs almost\n"
+              + "buried under grit and grass. A tilted signboard rests against a\n"
+              + "wall, its paint long gone.\n";
     dest_dir = ({
         "domain/original/area/vesla/room172", "south",
         "domain/original/area/vesla/room232", "west",

--- a/domain/original/area/vesla/room174.c
+++ b/domain/original/area/vesla/room174.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "A stretch of broken cobbles continues through the husks of old\n"
+              + "shops, their beams exposed to sky. Weeds knot in the joints\n"
+              + "where carts once passed.\n";
     dest_dir = ({
         "domain/original/area/vesla/room173", "south",
         "domain/original/area/vesla/room175", "north",

--- a/domain/original/area/vesla/room175.c
+++ b/domain/original/area/vesla/room175.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "The road dips slightly, collecting a shallow sheen of silt from\n"
+              + "past rains. Cracked thresholds line both sides, leading into\n"
+              + "roofless interiors.\n";
     dest_dir = ({
         "domain/original/area/vesla/room174", "south",
         "domain/original/area/vesla/room176", "north",

--- a/domain/original/area/vesla/room176.c
+++ b/domain/original/area/vesla/room176.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "A faint crown in the road has collapsed, leaving a long trough\n"
+              + "filled with grit and windblown leaves. The surrounding walls are\n"
+              + "scarred with old smoke stains.\n";
     dest_dir = ({
         "domain/original/area/vesla/room175", "south",
         "domain/original/area/vesla/room177", "north",

--- a/domain/original/area/vesla/room177.c
+++ b/domain/original/area/vesla/room177.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "The paving is patched with mismatched stones, as if repairs once\n"
+              + "stalled here. A low mound of rubble spills from the west, half\n"
+              + "blocking the way before the crossing.\n";
     dest_dir = ({
         "domain/original/area/vesla/room176", "south",
         "domain/original/area/vesla/room178", "north",

--- a/domain/original/area/vesla/room178.c
+++ b/domain/original/area/vesla/room178.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Scholar's Way and Caravan Road";
-    long_desc = "Intersection of Scholar's Way and Caravan Road\n";
+    short_desc = "Broken Crossing";
+    long_desc = "Two streets meet in a spread of fractured stone, their lines still\n"
+              + "clear beneath the dust. A collapsed corner wall exposes a dark\n"
+              + "room open to the weather.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "west",
         "domain/original/area/vesla/room177", "south",

--- a/domain/original/area/vesla/room179.c
+++ b/domain/original/area/vesla/room179.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Caravan Road";
-    long_desc = "Caravan Road\n";
+    short_desc = "Rutted Road";
+    long_desc = "The road straightens and grows bare, its center rutted by the\n"
+              + "ghost of old traffic. A broken post leans beside a gap where a\n"
+              + "shopfront has collapsed.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "south",
         "domain/original/area/vesla/room180", "north",

--- a/domain/original/area/vesla/room180.c
+++ b/domain/original/area/vesla/room180.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Intersection of Caravan Road and Wall Street";
-    long_desc = "Intersection of Caravan Road and Wall Street\n";
+    short_desc = "Wallside Crossing";
+    long_desc = "The crossing sits in the shadow of the inner wall, where the road\n"
+              + "turns and the stones are slick with old runoff. A gutter cuts\n"
+              + "across the paving and disappears into rubble.\n";
     dest_dir = ({
         "domain/original/area/vesla/room181", "west",
         "domain/original/area/vesla/room179", "south",

--- a/domain/original/area/vesla/room185.c
+++ b/domain/original/area/vesla/room185.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "The lane runs east and west between silent foundations, their\n"
+              + "doorways collapsed into piles of brick and slate. A brittle vine\n"
+              + "clings to the mortar seams.\n";
     dest_dir = ({
         "domain/original/area/vesla/room178", "east",
         "domain/original/area/vesla/room186", "west",

--- a/domain/original/area/vesla/room186.c
+++ b/domain/original/area/vesla/room186.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "Broken lintels and scattered tiles mark the edges of the way.\n"
+              + "Shadows pool in the empty frames of doorways, and loose plaster\n"
+              + "has long turned to dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room185", "east",
         "domain/original/area/vesla/room187", "west",

--- a/domain/original/area/vesla/room187.c
+++ b/domain/original/area/vesla/room187.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "The way widens a little, its stones cracked in a shallow fan where\n"
+              + "a side street meets from the north. The remains of a low wall\n"
+              + "trail off into weeds.\n";
     dest_dir = ({
         "domain/original/area/vesla/room188", "west",
         "domain/original/area/vesla/room186", "east",

--- a/domain/original/area/vesla/room188.c
+++ b/domain/original/area/vesla/room188.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "Fragments of carved stone lie half-buried along the edges of the\n"
+              + "lane, their markings softened by time. A faint ridge of sand has\n"
+              + "collected against the eastern curb.\n";
     dest_dir = ({
         "domain/original/area/vesla/room189", "west",
         "domain/original/area/vesla/room187", "east",

--- a/domain/original/area/vesla/room189.c
+++ b/domain/original/area/vesla/room189.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "The paving here is uneven, with gaps where stones have been pulled\n"
+              + "free or sunk. A narrow passage to the south is choked with grit\n"
+              + "and a slow spread of grass.\n";
     dest_dir = ({
         "domain/original/area/vesla/room190", "west",
         "domain/original/area/vesla/room188", "east",

--- a/domain/original/area/vesla/room190.c
+++ b/domain/original/area/vesla/room190.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "The way crosses another street in a small square of worn stone.\n"
+              + "Old foundations crowd the corners, their rooms open and empty.\n"
+              + "Wind moves freely through the gaps.\n";
     dest_dir = ({
         "domain/original/area/vesla/room740", "south",
         "domain/original/area/vesla/room191", "west",

--- a/domain/original/area/vesla/room191.c
+++ b/domain/original/area/vesla/room191.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "A long row of broken pillars lines the north side of the way,\n"
+              + "each stump dark with weathering. The ground is littered with\n"
+              + "slate chips and fine dust.\n";
     dest_dir = ({
         "domain/original/area/vesla/room742", "south",
         "domain/original/area/vesla/room192", "west",

--- a/domain/original/area/vesla/room192.c
+++ b/domain/original/area/vesla/room192.c
@@ -6,8 +6,10 @@ void reset(int arg) {
 
     set_light(1);
 
-    short_desc = "Scholar's Way";
-    long_desc = "Scholar's Way\n";
+    short_desc = "Fallen Way";
+    long_desc = "The lane ends at a wider crossing, its stones paling where\n"
+              + "sunlight reaches in. A toppled capstone rests near the curb, half\n"
+              + "sunk in silt.\n";
     dest_dir = ({
         "domain/original/area/vesla/room166", "west",
         "domain/original/area/vesla/room191", "east",


### PR DESCRIPTION
### Motivation
- Bring the Vesla thoroughfares into Phase 1’s aged, abandoned state by replacing present-day place names and blank placeholders with descriptive, weathered prose. 
- Replace fragile place-memory names with later-imposed, appearance-based names in accordance with `PHASE1.md` and `PROSE.md` guidance. 
- Ensure player-facing text follows `CODE-STYLE.md` line-length rules and restrained, atmospheric tone.

### Description
- Renamed and revised short descriptions and long descriptions across 19 room files in `domain/original/area/vesla` to reflect decay and abandonment. 
- Replaced `Caravan Road` stretches with `Rutted Road` passages and added multi-line, aged long descriptions for those rooms. 
- Replaced `Scholar's Way` runs with `Fallen Way` and updated crossings and detail to emphasize ruined foundations and weathering. 
- Updated `Wall Street` segments to `Wall Road` / `Wall Road West` and adjusted crossing names to `Broken Crossing` and `Wallside Crossing`, while formatting lines to remain close to 80 characters.

### Testing
- Ran a script to verify that player-facing long description string segments do not exceed 80 characters and it produced no violations. 
- No other automated unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968de90e2f48327b38b724d816a6c94)