### PR TITLE
Vesla: convert PHASE0 room descriptions to Phase 1 aged prose

### DIFF
--- a/domain/original/area/vesla/room193.c
+++ b/domain/original/area/vesla/room193.c
@@ -7,14 +7,13 @@ void reset(int arg) {
 
   set_light(1);
 
-  short_desc = "Worn Way";
-  long_desc = "PHASE0: Worn Way";
-              + "The stones are chipped and uneven, and dark dust has gathered deep in the\n"
-              + "seams.\n";
+  short_desc = "Weathered Path";
+  long_desc =
+    "The way is reduced to uneven slabs, their edges rounded and split by long\n"
+    "neglect. Silt and mildew pool in the seams, and the path fades into quiet\n"
+    "stonework to either side.\n";
   dest_dir = ({
     "domain/original/area/vesla/room194", "east",
     "domain/original/area/vesla/room137", "west",
   });
 }
-
-

--- a/domain/original/area/vesla/room198.c
+++ b/domain/original/area/vesla/room198.c
@@ -1,18 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Zand Boulevard";
-    long_desc = "PHASE0: Hidden Boulevard";
-    dest_dir = ({
-        "domain/original/area/vesla/room199", "south",
-        "domain/original/area/vesla/room857", "east",
-        "domain/original/area/vesla/room197", "north",
-    });
+  short_desc = "Sunken Way";
+  long_desc =
+    "The old paving has slumped into a shallow trough, stones split and slick\n"
+    "with moss. Dust and leaf mold blanket the centerline, and rusted iron bands\n"
+    "lie half-buried where something once hung above the road.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room199", "south",
+    "domain/original/area/vesla/room857", "east",
+    "domain/original/area/vesla/room197", "north",
+  });
 }
-
-

--- a/domain/original/area/vesla/room199.c
+++ b/domain/original/area/vesla/room199.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Zand Boulevard";
-    long_desc = "PHASE0: Hidden Boulevard";
-    dest_dir = ({
-        "domain/original/area/vesla/room200", "south",
-        "domain/original/area/vesla/room962", "east",
-        "domain/original/area/vesla/room198", "north",
-    });
+  short_desc = "Mossed Way";
+  long_desc =
+    "Broken curbstones edge a long, silent way, their faces dark with mildew\n"
+    "and rain stain. A scatter of toppled posts and empty brackets hints at old\n"
+    "markers now swallowed by grit.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room200", "south",
+    "domain/original/area/vesla/room962", "east",
+    "domain/original/area/vesla/room198", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room200.c
+++ b/domain/original/area/vesla/room200.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Street of the Bells and Zand Boulevard";
-    long_desc = "PHASE0: Junction of Ruined Street and Hidden Boulevard";
-    dest_dir = ({
-        "domain/original/area/vesla/room201", "west",
-        "domain/original/area/vesla/room199", "north",
-    });
+  short_desc = "Cracked Crossing";
+  long_desc =
+    "Two worn ways meet in a sagging cross, their seams packed with damp grit\n"
+    "and tiny weeds. The center stones are polished hollow by long-forgotten\n"
+    "traffic, with rust flakes gathered in the low joints.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room201", "west",
+    "domain/original/area/vesla/room199", "north",
+  });
 }
-

--- a/domain/original/area/vesla/room201.c
+++ b/domain/original/area/vesla/room201.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "PHASE0: Ruined Street";
-    dest_dir = ({
-        "domain/original/area/vesla/room843", "south",
-        "domain/original/area/vesla/room202", "west",
-        "domain/original/area/vesla/room200", "east",
-    });
+  short_desc = "Silent Way";
+  long_desc =
+    "A narrow run of stone drifts westward, the joints packed with gray silt and\n"
+    "moss. A bent iron frame clings to one wall, as if a bell or lantern once\n"
+    "marked the passage.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room843", "south",
+    "domain/original/area/vesla/room202", "west",
+    "domain/original/area/vesla/room200", "east",
+  });
 }
-

