### PR TITLE
Age Vesla rooms for Phase 1 — rename and replace PHASE0 descriptions

### DIFF
--- a/domain/original/area/vesla/room169.c
+++ b/domain/original/area/vesla/room169.c
@@ -1,17 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Northern Gate";
-    long_desc = "PHASE0: Northern Gate";
-    dest_dir = ({
-        "domain/original/area/vesla/room168", "south",
-        "domain/original/area/vesla/room753", "northeast",
-    });
+  short_desc = "Riven Arch";
+  long_desc = "A split stone arch leans over a scatter of fallen gate timbers and\n"
+    "rusted iron. Deep grooves where a portcullis once slid are\n"
+    "choked with mildew and windblown grit.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room168", "south",
+    "domain/original/area/vesla/room753", "northeast",
+  });
 }
-
-

--- a/domain/original/area/vesla/room754.c
+++ b/domain/original/area/vesla/room754.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Between the towers";
-    long_desc = "PHASE0: Between two towers";
-    dest_dir = ({
-        "domain/original/area/vesla/room753", "south",
-        "domain/original/area/vesla/room755", "north",
-    });
+  short_desc = "Twin Shadows";
+  long_desc = "Two battered towers hem in this passage, their upper floors cracked\n"
+    "and open to the sky. Loose stones and damp rubble gather where a\n"
+    "wooden span once steadied the gap.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room753", "south",
+    "domain/original/area/vesla/room755", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room755.c
+++ b/domain/original/area/vesla/room755.c
@@ -1,17 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Between the towers";
-    long_desc = "PHASE0: Between two towers";
-    dest_dir = ({
-        "domain/original/area/vesla/room754", "south",
-        "domain/original/area/vesla/room756", "north",
-    });
+  short_desc = "Tower Gap";
+  long_desc = "The gap between the towers narrows here, with soot-dark stone and\n"
+    "warped iron bands clinging to the walls. The floor is littered with\n"
+    "crumbling mortar and a rot-stained beam that once barred the way.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room754", "south",
+    "domain/original/area/vesla/room756", "north",
+  });
 }
-
-

--- a/domain/original/area/vesla/room756.c
+++ b/domain/original/area/vesla/room756.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room755", "south",
-        "domain/original/area/vesla/room757", "north",
-    });
+  short_desc = "Hollow Court";
+  long_desc = "A wide paved court lies quiet, its cobbles sunken and furred with\n"
+    "mildew. Old drain lines and a broken curb hint at orderly traffic\n"
+    "long gone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room755", "south",
+    "domain/original/area/vesla/room757", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room757.c
+++ b/domain/original/area/vesla/room757.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room756", "south",
-        "domain/original/area/vesla/room765", "northeast",
-        "domain/original/area/vesla/room758", "east",
-        "domain/original/area/vesla/room766", "north",
-    });
+  short_desc = "Dust Court";
+  long_desc = "Dust drifts along the open court, pooling against slumped walls and\n"
+    "empty doorways. The stones are worn smooth in a broad path, the\n"
+    "track of forgotten patrols.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room756", "south",
+    "domain/original/area/vesla/room765", "northeast",
+    "domain/original/area/vesla/room758", "east",
+    "domain/original/area/vesla/room766", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room758.c
+++ b/domain/original/area/vesla/room758.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room757", "west",
-        "domain/original/area/vesla/room759", "south",
-        "domain/original/area/vesla/room766", "northwest",
-        "domain/original/area/vesla/room765", "north",
-    });
+  short_desc = "Silent Court";
+  long_desc = "Silence hangs in this inner court where weeds thread between cracked\n"
+    "stones. A low step and a cracked curb trace where carts once\n"
+    "turned.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room757", "west",
+    "domain/original/area/vesla/room759", "south",
+    "domain/original/area/vesla/room766", "northwest",
+    "domain/original/area/vesla/room765", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room759.c
+++ b/domain/original/area/vesla/room759.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern guard room";
-    long_desc = "PHASE0: Eastern Guard Room";
-    dest_dir = ({
-        "domain/original/area/vesla/room760", "northeast",
-        "domain/original/area/vesla/room758", "north",
-    });
+  short_desc = "Watch Nook";
+  long_desc = "A low chamber opens off the court, with arrow slits clogged by rot\n"
+    "and mildew. An overturned bench and a rusted hook speak of watchers\n"
+    "gone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room760", "northeast",
+    "domain/original/area/vesla/room758", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room760.c
+++ b/domain/original/area/vesla/room760.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Lower eastern stairwell";
-    long_desc = "PHASE0: Lower Eastern Stairwell";
-    dest_dir = ({
-        "domain/original/area/vesla/room759", "southwest",
-        "domain/original/area/vesla/room761", "up",
-    });
+  short_desc = "Lower Steps";
+  long_desc = "These steps descend into damp shadow, their edges rounded and slick\n"
+    "with moss. A crumbling handrail line and iron pegs show where the\n"
+    "stair was once kept tight.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room759", "southwest",
+    "domain/original/area/vesla/room761", "up",
+  });
 }
