### PR TITLE
Age Indel passage descriptions

### DIFF
--- a/domain/original/area/indel/room1401.c
+++ b/domain/original/area/indel/room1401.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Broken Bleached Crossing";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way opens into a broad break where several lines of ruin meet. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1402", "south",
         "domain/original/area/indel/room1636", "east",

--- a/domain/original/area/indel/room1402.c
+++ b/domain/original/area/indel/room1402.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Crossing";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several lines of ruin meet. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1401", "north",
         "domain/original/area/indel/room1403", "south",

--- a/domain/original/area/indel/room1403.c
+++ b/domain/original/area/indel/room1403.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Crossing";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several lines of ruin meet. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1402", "north",
         "domain/original/area/indel/room1404", "south",

--- a/domain/original/area/indel/room1404.c
+++ b/domain/original/area/indel/room1404.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Mossy Bleached Crossing";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several lines of ruin meet. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1403", "north",
         "domain/original/area/indel/room1405", "south",

--- a/domain/original/area/indel/room1405.c
+++ b/domain/original/area/indel/room1405.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Choked Split Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1404", "north",
         "domain/original/area/indel/room1406", "south",

--- a/domain/original/area/indel/room1406.c
+++ b/domain/original/area/indel/room1406.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Crossing";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way opens into a broad break where several lines of ruin meet. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1405", "north",
         "domain/original/area/indel/room1584", "south",

--- a/domain/original/area/indel/room1407.c
+++ b/domain/original/area/indel/room1407.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Charred Bleached Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1406", "east",
         "domain/original/area/indel/room1408", "west",

--- a/domain/original/area/indel/room1408.c
+++ b/domain/original/area/indel/room1408.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Rubble Split Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1589", "south",
         "domain/original/area/indel/room1407", "east",

--- a/domain/original/area/indel/room1409.c
+++ b/domain/original/area/indel/room1409.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Split Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1590", "south",
         "domain/original/area/indel/room1408", "east",

--- a/domain/original/area/indel/room1410.c
+++ b/domain/original/area/indel/room1410.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Jagged Bleached Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1409", "east",
         "domain/original/area/indel/room1411", "west",

--- a/domain/original/area/indel/room1411.c
+++ b/domain/original/area/indel/room1411.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ashen Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1410", "east",
         "domain/original/area/indel/room1412", "west",

--- a/domain/original/area/indel/room1412.c
+++ b/domain/original/area/indel/room1412.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1411", "east",
         "domain/original/area/indel/room1413", "west",

--- a/domain/original/area/indel/room1413.c
+++ b/domain/original/area/indel/room1413.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sagging Bleached Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1412", "east",
         "domain/original/area/indel/room1414", "west",

--- a/domain/original/area/indel/room1414.c
+++ b/domain/original/area/indel/room1414.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Eroded Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1413", "east",
         "domain/original/area/indel/room1415", "west",

--- a/domain/original/area/indel/room1415.c
+++ b/domain/original/area/indel/room1415.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1414", "east",
         "domain/original/area/indel/room1416", "west",

--- a/domain/original/area/indel/room1416.c
+++ b/domain/original/area/indel/room1416.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Shattered Bleached Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1415", "east",
         "domain/original/area/indel/room1417", "west",

--- a/domain/original/area/indel/room1417.c
+++ b/domain/original/area/indel/room1417.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Lichen Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1416", "east",
         "domain/original/area/indel/room1418", "west",

--- a/domain/original/area/indel/room1418.c
+++ b/domain/original/area/indel/room1418.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Split Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1448", "north",
         "domain/original/area/indel/room1419", "south",

--- a/domain/original/area/indel/room1419.c
+++ b/domain/original/area/indel/room1419.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Pitted Bleached Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1418", "north",
         "domain/original/area/indel/room1420", "south",

--- a/domain/original/area/indel/room1420.c
+++ b/domain/original/area/indel/room1420.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Stained Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1419", "north",
         "domain/original/area/indel/room1421", "south",

