### PR TITLE
Phase 1: Age Exedoria rooms

### DIFF
--- a/domain/original/area/exedoria/room286.c
+++ b/domain/original/area/exedoria/room286.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Entrance to Exedoria";
-    long_desc = "Entrance to Exedoria.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room287", "east",
-        "domain/original/area/roadway/room28", "exit",
-    });
+  short_desc = "Broken Gate";
+  long_desc = "A fractured gatehouse leans over the road, its doors long gone. Wind moves\nthrough the empty arch where iron once hung.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room287", "east",
+    "domain/original/area/roadway/room28", "exit",
+  });
 
   add_exit_alias("x", "exit");
 }

--- a/domain/original/area/exedoria/room287.c
+++ b/domain/original/area/exedoria/room287.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room286", "west",
-        "domain/original/area/exedoria/room288", "east",
-        "domain/original/area/exedoria/room330", "south",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Deep ruts crease the old street, packed with silt and stray grass. Collapsed\ncurbs and leaning posts hint at buildings beyond the weeds.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room286", "west",
+    "domain/original/area/exedoria/room288", "east",
+    "domain/original/area/exedoria/room330", "south",
+  });
 }

--- a/domain/original/area/exedoria/room288.c
+++ b/domain/original/area/exedoria/room288.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room368", "south",
-        "domain/original/area/exedoria/room287", "west",
-        "domain/original/area/exedoria/room289", "east",
-        "domain/original/area/exedoria/room367", "north",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Broken stones show where wheels once cut a track through the city. Old gutter\nstones run broken and half buried at the sides.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room368", "south",
+    "domain/original/area/exedoria/room287", "west",
+    "domain/original/area/exedoria/room289", "east",
+    "domain/original/area/exedoria/room367", "north",
+  });
 }

--- a/domain/original/area/exedoria/room289.c
+++ b/domain/original/area/exedoria/room289.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room288", "west",
-        "domain/original/area/exedoria/room290", "east",
-        "domain/original/area/exedoria/room366", "south",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Loose gravel and dirt bury the street's edge. Low foundations crouch in the\nweeds, their doorways open to the air.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room288", "west",
+    "domain/original/area/exedoria/room290", "east",
+    "domain/original/area/exedoria/room366", "south",
+  });
 }

--- a/domain/original/area/exedoria/room290.c
+++ b/domain/original/area/exedoria/room290.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Monument Circle, Rutted Street";
-    long_desc = "Monument Circle, Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room299", "south",
-        "domain/original/area/exedoria/room289", "west",
-        "domain/original/area/exedoria/room291", "east",
-        "domain/original/area/exedoria/room369", "north",
-    });
+  short_desc = "Cracked Circle";
+  long_desc = "A low ring of stone marks a circle at the center of the road. Whatever stood\nhere is gone, leaving only shattered plinths.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room299", "south",
+    "domain/original/area/exedoria/room289", "west",
+    "domain/original/area/exedoria/room291", "east",
+    "domain/original/area/exedoria/room369", "north",
+  });
 }

--- a/domain/original/area/exedoria/room291.c
+++ b/domain/original/area/exedoria/room291.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room298", "south",
-        "domain/original/area/exedoria/room290", "west",
-        "domain/original/area/exedoria/room292", "east",
-        "domain/original/area/exedoria/room370", "north",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Water has eaten shallow channels along the roadbed. Windblown dust gathers in\nthe ruts where traffic once passed.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room298", "south",
+    "domain/original/area/exedoria/room290", "west",
+    "domain/original/area/exedoria/room292", "east",
+    "domain/original/area/exedoria/room370", "north",
+  });
 }

--- a/domain/original/area/exedoria/room292.c
+++ b/domain/original/area/exedoria/room292.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room291", "west",
-        "domain/original/area/exedoria/room293", "east",
-        "domain/original/area/exedoria/room383", "south",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Weeds press up through the cracked paving stones. Small stones and splinters\nof brick mark where walls fell.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room291", "west",
+    "domain/original/area/exedoria/room293", "east",
+    "domain/original/area/exedoria/room383", "south",
+  });
 }

--- a/domain/original/area/exedoria/room293.c
+++ b/domain/original/area/exedoria/room293.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room294", "east",
-        "domain/original/area/exedoria/room292", "west",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "The street lies uneven, its stones tilted and split. Vines trail across the\nroad in slow, careless loops.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room294", "east",
+    "domain/original/area/exedoria/room292", "west",
+  });
 }

--- a/domain/original/area/exedoria/room294.c
+++ b/domain/original/area/exedoria/room294.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room295", "east",
-        "domain/original/area/exedoria/room293", "west",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Ruts and puddled clay mark the old path between low walls. Scattered rubble\nsuggests a long abandoned block.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room295", "east",
+    "domain/original/area/exedoria/room293", "west",
+  });
 }

--- a/domain/original/area/exedoria/room295.c
+++ b/domain/original/area/exedoria/room295.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room296", "east",
-        "domain/original/area/exedoria/room294", "west",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Thin grass grows in the grooves left by carts. Loose brick and fallen beams\ndot the edges of the street.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room296", "east",
+    "domain/original/area/exedoria/room294", "west",
+  });
 }

--- a/domain/original/area/exedoria/room296.c
+++ b/domain/original/area/exedoria/room296.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rutted Street";
-    long_desc = "Rutted Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room297", "east",
-        "domain/original/area/exedoria/room295", "west",
-    });
+  short_desc = "Rutted Street";
+  long_desc = "Dry mud fills the depressions in the street. Thistles and briars knot along\nthe broken verge.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room297", "east",
+    "domain/original/area/exedoria/room295", "west",
+  });
 }

--- a/domain/original/area/exedoria/room297.c
+++ b/domain/original/area/exedoria/room297.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Corigan Court Intersection";
-    long_desc = "Corigan Court Intersection.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room296", "west",
-    });
+  short_desc = "Stone Cross";
+  long_desc = "Two worn streets cross in a patch of sunken stone. The corners are choked with\nrubble from nearby walls.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room296", "west",
+  });
 }

--- a/domain/original/area/exedoria/room298.c
+++ b/domain/original/area/exedoria/room298.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "City Hall";
-    long_desc = "City Hall.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room291", "north",
-    });
+  short_desc = "Crumbling Hall";
+  long_desc = "A broad civic hall slumps behind a fallen portico. Its doors gape open onto\ndust and broken benches.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room291", "north",
+  });
 }

--- a/domain/original/area/exedoria/room299.c
+++ b/domain/original/area/exedoria/room299.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eithel Sirion";
-    long_desc = "Eithel Sirion.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room300", "south",
-        "domain/original/area/exedoria/room290", "north",
-    });
+  short_desc = "Old Plaza";
+  long_desc = "A small plaza opens between low buildings, its paving split by weeds. A dry\nfountain basin lies cracked at its center.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room300", "south",
+    "domain/original/area/exedoria/room290", "north",
+  });
 }

--- a/domain/original/area/exedoria/room300.c
+++ b/domain/original/area/exedoria/room300.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room301", "south",
-        "domain/original/area/exedoria/room302", "west",
-        "domain/original/area/exedoria/room385", "east",
-        "domain/original/area/exedoria/room299", "north",
-    });
+  short_desc = "Broken Road";
+  long_desc = "A broad road runs between fractured curbstones and toppled markers. The center\nis worn smooth where traffic once passed.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room301", "south",
+    "domain/original/area/exedoria/room302", "west",
+    "domain/original/area/exedoria/room385", "east",
+    "domain/original/area/exedoria/room299", "north",
+  });
 }

--- a/domain/original/area/exedoria/room301.c
+++ b/domain/original/area/exedoria/room301.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Frenchie's II";
-    long_desc = "Frenchie's II.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room300", "north",
-    });
+  short_desc = "Shuttered Shop";
+  long_desc = "A narrow storefront sits silent, its signboard fallen into the street. The\ninterior is stripped and open to weather.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room300", "north",
+  });
 }

--- a/domain/original/area/exedoria/room302.c
+++ b/domain/original/area/exedoria/room302.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room303", "west",
-        "domain/original/area/exedoria/room300", "east",
-        "domain/original/area/exedoria/room392", "south",
-    });
+  short_desc = "Broken Road";
+  long_desc = "Old paving stones show through a blanket of dust and grit. Grass collects\nalong the edges in long seams.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room303", "west",
+    "domain/original/area/exedoria/room300", "east",
+    "domain/original/area/exedoria/room392", "south",
+  });
 }

--- a/domain/original/area/exedoria/room303.c
+++ b/domain/original/area/exedoria/room303.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Middle of Brapnor Road";
-    long_desc = "Middle of Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room304", "west",
-        "domain/original/area/exedoria/room302", "east",
-        "domain/original/area/exedoria/room329", "south",
-    });
+  short_desc = "Road Middle";
+  long_desc = "The road runs straight between broken foundations. Dust and grit have buried\nthe old curb.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room304", "west",
+    "domain/original/area/exedoria/room302", "east",
+    "domain/original/area/exedoria/room329", "south",
+  });
 }

--- a/domain/original/area/exedoria/room304.c
+++ b/domain/original/area/exedoria/room304.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room305", "west",
-        "domain/original/area/exedoria/room303", "east",
-        "domain/original/area/exedoria/room330", "north",
-    });
+  short_desc = "Broken Road";
+  long_desc = "The roadbed dips where the ground has settled. Broken walls crowd close on\neither side.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room305", "west",
+    "domain/original/area/exedoria/room303", "east",
+    "domain/original/area/exedoria/room330", "north",
+  });
 }

