### PR TITLE
Age Anshelm rooms for Phase 1 ambiance

### DIFF
--- a/domain/original/area/anshelm/room1135.c
+++ b/domain/original/area/anshelm/room1135.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western Guard Post";
-    long_desc = "Western Guard Post.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1136", "up",
-        "domain/original/area/anshelm/room237", "northeast",
-    });
+  short_desc = "West Post";
+  long_desc =
+    "A small guard nook overlooks the outer road, its slit windows broken and\n"
+    "widened by time. Dusty stone benches remain where sentries once rested.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1136", "up",
+    "domain/original/area/anshelm/room237", "northeast",
+  });
 }

--- a/domain/original/area/anshelm/room1136.c
+++ b/domain/original/area/anshelm/room1136.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Arleg bows to you.";
-    long_desc = "Arleg bows to you.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1135", "down",
-        "domain/original/area/anshelm/room1137", "up",
-    });
+  short_desc = "Guard Stair";
+  long_desc =
+    "A tight stairwell spirals upward through the west tower, its steps worn into\n"
+    "shallow cups. The air carries the scent of damp stone and old ash.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1135", "down",
+    "domain/original/area/anshelm/room1137", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1137.c
+++ b/domain/original/area/anshelm/room1137.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Second Floor Landing";
-    long_desc = "Second Floor Landing.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1136", "down",
-        "domain/original/area/anshelm/room1142", "east",
-        "domain/original/area/anshelm/room1138", "up",
-    });
+  short_desc = "Upper Landing";
+  long_desc =
+    "The landing opens onto two dark passages with flaked plaster. A fallen torch\n"
+    "bracket lies on the floor.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1136", "down",
+    "domain/original/area/anshelm/room1142", "east",
+    "domain/original/area/anshelm/room1138", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1138.c
+++ b/domain/original/area/anshelm/room1138.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Third Floor Passage";
-    long_desc = "Third Floor Passage.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1137", "down",
-        "domain/original/area/anshelm/room1144", "east",
-        "domain/original/area/anshelm/room1139", "up",
-    });
+  short_desc = "High Passage";
+  long_desc =
+    "This passage runs along the upper wall, with gaps where the parapet has\n"
+    "crumbled. Wind slips through the open stonework.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1137", "down",
+    "domain/original/area/anshelm/room1144", "east",
+    "domain/original/area/anshelm/room1139", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1139.c
+++ b/domain/original/area/anshelm/room1139.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western Spire Stairwell";
-    long_desc = "Western Spire Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1138", "down",
-        "domain/original/area/anshelm/room1140", "up",
-    });
+  short_desc = "West Stair";
+  long_desc =
+    "A steep stair climbs the western spire, the inner wall scarred by old tool\n"
+    "marks. Loose rubble gathers in the corners.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1138", "down",
+    "domain/original/area/anshelm/room1140", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1140.c
+++ b/domain/original/area/anshelm/room1140.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Roof of the Western Spire";
-    long_desc = "Roof of the Western Spire.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1139", "down",
-    });
+  short_desc = "West Roof";
+  long_desc =
+    "The roof is bare to the sky, ringed by a broken parapet. Pooled rainwater\n"
+    "glints in shallow basins.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1139", "down",
+  });
 }

--- a/domain/original/area/anshelm/room1141.c
+++ b/domain/original/area/anshelm/room1141.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western Stairwell";
-    long_desc = "Western Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1137", "up",
-    });
+  short_desc = "West Steps";
+  long_desc =
+    "Broad steps descend through the gatehouse, cracked and uneven. A strip of\n"
+    "faded tile clings to the wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1137", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1142.c
+++ b/domain/original/area/anshelm/room1142.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Killing Room";
-    long_desc = "Killing Room.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1153", "east",
-        "domain/original/area/anshelm/room1137", "west",
-    });
+  short_desc = "Ruined Hall";
+  long_desc =
+    "A long chamber lies open and empty, its ceiling partially collapsed. Soot\n"
+    "stains the stone where braziers once burned.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1153", "east",
+    "domain/original/area/anshelm/room1137", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1143.c
+++ b/domain/original/area/anshelm/room1143.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Anshelm Lounge";
-    long_desc = "Anshelm Lounge.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room236", "east",
-        "domain/original/area/anshelm/room1204", "west",
-    });
+  short_desc = "Empty Lounge";
+  long_desc =
+    "Wide windows face the street, their frames hanging loose and bare. Bits of\n"
+    "colored plaster remain on the walls, muted by age.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room236", "east",
+    "domain/original/area/anshelm/room1204", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1144.c
+++ b/domain/original/area/anshelm/room1144.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gatehouse Mess Hall";
-    long_desc = "Gatehouse Mess Hall.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1145", "east",
-        "domain/original/area/anshelm/room1138", "west",
-    });
+  short_desc = "Silent Hall";
+  long_desc =
+    "Long tables are gone, but their scars remain in the floor. A hearth stands\n"
+    "cold beneath a chipped mantle.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1145", "east",
+    "domain/original/area/anshelm/room1138", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1145.c
+++ b/domain/original/area/anshelm/room1145.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gatehouse Barracks";
-    long_desc = "Gatehouse Barracks.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1146", "east",
-        "domain/original/area/anshelm/room1144", "west",
-    });
+  short_desc = "Barracks";
+  long_desc =
+    "Low bunks have collapsed into heaps of wood and straw. The air carries a trace\n"
+    "of old straw and dust.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1146", "east",
+    "domain/original/area/anshelm/room1144", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1146.c
+++ b/domain/original/area/anshelm/room1146.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Third Floor Passage";
-    long_desc = "Third Floor Passage.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1151", "up",
-        "domain/original/area/anshelm/room1145", "west",
-    });
+  short_desc = "Upper Passage";
+  long_desc =
+    "A narrow passage runs along the inner wall, lit by a broken slit. Fine grit\n"
+    "lies under fallen plaster.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1151", "up",
+    "domain/original/area/anshelm/room1145", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1147.c
+++ b/domain/original/area/anshelm/room1147.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad at the Promenade";
-    long_desc = "Beitel Straad at the Promenade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1150", "west",
-        "domain/original/area/anshelm/room414", "east",
-        "domain/original/area/anshelm/room1169", "north",
-    });
+  short_desc = "Promenade";
+  long_desc =
+    "A broad walk runs along the inner wall, its stone railing cracked and low.\n"
+    "Ornate ironwork curves still cling to a few posts.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1150", "west",
+    "domain/original/area/anshelm/room414", "east",
+    "domain/original/area/anshelm/room1169", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1148.c
+++ b/domain/original/area/anshelm/room1148.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern Stairwell";
-    long_desc = "Eastern Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1149", "down",
-    });
+  short_desc = "East Steps";
+  long_desc =
+    "Stone steps climb within the eastern tower, their edges worn thin. A trickle\n"
+    "of water runs down one wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1149", "down",
+  });
 }