-

--- a/domain/original/area/vesla/room761.c
+++ b/domain/original/area/vesla/room761.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Middle eastern stairwell";
-    long_desc = "PHASE0: Middle Eastern Stairwell";
-    dest_dir = ({
-        "domain/original/area/vesla/room762", "southwest",
-        "domain/original/area/vesla/room760", "down",
-        "domain/original/area/vesla/room763", "up",
-    });
+  short_desc = "Middle Steps";
+  long_desc = "The stairwell turns here, crowded by damp stone and a fractured\n"
+    "landing. Dust cakes the treads, and a broken sconce hints at night\n"
+    "watches that ended long ago.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room762", "southwest",
+    "domain/original/area/vesla/room760", "down",
+    "domain/original/area/vesla/room763", "up",
+  });
 }
-

--- a/domain/original/area/vesla/room762.c
+++ b/domain/original/area/vesla/room762.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern guard quarters";
-    long_desc = "PHASE0: Eastern Guard Quarters";
-    dest_dir = ({
-        "domain/original/area/vesla/room761", "northeast",
-    });
+  short_desc = "Bunk Row";
+  long_desc = "A long narrow room holds the remains of low platforms, their frames\n"
+    "rotted and collapsed. The air is stale with old mildew, and a strip\n"
+    "of wall hooks suggests ordered kit.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room761", "northeast",
+  });
 }
-

--- a/domain/original/area/vesla/room763.c
+++ b/domain/original/area/vesla/room763.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Upper eastern stairwell";
-    long_desc = "PHASE0: Upper Eastern Stairwell";
-    dest_dir = ({
-        "domain/original/area/vesla/room764", "southwest",
-        "domain/original/area/vesla/room761", "down",
-    });
+  short_desc = "Upper Steps";
+  long_desc = "The upper steps rise into a roofless shaft where rain darkens the\n"
+    "stone. Loose grit and rust flakes collect along the wall where a\n"
+    "rail once ran.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room764", "southwest",
+    "domain/original/area/vesla/room761", "down",
+  });
 }
-

--- a/domain/original/area/vesla/room764.c
+++ b/domain/original/area/vesla/room764.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern tower observatory";
-    long_desc = "PHASE0: Eastern Tower Observatory";
-    dest_dir = ({
-        "domain/original/area/vesla/room763", "northeast",
-    });
+  short_desc = "High Lookout";
+  long_desc = "This lofty chamber opens to the wind, its outer wall cracked and\n"
+    "partly fallen away. A ring of worn stone at the edge hints at a\n"
+    "place of watch and signal.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room763", "northeast",
+  });
 }
-