--- a/domain/original/area/exedoria/room305.c
+++ b/domain/original/area/exedoria/room305.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room306", "west",
-        "domain/original/area/exedoria/room304", "east",
-        "domain/original/area/exedoria/room393", "north",
-    });
+  short_desc = "Broken Road";
+  long_desc = "A long stretch of road lies quiet under a thin scatter of leaves. The gutters\nare choked with soil and moss.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room306", "west",
+    "domain/original/area/exedoria/room304", "east",
+    "domain/original/area/exedoria/room393", "north",
+  });
 }

--- a/domain/original/area/exedoria/room306.c
+++ b/domain/original/area/exedoria/room306.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room305", "east",
-        "domain/original/area/exedoria/room307", "west",
-    });
+  short_desc = "Broken Road";
+  long_desc = "Cracked paving gives way to patches of dirt and gravel. A few stones still\nhold the line of the old curb.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room305", "east",
+    "domain/original/area/exedoria/room307", "west",
+  });
 }

--- a/domain/original/area/exedoria/room307.c
+++ b/domain/original/area/exedoria/room307.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "End of Brapnor Road";
-    long_desc = "End of Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room306", "east",
-        "domain/original/area/exedoria/room331", "northwest",
-        "domain/original/area/exedoria/room308", "south",
-    });
+  short_desc = "Road End";
+  long_desc = "The road narrows and loses its paving in a drift of soil. Beyond it, the track\ndissolves into grass.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room306", "east",
+    "domain/original/area/exedoria/room331", "northwest",
+    "domain/original/area/exedoria/room308", "south",
+  });
 }

--- a/domain/original/area/exedoria/room308.c
+++ b/domain/original/area/exedoria/room308.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beginning of Lilu Lane";
-    long_desc = "Beginning of Lilu Lane.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room309", "south",
-        "domain/original/area/exedoria/room307", "north",
-    });
+  short_desc = "Lane Start";
+  long_desc = "A narrow lane begins between sagging houses. The stones are uneven and broken.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room309", "south",
+    "domain/original/area/exedoria/room307", "north",
+  });
 }

--- a/domain/original/area/exedoria/room309.c
+++ b/domain/original/area/exedoria/room309.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Lilu Lane";
-    long_desc = "Lilu Lane.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room310", "south",
-        "domain/original/area/exedoria/room308", "north",
-    });
+  short_desc = "Narrow Lane";
+  long_desc = "A narrow lane winds between close houses with shuttered windows. Damp stains\nstripe the stone.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room310", "south",
+    "domain/original/area/exedoria/room308", "north",
+  });
 }

--- a/domain/original/area/exedoria/room310.c
+++ b/domain/original/area/exedoria/room310.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Middle of Lilu Lane";
-    long_desc = "Middle of Lilu Lane.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room355", "west",
-        "domain/original/area/exedoria/room311", "south",
-        "domain/original/area/exedoria/room309", "north",
-    });
+  short_desc = "Narrow Lane";
+  long_desc = "The lane runs straight between close walls streaked with damp. A thin line of\ngrass follows the center.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room355", "west",
+    "domain/original/area/exedoria/room311", "south",
+    "domain/original/area/exedoria/room309", "north",
+  });
 }

--- a/domain/original/area/exedoria/room311.c
+++ b/domain/original/area/exedoria/room311.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Lilu Lane";
-    long_desc = "Lilu Lane.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room312", "south",
-        "domain/original/area/exedoria/room310", "north",
-    });
+  short_desc = "Narrow Lane";
+  long_desc = "The lane is quiet and tight, its paving broken in places. Moss spreads along\nthe base of each wall.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room312", "south",
+    "domain/original/area/exedoria/room310", "north",
+  });
 }

--- a/domain/original/area/exedoria/room312.c
+++ b/domain/original/area/exedoria/room312.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "End of Lilu Lane";
-    long_desc = "End of Lilu Lane.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room354", "west",
-        "domain/original/area/exedoria/room313", "south",
-        "domain/original/area/exedoria/room311", "north",
-    });
+  short_desc = "Lane End";
+  long_desc = "The lane ends at a collapsed wall and a heap of stone. The path beyond has\nfaded into dirt.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room354", "west",
+    "domain/original/area/exedoria/room313", "south",
+    "domain/original/area/exedoria/room311", "north",
+  });
 }

--- a/domain/original/area/exedoria/room313.c
+++ b/domain/original/area/exedoria/room313.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beginning of Embassy Row";
-    long_desc = "Beginning of Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room314", "east",
-        "domain/original/area/exedoria/room312", "north",
-    });
+  short_desc = "Row Start";
+  long_desc = "Tall facades begin along the street, their windows hollow. The paving here is\ncleaner, though still cracked.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room314", "east",
+    "domain/original/area/exedoria/room312", "north",
+  });
 }

--- a/domain/original/area/exedoria/room314.c
+++ b/domain/original/area/exedoria/room314.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Embassy Row";
-    long_desc = "Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room313", "west",
-        "domain/original/area/exedoria/room315", "east",
-        "domain/original/area/exedoria/room322", "south",
-    });
+  short_desc = "Silent Row";
+  long_desc = "Tall facades line the street, their balconies empty. Old banners have left\npale marks on the stone.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room313", "west",
+    "domain/original/area/exedoria/room315", "east",
+    "domain/original/area/exedoria/room322", "south",
+  });
 }

--- a/domain/original/area/exedoria/room315.c
+++ b/domain/original/area/exedoria/room315.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Embassy Row";
-    long_desc = "Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room320", "south",
-        "domain/original/area/exedoria/room314", "west",
-        "domain/original/area/exedoria/room316", "east",
-        "domain/original/area/exedoria/room321", "north",
-    });
+  short_desc = "Silent Row";
+  long_desc = "A formal row of buildings rises in matched stone. Windows stare out as dark,\nbroken squares.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room320", "south",
+    "domain/original/area/exedoria/room314", "west",
+    "domain/original/area/exedoria/room316", "east",
+    "domain/original/area/exedoria/room321", "north",
+  });
 }

--- a/domain/original/area/exedoria/room316.c
+++ b/domain/original/area/exedoria/room316.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Embassy Row";
-    long_desc = "Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room318", "south",
-        "domain/original/area/exedoria/room315", "west",
-        "domain/original/area/exedoria/room317", "east",
-        "domain/original/area/exedoria/room319", "north",
-    });
+  short_desc = "Silent Row";
+  long_desc = "Wide steps front each entrance, all worn to hollows. Rain has streaked the\ncarved lintels.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room318", "south",
+    "domain/original/area/exedoria/room315", "west",
+    "domain/original/area/exedoria/room317", "east",
+    "domain/original/area/exedoria/room319", "north",
+  });
 }

--- a/domain/original/area/exedoria/room317.c
+++ b/domain/original/area/exedoria/room317.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Embassy Row";
-    long_desc = "Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room316", "west",
-        "domain/original/area/exedoria/room323", "east",
-        "domain/original/area/exedoria/room333", "north",
-    });
+  short_desc = "Silent Row";
+  long_desc = "The street feels ceremonial, though no one walks it now. Even the paving here\nis fractured and dull.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room316", "west",
+    "domain/original/area/exedoria/room323", "east",
+    "domain/original/area/exedoria/room333", "north",
+  });
 }

--- a/domain/original/area/exedoria/room318.c
+++ b/domain/original/area/exedoria/room318.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A Dark Hole in the Ground";
-    long_desc = "A Dark Hole in the Ground.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room316", "north",
-    });
+  short_desc = "Dark Pit";
+  long_desc = "A round shaft drops into darkness, its rim lined with broken stone. Cold air\npools at the mouth and carries the scent of damp earth.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room316", "north",
+  });
 }

--- a/domain/original/area/exedoria/room319.c
+++ b/domain/original/area/exedoria/room319.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guard Post for Gnome Embassy";
-    long_desc = "Guard Post for Gnome Embassy.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room316", "south",
-        "domain/original/area/exedoria/room926", "north",
-    });
+  short_desc = "Ruined Post";
+  long_desc = "A small guard niche sits beside the street, its roof fallen in. A rusted bell\nlies in the debris.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room316", "south",
+    "domain/original/area/exedoria/room926", "north",
+  });
 }

--- a/domain/original/area/exedoria/room320.c
+++ b/domain/original/area/exedoria/room320.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Before a round door";
-    long_desc = "Before a round door.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room315", "north",
-    });
+  short_desc = "Round Door";
+  long_desc = "A heavy round door stands in a curved wall, swollen and cracked by time. Moss\ngathers in the seams where the frame once fit tight.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room315", "north",
+  });
 }

--- a/domain/original/area/exedoria/room321.c
+++ b/domain/original/area/exedoria/room321.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Junk yard";
-    long_desc = "Junk yard.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room315", "south",
-    });
+  short_desc = "Scrap Yard";
+  long_desc = "A yard of scattered metal and broken carts sprawls between low fences. Rusted\nframes and bent tools lie half buried in dirt.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room315", "south",
+  });
 }