--- a/domain/original/area/vesla/room202.c
+++ b/domain/original/area/vesla/room202.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "PHASE0: Ruined Street";
-    dest_dir = ({
-        "domain/original/area/vesla/room203", "west",
-        "domain/original/area/vesla/room201", "east",
-        "domain/original/area/vesla/room844", "south",
-    });
+  short_desc = "Silent Way";
+  long_desc =
+    "The paving narrows here, uneven and chipped, with damp dust clotted along\n"
+    "the edges. Empty brackets jut from the masonry overhead, their purpose lost\n"
+    "to the quiet.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room203", "west",
+    "domain/original/area/vesla/room201", "east",
+    "domain/original/area/vesla/room844", "south",
+  });
 }
-

--- a/domain/original/area/vesla/room203.c
+++ b/domain/original/area/vesla/room203.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "PHASE0: Ruined Street";
-    dest_dir = ({
-        "domain/original/area/vesla/room202", "east",
-        "domain/original/area/vesla/room204", "west",
-    });
+  short_desc = "Silent Way";
+  long_desc =
+    "The street has sagged and cracked, letting patches of weeds break through\n"
+    "the seams. A fallen crossbeam lies against the wall, its fittings scarred as\n"
+    "if something once hung there and rang.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room202", "east",
+    "domain/original/area/vesla/room204", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room204.c
+++ b/domain/original/area/vesla/room204.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Street of the Bells";
-    long_desc = "PHASE0: Ruined Street";
-    dest_dir = ({
-        "domain/original/area/vesla/room203", "east",
-        "domain/original/area/vesla/room140", "west",
-    });
+  short_desc = "Silent Way";
+  long_desc =
+    "Loose stone chips blanket the ground, and the walls carry streaks of water\n"
+    "rot and mildew. A line of small iron mounts runs along the lintel, hints of\n"
+    "old bells or lamps now gone.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room203", "east",
+    "domain/original/area/vesla/room140", "west",
+  });
 }
-

--- a/domain/original/area/vesla/room410.c
+++ b/domain/original/area/vesla/room410.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A dingy alleyway";
-    long_desc = "PHASE0: A Dingy Alleyway";
-    dest_dir = ({
-        "domain/original/area/vesla/room411", "west",
-        "domain/original/area/vesla/room122", "south",
-        "domain/original/area/vesla/room792", "north",
-    });
+  short_desc = "Narrow Cut";
+  long_desc =
+    "A tight passage runs between leaning walls, choked with damp rot and black\n"
+    "mildew. Broken drains and sagging lintels suggest a service way once kept\n"
+    "clear, now sealed in silence.\n";
+  dest_dir = ({
+    "domain/original/area/vesla/room411", "west",
+    "domain/original/area/vesla/room122", "south",
+    "domain/original/area/vesla/room792", "north",
+  });
 }
-


### PR DESCRIPTION
### Motivation
- Bring Vesla rooms marked with `PHASE0:` into the Phase 1 worldstate by replacing placeholder text with aged, abandoned prose that implies a former purpose without naming it explicitly.
- Apply `PHASE1.md`, `PROSE.md`, and `CODE-STYLE.md` guidance by emphasizing abandonment, rot, and quiet, and by wrapping player-facing text to near 80 columns.

### Description
- Rewrote `short_desc` and `long_desc` for the affected Vesla rooms (`room193.c`, `room198.c`, `room199.c`, `room200.c`, `room201.c`, `room202.c`, `room203.c`, `room204.c`, `room410.c`) to subdued names and Phase 1–appropriate, evocative long descriptions.
- Reformatted `long_desc` strings so each line contains grammatically correct line breaks near 80 characters and follows the repository's prose rules.
- Normalized `reset` block formatting and brace style to match `CODE-STYLE.md` conventions (two-space indentation and explicit `if (arg) { return; }`).
- Left room exits (`dest_dir`) and lighting unchanged, preserving navigation and mechanical constraints for Phase 1.

### Testing
- No automated tests were run because the changes are content-only modifications to room prose and formatting.
- Verified replacements and formatting via local file inspection and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69698d6c68f483278bd279a860f8f619)