--- a/domain/original/area/indel/room1421.c
+++ b/domain/original/area/indel/room1421.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1420", "north",
         "domain/original/area/indel/room1422", "south",

--- a/domain/original/area/indel/room1422.c
+++ b/domain/original/area/indel/room1422.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Seamed Bleached Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1421", "north",
         "domain/original/area/indel/room1423", "south",

--- a/domain/original/area/indel/room1423.c
+++ b/domain/original/area/indel/room1423.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Leaning Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1422", "north",
         "domain/original/area/indel/room1424", "south",

--- a/domain/original/area/indel/room1424.c
+++ b/domain/original/area/indel/room1424.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1423", "north",
         "domain/original/area/indel/room1425", "south",

--- a/domain/original/area/indel/room1425.c
+++ b/domain/original/area/indel/room1425.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Bleached Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1424", "north",
         "domain/original/area/indel/room1426", "south",

--- a/domain/original/area/indel/room1426.c
+++ b/domain/original/area/indel/room1426.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Slick Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1425", "north",
         "domain/original/area/indel/room1427", "south",

--- a/domain/original/area/indel/room1427.c
+++ b/domain/original/area/indel/room1427.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1426", "north",
         "domain/original/area/indel/room1428", "south",

--- a/domain/original/area/indel/room1428.c
+++ b/domain/original/area/indel/room1428.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ruined Bleached Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1427", "north",
         "domain/original/area/indel/room1429", "south",

--- a/domain/original/area/indel/room1429.c
+++ b/domain/original/area/indel/room1429.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Spalled Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1428", "north",
         "domain/original/area/indel/room1430", "south",

--- a/domain/original/area/indel/room1430.c
+++ b/domain/original/area/indel/room1430.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1429", "north",
         "domain/original/area/indel/room1431", "south",

--- a/domain/original/area/indel/room1431.c
+++ b/domain/original/area/indel/room1431.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Split Bleached Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1430", "north",
         "domain/original/area/indel/room1432", "south",

--- a/domain/original/area/indel/room1432.c
+++ b/domain/original/area/indel/room1432.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1431", "north",
         "domain/original/area/indel/room1433", "south",

--- a/domain/original/area/indel/room1433.c
+++ b/domain/original/area/indel/room1433.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1432", "north",
         "domain/original/area/indel/room1434", "south",

--- a/domain/original/area/indel/room1434.c
+++ b/domain/original/area/indel/room1434.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Smeared Bleached Split Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1433", "north",
         "domain/original/area/indel/room1435", "south",

--- a/domain/original/area/indel/room1435.c
+++ b/domain/original/area/indel/room1435.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Worn Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1434", "north",
         "domain/original/area/indel/room1436", "south",

--- a/domain/original/area/indel/room1436.c
+++ b/domain/original/area/indel/room1436.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1435", "north",
         "domain/original/area/indel/room1437", "south",

--- a/domain/original/area/indel/room1437.c
+++ b/domain/original/area/indel/room1437.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Faded Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1436", "north",
         "domain/original/area/indel/room1438", "south",

--- a/domain/original/area/indel/room1438.c
+++ b/domain/original/area/indel/room1438.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sundered Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1437", "north",
         "domain/original/area/indel/room1439", "south",

--- a/domain/original/area/indel/room1439.c
+++ b/domain/original/area/indel/room1439.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Choked End";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1438", "north",
     });

--- a/domain/original/area/indel/room1448.c
+++ b/domain/original/area/indel/room1448.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Choked Faded Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1507", "north",
         "domain/original/area/indel/room1418", "south",

--- a/domain/original/area/indel/room1507.c
+++ b/domain/original/area/indel/room1507.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Scorched Choked End";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force.\n\nA collapsed heap chokes the line, forcing a retreat. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force.\n\nA collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1448", "south",
     });

--- a/domain/original/area/indel/room1508.c
+++ b/domain/original/area/indel/room1508.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1509", "east",
         "domain/original/area/indel/room1406", "west",