--- a/domain/original/area/anshelm/room1149.c
+++ b/domain/original/area/anshelm/room1149.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Base of the Eastern Stairwell";
-    long_desc = "Base of the Eastern Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1148", "up",
-    });
+  short_desc = "Stair Base";
+  long_desc =
+    "The base of the eastern stairwell is ringed with fallen tiles. The doorway to\n"
+    "the yard stands doorless and warped.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1148", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1150.c
+++ b/domain/original/area/anshelm/room1150.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1157", "west",
-        "domain/original/area/anshelm/room1147", "east",
-        "domain/original/area/anshelm/room1168", "south",
-    });
+  short_desc = "Stone Avenue";
+  long_desc =
+    "A wide street runs between elegant facades, their arches chipped and open.\n"
+    "Wrought iron balconies sag above the broken paving.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1157", "west",
+    "domain/original/area/anshelm/room1147", "east",
+    "domain/original/area/anshelm/room1168", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1151.c
+++ b/domain/original/area/anshelm/room1151.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern Spire Stairwell";
-    long_desc = "Eastern Spire Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1149", "down",
-        "domain/original/area/anshelm/room1152", "up",
-    });
+  short_desc = "East Stair";
+  long_desc =
+    "The stairwell narrows as it rises, with crumbling plaster exposing rough\n"
+    "stone. Iron nails protrude where a railing once stood.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1149", "down",
+    "domain/original/area/anshelm/room1152", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1152.c
+++ b/domain/original/area/anshelm/room1152.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Roof of the Eastern Spire";
-    long_desc = "Roof of the Eastern Spire.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1151", "down",
-    });
+  short_desc = "East Roof";
+  long_desc =
+    "The roof of the eastern spire is open to the weather, its parapet broken. A\n"
+    "lone flagpole lies across the stones.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1151", "down",
+  });
 }

--- a/domain/original/area/anshelm/room1153.c
+++ b/domain/original/area/anshelm/room1153.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Tider bows to you.";
-    long_desc = "Tider bows to you.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1142", "west",
-    });
+  short_desc = "Upper Room";
+  long_desc =
+    "A small chamber holds a cracked basin and a warped doorway. The walls are\n"
+    "stained by long-dry smoke.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1142", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1154.c
+++ b/domain/original/area/anshelm/room1154.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern Guard Post";
-    long_desc = "Eastern Guard Post.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room237", "northwest",
-        "domain/original/area/anshelm/room1155", "east",
-    });
+  short_desc = "East Post";
+  long_desc =
+    "A guard niche watches the road through a broken arrow slit. The ledge is slick\n"
+    "with damp and moss.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room237", "northwest",
+    "domain/original/area/anshelm/room1155", "east",
+  });
 }

--- a/domain/original/area/anshelm/room1155.c
+++ b/domain/original/area/anshelm/room1155.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Ganran bows to you.";
-    long_desc = "Ganran bows to you.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1158", "up",
-        "domain/original/area/anshelm/room1156", "down",
-        "domain/original/area/anshelm/room1154", "west",
-    });
+  short_desc = "Side Room";
+  long_desc =
+    "A side chamber sits empty except for scattered rubble. The plaster has peeled\n"
+    "away in long, curling strips.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1158", "up",
+    "domain/original/area/anshelm/room1156", "down",
+    "domain/original/area/anshelm/room1154", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1156.c
+++ b/domain/original/area/anshelm/room1156.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gatehouse Armoury";
-    long_desc = "Gatehouse Armoury.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1155", "up",
-    });
+  short_desc = "Armoury";
+  long_desc =
+    "Hooks and empty racks line the walls of this small armoury. The floor is\n"
+    "strewn with rust flakes and rot.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1155", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1157.c
+++ b/domain/original/area/anshelm/room1157.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western end of Beitel Straad";
-    long_desc = "Western end of Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1150", "east",
-        "domain/original/area/anshelm/room1164", "north",
-    });
+  short_desc = "West Avenue";
+  long_desc =
+    "The broad street narrows toward the western gate, its paving cracked.\n"
+    "Shuttered archways watch over the quiet way.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1150", "east",
+    "domain/original/area/anshelm/room1164", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1158.c
+++ b/domain/original/area/anshelm/room1158.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern Stairwell";
-    long_desc = "Eastern Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1155", "down",
-        "domain/original/area/anshelm/room1159", "up",
-    });
+  short_desc = "Inner Stair";
+  long_desc =
+    "A stone stair rises along a battered wall, its steps chipped and damp. A\n"
+    "broken lantern hook hangs above the landing.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1155", "down",
+    "domain/original/area/anshelm/room1159", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1159.c
+++ b/domain/original/area/anshelm/room1159.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Olotia bows to you.";
-    long_desc = "Olotia bows to you.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1158", "down",
-        "domain/original/area/anshelm/room1160", "west",
-    });
+  short_desc = "Upper Cell";
+  long_desc =
+    "This cramped room has a narrow slit for light and a floor of cracked stone.\n"
+    "Water stains run down the corners.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1158", "down",
+    "domain/original/area/anshelm/room1160", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1160.c
+++ b/domain/original/area/anshelm/room1160.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Tiran bows to you.";
-    long_desc = "Tiran bows to you.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1159", "east",
-        "domain/original/area/anshelm/room1161", "west",
-    });
+  short_desc = "Small Chamber";
+  long_desc =
+    "A small chamber opens off the stair, bare and silent. A broken latch hangs\n"
+    "from the doorframe.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1159", "east",
+    "domain/original/area/anshelm/room1161", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1161.c
+++ b/domain/original/area/anshelm/room1161.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Killing Room";
-    long_desc = "Killing Room.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1160", "east",
-        "domain/original/area/anshelm/room1162", "west",
-    });
+  short_desc = "Broken Chamber";
+  long_desc =
+    "The chamber is broad but empty, with a roof caved in at one end. Charred beams\n"
+    "lie across the floor.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1160", "east",
+    "domain/original/area/anshelm/room1162", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1162.c
+++ b/domain/original/area/anshelm/room1162.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Second Floor Landing";
-    long_desc = "Second Floor Landing.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1161", "east",
-        "domain/original/area/anshelm/room1163", "down",
-    });
+  short_desc = "High Landing";
+  long_desc =
+    "The landing connects two stairwells, its stone worn smooth. A length of\n"
+    "collapsed railing rests against the wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1161", "east",
+    "domain/original/area/anshelm/room1163", "down",
+  });
 }

--- a/domain/original/area/anshelm/room1163.c
+++ b/domain/original/area/anshelm/room1163.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western Stairwell";
-    long_desc = "Western Stairwell.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1135", "down",
-        "domain/original/area/anshelm/room1162", "up",
-    });
+  short_desc = "Outer Stair";
+  long_desc =
+    "The stairwell winds downward in the west wall, slick with damp. Chips of\n"
+    "limestone litter the treads.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1135", "down",
+    "domain/original/area/anshelm/room1162", "up",
+  });
 }

