### PR TITLE
Prefix room long descriptions with 80‑char ruler

### DIFF
--- a/room/room.c
+++ b/room/room.c
@@ -107,27 +107,31 @@ string exitsDescription(int brief) {
 }
 
 void long(string str) {
-    int i;
-    if (set_light(0) == 0) {
-        write("It is dark.\n");
-        return;
-    }
-    if (!str) {
-        write(long_desc);
+  int i;
+  string ruler;
 
-        write(exitsDescription(0));
-        return;
+  if (set_light(0) == 0) {
+    write("It is dark.\n");
+    return;
+  }
+  if (!str) {
+    ruler = "123456789=123456789=123456789=123456789=123456789=123456789=123456789=123456789=";
+    write(ruler + "\n");
+    write(long_desc);
+
+    write(exitsDescription(0));
+    return;
+  }
+  if (!items)
+    return;
+  i = 0;
+  while (i < sizeof(items)) {
+    if (items[i] == str) {
+      write(items[i + 1] + ".\n");
+      return;
     }
-    if (!items)
-        return;
-    i = 0;
-    while (i < sizeof(items)) {
-        if (items[i] == str) {
-            write(items[i + 1] + ".\n");
-            return;
-        }
-        i += 2;
-    }
+    i += 2;
+  }
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Provide a consistent visual ruler line when a room’s full `long` description is printed to help with alignment and line-length debugging for player-facing text.
- Apply the change at the room level so inheriting room files display the ruler without modifying thousands of per-room files.

### Description
- Updated `room/room.c` `long(string str)` to prepend a fixed 80-character ruler string before printing the room `long_desc` when `str` is not provided. 
- The darkness check (`set_light(0)`) and item-specific `long` behavior were preserved and remain unchanged.
- The ruler is stored in a local `ruler` string and written with a trailing newline immediately before `long_desc` and the exits description.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8a5a7c048327977356ec2adcaf18)