### PR TITLE
Restore original `this_object` after external `cat` calls

### DIFF
--- a/obj/simul_efun.c
+++ b/obj/simul_efun.c
@@ -798,37 +798,46 @@ object query_snoop(object ob)
 varargs int cat(string file, int start, int num)
 {
   int more;
+  int result;
+  object original_object;
   string txt;
 
   if (extern_call()) {
+    original_object = this_object();
     set_this_object(previous_object());
   }
 
   if (num < 0 || !this_player()) {
-    return 0;
+    result = 0;
+  } else {
+    if (!start) {
+      start = 1;
+    }
+
+    if (!num || num > CAT_MAX_LINES) {
+      num = CAT_MAX_LINES;
+      more = sizeof(read_file(file, start + num, 1));
+    }
+
+    txt = read_file(file, start, num);
+    if (!txt) {
+      result = 0;
+    } else {
+      tell_object(this_player(), txt);
+
+      if (more) {
+        tell_object(this_player(), "*****TRUNCATED****\n");
+      }
+
+      result = sizeof(txt & "\n");
+    }
   }
 
-  if (!start) {
-    start = 1;
+  if (original_object) {
+    set_this_object(original_object);
   }
 
-  if (!num || num > CAT_MAX_LINES) {
-    num = CAT_MAX_LINES;
-    more = sizeof(read_file(file, start + num, 1));
-  }
-
-  txt = read_file(file, start, num);
-  if (!txt) {
-    return 0;
-  }
-
-  tell_object(this_player(), txt);
-
-  if (more) {
-    tell_object(this_player(), "*****TRUNCATED****\n");
-  }
-
-  return sizeof(txt & "\n");
+  return result;
 }
 #endif
 


### PR DESCRIPTION
### Motivation
- Prevent `cat` from leaving a lingering `set_this_object()` state when invoked via `extern_call`, which can cause "Can't execute with set_this_object() in effect" errors during subsequent operations. 
- Ensure `cat` behaves safely when called from other objects while preserving its existing output behavior.

### Description
- Save the caller's `this_object()` into a local `original_object` when `extern_call()` is true and restore it at the end of `cat` in `obj/simul_efun.c`.
- Refactor `cat`'s control flow to use a `result` variable for a single return point and to avoid early returns that could leave `this_object` changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bcf44dac88327b0aa40b1a73204cb)