--- a/domain/original/area/indel/room1509.c
+++ b/domain/original/area/indel/room1509.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Rubble Faded Split Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1624", "north",
         "domain/original/area/indel/room1510", "east",

--- a/domain/original/area/indel/room1510.c
+++ b/domain/original/area/indel/room1510.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Collapsed Split Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1623", "north",
         "domain/original/area/indel/room1511", "east",

--- a/domain/original/area/indel/room1511.c
+++ b/domain/original/area/indel/room1511.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Split Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1622", "north",
         "domain/original/area/indel/room1512", "east",

--- a/domain/original/area/indel/room1512.c
+++ b/domain/original/area/indel/room1512.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ashen Faded Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1513", "east",
         "domain/original/area/indel/room1511", "west",

--- a/domain/original/area/indel/room1513.c
+++ b/domain/original/area/indel/room1513.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Blasted Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1514", "east",
         "domain/original/area/indel/room1512", "west",

--- a/domain/original/area/indel/room1514.c
+++ b/domain/original/area/indel/room1514.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Split Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1621", "north",
         "domain/original/area/indel/room1515", "east",

--- a/domain/original/area/indel/room1515.c
+++ b/domain/original/area/indel/room1515.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Eroded Faded Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1516", "east",
         "domain/original/area/indel/room1514", "west",

--- a/domain/original/area/indel/room1516.c
+++ b/domain/original/area/indel/room1516.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Splintered Split Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1520", "south",
         "domain/original/area/indel/room1517", "east",

--- a/domain/original/area/indel/room1517.c
+++ b/domain/original/area/indel/room1517.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1518", "east",
         "domain/original/area/indel/room1516", "west",

--- a/domain/original/area/indel/room1518.c
+++ b/domain/original/area/indel/room1518.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Lichen Faded Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1519", "east",
         "domain/original/area/indel/room1517", "west",

--- a/domain/original/area/indel/room1519.c
+++ b/domain/original/area/indel/room1519.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Gritted Choked End";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, forcing a retreat. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1518", "west",
     });

--- a/domain/original/area/indel/room1520.c
+++ b/domain/original/area/indel/room1520.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1516", "north",
         "domain/original/area/indel/room1521", "south",

--- a/domain/original/area/indel/room1521.c
+++ b/domain/original/area/indel/room1521.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Stained Faded Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1520", "north",
         "domain/original/area/indel/room1522", "south",

--- a/domain/original/area/indel/room1522.c
+++ b/domain/original/area/indel/room1522.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Fractured Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1521", "north",
         "domain/original/area/indel/room1523", "south",

--- a/domain/original/area/indel/room1523.c
+++ b/domain/original/area/indel/room1523.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1522", "north",
         "domain/original/area/indel/room1524", "south",

--- a/domain/original/area/indel/room1524.c
+++ b/domain/original/area/indel/room1524.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Leaning Faded Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1523", "north",
         "domain/original/area/indel/room1525", "south",

--- a/domain/original/area/indel/room1525.c
+++ b/domain/original/area/indel/room1525.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Hollow Split Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1524", "north",
         "domain/original/area/indel/room1526", "south",

--- a/domain/original/area/indel/room1526.c
+++ b/domain/original/area/indel/room1526.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1525", "north",
         "domain/original/area/indel/room1527", "south",

--- a/domain/original/area/indel/room1527.c
+++ b/domain/original/area/indel/room1527.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Slick Faded Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1526", "north",
         "domain/original/area/indel/room1528", "south",

--- a/domain/original/area/indel/room1528.c
+++ b/domain/original/area/indel/room1528.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Fallen Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1527", "north",
         "domain/original/area/indel/room1529", "south",

--- a/domain/original/area/indel/room1529.c
+++ b/domain/original/area/indel/room1529.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1528", "north",
         "domain/original/area/indel/room1530", "south",

--- a/domain/original/area/indel/room1530.c
+++ b/domain/original/area/indel/room1530.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Spalled Faded Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1529", "north",
         "domain/original/area/indel/room1531", "south",

