### PR TITLE
Age Vesla room 426 to Phase 1 abandoned state

### DIFF
--- a/domain/original/area/vesla/room426.c
+++ b/domain/original/area/vesla/room426.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Deora's Outfitters";
-    long_desc = "PHASE0: a player-owned armory";
-    dest_dir = ({
-        "domain/original/area/vesla/room231", "south",
-    });
+  short_desc = "Empty Shopfront";
+  long_desc =
+  "Rotted timbers sag above a cramped room, the floor buried in grit\n"
+  "and splintered boards. Rust-flecked hooks and a few warped racks\n"
+  "cling to the walls, hinting at what once lined them. A stale hush\n"
+  "and mildew settle over the hollow space.";
+  dest_dir = ({
+    "domain/original/area/vesla/room231", "south",
+  });
 }
-


### PR DESCRIPTION
### Motivation
- Align the room with Phase 1 world state and prose rules by presenting it as long-abandoned and visually aged per `PHASE1.md` and `PROSE.md` guidance.

### Description
- Replace `short_desc` and `long_desc` in `domain/original/area/vesla/room426.c` with a restrained, aged description (wrapped near 80 columns) and adjust indentation for consistency.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969863b55108327aa29fd475bac44c4)