--- a/domain/original/area/exedoria/room322.c
+++ b/domain/original/area/exedoria/room322.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Elven Embassy checkpoint";
-    long_desc = "Elven Embassy checkpoint.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room314", "north",
-    });
+  short_desc = "Stone Check";
+  long_desc = "A narrow archway divides the street, flanked by low guard niches. The stone\nbears faint carvings worn flat by time.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room314", "north",
+  });
 }

--- a/domain/original/area/exedoria/room323.c
+++ b/domain/original/area/exedoria/room323.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "End of Embassy Row";
-    long_desc = "End of Embassy Row.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room317", "west",
-        "domain/original/area/exedoria/room324", "north",
-    });
+  short_desc = "Row End";
+  long_desc = "The line of grand facades fades into a broken cul-de-sac. A fallen wall spills\ninto the street, blocking the far end.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room317", "west",
+    "domain/original/area/exedoria/room324", "north",
+  });
 }

--- a/domain/original/area/exedoria/room324.c
+++ b/domain/original/area/exedoria/room324.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern end of alley";
-    long_desc = "Southern end of alley.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room323", "south",
-        "domain/original/area/exedoria/room325", "north",
-    });
+  short_desc = "Alley End";
+  long_desc = "The alley narrows to a dead end cluttered with collapsed beams. Damp stains\nrun down the brick where rooflines failed.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room323", "south",
+    "domain/original/area/exedoria/room325", "north",
+  });
 }

--- a/domain/original/area/exedoria/room325.c
+++ b/domain/original/area/exedoria/room325.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Bend in an alley";
-    long_desc = "Bend in an alley.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room326", "west",
-        "domain/original/area/exedoria/room324", "south",
-    });
+  short_desc = "Alley Bend";
+  long_desc = "The alley turns around a sagging corner where bricks have slipped. Loose\nstones and soot gather along the base.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room326", "west",
+    "domain/original/area/exedoria/room324", "south",
+  });
 }

--- a/domain/original/area/exedoria/room326.c
+++ b/domain/original/area/exedoria/room326.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A bend in the alley";
-    long_desc = "A bend in the alley.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room325", "east",
-        "domain/original/area/exedoria/room327", "north",
-    });
+  short_desc = "Shadow Bend";
+  long_desc = "A tight bend hides the alley from the street, keeping it dark and stale. The\nwalls are pocked with old nail holes and cracks.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room325", "east",
+    "domain/original/area/exedoria/room327", "north",
+  });
 }

--- a/domain/original/area/exedoria/room327.c
+++ b/domain/original/area/exedoria/room327.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dark and narrow alley";
-    long_desc = "Dark and narrow alley.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room326", "south",
-        "domain/original/area/exedoria/room328", "north",
-    });
+  short_desc = "Narrow Alley";
+  long_desc = "This passage is hemmed by close walls and a broken gutter. Thin weeds reach up\nfrom packed dirt.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room326", "south",
+    "domain/original/area/exedoria/room328", "north",
+  });
 }

--- a/domain/original/area/exedoria/room328.c
+++ b/domain/original/area/exedoria/room328.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dark alley";
-    long_desc = "Dark alley.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room327", "south",
-        "domain/original/area/exedoria/room329", "north",
-    });
+  short_desc = "Dark Alley";
+  long_desc = "The alley lies in permanent shade, its stones damp and uneven. Refuse has long\nsince rotted into the cracks.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room327", "south",
+    "domain/original/area/exedoria/room329", "north",
+  });
 }

--- a/domain/original/area/exedoria/room329.c
+++ b/domain/original/area/exedoria/room329.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Alley entrance";
-    long_desc = "Alley entrance.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room328", "south",
-        "domain/original/area/exedoria/room303", "north",
-    });
+  short_desc = "Alley Mouth";
+  long_desc = "A narrow opening splits the row of buildings, leading into shadow. The lintel\nabove is cracked and sagging.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room328", "south",
+    "domain/original/area/exedoria/room303", "north",
+  });
 }

--- a/domain/original/area/exedoria/room330.c
+++ b/domain/original/area/exedoria/room330.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Excalibur, a closed guild";
-    long_desc = "The Excalibur, a closed guild.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room304", "south",
-        "domain/original/area/exedoria/room287", "north",
-    });
+  short_desc = "Sealed Hall";
+  long_desc = "A heavy door and shuttered windows mark a hall that was once important. The\nsign above the entrance hangs broken and unreadable.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room304", "south",
+    "domain/original/area/exedoria/room287", "north",
+  });
 }

--- a/domain/original/area/exedoria/room331.c
+++ b/domain/original/area/exedoria/room331.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Foyer of the Exedorian Inn";
-    long_desc = "Foyer of the Exedorian Inn.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room307", "southeast",
-        "domain/original/area/exedoria/room332", "west",
-    });
+  short_desc = "Empty Foyer";
+  long_desc = "A wide entry hall stands open to the street, swept by dust. Torn curtains hang\nfrom a balcony that no longer shelters the floor.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room307", "southeast",
+    "domain/original/area/exedoria/room332", "west",
+  });
 }

--- a/domain/original/area/exedoria/room332.c
+++ b/domain/original/area/exedoria/room332.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Exedorian saloon";
-    long_desc = "Exedorian saloon.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room331", "east",
-    });
+  short_desc = "Dusty Taproom";
+  long_desc = "A low room of tables and a cracked bar lies silent. Dull glass and dry spills\nstain the floor.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room331", "east",
+  });
 }

--- a/domain/original/area/exedoria/room333.c
+++ b/domain/original/area/exedoria/room333.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Before the Dwarven Embassy";
-    long_desc = "Before the Dwarven Embassy.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room317", "south",
-        "domain/original/area/exedoria/room920", "north",
-    });
+  short_desc = "Stone Threshold";
+  long_desc = "Wide steps lead up to a carved facade streaked with rain. The doorway stands\nopen, its lintel chipped and scarred.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room317", "south",
+    "domain/original/area/exedoria/room920", "north",
+  });
 }

--- a/domain/original/area/exedoria/room334.c
+++ b/domain/original/area/exedoria/room334.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street West";
-    long_desc = "Keen Street West.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room335", "east",
-    });
+  short_desc = "West Street";
+  long_desc = "The street widens slightly here before narrowing into ruins. Broken shutters\nand beams lie along the verge.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room335", "east",
+  });
 }

--- a/domain/original/area/exedoria/room335.c
+++ b/domain/original/area/exedoria/room335.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street";
-    long_desc = "Keen Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room336", "east",
-        "domain/original/area/exedoria/room334", "west",
-    });
+  short_desc = "Stone Street";
+  long_desc = "A straight street runs between low walls and empty storefronts. Loose grit\ncrunches over the paving.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room336", "east",
+    "domain/original/area/exedoria/room334", "west",
+  });
 }

--- a/domain/original/area/exedoria/room336.c
+++ b/domain/original/area/exedoria/room336.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street";
-    long_desc = "Keen Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room335", "west",
-        "domain/original/area/exedoria/room337", "east",
-        "domain/original/area/exedoria/room602", "north",
-    });
+  short_desc = "Stone Street";
+  long_desc = "The street here is broad, its stones worn smooth in places. Small piles of\nrubble mark fallen doorways.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room335", "west",
+    "domain/original/area/exedoria/room337", "east",
+    "domain/original/area/exedoria/room602", "north",
+  });
 }

--- a/domain/original/area/exedoria/room337.c
+++ b/domain/original/area/exedoria/room337.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street";
-    long_desc = "Keen Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room336", "west",
-        "domain/original/area/exedoria/room338", "east",
-        "domain/original/area/exedoria/room603", "south",
-    });
+  short_desc = "Stone Street";
+  long_desc = "Cracked paving leads past shuttered houses with sagging roofs. Grass grows in\na thin line along the middle.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room336", "west",
+    "domain/original/area/exedoria/room338", "east",
+    "domain/original/area/exedoria/room603", "south",
+  });
 }

--- a/domain/original/area/exedoria/room338.c
+++ b/domain/original/area/exedoria/room338.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "East Keen Street Bridge";
-    long_desc = "East Keen Street Bridge.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room337", "west",
-        "domain/original/area/exedoria/room339", "east",
-        "domain/original/area/exedoria/room604", "north",
-    });
+  short_desc = "East Bridge";
+  long_desc = "A narrow stone bridge spans a shallow, weed-choked channel. Several stones are\nmissing, leaving gaps that show the water below.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room337", "west",
+    "domain/original/area/exedoria/room339", "east",
+    "domain/original/area/exedoria/room604", "north",
+  });
 }

--- a/domain/original/area/exedoria/room339.c
+++ b/domain/original/area/exedoria/room339.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street Bridge";
-    long_desc = "Keen Street Bridge.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room340", "east",
-        "domain/original/area/exedoria/room338", "west",
-    });
+  short_desc = "Stone Bridge";
+  long_desc = "The bridge arches over a dry channel, its sides worn smooth. Moss gathers\nalong the parapet where hands once rested.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room340", "east",
+    "domain/original/area/exedoria/room338", "west",
+  });
 }

--- a/domain/original/area/exedoria/room340.c
+++ b/domain/original/area/exedoria/room340.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street";
-    long_desc = "Keen Street.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room339", "west",
-        "domain/original/area/exedoria/room341", "east",
-        "domain/original/area/exedoria/room343", "south",
-    });
+  short_desc = "Stone Street";
+  long_desc = "A stretch of street opens toward a cluster of ruined roofs. Shadows gather\nwhere eaves once held light.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room339", "west",
+    "domain/original/area/exedoria/room341", "east",
+    "domain/original/area/exedoria/room343", "south",
+  });
 }