--- a/domain/original/area/indel/room1531.c
+++ b/domain/original/area/indel/room1531.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Dusted Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1530", "north",
         "domain/original/area/indel/room1532", "south",

--- a/domain/original/area/indel/room1532.c
+++ b/domain/original/area/indel/room1532.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1531", "north",
         "domain/original/area/indel/room1533", "south",

--- a/domain/original/area/indel/room1533.c
+++ b/domain/original/area/indel/room1533.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Faded Split Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1532", "north",
         "domain/original/area/indel/room1534", "south",

--- a/domain/original/area/indel/room1534.c
+++ b/domain/original/area/indel/room1534.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Dulled Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1533", "north",
         "domain/original/area/indel/room1542", "south",

--- a/domain/original/area/indel/room1535.c
+++ b/domain/original/area/indel/room1535.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Faded Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1536", "east",
         "domain/original/area/indel/room1557", "west",

--- a/domain/original/area/indel/room1536.c
+++ b/domain/original/area/indel/room1536.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Worn Faded Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1537", "east",
         "domain/original/area/indel/room1535", "west",

--- a/domain/original/area/indel/room1537.c
+++ b/domain/original/area/indel/room1537.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Broken Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Chunks of wall have been scooped away, leaving raw ribs of stone.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Chunks of wall have been scooped away, leaving raw ribs of stone.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1538", "east",
         "domain/original/area/indel/room1536", "west",

--- a/domain/original/area/indel/room1538.c
+++ b/domain/original/area/indel/room1538.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1539", "east",
         "domain/original/area/indel/room1537", "west",

--- a/domain/original/area/indel/room1539.c
+++ b/domain/original/area/indel/room1539.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sundered Sunk Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1540", "east",
         "domain/original/area/indel/room1538", "west",

--- a/domain/original/area/indel/room1540.c
+++ b/domain/original/area/indel/room1540.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Mossy Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1541", "east",
         "domain/original/area/indel/room1539", "west",

--- a/domain/original/area/indel/room1541.c
+++ b/domain/original/area/indel/room1541.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1542", "east",
         "domain/original/area/indel/room1540", "west",

--- a/domain/original/area/indel/room1542.c
+++ b/domain/original/area/indel/room1542.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Scorched Sunk Split Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Chunks of wall have been scooped away, leaving raw ribs of stone.\n\nThe path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Chunks of wall have been scooped away, leaving raw ribs of stone.\n\nThe path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1534", "north",
         "domain/original/area/indel/room1591", "east",

--- a/domain/original/area/indel/room1543.c
+++ b/domain/original/area/indel/room1543.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Charred Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1544", "north",
         "domain/original/area/indel/room1546", "south",

--- a/domain/original/area/indel/room1544.c
+++ b/domain/original/area/indel/room1544.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1558", "north",
         "domain/original/area/indel/room1543", "south",

--- a/domain/original/area/indel/room1545.c
+++ b/domain/original/area/indel/room1545.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Collapsed Sunk Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1546", "east",
         "domain/original/area/indel/room1434", "west",

--- a/domain/original/area/indel/room1546.c
+++ b/domain/original/area/indel/room1546.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Jagged Split Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Chunks of wall have been scooped away, leaving raw ribs of stone. The path splits around a heap of fallen blocks, offering multiple ruined lines. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Chunks of wall have been scooped away, leaving raw ribs of stone. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1543", "north",
         "domain/original/area/indel/room1547", "east",

--- a/domain/original/area/indel/room1547.c
+++ b/domain/original/area/indel/room1547.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Masonry slumps inward, its edges scored and melted in places.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Masonry slumps inward, its edges scored and melted in places.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1548", "east",
         "domain/original/area/indel/room1546", "west",

--- a/domain/original/area/indel/room1548.c
+++ b/domain/original/area/indel/room1548.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Blasted Sunk Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1549", "east",
         "domain/original/area/indel/room1547", "west",

--- a/domain/original/area/indel/room1549.c
+++ b/domain/original/area/indel/room1549.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sagging Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1550", "east",
         "domain/original/area/indel/room1548", "west",

