### PR TITLE
Wrap simul_efun output to 80 columns

### DIFF
--- a/obj/simul_efun.c
+++ b/obj/simul_efun.c
@@ -46,6 +46,100 @@ void start_simul_efun()
 }
 
 //---------------------------------------------------------------------------
+string wrap_text_line(string line, int width)
+{
+  string *words;
+  string output;
+  string current;
+  string word;
+  int i;
+
+  if (sizeof(line) <= width) {
+    return line;
+  }
+
+  words = explode(line, " ");
+  if (!sizeof(words)) {
+    return line;
+  }
+
+  output = "";
+  current = "";
+
+  for (i = 0; i < sizeof(words); i++) {
+    word = words[i];
+
+    if (sizeof(word) > width) {
+      if (sizeof(current)) {
+        output += current + "\n";
+        current = "";
+      }
+      while (sizeof(word) > width) {
+        output += word[0..width - 1] + "\n";
+        word = word[width..];
+      }
+    }
+
+    if (!sizeof(word)) {
+      continue;
+    }
+
+    if (!sizeof(current)) {
+      current = word;
+      continue;
+    }
+
+    if (sizeof(current) + 1 + sizeof(word) <= width) {
+      current += " " + word;
+      continue;
+    }
+
+    output += current + "\n";
+    current = word;
+  }
+
+  if (sizeof(current)) {
+    output += current;
+  }
+
+  return output;
+}
+
+//---------------------------------------------------------------------------
+string wrap_text(string text, int width)
+{
+  string *lines;
+  string result;
+  string wrapped;
+  int i;
+
+  lines = explode(text, "\n");
+  result = "";
+
+  for (i = 0; i < sizeof(lines); i++) {
+    wrapped = wrap_text_line(lines[i], width);
+    result += wrapped;
+    if (i < sizeof(lines) - 1) {
+      result += "\n";
+    }
+  }
+
+  return result;
+}
+
+//---------------------------------------------------------------------------
+void write_wrapped(string text)
+{
+  write(wrap_text(text, 80));
+}
+
+//---------------------------------------------------------------------------
+void tell_object_wrapped(object target, string text)
+{
+  tell_object(target, wrap_text(text, 80));
+}
+
+//---------------------------------------------------------------------------
 void ls (string path)
 
 /* Print the directory listing of <path>, like the unix command.
@@ -60,7 +154,7 @@ void ls (string path)
     if (path != "/")
 	path += "/";
     if (!dir) {
-        write("No such directory.\n");
+        write_wrapped("No such directory.\n");
         return;
     }
     if (sizeof(dir) > 999)
@@ -96,7 +190,7 @@ void ls (string path)
         }
     }
     write("\n");
-    if (trunc_flag) write("***TRUNCATED***\n");
+    if (trunc_flag) write_wrapped("***TRUNCATED***\n");
 }
 
 //---------------------------------------------------------------------------
@@ -121,7 +215,7 @@ void log_file(string file,string str)
 #ifdef COMPAT_FLAG
     if (sizeof(regexp(({file}), "/")) || file[0] == '.' || sizeof(file) > 30 )
     {
-        write("Illegal file name to log_file("+file+")\n");
+        write_wrapped("Illegal file name to log_file("+file+")\n");
         return;
     }
 #endif
@@ -136,13 +230,19 @@ void log_file(string file,string str)
 void localcmd()
 {
     string *verbs;
+    string output;
     int i,j;
 
     verbs = query_actions(this_player());
+    output = "";
     for (i=0, j = sizeof(verbs); --j >= 0; i++) {
-	write(verbs[i]+" ");
+	output += verbs[i];
+        if (j > 0) {
+          output += " ";
+        }
     }
-    write("\n");
+    output += "\n";
+    write_wrapped(output);
 }
 
 //---------------------------------------------------------------------------
@@ -184,20 +284,20 @@ varargs mixed snoop(mixed snoopee)
     int result;
 
     if (snoopee && interactive(snoopee) && interactive_info(snoopee, II_SNOOP_NEXT)) {
-        write("Busy.\n");
+        write_wrapped("Busy.\n");
         return 0;
     }
     result = snoopee ? efun::snoop(this_player(), snoopee)
                      : efun::snoop(this_player());
     switch (result) {
 	case -1:
-	    write("Busy.\n");
+	    write_wrapped("Busy.\n");
 	    break;
 	case  0:
-	    write("Failed.\n");
+	    write_wrapped("Failed.\n");
 	    break;
 	case  1:
-	    write("Ok.\n");
+	    write_wrapped("Ok.\n");
 	    break;
     }
     if (result > 0) return snoopee;
@@ -208,16 +308,17 @@ varargs mixed snoop(mixed snoopee)
 //---------------------------------------------------------------------------
 void notify_fail(mixed message)
 {
+    string processed;
+
     if ( !(stringp(message) && strstr(message, "@@") < 0) ) {
 	efun::notify_fail(message);
 	return;
     }
-    efun::notify_fail(
-      funcall(
-        bind_lambda(#'lambda, previous_object()),
-        0, ({#'process_string, message})
-      )
+    processed = funcall(
+      bind_lambda(#'lambda, previous_object()),
+      0, ({#'process_string, message})
     );
+    efun::notify_fail(wrap_text(processed, 80));
 }
 
 //---------------------------------------------------------------------------
@@ -270,7 +371,7 @@ varargs void wizlist(string name)
         name = this_player()->query_real_name();
         if (!name)
         {
-            write("Need to provide a name or 'ALL' to the wizlist function.\n");
+            write_wrapped("Need to provide a name or 'ALL' to the wizlist function.\n");
             return;
         }
     }
@@ -286,7 +387,7 @@ varargs void wizlist(string name)
 
     if ((pos = member(a[WL_NAME], name)) < 0 && name != "ALL")
     {
-        write("No wizlist info for '"+name+"' found.\n");
+        write_wrapped("No wizlist info for '"+name+"' found.\n");
         return;
     }
     b = allocate(sizeof(cmds));
@@ -304,38 +405,50 @@ varargs void wizlist(string name)
             a = a[<15..];
         }
     }
-    write("\nWizard top score list\n\n");
+    write_wrapped("\nWizard top score list\n\n");
     if (total_cmd == 0)
         total_cmd = 1;
     for (i = sizeof(a); i; ) {
         b = a[<i--];
-        if (b[WL_GIGACOST] > 1000)
-            printf("%-15s %5d %2d%% (%d)\t[%d%4dk,%5d] %6d %d\n",
+        if (b[WL_GIGACOST] > 1000) {
+            write_wrapped(sprintf("%-15s %5d %2d%% (%d)\t[%d%4dk,%5d] %6d %d\n",
               b[WL_NAME], b[WL_COMMANDS],
               b[WL_COMMANDS] * 100 / total_cmd, b[<1],
               b[WL_GIGACOST] / 1000,
               b[WL_COST] / 1000 + (b[WL_GIGACOST] % 1000) * 1000000000,
               b[WL_HEART_BEATS], b[WL_EXTRA], b[WL_ARRAY_TOTAL]
-            );
-        else
-            printf("%-15s %5d %2d%% (%d)\t[%4dk,%5d] %6d %d\n",
+            ));
+        } else {
+            write_wrapped(sprintf("%-15s %5d %2d%% (%d)\t[%4dk,%5d] %6d %d\n",
               b[WL_NAME], b[WL_COMMANDS],
               b[WL_COMMANDS] * 100 / total_cmd, b[<1],
               b[WL_COST] / 1000 + (b[WL_GIGACOST] % 1000) * 1000000000,
               b[WL_HEART_BEATS], b[WL_EXTRA], b[WL_ARRAY_TOTAL]
-            );
+            ));
+        }
     }
-    printf("\nTotal         %7d     (%d)\n\n", total_cmd, sizeof(cmds));
+    write_wrapped(sprintf("\nTotal         %7d     (%d)\n\n", total_cmd, sizeof(cmds)));
 }
 
 //---------------------------------------------------------------------------
 void shout(string s)
 {
-    filter(users(), lambda(({'u}),({#'&&,
-      ({#'environment, 'u}),
-      ({#'!=, 'u, ({#'this_player})}),
-      ({#'tell_object, 'u, to_string(s)})
-    })));
+    object *people;
+    string msg;
+    int i;
+
+    msg = wrap_text(to_string(s), 80);
+    people = users();
+
+    for (i = 0; i < sizeof(people); i++) {
+      if (!environment(people[i])) {
+        continue;
+      }
+      if (people[i] == this_player()) {
+        continue;
+      }
+      tell_object(people[i], msg);
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -815,10 +928,10 @@ varargs int cat(string file, int start, int num)
     if (!txt)
         return 0;
 
-    tell_object(this_player(), txt);
+    tell_object_wrapped(this_player(), txt);
 
     if (more)
-        tell_object(this_player(), "*****TRUNCATED****\n");
+        tell_object_wrapped(this_player(), "*****TRUNCATED****\n");
 
     return sizeof(txt & "\n");
 }
@@ -847,7 +960,7 @@ varargs int tail(string file)
             txt = "";
     }
 
-    tell_object(this_player(), txt);
+    tell_object_wrapped(this_player(), txt);
 
     return 1;
 }

--- a/obj/spare_simul_efun.c
+++ b/obj/spare_simul_efun.c
@@ -46,6 +46,100 @@ void start_simul_efun()
 }
 
 //---------------------------------------------------------------------------
+string wrap_text_line(string line, int width)
+{
+  string *words;
+  string output;
+  string current;
+  string word;
+  int i;
+
+  if (sizeof(line) <= width) {
+    return line;
+  }
+
+  words = explode(line, " ");
+  if (!sizeof(words)) {
+    return line;
+  }
+
+  output = "";
+  current = "";
+
+  for (i = 0; i < sizeof(words); i++) {
+    word = words[i];
+
+    if (sizeof(word) > width) {
+      if (sizeof(current)) {
+        output += current + "\n";
+        current = "";
+      }
+      while (sizeof(word) > width) {
+        output += word[0..width - 1] + "\n";
+        word = word[width..];
+      }
+    }
+
+    if (!sizeof(word)) {
+      continue;
+    }
+
+    if (!sizeof(current)) {
+      current = word;
+      continue;
+    }
+
+    if (sizeof(current) + 1 + sizeof(word) <= width) {
+      current += " " + word;
+      continue;
+    }
+
+    output += current + "\n";
+    current = word;
+  }
+
+  if (sizeof(current)) {
+    output += current;
+  }
+
+  return output;
+}
+
+//---------------------------------------------------------------------------
+string wrap_text(string text, int width)
+{
+  string *lines;
+  string result;
+  string wrapped;
+  int i;
+
+  lines = explode(text, "\n");
+  result = "";
+
+  for (i = 0; i < sizeof(lines); i++) {
+    wrapped = wrap_text_line(lines[i], width);
+    result += wrapped;
+    if (i < sizeof(lines) - 1) {
+      result += "\n";
+    }
+  }
+
+  return result;
+}
+
+//---------------------------------------------------------------------------
+void write_wrapped(string text)
+{
+  write(wrap_text(text, 80));
+}
+
+//---------------------------------------------------------------------------
+void tell_object_wrapped(object target, string text)
+{
+  tell_object(target, wrap_text(text, 80));
+}
+
+//---------------------------------------------------------------------------
 void ls (string path)
 
 /* Print the directory listing of <path>, like the unix command.
@@ -60,7 +154,7 @@ void ls (string path)
     if (path != "/")
 	path += "/";
     if (!dir) {
-        write("No such directory.\n");
+        write_wrapped("No such directory.\n");
         return;
     }
     if (sizeof(dir) > 999)
@@ -96,7 +190,7 @@ void ls (string path)
         }
     }
     write("\n");
-    if (trunc_flag) write("***TRUNCATED***\n");
+    if (trunc_flag) write_wrapped("***TRUNCATED***\n");
 }
 
 //---------------------------------------------------------------------------
@@ -121,7 +215,7 @@ void log_file(string file,string str)
 #ifdef COMPAT_FLAG
     if (sizeof(regexp(({file}), "/")) || file[0] == '.' || sizeof(file) > 30 )
     {
-        write("Illegal file name to log_file("+file+")\n");
+        write_wrapped("Illegal file name to log_file("+file+")\n");
         return;
     }
 #endif
@@ -136,13 +230,19 @@ void log_file(string file,string str)
 void localcmd()
 {
     string *verbs;
+    string output;
     int i,j;
 
     verbs = query_actions(this_player());
+    output = "";
     for (i=0, j = sizeof(verbs); --j >= 0; i++) {
-	write(verbs[i]+" ");
+	output += verbs[i];
+        if (j > 0) {
+          output += " ";
+        }
     }
-    write("\n");
+    output += "\n";
+    write_wrapped(output);
 }
 
 //---------------------------------------------------------------------------
@@ -184,20 +284,20 @@ varargs mixed snoop(mixed snoopee)
     int result;
 
     if (snoopee && interactive(snoopee) && interactive_info(snoopee, II_SNOOP_NEXT)) {
-        write("Busy.\n");
+        write_wrapped("Busy.\n");
         return 0;
     }
     result = snoopee ? efun::snoop(this_player(), snoopee)
                      : efun::snoop(this_player());
     switch (result) {
 	case -1:
-	    write("Busy.\n");
+	    write_wrapped("Busy.\n");
 	    break;
 	case  0:
-	    write("Failed.\n");
+	    write_wrapped("Failed.\n");
 	    break;
 	case  1:
-	    write("Ok.\n");
+	    write_wrapped("Ok.\n");
 	    break;
     }
     if (result > 0) return snoopee;
@@ -206,16 +306,17 @@ varargs mixed snoop(mixed snoopee)
 //---------------------------------------------------------------------------
 void notify_fail(mixed message)
 {
+    string processed;
+
     if ( !(stringp(message) && strstr(message, "@@") < 0) ) {
 	efun::notify_fail(message);
 	return;
     }
-    efun::notify_fail(
-      funcall(
-        bind_lambda(#'lambda, previous_object()),
-        0, ({#'process_string, message})
-      )
+    processed = funcall(
+      bind_lambda(#'lambda, previous_object()),
+      0, ({#'process_string, message})
     );
+    efun::notify_fail(wrap_text(processed, 80));
 }
 
 //---------------------------------------------------------------------------
@@ -268,7 +369,7 @@ varargs void wizlist(string name)
         name = this_player()->query_real_name();
         if (!name)
         {
-            write("Need to provide a name or 'ALL' to the wizlist function.\n");
+            write_wrapped("Need to provide a name or 'ALL' to the wizlist function.\n");
             return;
         }
     }
@@ -284,7 +385,7 @@ varargs void wizlist(string name)
 
     if ((pos = member(a[WL_NAME], name)) < 0 && name != "ALL")
     {
-        write("No wizlist info for '"+name+"' found.\n");
+        write_wrapped("No wizlist info for '"+name+"' found.\n");
         return;
     }
     b = allocate(sizeof(cmds));
@@ -302,38 +403,50 @@ varargs void wizlist(string name)
             a = a[<15..];
         }
     }
-    write("\nWizard top score list\n\n");
+    write_wrapped("\nWizard top score list\n\n");
     if (total_cmd == 0)
         total_cmd = 1;
     for (i = sizeof(a); i; ) {
         b = a[<i--];
-        if (b[WL_GIGACOST] > 1000)
-            printf("%-15s %5d %2d%% (%d)\t[%d%4dk,%5d] %6d %d\n",
+        if (b[WL_GIGACOST] > 1000) {
+            write_wrapped(sprintf("%-15s %5d %2d%% (%d)\t[%d%4dk,%5d] %6d %d\n",
               b[WL_NAME], b[WL_COMMANDS],
               b[WL_COMMANDS] * 100 / total_cmd, b[<1],
               b[WL_GIGACOST] / 1000,
               b[WL_COST] / 1000 + (b[WL_GIGACOST] % 1000) * 1000000000,
               b[WL_HEART_BEATS], b[WL_EXTRA], b[WL_ARRAY_TOTAL]
-            );
-        else
-            printf("%-15s %5d %2d%% (%d)\t[%4dk,%5d] %6d %d\n",
+            ));
+        } else {
+            write_wrapped(sprintf("%-15s %5d %2d%% (%d)\t[%4dk,%5d] %6d %d\n",
               b[WL_NAME], b[WL_COMMANDS],
               b[WL_COMMANDS] * 100 / total_cmd, b[<1],
               b[WL_COST] / 1000 + (b[WL_GIGACOST] % 1000) * 1000000000,
               b[WL_HEART_BEATS], b[WL_EXTRA], b[WL_ARRAY_TOTAL]
-            );
+            ));
+        }
     }
-    printf("\nTotal         %7d     (%d)\n\n", total_cmd, sizeof(cmds));
+    write_wrapped(sprintf("\nTotal         %7d     (%d)\n\n", total_cmd, sizeof(cmds)));
 }
 
 //---------------------------------------------------------------------------
 void shout(string s)
 {
-    filter(users(), lambda(({'u}),({#'&&,
-      ({#'environment, 'u}),
-      ({#'!=, 'u, ({#'this_player})}),
-      ({#'tell_object, 'u, to_string(s)})
-    })));
+    object *people;
+    string msg;
+    int i;
+
+    msg = wrap_text(to_string(s), 80);
+    people = users();
+
+    for (i = 0; i < sizeof(people); i++) {
+      if (!environment(people[i])) {
+        continue;
+      }
+      if (people[i] == this_player()) {
+        continue;
+      }
+      tell_object(people[i], msg);
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -813,10 +926,10 @@ varargs int cat(string file, int start, int num)
     if (!txt)
         return 0;
 
-    tell_object(this_player(), txt);
+    tell_object_wrapped(this_player(), txt);
 
     if (more)
-        tell_object(this_player(), "*****TRUNCATED****\n");
+        tell_object_wrapped(this_player(), "*****TRUNCATED****\n");
 
     return sizeof(txt & "\n");
 }
@@ -845,7 +958,7 @@ varargs int tail(string file)
             txt = "";
     }
 
-    tell_object(this_player(), txt);
+    tell_object_wrapped(this_player(), txt);
 
     return 1;
 }


### PR DESCRIPTION
### Motivation
- Ensure all player-facing output emitted by the simul_efun layer is chunked to lines as close to 80 characters as possible, following the `CODE-STYLE.md` line-length rule for in-game text.

### Description
- Added wrapping helpers: `wrap_text_line`, `wrap_text`, `write_wrapped`, and `tell_object_wrapped` to handle grammatically-aware line breaks at a configurable width (used at 80 columns).
- Replaced direct user-output calls with wrapped equivalents across the simul-efun surface: adjusted `ls`, error messages in `log_file`, `localcmd`, `snoop` responses, `notify_fail` processing, `wizlist` reporting (replaced `printf` with `write_wrapped(sprintf(...))`), `shout` (now formats with wrapping and iterates recipients), and file viewers `cat`/`tail` (now use `tell_object_wrapped`).
- Applied the same helper functions and output routing in both `obj/simul_efun.c` and `obj/spare_simul_efun.c` to keep behavior consistent when the spare simul-efun is used.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc126371c83279d305890bf583cf6)