--- a/domain/original/area/exedoria/room341.c
+++ b/domain/original/area/exedoria/room341.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Keen Street East";
-    long_desc = "Keen Street East.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room340", "west",
-        "domain/original/area/exedoria/room342", "north",
-    });
+  short_desc = "East Street";
+  long_desc = "The stone street runs toward a tangle of fallen masonry. Its edges are\nsoftened by drifted soil and grass.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room340", "west",
+    "domain/original/area/exedoria/room342", "north",
+  });
 }

--- a/domain/original/area/exedoria/room342.c
+++ b/domain/original/area/exedoria/room342.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guard Post";
-    long_desc = "Guard Post.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room341", "south",
-        "domain/original/area/exedoria/room350", "north",
-    });
+  short_desc = "Ruined Post";
+  long_desc = "A low guard post slumps beside the road, its roof fallen in. The doorway is\nfilled with debris.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room341", "south",
+    "domain/original/area/exedoria/room350", "north",
+  });
 }

--- a/domain/original/area/exedoria/room343.c
+++ b/domain/original/area/exedoria/room343.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Statued lawn";
-    long_desc = "Statued lawn.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room344", "south",
-        "domain/original/area/exedoria/room340", "north",
-    });
+  short_desc = "Ruined Lawn";
+  long_desc = "Broken statues stand amid tall grass, their faces worn away. Plinths sit\ncracked and empty where others fell.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room344", "south",
+    "domain/original/area/exedoria/room340", "north",
+  });
 }

--- a/domain/original/area/exedoria/room344.c
+++ b/domain/original/area/exedoria/room344.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Statued lawn";
-    long_desc = "Statued lawn.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room345", "south",
-        "domain/original/area/exedoria/room343", "north",
-    });
+  short_desc = "Ruined Lawn";
+  long_desc = "A lawn once trimmed is now wild, dotted with shattered stone figures. Moss\ncoats the remaining bases.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room345", "south",
+    "domain/original/area/exedoria/room343", "north",
+  });
 }

--- a/domain/original/area/exedoria/room345.c
+++ b/domain/original/area/exedoria/room345.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Manicured lawn";
-    long_desc = "Manicured lawn.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room346", "south",
-        "domain/original/area/exedoria/room344", "north",
-    });
+  short_desc = "Overgrown Lawn";
+  long_desc = "What was once a tended lawn is now a mat of tall grass. Stone borders still\ntrace its careful shape.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room346", "south",
+    "domain/original/area/exedoria/room344", "north",
+  });
 }

--- a/domain/original/area/exedoria/room346.c
+++ b/domain/original/area/exedoria/room346.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cavernous foyer";
-    long_desc = "Cavernous foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room348", "west",
-        "domain/original/area/exedoria/room347", "east",
-        "domain/original/area/exedoria/room345", "north",
-    });
+  short_desc = "Vast Foyer";
+  long_desc = "A high entry hall opens beneath a cracked vault. Dust lies deep where\nfootsteps once echoed.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room348", "west",
+    "domain/original/area/exedoria/room347", "east",
+    "domain/original/area/exedoria/room345", "north",
+  });
 }

--- a/domain/original/area/exedoria/room347.c
+++ b/domain/original/area/exedoria/room347.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Icy room";
-    long_desc = "Icy room.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room346", "west",
-    });
+  short_desc = "Cold Chamber";
+  long_desc = "This chamber holds a chill that lingers year round. Frost clings to the stone\nin thin, pale sheets.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room346", "west",
+  });
 }

--- a/domain/original/area/exedoria/room348.c
+++ b/domain/original/area/exedoria/room348.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cold hallway";
-    long_desc = "Cold hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room346", "east",
-        "domain/original/area/exedoria/room349", "south",
-    });
+  short_desc = "Cold Hall";
+  long_desc = "A narrow hall carries the breath of cold stone. The floor is slick with old\nmoisture.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room346", "east",
+    "domain/original/area/exedoria/room349", "south",
+  });
 }

--- a/domain/original/area/exedoria/room349.c
+++ b/domain/original/area/exedoria/room349.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Snowy cave";
-    long_desc = "Snowy cave.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room348", "north",
-    });
+  short_desc = "Snowy Vault";
+  long_desc = "Snow has drifted into a hollow chamber, piled in soft ridges. Bare rock shows\nthrough where the wind has scoured.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room348", "north",
+  });
 }

--- a/domain/original/area/exedoria/room350.c
+++ b/domain/original/area/exedoria/room350.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "With no gate guard present, you are able to enter the walled estate";
-    long_desc = "With no gate guard present, you are able to enter the walled estate.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room342", "south",
-        "domain/original/area/exedoria/room351", "north",
-    });
+  short_desc = "Open Gate";
+  long_desc = "A broken gate stands ajar in a high wall, its hinges rusted solid. The\ncourtyard beyond lies empty and windblown.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room342", "south",
+    "domain/original/area/exedoria/room351", "north",
+  });
 }

--- a/domain/original/area/exedoria/room351.c
+++ b/domain/original/area/exedoria/room351.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Foyer";
-    long_desc = "Foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room352", "east",
-        "domain/original/area/exedoria/room350", "south",
-    });
+  short_desc = "Stone Foyer";
+  long_desc = "A plain foyer opens onto several doorways, each stripped of its doors. The\nceiling has darkened with age.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room352", "east",
+    "domain/original/area/exedoria/room350", "south",
+  });
 }

--- a/domain/original/area/exedoria/room352.c
+++ b/domain/original/area/exedoria/room352.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Wood-paneled Hallway";
-    long_desc = "Wood-paneled Hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room351", "west",
-        "domain/original/area/exedoria/room353", "north",
-    });
+  short_desc = "Paneled Hall";
+  long_desc = "Wood panels line the hall, warped and split by damp. Their varnish has dulled\nto a gray sheen.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room351", "west",
+    "domain/original/area/exedoria/room353", "north",
+  });
 }

--- a/domain/original/area/exedoria/room353.c
+++ b/domain/original/area/exedoria/room353.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Busy Kitchen";
-    long_desc = "Busy Kitchen.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room352", "south",
-    });
+  short_desc = "Cold Kitchen";
+  long_desc = "A long hearth sits cold beneath a soot-dark hood. Cracked tables and empty\nshelves crowd the room.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room352", "south",
+  });
 }

--- a/domain/original/area/exedoria/room354.c
+++ b/domain/original/area/exedoria/room354.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Fragmented Walls";
-    long_desc = "Fragmented Walls.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room312", "east",
-    });
+  short_desc = "Broken Walls";
+  long_desc = "Fragments of wall stand like ribs around a roofless room. The open sky looks\ndown on rubble and weeds.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room312", "east",
+  });
 }

--- a/domain/original/area/exedoria/room355.c
+++ b/domain/original/area/exedoria/room355.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Drawbridge";
-    long_desc = "Drawbridge.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room310", "east",
-        "domain/original/area/exedoria/room356", "west",
-    });
+  short_desc = "Old Bridge";
+  long_desc = "A heavy bridge spans a shallow moat now filled with reed and mud. Chains hang\nslack where the lift once rose.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room310", "east",
+    "domain/original/area/exedoria/room356", "west",
+  });
 }

--- a/domain/original/area/exedoria/room356.c
+++ b/domain/original/area/exedoria/room356.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Library's entrance";
-    long_desc = "Library's entrance.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room357", "south",
-        "domain/original/area/exedoria/room361", "west",
-        "domain/original/area/exedoria/room355", "east",
-        "domain/original/area/exedoria/room362", "north",
-    });
+  short_desc = "Library Door";
+  long_desc = "An arched entry stands flanked by shattered shelves. Damp paper lies in curled\nfragments on the stone.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room357", "south",
+    "domain/original/area/exedoria/room361", "west",
+    "domain/original/area/exedoria/room355", "east",
+    "domain/original/area/exedoria/room362", "north",
+  });
 }

--- a/domain/original/area/exedoria/room357.c
+++ b/domain/original/area/exedoria/room357.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cobblestoned hallway";
-    long_desc = "Cobblestoned hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room358", "south",
-        "domain/original/area/exedoria/room360", "east",
-        "domain/original/area/exedoria/room356", "north",
-    });
+  short_desc = "Cobble Hall";
+  long_desc = "Round cobbles form the hall floor, slick with age. The walls narrow as the\ncorridor stretches on.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room358", "south",
+    "domain/original/area/exedoria/room360", "east",
+    "domain/original/area/exedoria/room356", "north",
+  });
 }

--- a/domain/original/area/exedoria/room358.c
+++ b/domain/original/area/exedoria/room358.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A bend in the hallway";
-    long_desc = "A bend in the hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room359", "west",
-        "domain/original/area/exedoria/room357", "north",
-    });
+  short_desc = "Hall Bend";
+  long_desc = "The hallway bends around a thick pillar, hiding what lies beyond. Dust gathers\nin the corner where the light fades.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room359", "west",
+    "domain/original/area/exedoria/room357", "north",
+  });
 }