--- a/domain/original/area/anshelm/room1168.c
+++ b/domain/original/area/anshelm/room1168.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Inner Bailey";
-    long_desc = "The Inner Bailey.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1150", "north",
-    });
+  short_desc = "Inner Yard";
+  long_desc =
+    "The bailey is an open court of broken stone and patches of grass. A low well\n"
+    "curb sits dry near the center.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1150", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1185.c
+++ b/domain/original/area/anshelm/room1185.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room239", "west",
-        "domain/original/area/anshelm/room1186", "east",
-        "domain/original/area/anshelm/room1191", "north",
-    });
+  short_desc = "Broad Street";
+  long_desc =
+    "A wide street runs beneath faded facades with ornate iron balconies. Many of\n"
+    "the balconies have collapsed, leaving jagged anchors.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room239", "west",
+    "domain/original/area/anshelm/room1186", "east",
+    "domain/original/area/anshelm/room1191", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1186.c
+++ b/domain/original/area/anshelm/room1186.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1185", "west",
-        "domain/original/area/anshelm/room1187", "east",
-        "domain/original/area/anshelm/room1190", "north",
-    });
+  short_desc = "Arcade Row";
+  long_desc =
+    "Shallow arcades line the street, their arches chipped and stained. Bits of\n"
+    "colored tile still cling to the lower walls.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1185", "west",
+    "domain/original/area/anshelm/room1187", "east",
+    "domain/original/area/anshelm/room1190", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1187.c
+++ b/domain/original/area/anshelm/room1187.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1188", "east",
-        "domain/original/area/anshelm/room1186", "west",
-    });
+  short_desc = "Shuttered Street";
+  long_desc =
+    "Tall shutters hang open or lie broken along the street. A few carved lintels\n"
+    "remain, softened by weather.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1188", "east",
+    "domain/original/area/anshelm/room1186", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1188.c
+++ b/domain/original/area/anshelm/room1188.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1189", "east",
-        "domain/original/area/anshelm/room1187", "west",
-    });
+  short_desc = "Stone Avenue";
+  long_desc =
+    "The avenue is paved in broad stones worn smooth by time. A row of bent iron\n"
+    "lamps leans over the gutter.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1189", "east",
+    "domain/original/area/anshelm/room1187", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1189.c
+++ b/domain/original/area/anshelm/room1189.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern end of Beitel Straad";
-    long_desc = "Eastern end of Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1188", "west",
-    });
+  short_desc = "East Avenue";
+  long_desc =
+    "The street widens near a cluster of fallen columns and brick. Dried vines lace\n"
+    "across the cracked masonry.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1188", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1190.c
+++ b/domain/original/area/anshelm/room1190.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "The Banana Hammock";
-    long_desc = "The Banana Hammock.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1191", "west",
-        "domain/original/area/anshelm/room1186", "south",
-    });
+  short_desc = "Silent Taproom";
+  long_desc =
+    "A low room opens onto the street, its counter broken and bare. Stained glass\n"
+    "fragments glimmer in the dust.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1191", "west",
+    "domain/original/area/anshelm/room1186", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1191.c
+++ b/domain/original/area/anshelm/room1191.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Jack's Bistro";
-    long_desc = "Jack's Bistro.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1190", "east",
-        "domain/original/area/anshelm/room1185", "south",
-    });
+  short_desc = "Empty Bistro";
+  long_desc =
+    "Small tables have rotted away, leaving only rusted hooks in the floor. A\n"
+    "decorative mirror hangs cracked above a cold hearth.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1190", "east",
+    "domain/original/area/anshelm/room1185", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1192.c
+++ b/domain/original/area/anshelm/room1192.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Collapsed Chamber";
-    long_desc = "Collapsed Chamber.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room240", "west",
-    });
+  short_desc = "Caved Chamber";
+  long_desc =
+    "A heavy collapse has split this chamber, exposing the sky. Slabs of stone lie\n"
+    "piled in the center.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room240", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1193.c
+++ b/domain/original/area/anshelm/room1193.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Ruined Passage";
-    long_desc = "Ruined Passage.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room251", "west",
-    });
+  short_desc = "Ruin Passage";
+  long_desc =
+    "A narrow passage runs through broken walls, half open to the air. Rubble\n"
+    "mounds force the path to one side.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room251", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1194.c
+++ b/domain/original/area/anshelm/room1194.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room255", "west",
-    });
+  short_desc = "Rubble Yard";
+  long_desc =
+    "This open yard is choked with split stone and mortar dust. A collapsed crane\n"
+    "frame lies among the weeds.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room255", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1195.c
+++ b/domain/original/area/anshelm/room1195.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Anshelmish Keep's drawbridge";
-    long_desc = "Anshelmish Keep's drawbridge.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room255", "east",
-        "domain/original/area/anshelm/room1196", "west",
-    });
+  short_desc = "Broken Bridge";
+  long_desc =
+    "The drawbridge sags at its chains, its planks split and dark. A dry moat lies\n"
+    "beneath, scattered with fallen stone.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room255", "east",
+    "domain/original/area/anshelm/room1196", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1196.c
+++ b/domain/original/area/anshelm/room1196.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1195", "east",
-    });
+  short_desc = "Halfbuilt Hall";
+  long_desc =
+    "Half-raised walls stand in a rectangle, their courses uneven and cracked. Old\n"
+    "scaffolding poles lie snapped across the ground.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1195", "east",
+  });
 }

--- a/domain/original/area/anshelm/room1197.c
+++ b/domain/original/area/anshelm/room1197.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Private Entry";
-    long_desc = "Private Entry.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room281", "south",
-    });
+  short_desc = "Sealed Entry";
+  long_desc =
+    "A narrow entryway is blocked by a fallen lintel and drifted rubble. Faded\n"
+    "plaster still shows hints of old paint.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room281", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1198.c
+++ b/domain/original/area/anshelm/room1198.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "You have to turn sideways a bit to squeeze through the narrow passage.";
-    long_desc = "You have to turn sideways a bit to squeeze through the narrow passage.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room265", "west",
-    });
+  short_desc = "Tight Passage";
+  long_desc =
+    "A narrow passage squeezes between two thick walls of stone. The floor is\n"
+    "polished smooth where many feet once passed.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room265", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1199.c
+++ b/domain/original/area/anshelm/room1199.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Armourer's Shack";
-    long_desc = "Armourer's Shack.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room270", "north",
-    });
+  short_desc = "Old Smithy";
+  long_desc =
+    "A low shack of stone holds a cold forge and a broken anvil. Rust flakes\n"
+    "glitter across the hearth.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room270", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1200.c
+++ b/domain/original/area/anshelm/room1200.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room276", "south",
-    });
+  short_desc = "Broken Works";
+  long_desc =
+    "An unfinished structure lies open to the weather, its walls buckled. Bundles\n"
+    "of warped timber rot along the edges.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room276", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1201.c
+++ b/domain/original/area/anshelm/room1201.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room280", "north",
-    });
+  short_desc = "Stone Pit";
+  long_desc =
+    "A shallow pit is filled with shattered blocks and silt. A toppled winch frame\n"
+    "rests against the wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room280", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1202.c
+++ b/domain/original/area/anshelm/room1202.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room273", "southeast",
-    });
+  short_desc = "Abandoned Works";
+  long_desc =
+    "Loose courses of stone mark the outline of a forgotten build. Wind has piled\n"
+    "grit against a fallen beam.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room273", "southeast",
+  });
 }