--- a/domain/original/area/indel/room1550.c
+++ b/domain/original/area/indel/room1550.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1551", "east",
         "domain/original/area/indel/room1549", "west",

--- a/domain/original/area/indel/room1551.c
+++ b/domain/original/area/indel/room1551.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Splintered Sunk Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1552", "east",
         "domain/original/area/indel/room1550", "west",

--- a/domain/original/area/indel/room1552.c
+++ b/domain/original/area/indel/room1552.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Shattered Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Masonry slumps inward, its edges scored and melted in places.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Masonry slumps inward, its edges scored and melted in places.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1553", "east",
         "domain/original/area/indel/room1551", "west",

--- a/domain/original/area/indel/room1553.c
+++ b/domain/original/area/indel/room1553.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1554", "east",
         "domain/original/area/indel/room1552", "west",

--- a/domain/original/area/indel/room1554.c
+++ b/domain/original/area/indel/room1554.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Gritted Sunk Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1555", "east",
         "domain/original/area/indel/room1553", "west",

--- a/domain/original/area/indel/room1555.c
+++ b/domain/original/area/indel/room1555.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Pitted Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1556", "east",
         "domain/original/area/indel/room1554", "west",

--- a/domain/original/area/indel/room1556.c
+++ b/domain/original/area/indel/room1556.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1557", "east",
         "domain/original/area/indel/room1555", "west",

--- a/domain/original/area/indel/room1557.c
+++ b/domain/original/area/indel/room1557.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Fractured Sunk Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Jagged ribs of stone show cuts and pitting, some edges glassed by heat.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Jagged ribs of stone show cuts and pitting, some edges glassed by heat.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1535", "east",
         "domain/original/area/indel/room1556", "west",

--- a/domain/original/area/indel/room1558.c
+++ b/domain/original/area/indel/room1558.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Seamed Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1559", "north",
         "domain/original/area/indel/room1544", "south",

--- a/domain/original/area/indel/room1559.c
+++ b/domain/original/area/indel/room1559.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1560", "north",
         "domain/original/area/indel/room1558", "south",

--- a/domain/original/area/indel/room1560.c
+++ b/domain/original/area/indel/room1560.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Hollow Sunk Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1561", "north",
         "domain/original/area/indel/room1559", "south",

--- a/domain/original/area/indel/room1561.c
+++ b/domain/original/area/indel/room1561.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1562", "north",
         "domain/original/area/indel/room1560", "south",

--- a/domain/original/area/indel/room1562.c
+++ b/domain/original/area/indel/room1562.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Jagged ribs of stone show cuts and pitting, some edges glassed by heat.\n\nThe way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Jagged ribs of stone show cuts and pitting, some edges glassed by heat.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1563", "north",
         "domain/original/area/indel/room1561", "south",

--- a/domain/original/area/indel/room1563.c
+++ b/domain/original/area/indel/room1563.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Fallen Sunk Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1564", "north",
         "domain/original/area/indel/room1562", "south",

--- a/domain/original/area/indel/room1564.c
+++ b/domain/original/area/indel/room1564.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ruined Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1565", "north",
         "domain/original/area/indel/room1563", "south",

--- a/domain/original/area/indel/room1565.c
+++ b/domain/original/area/indel/room1565.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1566", "north",
         "domain/original/area/indel/room1564", "south",