--- a/domain/original/area/exedoria/room359.c
+++ b/domain/original/area/exedoria/room359.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A monk's cell";
-    long_desc = "A monk's cell.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room358", "east",
-    });
+  short_desc = "Stone Cell";
+  long_desc = "A narrow cell holds a bare cot frame and a low shelf. The stone is cold and\ndamp.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room358", "east",
+  });
 }

--- a/domain/original/area/exedoria/room360.c
+++ b/domain/original/area/exedoria/room360.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A monk's cell";
-    long_desc = "A monk's cell.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room357", "west",
-    });
+  short_desc = "Stone Cell";
+  long_desc = "This small chamber is plain, its walls marked by soot and smoke. A slit window\nadmits a thin stripe of light.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room357", "west",
+  });
 }

--- a/domain/original/area/exedoria/room361.c
+++ b/domain/original/area/exedoria/room361.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "With a grunt of effort, you manage to push open the heavy door, and enter";
-    long_desc = "With a grunt of effort, you manage to push open the heavy door, and enter.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room356", "east",
-    });
+  short_desc = "Heavy Door";
+  long_desc = "A massive door hangs from one hinge, leaving a gap into the dark. Rust and rot\nhave eaten the frame.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room356", "east",
+  });
 }

--- a/domain/original/area/exedoria/room362.c
+++ b/domain/original/area/exedoria/room362.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cobblestoned hallway";
-    long_desc = "Cobblestoned hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room356", "south",
-        "domain/original/area/exedoria/room363", "east",
-        "domain/original/area/exedoria/room364", "north",
-    });
+  short_desc = "Cobble Hall";
+  long_desc = "A cobbled corridor runs straight beneath a low ceiling. Water has darkened the\nstones near the edges.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room356", "south",
+    "domain/original/area/exedoria/room363", "east",
+    "domain/original/area/exedoria/room364", "north",
+  });
 }

--- a/domain/original/area/exedoria/room363.c
+++ b/domain/original/area/exedoria/room363.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A monk's cell";
-    long_desc = "A monk's cell.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room362", "west",
-    });
+  short_desc = "Stone Cell";
+  long_desc = "A cramped room opens off the hall, empty of comforts. Scratches line the wall\nwhere wood once hung.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room362", "west",
+  });
 }

--- a/domain/original/area/exedoria/room364.c
+++ b/domain/original/area/exedoria/room364.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A bend in the hallway";
-    long_desc = "A bend in the hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room365", "west",
-        "domain/original/area/exedoria/room362", "south",
-    });
+  short_desc = "Hall Bend";
+  long_desc = "A gentle turn shifts the corridor toward colder air. The floor stones are\nchipped and uneven.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room365", "west",
+    "domain/original/area/exedoria/room362", "south",
+  });
 }

--- a/domain/original/area/exedoria/room365.c
+++ b/domain/original/area/exedoria/room365.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "A monk's cell";
-    long_desc = "A monk's cell.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room364", "east",
-    });
+  short_desc = "Stone Cell";
+  long_desc = "The cell is spare and silent, its floor worn smooth. Moisture beads on the\ncorners.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room364", "east",
+  });
 }

--- a/domain/original/area/exedoria/room366.c
+++ b/domain/original/area/exedoria/room366.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Cadaver Emporium";
-    long_desc = "The Cadaver Emporium.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room289", "north",
-    });
+  short_desc = "Silent Shop";
+  long_desc = "This narrow shop is lined with empty hooks and dark stains. The air is stale\nand sweet with old rot.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room289", "north",
+  });
 }

--- a/domain/original/area/exedoria/room367.c
+++ b/domain/original/area/exedoria/room367.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Velvet Unicorn";
-    long_desc = "Velvet Unicorn.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room288", "south",
-    });
+  short_desc = "Faded Tavern";
+  long_desc = "A once-lively tavern sits dim behind broken windows. A sagging stage and\nsplintered stools fill the corners.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room288", "south",
+  });
 }

--- a/domain/original/area/exedoria/room368.c
+++ b/domain/original/area/exedoria/room368.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eidolon Warlords";
-    long_desc = "Eidolon Warlords.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room288", "north",
-    });
+  short_desc = "Empty Hall";
+  long_desc = "A grand hall stands stripped to bare stone, banners long gone. Ash marks a\nhearth that has not burned in years.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room288", "north",
+  });
 }

--- a/domain/original/area/exedoria/room369.c
+++ b/domain/original/area/exedoria/room369.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
-    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room290", "south",
-    });
+  short_desc = "Silent Board";
+  long_desc = "A weathered board stands against the wall, its notices long since torn away.\nRusted nails hold scraps of curled parchment.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room290", "south",
+  });
 }

--- a/domain/original/area/exedoria/room370.c
+++ b/domain/original/area/exedoria/room370.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beginning of park path";
-    long_desc = "Beginning of park path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room291", "south",
-        "domain/original/area/exedoria/room371", "north",
-    });
+  short_desc = "Park Edge";
+  long_desc = "The park path begins among low shrubs and toppled benches. Grass has pushed\nthrough the paving stones.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room291", "south",
+    "domain/original/area/exedoria/room371", "north",
+  });
 }

--- a/domain/original/area/exedoria/room371.c
+++ b/domain/original/area/exedoria/room371.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Park path intersection";
-    long_desc = "Park path intersection.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room370", "south",
-        "domain/original/area/exedoria/room372", "west",
-        "domain/original/area/exedoria/room378", "east",
-        "domain/original/area/exedoria/room373", "north",
-    });
+  short_desc = "Park Cross";
+  long_desc = "Two narrow paths cross under a thinning canopy. Fallen limbs lie where the\nwalkways once met cleanly.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room370", "south",
+    "domain/original/area/exedoria/room372", "west",
+    "domain/original/area/exedoria/room378", "east",
+    "domain/original/area/exedoria/room373", "north",
+  });
 }

--- a/domain/original/area/exedoria/room372.c
+++ b/domain/original/area/exedoria/room372.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Exedoria Pet Cemetary";
-    long_desc = "Exedoria Pet Cemetary.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room371", "east",
-    });
+  short_desc = "Small Graves";
+  long_desc = "Tiny stone markers jut from the earth in uneven lines. Many have tipped over\nor sunk into the soil.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room371", "east",
+  });
 }

--- a/domain/original/area/exedoria/room373.c
+++ b/domain/original/area/exedoria/room373.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Park path on the hill";
-    long_desc = "Park path on the hill.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room371", "south",
-        "domain/original/area/exedoria/room374", "north",
-    });
+  short_desc = "Hill Path";
+  long_desc = "The path climbs a low rise where the ground is bare and windy. A line of trees\nleans over the slope.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room371", "south",
+    "domain/original/area/exedoria/room374", "north",
+  });
 }

--- a/domain/original/area/exedoria/room374.c
+++ b/domain/original/area/exedoria/room374.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Elevated park path";
-    long_desc = "Elevated park path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room373", "south",
-        "domain/original/area/exedoria/room375", "north",
-    });
+  short_desc = "High Path";
+  long_desc = "This path runs along a raised embankment of cracked stone. The drop to either\nside is softened by weeds.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room373", "south",
+    "domain/original/area/exedoria/room375", "north",
+  });
 }

--- a/domain/original/area/exedoria/room375.c
+++ b/domain/original/area/exedoria/room375.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "End of park path";
-    long_desc = "End of park path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room376", "east",
-        "domain/original/area/exedoria/room374", "south",
-    });
+  short_desc = "Park End";
+  long_desc = "The path ends at a low wall broken into piles of stone. Beyond it, the park\ngives way to rough ground.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room376", "east",
+    "domain/original/area/exedoria/room374", "south",
+  });
 }

--- a/domain/original/area/exedoria/room376.c
+++ b/domain/original/area/exedoria/room376.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Temple ruins";
-    long_desc = "Temple ruins.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room377", "east",
-        "domain/original/area/exedoria/room375", "west",
-    });
+  short_desc = "Temple Ruin";
+  long_desc = "Broken columns and a fallen altar mark the remains of a temple. Vines trail\nthrough the shattered roofline.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room377", "east",
+    "domain/original/area/exedoria/room375", "west",
+  });
 }

--- a/domain/original/area/exedoria/room377.c
+++ b/domain/original/area/exedoria/room377.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Temple rotunda";
-    long_desc = "Temple rotunda.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room376", "west",
-    });
+  short_desc = "Broken Rotunda";
+  long_desc = "A circular chamber rises around a cracked dome. Light spills through gaps\nwhere the roof has fallen.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room376", "west",
+  });
 }

--- a/domain/original/area/exedoria/room378.c
+++ b/domain/original/area/exedoria/room378.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gravel path to the mansion";
-    long_desc = "Gravel path to the mansion.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room379", "east",
-        "domain/original/area/exedoria/room371", "west",
-    });
+  short_desc = "Gravel Walk";
+  long_desc = "A gravel path winds toward a distant, pale structure. Pebbles crunch in the\nwind where weeds have not taken hold.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room379", "east",
+    "domain/original/area/exedoria/room371", "west",
+  });
 }

--- a/domain/original/area/exedoria/room379.c
+++ b/domain/original/area/exedoria/room379.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gravel path on the hill";
-    long_desc = "Gravel path on the hill.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room380", "east",
-        "domain/original/area/exedoria/room378", "west",
-    });
+  short_desc = "Gravel Rise";
+  long_desc = "The gravel path climbs a slope scattered with loose stone. It narrows where\nthe hill has begun to slip.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room380", "east",
+    "domain/original/area/exedoria/room378", "west",
+  });
 }

