### PR TITLE
Add NW exit from roadway room14 to wilderness (room_26_24)

### DIFF
--- a/domain/original/area/roadway/room14.c
+++ b/domain/original/area/roadway/room14.c
@@ -1,20 +1,22 @@
 inherit "room/room";
 
 void reset(int arg) {
-    if (arg)
-        return;
+  if (arg) {
+    return;
+  }
 
-    set_light(1);
+  set_light(1);
 
-    short_desc = "Near Vesla City";
-    long_desc = "Near Vesla City.\n";
-    dest_dir = ({
-        "domain/original/area/roadway/room30", "north",
-        "domain/original/area/roadway/room43", "south",
-        "domain/original/area/roadway/room13", "west",
-        "domain/original/area/roadway/room16", "east",
-	"domain/original/area/vesla/room115", "city",
-    });
+  short_desc = "Near Vesla City";
+  long_desc = "Near Vesla City.\n";
+  dest_dir = ({
+    "domain/original/area/roadway/room30", "north",
+    "domain/original/area/roadway/room43", "south",
+    "domain/original/area/roadway/room13", "west",
+    "domain/original/area/roadway/room16", "east",
+    "domain/original/area/wilderness/room_26_24", "northwest",
+    "domain/original/area/vesla/room115", "city",
+  });
 
   add_exit_alias("c", "city");
 }

--- a/domain/original/area/wilderness/room_26_24.c
+++ b/domain/original/area/wilderness/room_26_24.c
@@ -14,5 +14,6 @@ void reset(int arg) {
     "domain/original/area/wilderness/room_27_24", "south",
     "domain/original/area/wilderness/room_26_25", "east",
     "domain/original/area/wilderness/room_26_23", "west",
+    "domain/original/area/roadway/room14", "southeast",
   });
 }


### PR DESCRIPTION
### Motivation
- Provide direct access from the roadway hub to the central wilderness so a player can step northwest from the roadway into the wilderness in one move. 
- The wilderness grid midpoint was identified around `room_27_25` and the northwest-adjacent tile `room_26_24` was chosen as the immediate access point.

### Description
- Added a `northwest` exit from `domain/original/area/roadway/room14.c` to `domain/original/area/wilderness/room_26_24.c`.
- Added a reciprocal `southeast` exit from `domain/original/area/wilderness/room_26_24.c` back to `domain/original/area/roadway/room14.c`.
- Reformatted `room14.c` reset block to align with the project's coding style (brace/indent adjustments) while preserving the existing `city` alias.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a43eae91c8327b77c8a67567cf72c)