--- a/domain/original/area/indel/room1566.c
+++ b/domain/original/area/indel/room1566.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Dusted Sunk Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.\n";
     dest_dir = ({
         "domain/original/area/indel/room1567", "north",
         "domain/original/area/indel/room1565", "south",

--- a/domain/original/area/indel/room1567.c
+++ b/domain/original/area/indel/room1567.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Split Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1568", "north",
         "domain/original/area/indel/room1566", "south",

--- a/domain/original/area/indel/room1568.c
+++ b/domain/original/area/indel/room1568.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1569", "north",
         "domain/original/area/indel/room1567", "south",

--- a/domain/original/area/indel/room1569.c
+++ b/domain/original/area/indel/room1569.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Dulled Sunk Broken Bend";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1568", "south",
         "domain/original/area/indel/room1570", "east",

--- a/domain/original/area/indel/room1570.c
+++ b/domain/original/area/indel/room1570.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Smeared Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1571", "east",
         "domain/original/area/indel/room1569", "west",

--- a/domain/original/area/indel/room1571.c
+++ b/domain/original/area/indel/room1571.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sunk Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1572", "east",
         "domain/original/area/indel/room1570", "west",

--- a/domain/original/area/indel/room1572.c
+++ b/domain/original/area/indel/room1572.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Broken Cold Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1573", "east",
         "domain/original/area/indel/room1571", "west",

--- a/domain/original/area/indel/room1573.c
+++ b/domain/original/area/indel/room1573.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Narrow Way";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1574", "east",
         "domain/original/area/indel/room1572", "west",

--- a/domain/original/area/indel/room1574.c
+++ b/domain/original/area/indel/room1574.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Narrow Way";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1575", "east",
         "domain/original/area/indel/room1573", "west",

--- a/domain/original/area/indel/room1575.c
+++ b/domain/original/area/indel/room1575.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Mossy Cold Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1576", "east",
         "domain/original/area/indel/room1574", "west",

--- a/domain/original/area/indel/room1576.c
+++ b/domain/original/area/indel/room1576.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Choked Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1577", "east",
         "domain/original/area/indel/room1575", "west",

--- a/domain/original/area/indel/room1577.c
+++ b/domain/original/area/indel/room1577.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Narrow Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1578", "east",
         "domain/original/area/indel/room1576", "west",

--- a/domain/original/area/indel/room1578.c
+++ b/domain/original/area/indel/room1578.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Charred Cold Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1579", "east",
         "domain/original/area/indel/room1577", "west",

--- a/domain/original/area/indel/room1579.c
+++ b/domain/original/area/indel/room1579.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Rubble Crossing";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several lines of ruin meet. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1584", "north",
         "domain/original/area/indel/room1585", "south",

--- a/domain/original/area/indel/room1580.c
+++ b/domain/original/area/indel/room1580.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Narrow Way";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1581", "east",
         "domain/original/area/indel/room1579", "west",

--- a/domain/original/area/indel/room1581.c
+++ b/domain/original/area/indel/room1581.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Jagged Cold Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1582", "east",
         "domain/original/area/indel/room1580", "west",

--- a/domain/original/area/indel/room1582.c
+++ b/domain/original/area/indel/room1582.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ashen Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1583", "east",
         "domain/original/area/indel/room1581", "west",

--- a/domain/original/area/indel/room1583.c
+++ b/domain/original/area/indel/room1583.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Broken Bend";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1582", "west",
         "domain/original/area/indel/room1653", "down",

--- a/domain/original/area/indel/room1584.c
+++ b/domain/original/area/indel/room1584.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sagging Cold Crossing";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several lines of ruin meet. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1406", "north",
         "domain/original/area/indel/room1579", "south",

--- a/domain/original/area/indel/room1585.c
+++ b/domain/original/area/indel/room1585.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Eroded Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1579", "north",
         "domain/original/area/indel/room1586", "south",

--- a/domain/original/area/indel/room1586.c
+++ b/domain/original/area/indel/room1586.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Choked End";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1585", "north",
     });

--- a/domain/original/area/indel/room1587.c
+++ b/domain/original/area/indel/room1587.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Shattered Cold Choked End";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nA collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nA collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1584", "west",
     });

--- a/domain/original/area/indel/room1588.c
+++ b/domain/original/area/indel/room1588.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Lichen Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1584", "east",
         "domain/original/area/indel/room1589", "west",

--- a/domain/original/area/indel/room1589.c
+++ b/domain/original/area/indel/room1589.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Split Way";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The path splits around a heap of fallen blocks, offering multiple ruined lines. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1408", "north",
         "domain/original/area/indel/room1588", "east",