--- a/domain/original/area/exedoria/room380.c
+++ b/domain/original/area/exedoria/room380.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection in the gravel path";
-    long_desc = "Intersection in the gravel path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room379", "west",
-        "domain/original/area/exedoria/room382", "southeast",
-        "domain/original/area/exedoria/room381", "north",
-    });
+  short_desc = "Gravel Cross";
+  long_desc = "Gravel paths meet in a small clearing of trampled stone. One branch is almost\nlost beneath grass.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room379", "west",
+    "domain/original/area/exedoria/room382", "southeast",
+    "domain/original/area/exedoria/room381", "north",
+  });
 }

--- a/domain/original/area/exedoria/room381.c
+++ b/domain/original/area/exedoria/room381.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Before a white mansion";
-    long_desc = "Before a white mansion.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room380", "south",
-    });
+  short_desc = "Pale Manor";
+  long_desc = "A pale manor stands behind a tangle of dead hedges. Its walls are stained and\nits windows are blind.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room380", "south",
+  });
 }

--- a/domain/original/area/exedoria/room382.c
+++ b/domain/original/area/exedoria/room382.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Outside the cemetery gate";
-    long_desc = "Outside the cemetery gate.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room380", "northwest",
-    });
+  short_desc = "Cemetery Gate";
+  long_desc = "An iron gate hangs open on one hinge, set in a low stone wall. The ground\nbeyond is uneven with old graves.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room380", "northwest",
+  });
 }

--- a/domain/original/area/exedoria/room383.c
+++ b/domain/original/area/exedoria/room383.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guard Post";
-    long_desc = "Guard Post.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room384", "south",
-        "domain/original/area/exedoria/room292", "north",
-    });
+  short_desc = "Ruined Post";
+  long_desc = "A simple post of stone stands abandoned at the corner. Only a cracked bench\nremains inside.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room384", "south",
+    "domain/original/area/exedoria/room292", "north",
+  });
 }

--- a/domain/original/area/exedoria/room384.c
+++ b/domain/original/area/exedoria/room384.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beginning of Brapnor Road";
-    long_desc = "Beginning of Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room385", "west",
-        "domain/original/area/exedoria/room386", "southeast",
-        "domain/original/area/exedoria/room383", "north",
-    });
+  short_desc = "Road Start";
+  long_desc = "A broader road begins near a low wall of fallen stone. The surface is cracked\nbut still passable.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room385", "west",
+    "domain/original/area/exedoria/room386", "southeast",
+    "domain/original/area/exedoria/room383", "north",
+  });
 }

--- a/domain/original/area/exedoria/room385.c
+++ b/domain/original/area/exedoria/room385.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brapnor Road";
-    long_desc = "Brapnor Road.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room384", "east",
-        "domain/original/area/exedoria/room300", "west",
-    });
+  short_desc = "Broken Road";
+  long_desc = "The road is scarred with shallow ruts and missing stones. Wind has piled grit\nagainst the surviving curb.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room384", "east",
+    "domain/original/area/exedoria/room300", "west",
+  });
 }

--- a/domain/original/area/exedoria/room386.c
+++ b/domain/original/area/exedoria/room386.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Necrom's Gate";
-    long_desc = "Necrom's Gate.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room384", "northwest",
-        "domain/original/area/exedoria/room387", "southeast",
-    });
+  short_desc = "Black Gate";
+  long_desc = "A tall gate of dark iron stands between two cracked pillars. The metal is\npitted and flecked with rust.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room384", "northwest",
+    "domain/original/area/exedoria/room387", "southeast",
+  });
 }

--- a/domain/original/area/exedoria/room387.c
+++ b/domain/original/area/exedoria/room387.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Paved intersection";
-    long_desc = "Paved intersection.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room388", "east",
-        "domain/original/area/exedoria/room386", "northwest",
-        "domain/original/area/exedoria/room527", "south",
-    });
+  short_desc = "Paved Cross";
+  long_desc = "A square of broken paving holds the meeting of several paths. The stones are\nsunken and split by roots.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room388", "east",
+    "domain/original/area/exedoria/room386", "northwest",
+    "domain/original/area/exedoria/room527", "south",
+  });
 }

--- a/domain/original/area/exedoria/room388.c
+++ b/domain/original/area/exedoria/room388.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern path through the University";
-    long_desc = "Eastern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room389", "east",
-        "domain/original/area/exedoria/room387", "west",
-    });
+  short_desc = "Quiet Walk";
+  long_desc = "A narrower walk skirts a line of study halls. The stones are uneven and\nspotted with moss.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room389", "east",
+    "domain/original/area/exedoria/room387", "west",
+  });
 }

--- a/domain/original/area/exedoria/room389.c
+++ b/domain/original/area/exedoria/room389.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern path through the University";
-    long_desc = "Eastern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room390", "east",
-        "domain/original/area/exedoria/room388", "west",
-    });
+  short_desc = "Quiet Walk";
+  long_desc = "The path runs beside a low wall, its capstones cracked. Weeds crowd the base\nwhere soil has risen.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room390", "east",
+    "domain/original/area/exedoria/room388", "west",
+  });
 }

--- a/domain/original/area/exedoria/room390.c
+++ b/domain/original/area/exedoria/room390.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "In front of a temporary building";
-    long_desc = "In front of a temporary building.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room389", "west",
-        "domain/original/area/exedoria/room391", "east",
-        "domain/original/area/exedoria/room904", "south",
-    });
+  short_desc = "Sagging Shed";
+  long_desc = "A low structure of rough boards leans at a tired angle. Its roof has caved in\nalong one side.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room389", "west",
+    "domain/original/area/exedoria/room391", "east",
+    "domain/original/area/exedoria/room904", "south",
+  });
 }

--- a/domain/original/area/exedoria/room391.c
+++ b/domain/original/area/exedoria/room391.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room390", "west",
-    });
+  short_desc = "Ruined Works";
+  long_desc = "Half-built walls stand around a pit of shattered stone. Tools and braces have\nlong since rotted away.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room390", "west",
+  });
 }

--- a/domain/original/area/exedoria/room392.c
+++ b/domain/original/area/exedoria/room392.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Delilah's Deli";
-    long_desc = "Delilah's Deli.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room302", "north",
-    });
+  short_desc = "Empty Kitchen";
+  long_desc = "A small dining room opens into a bare kitchen. The counters are bare and the\nhearth is cold.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room302", "north",
+  });
 }

--- a/domain/original/area/exedoria/room393.c
+++ b/domain/original/area/exedoria/room393.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Guard Tower Entrance";
-    long_desc = "Guard Tower Entrance.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room305", "south",
-    });
+  short_desc = "Tower Door";
+  long_desc = "The base of a watchtower opens into shadow beneath a cracked arch. Old arrows\nand stones lie scattered outside.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room305", "south",
+  });
 }

--- a/domain/original/area/exedoria/room527.c
+++ b/domain/original/area/exedoria/room527.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room528", "south",
-        "domain/original/area/exedoria/room387", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "A stone walk runs between broad buildings with blank windows. Leaves gather in\nshallow drifts along the edges.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room528", "south",
+    "domain/original/area/exedoria/room387", "north",
+  });
 }

--- a/domain/original/area/exedoria/room528.c
+++ b/domain/original/area/exedoria/room528.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room896", "south",
-        "domain/original/area/exedoria/room894", "east",
-        "domain/original/area/exedoria/room527", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "The path is straight and formal, though its stones have shifted. Silent\nfacades rise on both sides.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room896", "south",
+    "domain/original/area/exedoria/room894", "east",
+    "domain/original/area/exedoria/room527", "north",
+  });
 }

--- a/domain/original/area/exedoria/room602.c
+++ b/domain/original/area/exedoria/room602.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Railed entrance";
-    long_desc = "Railed entrance.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room336", "south",
-    });
+  short_desc = "Railed Gate";
+  long_desc = "A short railing borders a narrow entry in the wall. The iron bars are bent and\nmottled with rust.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room336", "south",
+  });
 }

--- a/domain/original/area/exedoria/room603.c
+++ b/domain/original/area/exedoria/room603.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Flagstoned entry";
-    long_desc = "Flagstoned entry.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room915", "south",
-        "domain/original/area/exedoria/room337", "north",
-    });
+  short_desc = "Flagstone Entry";
+  long_desc = "Flat stones form a short entry that has sunk into the ground. Weeds push\nthrough every seam.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room915", "south",
+    "domain/original/area/exedoria/room337", "north",
+  });
 }

--- a/domain/original/area/exedoria/room604.c
+++ b/domain/original/area/exedoria/room604.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "You rudely trespass on the private property.";
-    long_desc = "You rudely trespass on the private property.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room907", "northeast",
-        "domain/original/area/exedoria/room910", "northwest",
-        "domain/original/area/exedoria/room338", "south",
-    });
+  short_desc = "Private Yard";
+  long_desc = "A low wall encloses a yard gone to weeds. A warped signpost leans among the\ngrass.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room907", "northeast",
+    "domain/original/area/exedoria/room910", "northwest",
+    "domain/original/area/exedoria/room338", "south",
+  });
 }