--- a/domain/original/area/anshelm/room1204.c
+++ b/domain/original/area/anshelm/room1204.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible";
-    long_desc = "You feel a STRONG urge to read the Sanctuary board... You are responsible.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1143", "east",
-    });
+  short_desc = "Quiet Hall";
+  long_desc =
+    "A wide chamber opens in the keep, its floor swept bare by wind. A carved niche\n"
+    "stands empty above a cracked ledge.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1143", "east",
+  });
 }

--- a/domain/original/area/anshelm/room1326.c
+++ b/domain/original/area/anshelm/room1326.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "La Cosa Nostra";
-    long_desc = "La Cosa Nostra.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room283", "south",
-    });
+  short_desc = "Old Guild";
+  long_desc =
+    "A once-grand hall stands here, its pillars chipped and dim. Faded motifs curl\n"
+    "along the walls like ghosts of paint.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room283", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1327.c
+++ b/domain/original/area/anshelm/room1327.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Anshelm Stables";
-    long_desc = "Anshelm Stables.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room284", "south",
-    });
+  short_desc = "Ruined Stables";
+  long_desc =
+    "Low stalls line the walls, their timber slats collapsed and gray. A trough\n"
+    "sits dry beneath a broken window.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room284", "south",
+  });
 }

--- a/domain/original/area/anshelm/room1328.c
+++ b/domain/original/area/anshelm/room1328.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern end of Geld Strasse";
-    long_desc = "Eastern end of Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1329", "east",
-        "domain/original/area/anshelm/room281", "west",
-    });
+  short_desc = "East Lane";
+  long_desc =
+    "The lane opens toward the outer wall, its paving split and worn. A heap of\n"
+    "fallen bricks blocks one old doorway.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1329", "east",
+    "domain/original/area/anshelm/room281", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1329.c
+++ b/domain/original/area/anshelm/room1329.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "With a little strain, you are able to pull open the heavy doors and enter";
-    long_desc = "With a little strain, you are able to pull open the heavy doors and enter.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1330", "east",
-        "domain/original/area/anshelm/room1328", "west",
-    });
+  short_desc = "Stone Doors";
+  long_desc =
+    "Two heavy doors hang ajar, their iron hinges rusted thick. A draft moves\n"
+    "through the cracked threshold.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1330", "east",
+    "domain/original/area/anshelm/room1328", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1330.c
+++ b/domain/original/area/anshelm/room1330.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Naive";
-    long_desc = "Naive.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1332", "south",
-        "domain/original/area/anshelm/room1329", "west",
-        "domain/original/area/anshelm/room1331", "east",
-        "domain/original/area/anshelm/room1333", "north",
-    });
+  short_desc = "Faded Salon";
+  long_desc =
+    "A quiet room holds a few toppled chairs and a cracked mosaic floor. The walls\n"
+    "are stained with old smoke and damp.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1332", "south",
+    "domain/original/area/anshelm/room1329", "west",
+    "domain/original/area/anshelm/room1331", "east",
+    "domain/original/area/anshelm/room1333", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1331.c
+++ b/domain/original/area/anshelm/room1331.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Altar of the Rose";
-    long_desc = "Altar of the Rose.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1330", "west",
-    });
+  short_desc = "Rose Altar";
+  long_desc =
+    "A small altar of stone stands against the wall, its carvings softened. Dried\n"
+    "petals lie scattered in the dust.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1330", "west",
+  });
 }

--- a/domain/original/area/anshelm/room1332.c
+++ b/domain/original/area/anshelm/room1332.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern statuary";
-    long_desc = "Southern statuary.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1330", "north",
-    });
+  short_desc = "South Statuary";
+  long_desc =
+    "Broken statues lean against the south wall, their faces worn blank. Fragments\n"
+    "of marble litter the floor.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1330", "north",
+  });
 }

--- a/domain/original/area/anshelm/room1333.c
+++ b/domain/original/area/anshelm/room1333.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Northern statuary";
-    long_desc = "Northern statuary.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1330", "south",
-    });
+  short_desc = "North Statuary";
+  long_desc =
+    "The remains of carved figures crowd the north wall in silent rows. Lichen\n"
+    "spreads across their fractured bases.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1330", "south",
+  });
 }

--- a/domain/original/area/anshelm/room235.c
+++ b/domain/original/area/anshelm/room235.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Before the Anshelm Gatehouse";
-    long_desc = "Before the Anshelm Gatehouse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room236", "north",
-        "domain/original/area/roadway/room42", "exit",
-    });
+  short_desc = "Outer Gate";
+  long_desc =
+    "A low arch of stone stands ahead, its carved face worn smooth by rain. Broken\n"
+    "cobbles and weeded ruts mark the road leading toward the silent city.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room236", "north",
+    "domain/original/area/roadway/room42", "exit",
+  });
 
   add_exit_alias("x", "exit");
 }

--- a/domain/original/area/anshelm/room236.c
+++ b/domain/original/area/anshelm/room236.c
@@ -1,16 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Under the Anshelmish Gatehouse";
-    long_desc = "Under the Anshelmish Gatehouse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1143", "west",
-        "domain/original/area/anshelm/room235", "south",
-        "domain/original/area/anshelm/room237", "north",
-    });
+  short_desc = "Gate Arch";
+  long_desc =
+    "The vaulting of the gatehouse is blackened with soot and age, and the\n"
+    "portcullis is long gone. Light spills through gaps above where beams have\n"
+    "fallen.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1143", "west",
+    "domain/original/area/anshelm/room235", "south",
+    "domain/original/area/anshelm/room237", "north",
+  });
 }

--- a/domain/original/area/anshelm/room237.c
+++ b/domain/original/area/anshelm/room237.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Southern end of Rue du Nord";
-    long_desc = "Southern end of Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room1135", "southwest",
-        "domain/original/area/anshelm/room236", "south",
-        "domain/original/area/anshelm/room1154", "southeast",
-        "domain/original/area/anshelm/room238", "north",
-    });
+  short_desc = "South Road";
+  long_desc =
+    "The old thoroughfare begins in cracked stone and scattered gravel. A line of\n"
+    "shutterless facades leans inward, their plaster peeled away.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room1135", "southwest",
+    "domain/original/area/anshelm/room236", "south",
+    "domain/original/area/anshelm/room1154", "southeast",
+    "domain/original/area/anshelm/room238", "north",
+  });
 }

--- a/domain/original/area/anshelm/room238.c
+++ b/domain/original/area/anshelm/room238.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room413", "west",
-        "domain/original/area/anshelm/room237", "south",
-        "domain/original/area/anshelm/room239", "north",
-    });
+  short_desc = "Quiet Street";
+  long_desc =
+    "A narrow street of pale stone stretches between blank walls. Rusted iron\n"
+    "brackets jut where balconies once hung.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room413", "west",
+    "domain/original/area/anshelm/room237", "south",
+    "domain/original/area/anshelm/room239", "north",
+  });
 }