--- a/domain/original/area/indel/room1590.c
+++ b/domain/original/area/indel/room1590.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Pitted Cold Broken Bend";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1409", "north",
         "domain/original/area/indel/room1589", "east",

--- a/domain/original/area/indel/room1591.c
+++ b/domain/original/area/indel/room1591.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Stained Narrow Way";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1592", "east",
         "domain/original/area/indel/room1542", "west",

--- a/domain/original/area/indel/room1592.c
+++ b/domain/original/area/indel/room1592.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Narrow Way";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line.\n\nThe way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1593", "east",
         "domain/original/area/indel/room1591", "west",

--- a/domain/original/area/indel/room1593.c
+++ b/domain/original/area/indel/room1593.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Seamed Cold Broken Bend";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1594", "north",
         "domain/original/area/indel/room1592", "west",

--- a/domain/original/area/indel/room1594.c
+++ b/domain/original/area/indel/room1594.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Leaning Broken Bend";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1593", "south",
         "domain/original/area/indel/room1595", "west",

--- a/domain/original/area/indel/room1595.c
+++ b/domain/original/area/indel/room1595.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Narrow Way";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1594", "east",
         "domain/original/area/indel/room1596", "west",

--- a/domain/original/area/indel/room1596.c
+++ b/domain/original/area/indel/room1596.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Cold Broken Bend";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1597", "north",
         "domain/original/area/indel/room1595", "east",

--- a/domain/original/area/indel/room1597.c
+++ b/domain/original/area/indel/room1597.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Slick Split Way";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe path splits around a heap of fallen blocks, offering multiple ruined lines. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1598", "north",
         "domain/original/area/indel/room1596", "south",

--- a/domain/original/area/indel/room1598.c
+++ b/domain/original/area/indel/room1598.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Split Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering multiple ruined lines. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1599", "north",
         "domain/original/area/indel/room1597", "south",

--- a/domain/original/area/indel/room1599.c
+++ b/domain/original/area/indel/room1599.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ruined Cold Choked End";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1598", "south",
     });

--- a/domain/original/area/indel/room1600.c
+++ b/domain/original/area/indel/room1600.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Spalled Crossing";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The way opens into a broad break where several lines of ruin meet. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1603", "north",
         "domain/original/area/indel/room1602", "south",

--- a/domain/original/area/indel/room1601.c
+++ b/domain/original/area/indel/room1601.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Choked End";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1600", "west",
     });

--- a/domain/original/area/indel/room1602.c
+++ b/domain/original/area/indel/room1602.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Split Cold Broken Bend";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through.\n\nThe passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1600", "north",
         "domain/original/area/indel/room1605", "east",

--- a/domain/original/area/indel/room1603.c
+++ b/domain/original/area/indel/room1603.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Bleached Broken Bend";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1600", "south",
         "domain/original/area/indel/room1604", "east",

--- a/domain/original/area/indel/room1604.c
+++ b/domain/original/area/indel/room1604.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cold Choked End";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1603", "west",
     });

--- a/domain/original/area/indel/room1605.c
+++ b/domain/original/area/indel/room1605.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Smeared Cold Choked End";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1602", "west",
     });

--- a/domain/original/area/indel/room1621.c
+++ b/domain/original/area/indel/room1621.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Worn Choked End";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1514", "south",
     });

--- a/domain/original/area/indel/room1622.c
+++ b/domain/original/area/indel/room1622.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Choked End";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force.\n\nA collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force.\n\nA collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1511", "south",
     });

--- a/domain/original/area/indel/room1623.c
+++ b/domain/original/area/indel/room1623.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Cracked Silted Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1643", "north",
         "domain/original/area/indel/room1510", "south",

--- a/domain/original/area/indel/room1624.c
+++ b/domain/original/area/indel/room1624.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Sundered Choked End";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1509", "south",
     });

--- a/domain/original/area/indel/room1625.c
+++ b/domain/original/area/indel/room1625.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Choked End";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1405", "east",
     });