--- a/domain/original/area/exedoria/room894.c
+++ b/domain/original/area/exedoria/room894.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dormitory foyer";
-    long_desc = "Dormitory foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room528", "west",
-        "domain/original/area/exedoria/room895", "south",
-        "domain/original/area/exedoria/room903", "north",
-    });
+  short_desc = "Dorm Foyer";
+  long_desc = "A plain foyer opens into several small chambers. Dust lies thick where beds\nonce stood.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room528", "west",
+    "domain/original/area/exedoria/room895", "south",
+    "domain/original/area/exedoria/room903", "north",
+  });
 }

--- a/domain/original/area/exedoria/room895.c
+++ b/domain/original/area/exedoria/room895.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dining commons";
-    long_desc = "Dining commons.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room894", "north",
-    });
+  short_desc = "Common Hall";
+  long_desc = "Long tables stand in a wide hall, their surfaces split and gray. A cold hearth\nsits at the far end.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room894", "north",
+  });
 }

--- a/domain/original/area/exedoria/room896.c
+++ b/domain/original/area/exedoria/room896.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room897", "south",
-        "domain/original/area/exedoria/room528", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "Cracked paving leads past a row of empty doorways. Grass pushes up where the\njoints have widened.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room897", "south",
+    "domain/original/area/exedoria/room528", "north",
+  });
 }

--- a/domain/original/area/exedoria/room897.c
+++ b/domain/original/area/exedoria/room897.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room898", "south",
-        "domain/original/area/exedoria/room896", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "A long walk stretches across a quiet quadrangle. The air is still beneath\ntall, weathered walls.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room898", "south",
+    "domain/original/area/exedoria/room896", "north",
+  });
 }

--- a/domain/original/area/exedoria/room898.c
+++ b/domain/original/area/exedoria/room898.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room899", "south",
-        "domain/original/area/exedoria/room897", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "The path narrows where rubble has spilled from a broken stair. Dust and grit\nsoften the once-sharp edges.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room899", "south",
+    "domain/original/area/exedoria/room897", "north",
+  });
 }

--- a/domain/original/area/exedoria/room899.c
+++ b/domain/original/area/exedoria/room899.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern path through the University";
-    long_desc = "Southern path through the University.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room902", "south",
-        "domain/original/area/exedoria/room900", "east",
-        "domain/original/area/exedoria/room898", "north",
-    });
+  short_desc = "Stone Walk";
+  long_desc = "A formal walkway continues between shuttered halls. Only wind and birds move\namong the stones.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room902", "south",
+    "domain/original/area/exedoria/room900", "east",
+    "domain/original/area/exedoria/room898", "north",
+  });
 }

--- a/domain/original/area/exedoria/room900.c
+++ b/domain/original/area/exedoria/room900.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "School of Business";
-    long_desc = "School of Business.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room899", "west",
-        "domain/original/area/exedoria/room901", "north",
-    });
+  short_desc = "Study Hall";
+  long_desc = "Rows of benches face a high dais in a broad hall. The floor is scuffed by\nlong-quiet feet.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room899", "west",
+    "domain/original/area/exedoria/room901", "north",
+  });
 }

--- a/domain/original/area/exedoria/room901.c
+++ b/domain/original/area/exedoria/room901.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dean's office";
-    long_desc = "Dean's office.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room900", "south",
-    });
+  short_desc = "Old Office";
+  long_desc = "A modest office holds a cracked desk and empty shelves. The window shutters\nhang loose on their hinges.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room900", "south",
+  });
 }

--- a/domain/original/area/exedoria/room902.c
+++ b/domain/original/area/exedoria/room902.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room899", "north",
-    });
+  short_desc = "Ruined Works";
+  long_desc = "An unfinished foundation lies open to the weather. Broken scaffolds lean where\nthey were left.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room899", "north",
+  });
 }

--- a/domain/original/area/exedoria/room903.c
+++ b/domain/original/area/exedoria/room903.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Resident Advisor's office";
-    long_desc = "Resident Advisor's office.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room894", "south",
-    });
+  short_desc = "Steward Office";
+  long_desc = "A narrow office holds a broken chair and a faded ledger. The walls are stained\nwhere lamps once burned.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room894", "south",
+  });
 }

--- a/domain/original/area/exedoria/room904.c
+++ b/domain/original/area/exedoria/room904.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Science building's entry";
-    long_desc = "Science building's entry.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room905", "west",
-        "domain/original/area/exedoria/room906", "east",
-        "domain/original/area/exedoria/room390", "north",
-    });
+  short_desc = "Workshop Entry";
+  long_desc = "A stone entry opens into a building of long worktables. The lintel is etched\nwith worn markings.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room905", "west",
+    "domain/original/area/exedoria/room906", "east",
+    "domain/original/area/exedoria/room390", "north",
+  });
 }

--- a/domain/original/area/exedoria/room905.c
+++ b/domain/original/area/exedoria/room905.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Science laboratory";
-    long_desc = "Science laboratory.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room904", "east",
-    });
+  short_desc = "Workroom";
+  long_desc = "Long tables and rusted tools line the walls. A few cracked vessels still rest\non their shelves.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room904", "east",
+  });
 }

--- a/domain/original/area/exedoria/room906.c
+++ b/domain/original/area/exedoria/room906.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Science lecture hall";
-    long_desc = "Science lecture hall.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room904", "west",
-    });
+  short_desc = "Lecture Hall";
+  long_desc = "Stepped benches rise in a semicircle, all coated with dust. A cracked slate\nstands at the front.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room904", "west",
+  });
 }

--- a/domain/original/area/exedoria/room907.c
+++ b/domain/original/area/exedoria/room907.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gravel Path";
-    long_desc = "Gravel Path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room908", "northwest",
-        "domain/original/area/exedoria/room604", "southwest",
-    });
+  short_desc = "Gravel Path";
+  long_desc = "A gravel path winds between scrub and low stone walls. Small stones shift with\nany movement.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room908", "northwest",
+    "domain/original/area/exedoria/room604", "southwest",
+  });
 }

--- a/domain/original/area/exedoria/room908.c
+++ b/domain/original/area/exedoria/room908.c
@@ -1,16 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Vine-covered Entry";
-    long_desc = "Vine-covered Entry.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room910", "southwest",
-        "domain/original/area/exedoria/room907", "southeast",
-        "domain/original/area/exedoria/room909", "north",
-    });
+  short_desc = "Vine Gate";
+  long_desc = "Vines curtain a low arch, their roots wedged into the stone. The entry beyond\nis dim and cool.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room910", "southwest",
+    "domain/original/area/exedoria/room907", "southeast",
+    "domain/original/area/exedoria/room909", "north",
+  });
 }

--- a/domain/original/area/exedoria/room909.c
+++ b/domain/original/area/exedoria/room909.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Grand Foyer";
-    long_desc = "Grand Foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room914", "up",
-        "domain/original/area/exedoria/room911", "west",
-        "domain/original/area/exedoria/room912", "east",
-        "domain/original/area/exedoria/room908", "south",
-    });
+  short_desc = "Grand Foyer";
+  long_desc = "A tall foyer rises toward a broken skylight. Bits of colored glass glitter in\nthe dust.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room914", "up",
+    "domain/original/area/exedoria/room911", "west",
+    "domain/original/area/exedoria/room912", "east",
+    "domain/original/area/exedoria/room908", "south",
+  });
 }

--- a/domain/original/area/exedoria/room910.c
+++ b/domain/original/area/exedoria/room910.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gravel Path";
-    long_desc = "Gravel Path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room604", "southeast",
-        "domain/original/area/exedoria/room908", "northeast",
-    });
+  short_desc = "Gravel Path";
+  long_desc = "Loose gravel crunches along a narrow path. The ground beside it is soft with\nmoss.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room604", "southeast",
+    "domain/original/area/exedoria/room908", "northeast",
+  });
 }

--- a/domain/original/area/exedoria/room911.c
+++ b/domain/original/area/exedoria/room911.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Child's Den";
-    long_desc = "Child's Den.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room909", "east",
-    });
+  short_desc = "Small Den";
+  long_desc = "A low room sits tucked under a stair, its walls scratched and scuffed. A toy\nchest lies smashed in a corner.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room909", "east",
+  });
 }

--- a/domain/original/area/exedoria/room912.c
+++ b/domain/original/area/exedoria/room912.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Wooded Hallway";
-    long_desc = "Wooded Hallway.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room913", "east",
-        "domain/original/area/exedoria/room909", "west",
-    });
+  short_desc = "Wood Hall";
+  long_desc = "A hallway lined with wooden beams runs between stone walls. The boards are\nwarped and dark with age.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room913", "east",
+    "domain/original/area/exedoria/room909", "west",
+  });
 }

--- a/domain/original/area/exedoria/room913.c
+++ b/domain/original/area/exedoria/room913.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Brushing aside the hanging vines, you walk east into the servants' quarters.";
-    long_desc = "Brushing aside the hanging vines, you walk east into the servants' quarters.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room912", "west",
-    });
+  short_desc = "Servant Wing";
+  long_desc = "Hanging vines trail through a low entry into a row of small rooms. The floor\nis littered with leaves and dust.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room912", "west",
+  });
 }

--- a/domain/original/area/exedoria/room914.c
+++ b/domain/original/area/exedoria/room914.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Treetop Bedroom";
-    long_desc = "Treetop Bedroom.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room909", "down",
-    });
+  short_desc = "High Room";
+  long_desc = "A small room opens onto a broken balcony above the ground. The ceiling is\nstained with rain.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room909", "down",
+  });
 }

