### PR TITLE
Age Vesla rooms with Phase 1 descriptions

### DIFF
--- a/domain/original/area/vesla/room408.c
+++ b/domain/original/area/vesla/room408.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "MD Banking";
-    long_desc = "PHASE0: a player-owned guild (bank)";
-    dest_dir = ({
-        "domain/original/area/vesla/room217", "east",
-    });
+  short_desc = "Empty Ledger";
+  long_desc = "A low stone chamber lies open to weather, its floor thick with dust\n"
+              "and mildew, with drips tracing the walls where plaster once held.\n"
+              "Rust-tormented bars sag above a cracked counter, and a warped slot in\n"
+              "the wall still hints at where coins once passed.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room217", "east",
+  });
 }
-
 

--- a/domain/original/area/vesla/room735.c
+++ b/domain/original/area/vesla/room735.c
@@ -1,15 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guild/Shop Space for rent";
-    long_desc = "PHASE0: an empty lot for a player-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room172", "west",
-    });
+  short_desc = "Scoured Plot";
+  long_desc = "A rectangle of packed earth lies between leaning stones, choked with\n"
+              "weed and grit, with dark dampness sinking into the edges.\n"
+              "Rotted post stubs and a bent iron bracket mark where a sign once\n"
+              "hung, while broken boards sink into the mud.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room172", "west",
+  });
 }
-


### PR DESCRIPTION
### Motivation
- Present Vesla area rooms in the Phase‑1 abandoned/aged state by replacing explicit PHASE0 markers with restrained, suggestive prose that implies 200 years of neglect.
- Conform room names and descriptions to `PROSE.md` and `CODE-STYLE.md` guidance by using less explicit short names and wrapping player-facing text near 80 characters per line.

### Description
- Updated `short_desc` and `long_desc` in `domain/original/area/vesla/room408.c` to `"Empty Ledger"` with an aged, abandoned description replacing the `PHASE0:` marker.
- Updated `short_desc` and `long_desc` in `domain/original/area/vesla/room735.c` to `"Scoured Plot"` with an aged, abandoned description replacing the `PHASE0:` marker.
- Reformatted the `long_desc` strings so each line has grammatically correct breaks close to 80 characters per `CODE-STYLE.md` line length rules.
- Preserved existing exits (`dest_dir`) and other room structure; changes are text-only.

### Testing
- No automated tests were run because these are text-only room description changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969855166c483279488ed13c95d3996)