### PR TITLE
Guard `cat` simul-efun `set_this_object` calls

### DIFF
--- a/obj/simul_efun.c
+++ b/obj/simul_efun.c
@@ -797,30 +797,38 @@ object query_snoop(object ob)
 #define CAT_MAX_LINES 50
 varargs int cat(string file, int start, int num)
 {
+  int more;
+  string txt;
+
+  if (extern_call()) {
     set_this_object(previous_object());
-    int more;
+  }
 
-    if (num < 0 || !this_player())
-        return 0;
+  if (num < 0 || !this_player()) {
+    return 0;
+  }
 
-    if (!start)
-        start = 1;
+  if (!start) {
+    start = 1;
+  }
 
-    if (!num || num > CAT_MAX_LINES) {
-        num = CAT_MAX_LINES;
-        more = sizeof(read_file(file, start+num, 1));
-    }
+  if (!num || num > CAT_MAX_LINES) {
+    num = CAT_MAX_LINES;
+    more = sizeof(read_file(file, start + num, 1));
+  }
 
-    string txt = read_file(file, start, num);
-    if (!txt)
-        return 0;
+  txt = read_file(file, start, num);
+  if (!txt) {
+    return 0;
+  }
 
-    tell_object(this_player(), txt);
+  tell_object(this_player(), txt);
 
-    if (more)
-        tell_object(this_player(), "*****TRUNCATED****\n");
+  if (more) {
+    tell_object(this_player(), "*****TRUNCATED****\n");
+  }
 
-    return sizeof(txt & "\n");
+  return sizeof(txt & "\n");
 }
 #endif
 

--- a/obj/spare_simul_efun.c
+++ b/obj/spare_simul_efun.c
@@ -795,30 +795,38 @@ object query_snoop(object ob)
 #define CAT_MAX_LINES 50
 varargs int cat(string file, int start, int num)
 {
+  int more;
+  string txt;
+
+  if (extern_call()) {
     set_this_object(previous_object());
-    int more;
+  }
 
-    if (num < 0 || !this_player())
-        return 0;
+  if (num < 0 || !this_player()) {
+    return 0;
+  }
 
-    if (!start)
-        start = 1;
+  if (!start) {
+    start = 1;
+  }
 
-    if (!num || num > CAT_MAX_LINES) {
-        num = CAT_MAX_LINES;
-        more = sizeof(read_file(file, start+num, 1));
-    }
+  if (!num || num > CAT_MAX_LINES) {
+    num = CAT_MAX_LINES;
+    more = sizeof(read_file(file, start + num, 1));
+  }
 
-    string txt = read_file(file, start, num);
-    if (!txt)
-        return 0;
+  txt = read_file(file, start, num);
+  if (!txt) {
+    return 0;
+  }
 
-    tell_object(this_player(), txt);
+  tell_object(this_player(), txt);
 
-    if (more)
-        tell_object(this_player(), "*****TRUNCATED****\n");
+  if (more) {
+    tell_object(this_player(), "*****TRUNCATED****\n");
+  }
 
-    return sizeof(txt & "\n");
+  return sizeof(txt & "\n");
 }
 #endif
 


### PR DESCRIPTION
### Motivation
- Prevent runtime error seen during login (`Can't execute with set_this_object() in effect.`) by avoiding unconditional `set_this_object()` use in the `cat` simul-efun and to align the function with repository style rules about declarations and explicit control flow.

### Description
- Guard `set_this_object(previous_object())` in the `cat` function behind an `extern_call()` check so it only runs for external calls. 
- Move and consolidate local declarations to the top of the function (`int more; string txt;`) and reorganize early-return checks for clarity. 
- Preserve original `cat` behavior (line limiting and truncated notice) while restructuring read and `tell_object` logic. 
- Apply the same change to both `obj/simul_efun.c` and `obj/spare_simul_efun.c`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bce270220832780f6c4894454d9a3)