--- a/domain/original/area/anshelm/room239.c
+++ b/domain/original/area/anshelm/room239.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Rue du Nord and Beitel Straat";
-    long_desc = "Intersection of Rue du Nord and Beitel Straat.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room238", "south",
-        "domain/original/area/anshelm/room414", "west",
-        "domain/original/area/anshelm/room1185", "east",
-        "domain/original/area/anshelm/room240", "north",
-    });
+  short_desc = "Stone Crossing";
+  long_desc =
+    "Two streets meet in a small square of cracked paving. An empty fountain base\n"
+    "sits crooked against the curb.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room238", "south",
+    "domain/original/area/anshelm/room414", "west",
+    "domain/original/area/anshelm/room1185", "east",
+    "domain/original/area/anshelm/room240", "north",
+  });
 }

--- a/domain/original/area/anshelm/room240.c
+++ b/domain/original/area/anshelm/room240.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room239", "south",
-        "domain/original/area/anshelm/room415", "west",
-        "domain/original/area/anshelm/room1192", "east",
-        "domain/original/area/anshelm/room241", "north",
-    });
+  short_desc = "North Street";
+  long_desc =
+    "The roadway widens here, its center sunk and filled with damp leaves. A fallen\n"
+    "signboard lies half-buried in the grit.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room239", "south",
+    "domain/original/area/anshelm/room415", "west",
+    "domain/original/area/anshelm/room1192", "east",
+    "domain/original/area/anshelm/room241", "north",
+  });
 }

--- a/domain/original/area/anshelm/room241.c
+++ b/domain/original/area/anshelm/room241.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room416", "west",
-        "domain/original/area/anshelm/room240", "south",
-        "domain/original/area/anshelm/room242", "north",
-    });
+  short_desc = "Broken Row";
+  long_desc =
+    "Low buildings crowd the street, their doorways gaping and dark. Rainwater\n"
+    "gathers in the ruts where carts once passed.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room416", "west",
+    "domain/original/area/anshelm/room240", "south",
+    "domain/original/area/anshelm/room242", "north",
+  });
 }

--- a/domain/original/area/anshelm/room242.c
+++ b/domain/original/area/anshelm/room242.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gateway to Middle Bailey";
-    long_desc = "Gateway to Middle Bailey.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room241", "south",
-        "domain/original/area/anshelm/room243", "north",
-    });
+  short_desc = "Inner Gate";
+  long_desc =
+    "A second gate rises ahead, its guardwalk broken and open to the sky. Weed-\n"
+    "choked steps lead through the arch.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room241", "south",
+    "domain/original/area/anshelm/room243", "north",
+  });
 }

--- a/domain/original/area/anshelm/room243.c
+++ b/domain/original/area/anshelm/room243.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room242", "south",
-        "domain/original/area/anshelm/room244", "north",
-    });
+  short_desc = "Silent Row";
+  long_desc =
+    "Paving stones are missing in patches, leaving uneven earth. A stretch of\n"
+    "wrought iron railing clings to one wall, bent inward.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room242", "south",
+    "domain/original/area/anshelm/room244", "north",
+  });
 }

--- a/domain/original/area/anshelm/room244.c
+++ b/domain/original/area/anshelm/room244.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western intersection of Rue du Nord and Kirsch Lane";
-    long_desc = "Western intersection of Rue du Nord and Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room245", "west",
-        "domain/original/area/anshelm/room250", "east",
-        "domain/original/area/anshelm/room243", "south",
-    });
+  short_desc = "Lane Crossing";
+  long_desc =
+    "A side lane cuts west toward narrower houses. The corner stones are chipped\n"
+    "and slick with lichen.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room245", "west",
+    "domain/original/area/anshelm/room250", "east",
+    "domain/original/area/anshelm/room243", "south",
+  });
 }

--- a/domain/original/area/anshelm/room245.c
+++ b/domain/original/area/anshelm/room245.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kirsch Lane";
-    long_desc = "Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room244", "east",
-        "domain/original/area/anshelm/room246", "west",
-    });
+  short_desc = "Narrow Lane";
+  long_desc =
+    "The lane pinches between tall, close walls of mottled stone. A ribbon of ivy\n"
+    "trails down from a broken cornice.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room244", "east",
+    "domain/original/area/anshelm/room246", "west",
+  });
 }

--- a/domain/original/area/anshelm/room246.c
+++ b/domain/original/area/anshelm/room246.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kirsch Lane";
-    long_desc = "Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room247", "west",
-        "domain/original/area/anshelm/room245", "east",
-        "domain/original/area/anshelm/room249", "south",
-    });
+  short_desc = "Shaded Lane";
+  long_desc =
+    "The street stays in shadow beneath overhanging roofs. Damp plaster flakes from\n"
+    "the walls in thin curls.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room247", "west",
+    "domain/original/area/anshelm/room245", "east",
+    "domain/original/area/anshelm/room249", "south",
+  });
 }

--- a/domain/original/area/anshelm/room247.c
+++ b/domain/original/area/anshelm/room247.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western end of Kirsch Lane";
-    long_desc = "Western end of Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room246", "east",
-        "domain/original/area/anshelm/room248", "south",
-    });
+  short_desc = "Lane End";
+  long_desc =
+    "The lane narrows to a bend where the stones are nearly buried. A collapsed\n"
+    "stoop leaves a shallow pit of rubble.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room246", "east",
+    "domain/original/area/anshelm/room248", "south",
+  });
 }

--- a/domain/original/area/anshelm/room248.c
+++ b/domain/original/area/anshelm/room248.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room247", "north",
-    });
+  short_desc = "Halfbuilt Court";
+  long_desc =
+    "Unfinished walls stand in a rough square, their mortar crumbled into dust.\n"
+    "Timber scaffolds lie splintered across the ground.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room247", "north",
+  });
 }

--- a/domain/original/area/anshelm/room249.c
+++ b/domain/original/area/anshelm/room249.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kaneohe Armory";
-    long_desc = "Kaneohe Armory.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room246", "north",
-    });
+  short_desc = "Old Armory";
+  long_desc =
+    "A stout stone building squats behind a collapsed lintel. Rusted hooks and\n"
+    "empty racks line the interior walls.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room246", "north",
+  });
 }

--- a/domain/original/area/anshelm/room250.c
+++ b/domain/original/area/anshelm/room250.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern intersection of Rue du Nord and Kirsch Lane";
-    long_desc = "Eastern intersection of Rue du Nord and Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room244", "west",
-        "domain/original/area/anshelm/room283", "east",
-        "domain/original/area/anshelm/room251", "north",
-    });
+  short_desc = "East Crossing";
+  long_desc =
+    "The street opens to a small intersection marked by worn corner stones. Broken\n"
+    "shutters hang from a nearby window frame.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room244", "west",
+    "domain/original/area/anshelm/room283", "east",
+    "domain/original/area/anshelm/room251", "north",
+  });
 }

--- a/domain/original/area/anshelm/room251.c
+++ b/domain/original/area/anshelm/room251.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room250", "south",
-        "domain/original/area/anshelm/room1193", "east",
-        "domain/original/area/anshelm/room252", "north",
-    });
+  short_desc = "North Road";
+  long_desc =
+    "A broad band of stone runs between mute facades. Drifts of grit and leaves\n"
+    "gather along the curb.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room250", "south",
+    "domain/original/area/anshelm/room1193", "east",
+    "domain/original/area/anshelm/room252", "north",
+  });
 }