--- a/domain/original/area/vesla/room765.c
+++ b/domain/original/area/vesla/room765.c
@@ -1,21 +1,22 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room766", "west",
-        "domain/original/area/vesla/room767", "northwest",
-        "domain/original/area/vesla/room758", "south",
-        "domain/original/area/vesla/room757", "southwest",
-        "domain/original/area/vesla/room769", "northeast",
-        "domain/original/area/vesla/room770", "east",
-        "domain/original/area/vesla/room768", "north",
-    });
+  short_desc = "Ruined Court";
+  long_desc = "The court widens toward a collapsed corner, its paving buckled and\n"
+    "wet with seepage. A half-ruined post and iron ring suggest where\n"
+    "orders and notices once hung.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room766", "west",
+    "domain/original/area/vesla/room767", "northwest",
+    "domain/original/area/vesla/room758", "south",
+    "domain/original/area/vesla/room757", "southwest",
+    "domain/original/area/vesla/room769", "northeast",
+    "domain/original/area/vesla/room770", "east",
+    "domain/original/area/vesla/room768", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room766.c
+++ b/domain/original/area/vesla/room766.c
@@ -1,19 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room758", "southeast",
-        "domain/original/area/vesla/room757", "south",
-        "domain/original/area/vesla/room768", "northeast",
-        "domain/original/area/vesla/room765", "east",
-        "domain/original/area/vesla/room767", "north",
-    });
+  short_desc = "Stone Court";
+  long_desc = "Cold stone surrounds this open court, with mildew streaks and fallen\n"
+    "chips whitening the ground. A shallow channel in the paving runs\n"
+    "toward a broken drain, a remnant of tidy upkeep.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room758", "southeast",
+    "domain/original/area/vesla/room757", "south",
+    "domain/original/area/vesla/room768", "northeast",
+    "domain/original/area/vesla/room765", "east",
+    "domain/original/area/vesla/room767", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room767.c
+++ b/domain/original/area/vesla/room767.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room768", "east",
-        "domain/original/area/vesla/room765", "southeast",
-        "domain/original/area/vesla/room766", "south",
-    });
+  short_desc = "Echo Court";
+  long_desc = "The court here is narrower, hemmed by rough walls and roofless\n"
+    "alcoves. A rusted bracket and a shallow socket in the stone hint at\n"
+    "a former lantern line.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room768", "east",
+    "domain/original/area/vesla/room765", "southeast",
+    "domain/original/area/vesla/room766", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room768.c
+++ b/domain/original/area/vesla/room768.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The inner ward";
-    long_desc = "PHASE0: The Inner Ward";
-    dest_dir = ({
-        "domain/original/area/vesla/room766", "southwest",
-        "domain/original/area/vesla/room767", "west",
-        "domain/original/area/vesla/room769", "east",
-        "domain/original/area/vesla/room765", "south",
-    });
+  short_desc = "Gray Court";
+  long_desc = "Gray dust coats the paving, and fragments of plaster lie in soft\n"
+    "ridges. A broad, straight run of stones implies an old processional\n"
+    "path through the ward.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room766", "southwest",
+    "domain/original/area/vesla/room767", "west",
+    "domain/original/area/vesla/room769", "east",
+    "domain/original/area/vesla/room765", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room780.c
+++ b/domain/original/area/vesla/room780.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Wash area";
-    long_desc = "PHASE0: stable wash area";
-    dest_dir = ({
-        "domain/original/area/vesla/room778", "southeast",
-        "domain/original/area/vesla/room777", "south",
-    });
+  short_desc = "Stone Trough";
+  long_desc = "A shallow trough sits in a drained corner, its stones green with\n"
+    "mildew and grit. Cracked channels run toward a blocked grate,\n"
+    "suggesting long-abandoned care for animals.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room778", "southeast",
+    "domain/original/area/vesla/room777", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room795.c
+++ b/domain/original/area/vesla/room795.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A dingy alleyway";
-    long_desc = "PHASE0: A Dingy Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room813", "south",
-        "domain/original/area/vesla/room792", "west",
-        "domain/original/area/vesla/room796", "east",
-        "domain/original/area/vesla/room797", "north",
-    });
+  short_desc = "Narrow Cut";
+  long_desc = "The alley narrows between damp walls, with soot and slime streaking\n"
+    "the stone. Old drainage grooves and a collapsed plank hint at\n"
+    "service traffic that no longer comes.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room813", "south",
+    "domain/original/area/vesla/room792", "west",
+    "domain/original/area/vesla/room796", "east",
+    "domain/original/area/vesla/room797", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room796.c
+++ b/domain/original/area/vesla/room796.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "An alley";
-    long_desc = "PHASE0: An Alley";
-    dest_dir = ({
-        "domain/original/area/vesla/room814", "south",
-        "domain/original/area/vesla/room795", "west",
-        "domain/original/area/vesla/room231", "east",
-        "domain/original/area/vesla/room961", "north",
-    });
+  short_desc = "Blind Cut";
+  long_desc = "This tight passage ends in rubble, its floor sunk with dust and\n"
+    "mortar. A bricked arch and iron pins suggest a once-used service\n"
+    "door.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room814", "south",
+    "domain/original/area/vesla/room795", "west",
+    "domain/original/area/vesla/room231", "east",
+    "domain/original/area/vesla/room961", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room797.c
+++ b/domain/original/area/vesla/room797.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A dingy alley";
-    long_desc = "PHASE0: A Dingy Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room795", "south",
-        "domain/original/area/vesla/room798", "north",
-    });
+  short_desc = "Soot Cut";
+  long_desc = "Soot-blackened stone closes in here, and the air is still and\n"
+    "stale. A broken lintel and splintered frame imply a long-removed\n"
+    "gate.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room795", "south",
+    "domain/original/area/vesla/room798", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room798.c
+++ b/domain/original/area/vesla/room798.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A Dingy Alley";
-    long_desc = "PHASE0: A Dingy Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room797", "south",
-        "domain/original/area/vesla/room799", "north",
-    });
+  short_desc = "Sour Cut";
+  long_desc = "The passage bends in shadow, damp with rot and flecked with peeling\n"
+    "lime. A shallow gutter runs along the base of the wall, a remnant of\n"
+    "old refuse flow.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room797", "south",
+    "domain/original/area/vesla/room799", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room799.c
+++ b/domain/original/area/vesla/room799.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "PHASE0: A Stinky Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room802", "west",
-        "domain/original/area/vesla/room800", "east",
-        "domain/original/area/vesla/room798", "south",
-    });
+  short_desc = "Wet Cut";
+  long_desc = "Moisture beads on the close walls, and the paving is dark with\n"
+    "mildew. A rusted hinge stump and scored stone hint at a narrow door\n"
+    "once kept shut.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room802", "west",
+    "domain/original/area/vesla/room800", "east",
+    "domain/original/area/vesla/room798", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room800.c
+++ b/domain/original/area/vesla/room800.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "PHASE0: A Stinky Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room799", "west",
-        "domain/original/area/vesla/room801", "east",
-        "domain/original/area/vesla/room806", "north",
-    });
+  short_desc = "Rot Cut";
+  long_desc = "The alley widens slightly, filled with rotting boards and a soft bed\n"
+    "of dust. A leaning beam and iron staple suggest a former stall or\n"
+    "screen.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room799", "west",
+    "domain/original/area/vesla/room801", "east",
+    "domain/original/area/vesla/room806", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room801.c
+++ b/domain/original/area/vesla/room801.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "PHASE0: A Stinky Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room800", "west",
-    });
+  short_desc = "Stale Cut";
+  long_desc = "The dead-end passage is choked with grit and damp cobbles, quiet\n"
+    "under sagging walls. Faint nail holes in the stone imply shelving or\n"
+    "a lean-to long since gone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room800", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room802.c
+++ b/domain/original/area/vesla/room802.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Stink Alley Way";
-    long_desc = "PHASE0: A Stinky Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room805", "south",
-        "domain/original/area/vesla/room803", "west",
-        "domain/original/area/vesla/room799", "east",
-        "domain/original/area/vesla/room807", "north",
-    });
+  short_desc = "Crooked Cut";
+  long_desc = "This crooked alley is lined with cracked stone and peeling plaster\n"
+    "that smells of old damp. A broken curb and shallow ruts hint at\n"
+    "steady foot and cart traffic.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room805", "south",
+    "domain/original/area/vesla/room803", "west",
+    "domain/original/area/vesla/room799", "east",
+    "domain/original/area/vesla/room807", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room806.c
+++ b/domain/original/area/vesla/room806.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Barber Shop";
-    long_desc = "PHASE0: A Barber Shop (with an aggressive NPC)";
-    dest_dir = ({
-        "domain/original/area/vesla/room800", "south",
-    });
+  short_desc = "Shear Room";
+  long_desc = "A narrow room holds a cracked stone basin and a warped chair frame.\n"
+    "Rust flakes and dust cover the floor where tools once hung in neat\n"
+    "rows.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room800", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room823.c
+++ b/domain/original/area/vesla/room823.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Tea Shop";
-    long_desc = "PHASE0: an NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room157", "east",
-    });
+  short_desc = "Bitter Parlor";
+  long_desc = "A small parlor sits empty, its counters broken and its shelves\n"
+    "collapsed into dusty piles. A darkened hearth and stained ledges\n"
+    "suggest warm cups and quiet trade now gone cold.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room157", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room830.c
+++ b/domain/original/area/vesla/room830.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg)
+    return;
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Baker's Shop";
-    long_desc = "PHASE0: an NPC-owned business";
-    dest_dir = ({
-        "domain/original/area/vesla/room157", "west",
-    });
+  short_desc = "Cold Oven";
+  long_desc = "The room is thick with old flour dust and collapsed racks, the stone\n"
+    "floor sticky with mildew. A soot-dark oven mouth gapes in the back\n"
+    "wall, long since cold.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room157", "west",
+  });
 }
-


### PR DESCRIPTION
### Motivation
- Bring Vesla rooms into Phase 1 worldstate by presenting them as long-abandoned and aged rather than active or explicitly labeled `PHASE0:`. 
- Replace overt, functional room names with shorter, suggestive titles that hint at prior use without stating it directly. 
- Ensure prose follows Phase 1 / `PROSE.md` guidance and `CODE-STYLE.md` line-wrapping conventions so in-game descriptions read as restrained, atmospheric, and aged.

### Description
- Updated 28 room files under `domain/original/area/vesla/` to replace `PHASE0:` long descriptions with aged, abandoned prose that evokes rot, dust, mildew, and disrepair. 
- Replaced explicit `short_desc` values with shorter, less-explicit titles (one- or two-word descriptive names) to reflect the loss of original names. 
- Reformatted `long_desc` strings so each line is broken near 80 characters and follows repository indentation and string conventions. 
- Removed or neutralized references to active NPCs/usages in room text so descriptions match the silent, abandoned Phase 1 state.

### Testing
- Ran an automated line-length check over the modified files and found no lines longer than the threshold used by the check. 
- No unit or runtime tests were executed because these are text-only room description changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69698a55c5bc832789368556486f11df)