--- a/domain/original/area/indel/room1626.c
+++ b/domain/original/area/indel/room1626.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Choked Silted Choked End";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1404", "east",
     });

--- a/domain/original/area/indel/room1627.c
+++ b/domain/original/area/indel/room1627.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Scorched Broken Bend";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force.\n\nThe passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force.\n\nThe passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1637", "south",
         "domain/original/area/indel/room1404", "west",

--- a/domain/original/area/indel/room1628.c
+++ b/domain/original/area/indel/room1628.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Broken Bend";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The passage angles hard here, squeezed between leaning stone. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1403", "east",
         "domain/original/area/indel/room1629", "down",

--- a/domain/original/area/indel/room1629.c
+++ b/domain/original/area/indel/room1629.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Rubble Silted Choked End";
-    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1628", "up",
     });

--- a/domain/original/area/indel/room1630.c
+++ b/domain/original/area/indel/room1630.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Collapsed Choked End";
-    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1403", "west",
     });

--- a/domain/original/area/indel/room1631.c
+++ b/domain/original/area/indel/room1631.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Narrow Way";
-    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1402", "east",
         "domain/original/area/indel/room1632", "west",

--- a/domain/original/area/indel/room1632.c
+++ b/domain/original/area/indel/room1632.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Ashen Silted Choked End";
-    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nA collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nA collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1631", "east",
     });

--- a/domain/original/area/indel/room1633.c
+++ b/domain/original/area/indel/room1633.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Blasted Narrow Way";
-    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1634", "east",
         "domain/original/area/indel/room1402", "west",

--- a/domain/original/area/indel/room1634.c
+++ b/domain/original/area/indel/room1634.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Choked End";
-    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1633", "west",
     });

--- a/domain/original/area/indel/room1635.c
+++ b/domain/original/area/indel/room1635.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Eroded Silted Choked End";
-    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1401", "east",
     });

--- a/domain/original/area/indel/room1636.c
+++ b/domain/original/area/indel/room1636.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Splintered Choked End";
-    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1401", "west",
     });

--- a/domain/original/area/indel/room1637.c
+++ b/domain/original/area/indel/room1637.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Silted Choked End";
-    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nA collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits.\n\nA collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1627", "north",
     });

--- a/domain/original/area/indel/room1653.c
+++ b/domain/original/area/indel/room1653.c
@@ -6,7 +6,7 @@ void reset(int arg) {
 
     set_light(1);
     short_desc = "Lichen Silted Choked End";
-    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, forcing a retreat. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
+    long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.\n";
     dest_dir = ({
         "domain/original/area/indel/room1583", "up",
     });


### PR DESCRIPTION
### Motivation

- Bring Indel room prose into Phase 1 tone by foregrounding long abandonment, weathering, and silence.
- Remove wording that implies active or descriptive continuity and replace it with phrasing that signals decay and nature reclaiming the city.
- Apply consistent, restrained changes across the Indel grid so nearby rooms read as a coherent, aged district.

### Description

- Updated phrasing in 157 room files under `domain/original/area/indel` to emphasize weathered passage lines and quiet ruin.
- Replaced recurring lines with aged variants (for example, "The way runs on in a narrow line, hemmed by broken walls." → "...hemmed by broken walls left to weather.", "The way opens into a broad break where several lines of ruin meet." → "...where several ruined lines meet in silence.", and "A collapsed heap chokes the line, forcing a retreat." → "A collapsed heap chokes the line, the passage left to cave in.").
- No code or game logic was modified; only player-facing `long_desc` strings were edited to meet `PHASE1.md` and `PROSE.md` guidance.

### Testing

- Performed static checks with `rg` to locate candidate phrases and with small `python` scripts to count and sample descriptions and confirm replacements. 
- Verified the targeted phrases were removed repository-wide by re-running the search scripts and confirming no matches remained. 
- No runtime or unit tests were executed because these are text-only description updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3d1c776083278b35d1de37c1e989)