--- a/domain/original/area/anshelm/room252.c
+++ b/domain/original/area/anshelm/room252.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room251", "south",
-        "domain/original/area/anshelm/room253", "north",
-    });
+  short_desc = "Pale Road";
+  long_desc =
+    "The paving here is pale and smoothed by time. A cracked column base lies\n"
+    "beside a doorway.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room251", "south",
+    "domain/original/area/anshelm/room253", "north",
+  });
 }

--- a/domain/original/area/anshelm/room253.c
+++ b/domain/original/area/anshelm/room253.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room252", "south",
-        "domain/original/area/anshelm/room254", "north",
-    });
+  short_desc = "Dusty Way";
+  long_desc =
+    "Dust lies thick in the seams between stones. A sagging awning frame still\n"
+    "clings to a wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room252", "south",
+    "domain/original/area/anshelm/room254", "north",
+  });
 }

--- a/domain/original/area/anshelm/room254.c
+++ b/domain/original/area/anshelm/room254.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room253", "south",
-        "domain/original/area/anshelm/room255", "north",
-    });
+  short_desc = "Iron Walk";
+  long_desc =
+    "Old iron rails bracket the street, many bent or missing. The roadway is\n"
+    "scarred by shallow ruts.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room253", "south",
+    "domain/original/area/anshelm/room255", "north",
+  });
 }

--- a/domain/original/area/anshelm/room255.c
+++ b/domain/original/area/anshelm/room255.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Central Square on the Rue du Nord";
-    long_desc = "Central Square on the Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room254", "south",
-        "domain/original/area/anshelm/room1195", "west",
-        "domain/original/area/anshelm/room1194", "east",
-        "domain/original/area/anshelm/room256", "north",
-    });
+  short_desc = "Quiet Square";
+  long_desc =
+    "The street widens into a square of mottled stone. A dry basin sits at the\n"
+    "center, its rim chipped and stained.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room254", "south",
+    "domain/original/area/anshelm/room1195", "west",
+    "domain/original/area/anshelm/room1194", "east",
+    "domain/original/area/anshelm/room256", "north",
+  });
 }

--- a/domain/original/area/anshelm/room256.c
+++ b/domain/original/area/anshelm/room256.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room255", "south",
-        "domain/original/area/anshelm/room257", "north",
-    });
+  short_desc = "Lonely Row";
+  long_desc =
+    "Shuttered storefronts line the way, their thresholds choked with weeds. The\n"
+    "stone is slick where rainwater pools.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room255", "south",
+    "domain/original/area/anshelm/room257", "north",
+  });
 }

--- a/domain/original/area/anshelm/room257.c
+++ b/domain/original/area/anshelm/room257.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room256", "south",
-        "domain/original/area/anshelm/room258", "north",
-    });
+  short_desc = "Faded Row";
+  long_desc =
+    "Faded plaster clings to the walls in torn patches. A thin vine threads across\n"
+    "a cracked arch.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room256", "south",
+    "domain/original/area/anshelm/room258", "north",
+  });
 }

--- a/domain/original/area/anshelm/room258.c
+++ b/domain/original/area/anshelm/room258.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Rue du Nord and East Geld Strasse";
-    long_desc = "Intersection of Rue du Nord and East Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room259", "west",
-        "domain/original/area/anshelm/room281", "east",
-        "domain/original/area/anshelm/room257", "south",
-    });
+  short_desc = "Market Crossing";
+  long_desc =
+    "Two streets intersect around a scatter of broken paving. A split wagon wheel\n"
+    "rests in the gutter.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room259", "west",
+    "domain/original/area/anshelm/room281", "east",
+    "domain/original/area/anshelm/room257", "south",
+  });
 }

--- a/domain/original/area/anshelm/room259.c
+++ b/domain/original/area/anshelm/room259.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room258", "east",
-        "domain/original/area/anshelm/room260", "west",
-    });
+  short_desc = "North Passage";
+  long_desc =
+    "The street tightens, squeezed by leaning masonry. Loose slate tiles litter the\n"
+    "edges of the road.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room258", "east",
+    "domain/original/area/anshelm/room260", "west",
+  });
 }

--- a/domain/original/area/anshelm/room260.c
+++ b/domain/original/area/anshelm/room260.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Rue du Nord and West Geld Strasse";
-    long_desc = "Intersection of Rue du Nord and West Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room261", "west",
-        "domain/original/area/anshelm/room259", "east",
-        "domain/original/area/anshelm/room264", "north",
-    });
+  short_desc = "West Crossing";
+  long_desc =
+    "The intersection is marked by a low stone post worn smooth. Thin grass pushes\n"
+    "up through the central joints.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room261", "west",
+    "domain/original/area/anshelm/room259", "east",
+    "domain/original/area/anshelm/room264", "north",
+  });
 }

--- a/domain/original/area/anshelm/room261.c
+++ b/domain/original/area/anshelm/room261.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Geld Strasse";
-    long_desc = "Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room260", "east",
-        "domain/original/area/anshelm/room262", "west",
-    });
+  short_desc = "Stone Lane";
+  long_desc =
+    "A straight lane runs east and west through close-set houses. The walls show\n"
+    "traces of pale paint and old murals.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room260", "east",
+    "domain/original/area/anshelm/room262", "west",
+  });
 }

--- a/domain/original/area/anshelm/room262.c
+++ b/domain/original/area/anshelm/room262.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Geld Strasse";
-    long_desc = "Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room261", "east",
-        "domain/original/area/anshelm/room263", "west",
-    });
+  short_desc = "Dusty Lane";
+  long_desc =
+    "The lane is littered with fragments of tile and brick. A broken archway opens\n"
+    "into a hollowed shop.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room261", "east",
+    "domain/original/area/anshelm/room263", "west",
+  });
 }

--- a/domain/original/area/anshelm/room263.c
+++ b/domain/original/area/anshelm/room263.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western end of Geld Strasse";
-    long_desc = "Western end of Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room262", "east",
-    });
+  short_desc = "West Lane";
+  long_desc =
+    "The street ends at a tumbled wall where stones have slid down. A narrow alley\n"
+    "slips away beside the ruin.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room262", "east",
+  });
 }

--- a/domain/original/area/anshelm/room264.c
+++ b/domain/original/area/anshelm/room264.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room260", "south",
-        "domain/original/area/anshelm/room265", "north",
-    });
+  short_desc = "North Run";
+  long_desc =
+    "The road here is uneven, with stones heaved by roots. A bent streetlamp rises\n"
+    "from a base of cracked stone.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room260", "south",
+    "domain/original/area/anshelm/room265", "north",
+  });
 }

--- a/domain/original/area/anshelm/room265.c
+++ b/domain/original/area/anshelm/room265.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Gateway to Upper Bailey";
-    long_desc = "Gateway to Upper Bailey.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room264", "south",
-        "domain/original/area/anshelm/room282", "west",
-        "domain/original/area/anshelm/room1198", "east",
-        "domain/original/area/anshelm/room266", "north",
-    });
+  short_desc = "Upper Gate";
+  long_desc =
+    "A high arch leads toward the inner rise of the city. The guard slots are\n"
+    "empty, their stone edges crumbled.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room264", "south",
+    "domain/original/area/anshelm/room282", "west",
+    "domain/original/area/anshelm/room1198", "east",
+    "domain/original/area/anshelm/room266", "north",
+  });
 }

