### PR TITLE
Add 'c' and 'x' exit aliases at roadway–city junctions

### DIFF
--- a/domain/original/area/anshelm/room235.c
+++ b/domain/original/area/anshelm/room235.c
@@ -12,4 +12,6 @@ void reset(int arg) {
         "domain/original/area/anshelm/room236", "north",
         "domain/original/area/roadway/room42", "exit",
     });
+
+  add_exit_alias("x", "exit");
 }

--- a/domain/original/area/exedoria/room286.c
+++ b/domain/original/area/exedoria/room286.c
@@ -12,4 +12,6 @@ void reset(int arg) {
         "domain/original/area/exedoria/room287", "east",
         "domain/original/area/roadway/room28", "exit",
     });
+
+  add_exit_alias("x", "exit");
 }

--- a/domain/original/area/indel/room1401.c
+++ b/domain/original/area/indel/room1401.c
@@ -13,4 +13,6 @@ void reset(int arg) {
         "domain/original/area/indel/room1635", "west",
         "domain/original/area/roadway/room55", "exit",
     });
+
+  add_exit_alias("x", "exit");
 }

--- a/domain/original/area/roadway/room12.c
+++ b/domain/original/area/roadway/room12.c
@@ -13,4 +13,6 @@ void reset(int arg) {
         "domain/original/area/roadway/room13", "east",
 	"domain/original/area/vesla/room134", "city",
     });
+
+  add_exit_alias("c", "city");
 }

--- a/domain/original/area/roadway/room14.c
+++ b/domain/original/area/roadway/room14.c
@@ -15,4 +15,6 @@ void reset(int arg) {
         "domain/original/area/roadway/room16", "east",
 	"domain/original/area/vesla/room115", "city",
     });
+
+  add_exit_alias("c", "city");
 }

--- a/domain/original/area/roadway/room28.c
+++ b/domain/original/area/roadway/room28.c
@@ -12,4 +12,6 @@ void reset(int arg) {
         "domain/original/area/roadway/room27", "west",
         "domain/original/area/exedoria/room286", "city",
     });
+
+  add_exit_alias("c", "city");
 }

--- a/domain/original/area/roadway/room42.c
+++ b/domain/original/area/roadway/room42.c
@@ -12,4 +12,6 @@ void reset(int arg) {
         "domain/original/area/roadway/room41", "south",
         "domain/original/area/anshelm/room235", "city",
     });
+
+  add_exit_alias("c", "city");
 }

--- a/domain/original/area/roadway/room55.c
+++ b/domain/original/area/roadway/room55.c
@@ -12,4 +12,6 @@ void reset(int arg) {
         "domain/original/area/roadway/room54", "north",
         "domain/original/area/indel/room1401", "city",
     });
+
+  add_exit_alias("c", "city");
 }

--- a/domain/original/area/vesla/room134.c
+++ b/domain/original/area/vesla/room134.c
@@ -15,6 +15,8 @@ void reset(int arg) {
     "domain/original/area/vesla/room133", "east",
     "domain/original/area/roadway/room12", "exit",
   });
+
+  add_exit_alias("x", "exit");
 }
 
 void init() {


### PR DESCRIPTION
### Motivation
- Provide consistent, semantically related short aliases for moving between roadways and adjacent city entrances so players can use `c` to enter a city and `x` to return to the roadway.
- Improve navigation ergonomics by adding symmetric aliases where roadway rooms list a `"city"` exit and city rooms list an `"exit"` back to the roadway.

### Description
- Added `add_exit_alias("c", "city")` to roadway rooms that point at city entrances in `domain/original/area/roadway`: `room12.c`, `room14.c`, `room28.c`, `room42.c`, and `room55.c`.
- Added `add_exit_alias("x", "exit")` to the paired city-side rooms: `domain/original/area/anshelm/room235.c`, `domain/original/area/exedoria/room286.c`, `domain/original/area/indel/room1401.c`, and `domain/original/area/vesla/room134.c`.
- Changes are limited to inserting the alias calls inside existing `reset()` implementations and do not alter room descriptions or exit targets.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a313340988327a94943b351fc4a48)