### PR TITLE
Add exit alias support to rooms

### DIFF
--- a/room/room.c
+++ b/room/room.c
@@ -8,6 +8,9 @@
 /* An array with destinations and directions: "room/church", "north" ... */
 string *dest_dir;
 
+/* Exit aliases: "c":"city" */
+mapping exit_aliases;
+
 /* Short description of the room */
 string short_desc;
 
@@ -27,14 +30,25 @@ string convert_number(int n);
 string *query_numbers();
 
 void init() {
-    int i;
-    if (!dest_dir)
-        return;
-    i = 1;
-    while (i < sizeof(dest_dir)) {
-        add_action("move", dest_dir[i]);
-        i += 2;
-    }
+  int i;
+  string *aliases;
+
+  if (!dest_dir)
+    return;
+  i = 1;
+  while (i < sizeof(dest_dir)) {
+    add_action("move", dest_dir[i]);
+    i += 2;
+  }
+
+  if (!exit_aliases)
+    return;
+  aliases = keys(exit_aliases);
+  i = 0;
+  while (i < sizeof(aliases)) {
+    add_action("move_alias", aliases[i]);
+    i += 1;
+  }
 }
 
 int id(string str) {
@@ -151,6 +165,26 @@ int move(string str) {
     return 1;
 }
 
+int move_alias(string str) {
+  int i;
+  string canonical;
+
+  if (!exit_aliases)
+    return 0;
+  canonical = exit_aliases[query_verb()];
+  if (!canonical)
+    return 0;
+  i = 1;
+  while (i < sizeof(dest_dir)) {
+    if (dest_dir[i] == canonical) {
+      this_player()->move_player(dest_dir[i] + "#" + dest_dir[i - 1]);
+      return 1;
+    }
+    i += 2;
+  }
+  return 1;
+}
+
 string short() {
     if (set_light(0))
         return short_desc + "\n" + exitsDescription(1);
@@ -165,6 +199,14 @@ void set_short(string str) {
 
 void set_long(string str) {
   long_desc = str + "\n";
+
+  return;
+}
+
+void add_exit_alias(string alias, string canonical) {
+  if (!exit_aliases)
+    exit_aliases = ([]);
+  exit_aliases[alias] = canonical;
 
   return;
 }


### PR DESCRIPTION
### Motivation
- Provide a mechanism for rooms to register short or alternate exit commands (for example `"c"` -> `"city"`) so players can use aliases to move between rooms.
- Keep display of visible exits unchanged while allowing alternate verbs to trigger movement.

### Description
- Add a new `mapping exit_aliases` to store alias -> canonical exit mappings and a helper `add_exit_alias(string alias, string canonical)` to register them.
- Register alias actions in `init()` by calling `add_action("move_alias", alias)` for each key in `exit_aliases` and keep existing exit registration for canonical directions intact.
- Implement `move_alias(string str)` which resolves the alias via `exit_aliases`, finds the matching canonical exit in `dest_dir`, and invokes `this_player()->move_player(...)` to perform the movement.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2bfdcce48327bdc88abff6f4d481)