--- a/domain/original/area/anshelm/room266.c
+++ b/domain/original/area/anshelm/room266.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room265", "south",
-        "domain/original/area/anshelm/room267", "north",
-    });
+  short_desc = "High Road";
+  long_desc =
+    "The road climbs slightly, flanked by taller facades. Broken balcony ironwork\n"
+    "hangs over the street.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room265", "south",
+    "domain/original/area/anshelm/room267", "north",
+  });
 }

--- a/domain/original/area/anshelm/room267.c
+++ b/domain/original/area/anshelm/room267.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Intersection of Rue du Nord and Kasernegade";
-    long_desc = "Intersection of Rue du Nord and Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room266", "south",
-        "domain/original/area/anshelm/room268", "west",
-        "domain/original/area/anshelm/room276", "east",
-        "domain/original/area/anshelm/room273", "north",
-    });
+  short_desc = "Barrack Crossing";
+  long_desc =
+    "Two roads meet before a line of long, low buildings. Their doorways gape, dark\n"
+    "and silent.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room266", "south",
+    "domain/original/area/anshelm/room268", "west",
+    "domain/original/area/anshelm/room276", "east",
+    "domain/original/area/anshelm/room273", "north",
+  });
 }

--- a/domain/original/area/anshelm/room268.c
+++ b/domain/original/area/anshelm/room268.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room267", "east",
-        "domain/original/area/anshelm/room269", "west",
-    });
+  short_desc = "Barrack Road";
+  long_desc =
+    "Long stone halls march along the street, their roofs partly fallen. Rusted\n"
+    "nails and timbers lie in heaps.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room267", "east",
+    "domain/original/area/anshelm/room269", "west",
+  });
 }

--- a/domain/original/area/anshelm/room269.c
+++ b/domain/original/area/anshelm/room269.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room268", "east",
-        "domain/original/area/anshelm/room270", "west",
-    });
+  short_desc = "Sentry Street";
+  long_desc =
+    "The street is broader here, with a strip of packed earth between stones. A\n"
+    "toppled post leans against a wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room268", "east",
+    "domain/original/area/anshelm/room270", "west",
+  });
 }

--- a/domain/original/area/anshelm/room270.c
+++ b/domain/original/area/anshelm/room270.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room271", "west",
-        "domain/original/area/anshelm/room269", "east",
-        "domain/original/area/anshelm/room1199", "south",
-    });
+  short_desc = "Long Street";
+  long_desc =
+    "The road runs straight between crumbling barracks. Wind has pushed leaves into\n"
+    "slow drifts.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room271", "west",
+    "domain/original/area/anshelm/room269", "east",
+    "domain/original/area/anshelm/room1199", "south",
+  });
 }

--- a/domain/original/area/anshelm/room271.c
+++ b/domain/original/area/anshelm/room271.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Western end of Kasernegade";
-    long_desc = "Western end of Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room270", "east",
-        "domain/original/area/anshelm/room272", "north",
-    });
+  short_desc = "West Barracks";
+  long_desc =
+    "The row of barracks breaks down into broken foundations. A sagging gate frame\n"
+    "stands without doors.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room270", "east",
+    "domain/original/area/anshelm/room272", "north",
+  });
 }

--- a/domain/original/area/anshelm/room272.c
+++ b/domain/original/area/anshelm/room272.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Construction site";
-    long_desc = "Construction site.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room271", "south",
-    });
+  short_desc = "Ruin Lot";
+  long_desc =
+    "A pit of rubble and half-set stone marks an abandoned build. Weeds knot around\n"
+    "a snapped beam.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room271", "south",
+  });
 }

--- a/domain/original/area/anshelm/room273.c
+++ b/domain/original/area/anshelm/room273.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Rue du Nord";
-    long_desc = "Rue du Nord.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room267", "south",
-        "domain/original/area/anshelm/room1202", "northwest",
-        "domain/original/area/anshelm/room274", "north",
-    });
+  short_desc = "North Spur";
+  long_desc =
+    "The road narrows as the surrounding walls thin. A fragment of mosaic tile\n"
+    "glints among the dust.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room267", "south",
+    "domain/original/area/anshelm/room1202", "northwest",
+    "domain/original/area/anshelm/room274", "north",
+  });
 }

--- a/domain/original/area/anshelm/room274.c
+++ b/domain/original/area/anshelm/room274.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Under the Town Gate";
-    long_desc = "Under the Town Gate.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room273", "south",
-        "domain/original/area/anshelm/room275", "north",
-    });
+  short_desc = "Town Arch";
+  long_desc =
+    "The town gate's stone throat opens above, its portcullis long vanished. Rain\n"
+    "has carved dark trails down the blocks.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room273", "south",
+    "domain/original/area/anshelm/room275", "north",
+  });
 }

--- a/domain/original/area/anshelm/room275.c
+++ b/domain/original/area/anshelm/room275.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Before the Anshelm Town Gate";
-    long_desc = "Before the Anshelm Town Gate.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room274", "south",
-    });
+  short_desc = "Gate Approach";
+  long_desc =
+    "Broken paving leads up to the archway, scattered with fallen masonry. The\n"
+    "flanking towers stand cracked and hollow.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room274", "south",
+  });
 }

--- a/domain/original/area/anshelm/room276.c
+++ b/domain/original/area/anshelm/room276.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room267", "west",
-        "domain/original/area/anshelm/room277", "east",
-        "domain/original/area/anshelm/room1200", "north",
-    });
+  short_desc = "Barrack Way";
+  long_desc =
+    "The street is lined with long foundations and collapsed roofs. Rusted iron\n"
+    "hoops lie in the dirt.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room267", "west",
+    "domain/original/area/anshelm/room277", "east",
+    "domain/original/area/anshelm/room1200", "north",
+  });
 }

--- a/domain/original/area/anshelm/room277.c
+++ b/domain/original/area/anshelm/room277.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room278", "east",
-        "domain/original/area/anshelm/room276", "west",
-    });
+  short_desc = "Soldier Row";
+  long_desc =
+    "The buildings here are little more than low walls. Grass grows thick where\n"
+    "floors once lay.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room278", "east",
+    "domain/original/area/anshelm/room276", "west",
+  });
 }

--- a/domain/original/area/anshelm/room278.c
+++ b/domain/original/area/anshelm/room278.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room279", "east",
-        "domain/original/area/anshelm/room277", "west",
-    });
+  short_desc = "Empty Street";
+  long_desc =
+    "A wide track of stone holds pooled rainwater. A shattered doorway arches into\n"
+    "darkness.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room279", "east",
+    "domain/original/area/anshelm/room277", "west",
+  });
 }

--- a/domain/original/area/anshelm/room279.c
+++ b/domain/original/area/anshelm/room279.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kasernegade";
-    long_desc = "Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room280", "east",
-        "domain/original/area/anshelm/room278", "west",
-    });
+  short_desc = "Quiet Way";
+  long_desc =
+    "The stone is cracked and uneven, with weeds in the seams. A line of iron pegs\n"
+    "runs along one wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room280", "east",
+    "domain/original/area/anshelm/room278", "west",
+  });
 }

