### PR TITLE
Age Vesla plot room

### DIFF
--- a/domain/original/area/vesla/room735.c
+++ b/domain/original/area/vesla/room735.c
@@ -6,13 +6,12 @@ void reset(int arg) {
 
   set_light(1);
 
-  short_desc = "Scoured Plot";
-  long_desc = "PHASE0: an empty lot for a player-owned business";
-              "weed and grit, with dark dampness sinking into the edges.\n"
-              "Rotted post stubs and a bent iron bracket mark where a sign once\n"
-              "hung, while broken boards sink into the mud.\n";
+  short_desc = "Faded Plot";
+  long_desc = "A sunken patch of earth lies between low foundations, its surface matted\n"
+              "with weed, dust, and black mildew. Rotted post stubs and a bent iron\n"
+              "bracket linger at the edge, with scattered planks and a worn stone lip\n"
+              "hinting at some former frontage.\n";
   dest_dir = ({
     "domain/original/area/vesla/room172", "west",
   });
 }
-


### PR DESCRIPTION
### Motivation
- Replace the `PHASE0:` placeholder and explicit business label with an aged, abandoned description that matches Phase 1 guidance and the prose/style rules.

### Description
- Update `domain/original/area/vesla/room735.c` by changing `short_desc` from "Scoured Plot" to "Faded Plot" and replacing the `long_desc` (removing the `PHASE0:` line and a malformed string concatenation) with a four-line, aged description formatted with grammatically correct line breaks close to 80 columns.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696986da6fa083278a4d57cd55e3cf7a)