--- a/domain/original/area/exedoria/room915.c
+++ b/domain/original/area/exedoria/room915.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Flagstoned path";
-    long_desc = "Flagstoned path.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room916", "south",
-        "domain/original/area/exedoria/room919", "west",
-        "domain/original/area/exedoria/room918", "east",
-        "domain/original/area/exedoria/room603", "north",
-    });
+  short_desc = "Flagstone Path";
+  long_desc = "Flat stones form a narrow path, each one tilted and cracked. Grass grows thick\nbetween the joints.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room916", "south",
+    "domain/original/area/exedoria/room919", "west",
+    "domain/original/area/exedoria/room918", "east",
+    "domain/original/area/exedoria/room603", "north",
+  });
 }

--- a/domain/original/area/exedoria/room916.c
+++ b/domain/original/area/exedoria/room916.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gray foyer";
-    long_desc = "Gray foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room917", "south",
-        "domain/original/area/exedoria/room915", "north",
-    });
+  short_desc = "Gray Foyer";
+  long_desc = "A gray stone foyer holds a cold stillness. Damp stains stripe the walls from\nfloor to lintel.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room917", "south",
+    "domain/original/area/exedoria/room915", "north",
+  });
 }

--- a/domain/original/area/exedoria/room917.c
+++ b/domain/original/area/exedoria/room917.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Trinian merchant's office";
-    long_desc = "Trinian merchant's office.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room916", "north",
-    });
+  short_desc = "Trade Office";
+  long_desc = "A small office holds a counting table and empty shelves. The shutters are\ncracked and hang ajar.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room916", "north",
+  });
 }

--- a/domain/original/area/exedoria/room918.c
+++ b/domain/original/area/exedoria/room918.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Carriage house";
-    long_desc = "Carriage house.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room915", "west",
-    });
+  short_desc = "Coach House";
+  long_desc = "A wide shed holds the outlines of old stalls. The roof has gaps where light\nfalls through.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room915", "west",
+  });
 }

--- a/domain/original/area/exedoria/room919.c
+++ b/domain/original/area/exedoria/room919.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Slave quarters";
-    long_desc = "Slave quarters.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room915", "east",
-    });
+  short_desc = "Low Quarters";
+  long_desc = "A low-ceilinged room is divided into narrow cubbies. The partitions are warped\nand splintered.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room915", "east",
+  });
 }

--- a/domain/original/area/exedoria/room920.c
+++ b/domain/original/area/exedoria/room920.c
@@ -1,18 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dwarven Embassy foyer";
-    long_desc = "Dwarven Embassy foyer.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room923", "west",
-        "domain/original/area/exedoria/room921", "up",
-        "domain/original/area/exedoria/room333", "south",
-        "domain/original/area/exedoria/room925", "east",
-        "domain/original/area/exedoria/room924", "north",
-    });
+  short_desc = "Stone Foyer";
+  long_desc = "Thick stone columns flank the entry to a broad hall. Their carvings are worn\nsmooth.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room923", "west",
+    "domain/original/area/exedoria/room921", "up",
+    "domain/original/area/exedoria/room333", "south",
+    "domain/original/area/exedoria/room925", "east",
+    "domain/original/area/exedoria/room924", "north",
+  });
 }

--- a/domain/original/area/exedoria/room921.c
+++ b/domain/original/area/exedoria/room921.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dwarven watchtower";
-    long_desc = "Dwarven watchtower.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room920", "down",
-        "domain/original/area/exedoria/room922", "north",
-    });
+  short_desc = "Stone Watch";
+  long_desc = "A squat tower rises above the wall, its stairs broken. The top is open to rain\nand birds.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room920", "down",
+    "domain/original/area/exedoria/room922", "north",
+  });
 }

--- a/domain/original/area/exedoria/room922.c
+++ b/domain/original/area/exedoria/room922.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Ambassadors Suite";
-    long_desc = "Ambassadors Suite.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room921", "south",
-    });
+  short_desc = "Quiet Suite";
+  long_desc = "A suite of rooms lies empty beyond a carved doorway. Dust lies in drifts where\nrugs once lay.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room921", "south",
+  });
 }

--- a/domain/original/area/exedoria/room923.c
+++ b/domain/original/area/exedoria/room923.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dwarven brewery";
-    long_desc = "Dwarven brewery.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room920", "east",
-    });
+  short_desc = "Old Brewery";
+  long_desc = "Large vats sit rusted in a cool chamber. The floor is sticky with old spills\nand mold.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room920", "east",
+  });
 }

--- a/domain/original/area/exedoria/room924.c
+++ b/domain/original/area/exedoria/room924.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dwarven Ambassador's office";
-    long_desc = "Dwarven Ambassador's office.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room920", "south",
-    });
+  short_desc = "Stone Office";
+  long_desc = "A square office holds a heavy desk and a cracked seal. The walls bear faint\nmarks of old banners.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room920", "south",
+  });
 }

--- a/domain/original/area/exedoria/room925.c
+++ b/domain/original/area/exedoria/room925.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Dwarven armoury";
-    long_desc = "Dwarven armoury.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room920", "west",
-    });
+  short_desc = "Old Armoury";
+  long_desc = "Empty racks line the walls, their pegs snapped off. A few rusted scraps lie in\nthe corners.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room920", "west",
+  });
 }

--- a/domain/original/area/exedoria/room926.c
+++ b/domain/original/area/exedoria/room926.c
@@ -1,17 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Ground Floor of the Windmill";
-    long_desc = "Ground Floor of the Windmill.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room929", "up",
-        "domain/original/area/exedoria/room927", "west",
-        "domain/original/area/exedoria/room928", "east",
-        "domain/original/area/exedoria/room319", "south",
-    });
+  short_desc = "Windmill Base";
+  long_desc = "The base of a windmill stands open to the wind, its beams creaking. Grain dust\nhas long settled into the floor.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room929", "up",
+    "domain/original/area/exedoria/room927", "west",
+    "domain/original/area/exedoria/room928", "east",
+    "domain/original/area/exedoria/room319", "south",
+  });
 }

--- a/domain/original/area/exedoria/room927.c
+++ b/domain/original/area/exedoria/room927.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Garden of Machines";
-    long_desc = "Garden of Machines.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room926", "east",
-    });
+  short_desc = "Rust Garden";
+  long_desc = "Rusting frames and gears sit half swallowed by vines. A path winds between\nthem in silence.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room926", "east",
+  });
 }

--- a/domain/original/area/exedoria/room928.c
+++ b/domain/original/area/exedoria/room928.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Cemetery";
-    long_desc = "Cemetery.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room926", "west",
-    });
+  short_desc = "Old Cemetery";
+  long_desc = "Graves spread across a low field, their markers tilted and worn. The ground is\nuneven with sunken plots.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room926", "west",
+  });
 }

--- a/domain/original/area/exedoria/room929.c
+++ b/domain/original/area/exedoria/room929.c
@@ -1,15 +1,16 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gnome Laboratory";
-    long_desc = "Gnome Laboratory.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room926", "down",
-        "domain/original/area/exedoria/room930", "up",
-    });
+  short_desc = "Small Lab";
+  long_desc = "A cramped workroom holds tiny benches and cracked tools. The walls are\nblackened by old smoke.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room926", "down",
+    "domain/original/area/exedoria/room930", "up",
+  });
 }

--- a/domain/original/area/exedoria/room930.c
+++ b/domain/original/area/exedoria/room930.c
@@ -1,14 +1,15 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Machinery Room";
-    long_desc = "Machinery Room.\n";
-    dest_dir = ({
-        "domain/original/area/exedoria/room929", "down",
-    });
+  short_desc = "Workshop";
+  long_desc = "A heavy room holds idle mechanisms, their belts long rotted away. Oil stains\nand rust mark the floor.\n";
+  dest_dir = ({
+    "domain/original/area/exedoria/room929", "down",
+  });
 }


### PR DESCRIPTION
### Motivation
- Put Exedoria into the Phase 1, aged/abandoned state defined by `PHASE1.md` so rooms read as late‑abandonment scenes rather than active settlements.
- Ensure player‑facing text follows the authoritative `PROSE.md` rules for concise, atmospheric descriptions and non‑prescriptive emotional language.
- Apply `CODE-STYLE.md` conventions for clarity and consistency across room definitions while preserving existing navigation and game constraints.

### Description
- Rewrote `short_desc` and `long_desc` for Exedoria rooms to generic, descriptive names and 2–3 sentence aged descriptions (examples: `Broken Gate`, `Rutted Street`, `Small Lab`).
- Updated descriptions to emphasize environmental storytelling (decay, vegetation, broken stone, rust) and wrapped text to the repository’s line width conventions.
- Normalized room function formatting (consistent braces/indentation, explicit `if (arg) { return; }`, `set_light(1);`) while preserving all original `dest_dir` exits and any `add_exit_alias` lines.
- Changes applied broadly across the Exedoria area (~150 room files) to produce a coherent abandoned atmosphere without introducing items, NPCs, or mechanics.

### Testing
- No automated tests were executed against these changes.
- The change is limited to room descriptions and formatting and preserves existing exit tables; recommend running the usual game integration/startup checks on the MUD server to validate load and descriptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a33a21c5c83279709b7a15b79b037)