--- a/domain/original/area/anshelm/room280.c
+++ b/domain/original/area/anshelm/room280.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern end of Kasernegade";
-    long_desc = "Eastern end of Kasernegade.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room279", "west",
-        "domain/original/area/anshelm/room1201", "south",
-    });
+  short_desc = "East Barracks";
+  long_desc =
+    "The road ends near a heap of collapsed roof tiles. A rusted bell frame tilts\n"
+    "in the rubble.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room279", "west",
+    "domain/original/area/anshelm/room1201", "south",
+  });
 }

--- a/domain/original/area/anshelm/room281.c
+++ b/domain/original/area/anshelm/room281.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Geld Strasse";
-    long_desc = "Geld Strasse.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room258", "west",
-        "domain/original/area/anshelm/room1328", "east",
-        "domain/original/area/anshelm/room1197", "north",
-    });
+  short_desc = "Stone Row";
+  long_desc =
+    "The lane is straight and silent, edged by worn thresholds. A chipped well cap\n"
+    "sits off to one side.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room258", "west",
+    "domain/original/area/anshelm/room1328", "east",
+    "domain/original/area/anshelm/room1197", "north",
+  });
 }

--- a/domain/original/area/anshelm/room282.c
+++ b/domain/original/area/anshelm/room282.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "You have to turn sideways a bit to squeeze through the narrow passage.";
-    long_desc = "You have to turn sideways a bit to squeeze through the narrow passage.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room265", "east",
-    });
+  short_desc = "Narrow Gap";
+  long_desc =
+    "A tight passage squeezes between two leaning walls. The stone here is smooth\n"
+    "with wear and damp.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room265", "east",
+  });
 }

--- a/domain/original/area/anshelm/room283.c
+++ b/domain/original/area/anshelm/room283.c
@@ -1,16 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kirsch Lane";
-    long_desc = "Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room250", "west",
-        "domain/original/area/anshelm/room284", "east",
-        "domain/original/area/anshelm/room1326", "north",
-    });
+  short_desc = "Back Lane";
+  long_desc =
+    "A small lane winds between cramped houses. Broken shutters lie in the weeds.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room250", "west",
+    "domain/original/area/anshelm/room284", "east",
+    "domain/original/area/anshelm/room1326", "north",
+  });
 }

--- a/domain/original/area/anshelm/room284.c
+++ b/domain/original/area/anshelm/room284.c
@@ -1,16 +1,19 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Kirsch Lane";
-    long_desc = "Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room283", "west",
-        "domain/original/area/anshelm/room285", "east",
-        "domain/original/area/anshelm/room1327", "north",
-    });
+  short_desc = "Brick Lane";
+  long_desc =
+    "The lane is edged by low brickwork and crumbling steps. A faded tile pattern\n"
+    "lingers in the dust.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room283", "west",
+    "domain/original/area/anshelm/room285", "east",
+    "domain/original/area/anshelm/room1327", "north",
+  });
 }

--- a/domain/original/area/anshelm/room285.c
+++ b/domain/original/area/anshelm/room285.c
@@ -1,14 +1,17 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Eastern end of Kirsch Lane";
-    long_desc = "Eastern end of Kirsch Lane.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room284", "west",
-    });
+  short_desc = "East Lane";
+  long_desc =
+    "The lane opens toward a wider street, its stones chipped and uneven. A sagging\n"
+    "lintel hangs over a dark doorway.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room284", "west",
+  });
 }

--- a/domain/original/area/anshelm/room413.c
+++ b/domain/original/area/anshelm/room413.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Hawaiian Ryan's";
-    long_desc = "Hawaiian Ryan's.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room238", "east",
-        "domain/original/area/anshelm/room414", "north",
-    });
+  short_desc = "Empty Club";
+  long_desc =
+    "A small hall opens here with a low stage and a cracked rail. Tattered curtains\n"
+    "hang in strips along the back wall.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room238", "east",
+    "domain/original/area/anshelm/room414", "north",
+  });
 }

--- a/domain/original/area/anshelm/room414.c
+++ b/domain/original/area/anshelm/room414.c
@@ -1,17 +1,20 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Beitel Straad";
-    long_desc = "Beitel Straad.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room413", "south",
-        "domain/original/area/anshelm/room1147", "west",
-        "domain/original/area/anshelm/room239", "east",
-        "domain/original/area/anshelm/room415", "north",
-    });
+  short_desc = "Lamp Street";
+  long_desc =
+    "The street bends past a row of battered lamp posts and narrow doors. Faded\n"
+    "plaster still carries traces of painted vines.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room413", "south",
+    "domain/original/area/anshelm/room1147", "west",
+    "domain/original/area/anshelm/room239", "east",
+    "domain/original/area/anshelm/room415", "north",
+  });
 }

--- a/domain/original/area/anshelm/room415.c
+++ b/domain/original/area/anshelm/room415.c
@@ -1,15 +1,18 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Club Femme Nu";
-    long_desc = "Club Femme Nu.\n";
-    dest_dir = ({
-        "domain/original/area/anshelm/room240", "east",
-        "domain/original/area/anshelm/room414", "south",
-    });
+  short_desc = "Quiet Salon";
+  long_desc =
+    "A wide room holds a chipped dance floor and a sagging balcony. Dust coats the\n"
+    "rail where hands once rested.\n";
+  dest_dir = ({
+    "domain/original/area/anshelm/room240", "east",
+    "domain/original/area/anshelm/room414", "south",
+  });
 }


### PR DESCRIPTION
### Motivation
- Bring the Anshelm area into the Phase 1 world state by replacing specific/modern place names and terse placeholders with restrained, aged, and anonymous prose that matches `PHASE1.md` and `PROSE.md` guidance.
- Preserve Phase 1 constraints (no NPCs, items, or dynamic systems) while conveying reclaimed, bohemian, and weathered city imagery.
- Align room source formatting with the repository `CODE-STYLE.md` conventions for clarity and future edits.

### Description
- Updated `short_desc` and `long_desc` for the Anshelm room set (111 files under `domain/original/area/anshelm`) to anonymous, aged names and two-to-three sentence descriptions reflecting long-abandoned architecture and muted sensory detail.
- Reformatted `reset` blocks and `long_desc` string wrapping to conform to the code style (K&R braces, two-space indentation, and ~80-column wrapped player text) while preserving each room's `dest_dir` exits and any exit aliases.
- Normalized interior and special-space descriptions (stables, armory, salon, gatehouse, bailey, etc.) to avoid modern or anachronistic language and to keep emotional restraint per `PROSE.md`.
- Committed the changed files with the message `Age Anshelm rooms for phase one` (111 files changed).

### Testing
- Ran a line-wrap/length audit on wrapped `long_desc` strings and found no player-facing lines exceeding the configured width (passed).
- Performed a file update audit to ensure the intended `room*.c` files were processed and none were missed (passed).
- Verified a successful `git` add/commit of the modified files (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3a0a09888327af1fecc95606cb31)