### PR TITLE
Generate maps/globe-edaw.json from spreadsheet range (A3:AX52)

### DIFF
--- a/maps/globe-edaw.json
+++ b/maps/globe-edaw.json
@@ -1,27507 +1,24803 @@
 {
-  "grid": {
-    "rows": 131,
-    "cols": 51
-  },
   "rooms": [
     {
-      "row": 3,
-      "col": 1,
-      "color": null,
+      "id": "A3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": false,
-        "east": true
+        "south": "A4",
+        "east": "B3"
       }
     },
     {
-      "row": 3,
-      "col": 2,
-      "color": null,
+      "id": "B3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "B4",
+        "west": "A3",
+        "east": "C3"
       }
     },
     {
-      "row": 3,
-      "col": 3,
-      "color": null,
+      "id": "C3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "C4",
+        "west": "B3",
+        "east": "D3"
       }
     },
     {
-      "row": 3,
-      "col": 4,
-      "color": null,
+      "id": "D3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "D4",
+        "west": "C3",
+        "east": "E3"
       }
     },
     {
-      "row": 3,
-      "col": 5,
-      "color": null,
+      "id": "E3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "E4",
+        "west": "D3",
+        "east": "F3"
       }
     },
     {
-      "row": 3,
-      "col": 6,
-      "color": null,
+      "id": "F3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "F4",
+        "west": "E3",
+        "east": "G3"
       }
     },
     {
-      "row": 3,
-      "col": 7,
-      "color": null,
+      "id": "G3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "G4",
+        "west": "F3",
+        "east": "H3"
       }
     },
     {
-      "row": 3,
-      "col": 8,
-      "color": null,
+      "id": "H3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "H4",
+        "west": "G3",
+        "east": "I3"
       }
     },
     {
-      "row": 3,
-      "col": 9,
-      "color": null,
+      "id": "I3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "I4",
+        "west": "H3",
+        "east": "J3"
       }
     },
     {
-      "row": 3,
-      "col": 10,
-      "color": null,
+      "id": "J3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "J4",
+        "west": "I3",
+        "east": "K3"
       }
     },
     {
-      "row": 3,
-      "col": 11,
-      "color": null,
+      "id": "K3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "K4",
+        "west": "J3",
+        "east": "L3"
       }
     },
     {
-      "row": 3,
-      "col": 12,
-      "color": null,
+      "id": "L3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "L4",
+        "west": "K3",
+        "east": "M3"
       }
     },
     {
-      "row": 3,
-      "col": 13,
-      "color": null,
+      "id": "M3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "M4",
+        "west": "L3",
+        "east": "N3"
       }
     },
     {
-      "row": 3,
-      "col": 14,
-      "color": null,
+      "id": "N3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "N4",
+        "west": "M3",
+        "east": "O3"
       }
     },
     {
-      "row": 3,
-      "col": 15,
-      "color": null,
+      "id": "O3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "O4",
+        "west": "N3",
+        "east": "P3"
       }
     },
     {
-      "row": 3,
-      "col": 16,
-      "color": null,
+      "id": "P3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "P4",
+        "west": "O3",
+        "east": "Q3"
       }
     },
     {
-      "row": 3,
-      "col": 17,
-      "color": null,
+      "id": "Q3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "Q4",
+        "west": "P3",
+        "east": "R3"
       }
     },
     {
-      "row": 3,
-      "col": 18,
-      "color": null,
+      "id": "R3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "R4",
+        "west": "Q3",
+        "east": "S3"
       }
     },
     {
-      "row": 3,
-      "col": 19,
-      "color": null,
+      "id": "S3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "S4",
+        "west": "R3",
+        "east": "T3"
       }
     },
     {
-      "row": 3,
-      "col": 20,
-      "color": null,
+      "id": "T3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "T4",
+        "west": "S3",
+        "east": "U3"
       }
     },
     {
-      "row": 3,
-      "col": 21,
-      "color": null,
+      "id": "U3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "U4",
+        "west": "T3",
+        "east": "V3"
       }
     },
     {
-      "row": 3,
-      "col": 22,
-      "color": null,
+      "id": "V3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "V4",
+        "west": "U3",
+        "east": "W3"
       }
     },
     {
-      "row": 3,
-      "col": 23,
-      "color": null,
+      "id": "W3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "W4",
+        "west": "V3",
+        "east": "X3"
       }
     },
     {
-      "row": 3,
-      "col": 24,
-      "color": null,
+      "id": "X3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "X4",
+        "west": "W3",
+        "east": "Y3"
       }
     },
     {
-      "row": 3,
-      "col": 25,
-      "color": null,
+      "id": "Y3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "Y4",
+        "west": "X3",
+        "east": "Z3"
       }
     },
     {
-      "row": 3,
-      "col": 26,
-      "color": null,
+      "id": "Z3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "Z4",
+        "west": "Y3",
+        "east": "AA3"
       }
     },
     {
-      "row": 3,
-      "col": 27,
-      "color": null,
+      "id": "AA3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AA4",
+        "west": "Z3",
+        "east": "AB3"
       }
     },
     {
-      "row": 3,
-      "col": 28,
-      "color": null,
+      "id": "AB3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AB4",
+        "west": "AA3",
+        "east": "AC3"
       }
     },
     {
-      "row": 3,
-      "col": 29,
-      "color": null,
+      "id": "AC3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AC4",
+        "west": "AB3",
+        "east": "AD3"
       }
     },
     {
-      "row": 3,
-      "col": 30,
-      "color": null,
+      "id": "AD3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AD4",
+        "west": "AC3",
+        "east": "AE3"
       }
     },
     {
-      "row": 3,
-      "col": 31,
-      "color": null,
+      "id": "AE3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AE4",
+        "west": "AD3",
+        "east": "AF3"
       }
     },
     {
-      "row": 3,
-      "col": 32,
-      "color": null,
+      "id": "AF3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AF4",
+        "west": "AE3",
+        "east": "AG3"
       }
     },
     {
-      "row": 3,
-      "col": 33,
-      "color": null,
+      "id": "AG3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AG4",
+        "west": "AF3",
+        "east": "AH3"
       }
     },
     {
-      "row": 3,
-      "col": 34,
-      "color": null,
+      "id": "AH3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AH4",
+        "west": "AG3",
+        "east": "AI3"
       }
     },
     {
-      "row": 3,
-      "col": 35,
-      "color": null,
+      "id": "AI3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AI4",
+        "west": "AH3",
+        "east": "AJ3"
       }
     },
     {
-      "row": 3,
-      "col": 36,
-      "color": null,
+      "id": "AJ3",
+      "terrain": "lf",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AJ4",
+        "west": "AI3",
+        "east": "AK3"
       }
     },
     {
-      "row": 3,
-      "col": 37,
-      "color": null,
+      "id": "AK3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AK4",
+        "west": "AJ3",
+        "east": "AL3"
       }
     },
     {
-      "row": 3,
-      "col": 38,
-      "color": null,
+      "id": "AL3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AL4",
+        "west": "AK3",
+        "east": "AM3"
       }
     },
     {
-      "row": 3,
-      "col": 39,
-      "color": null,
+      "id": "AM3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AM4",
+        "west": "AL3",
+        "east": "AN3"
       }
     },
     {
-      "row": 3,
-      "col": 40,
-      "color": null,
+      "id": "AN3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AN4",
+        "west": "AM3",
+        "east": "AO3"
       }
     },
     {
-      "row": 3,
-      "col": 41,
-      "color": null,
+      "id": "AO3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AO4",
+        "west": "AN3",
+        "east": "AP3"
       }
     },
     {
-      "row": 3,
-      "col": 42,
-      "color": null,
+      "id": "AP3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AP4",
+        "west": "AO3",
+        "east": "AQ3"
       }
     },
     {
-      "row": 3,
-      "col": 43,
-      "color": null,
+      "id": "AQ3",
+      "terrain": "p",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AQ4",
+        "west": "AP3",
+        "east": "AR3"
       }
     },
     {
-      "row": 3,
-      "col": 44,
-      "color": null,
+      "id": "AR3",
+      "terrain": "b",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AR4",
+        "west": "AQ3",
+        "east": "AS3"
       }
     },
     {
-      "row": 3,
-      "col": 45,
-      "color": null,
+      "id": "AS3",
+      "terrain": "b",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AS4",
+        "west": "AR3",
+        "east": "AT3"
       }
     },
     {
-      "row": 3,
-      "col": 46,
-      "color": null,
+      "id": "AT3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AT4",
+        "west": "AS3",
+        "east": "AU3"
       }
     },
     {
-      "row": 3,
-      "col": 47,
-      "color": null,
+      "id": "AU3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AU4",
+        "west": "AT3",
+        "east": "AV3"
       }
     },
     {
-      "row": 3,
-      "col": 48,
-      "color": null,
+      "id": "AV3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AV4",
+        "west": "AU3",
+        "east": "AW3"
       }
     },
     {
-      "row": 3,
-      "col": 49,
-      "color": null,
+      "id": "AW3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": true
+        "south": "AW4",
+        "west": "AV3",
+        "east": "AX3"
       }
     },
     {
-      "row": 3,
-      "col": 50,
-      "color": null,
+      "id": "AX3",
+      "terrain": "h",
       "exits": {
-        "north": false,
-        "south": true,
-        "west": true,
-        "east": false
+        "south": "AX4",
+        "west": "AW3"
       }
     },
     {
-      "row": 4,
-      "col": 1,
-      "color": null,
+      "id": "A4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A3",
+        "south": "A5",
+        "east": "B4"
       }
     },
     {
-      "row": 4,
-      "col": 2,
-      "color": null,
+      "id": "B4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B3",
+        "south": "B5",
+        "west": "A4",
+        "east": "C4"
       }
     },
     {
-      "row": 4,
-      "col": 3,
-      "color": null,
+      "id": "C4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C3",
+        "south": "C5",
+        "west": "B4",
+        "east": "D4"
       }
     },
     {
-      "row": 4,
-      "col": 4,
-      "color": null,
+      "id": "D4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D3",
+        "south": "D5",
+        "west": "C4",
+        "east": "E4"
       }
     },
     {
-      "row": 4,
-      "col": 5,
-      "color": null,
+      "id": "E4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E3",
+        "south": "E5",
+        "west": "D4",
+        "east": "F4"
       }
     },
     {
-      "row": 4,
-      "col": 6,
-      "color": null,
+      "id": "F4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F3",
+        "south": "F5",
+        "west": "E4",
+        "east": "G4"
       }
     },
     {
-      "row": 4,
-      "col": 7,
-      "color": null,
+      "id": "G4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G3",
+        "south": "G5",
+        "west": "F4",
+        "east": "H4"
       }
     },
     {
-      "row": 4,
-      "col": 8,
-      "color": null,
+      "id": "H4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H3",
+        "south": "H5",
+        "west": "G4",
+        "east": "I4"
       }
     },
     {
-      "row": 4,
-      "col": 9,
-      "color": null,
+      "id": "I4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I3",
+        "south": "I5",
+        "west": "H4",
+        "east": "J4"
       }
     },
     {
-      "row": 4,
-      "col": 10,
-      "color": null,
+      "id": "J4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J3",
+        "south": "J5",
+        "west": "I4",
+        "east": "K4"
       }
     },
     {
-      "row": 4,
-      "col": 11,
-      "color": null,
+      "id": "K4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K3",
+        "south": "K5",
+        "west": "J4",
+        "east": "L4"
       }
     },
     {
-      "row": 4,
-      "col": 12,
-      "color": null,
+      "id": "L4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L3",
+        "south": "L5",
+        "west": "K4",
+        "east": "M4"
       }
     },
     {
-      "row": 4,
-      "col": 13,
-      "color": null,
+      "id": "M4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M3",
+        "south": "M5",
+        "west": "L4",
+        "east": "N4"
       }
     },
     {
-      "row": 4,
-      "col": 14,
-      "color": null,
+      "id": "N4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N3",
+        "south": "N5",
+        "west": "M4",
+        "east": "O4"
       }
     },
     {
-      "row": 4,
-      "col": 15,
-      "color": null,
+      "id": "O4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O3",
+        "south": "O5",
+        "west": "N4",
+        "east": "P4"
       }
     },
     {
-      "row": 4,
-      "col": 16,
-      "color": null,
+      "id": "P4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P3",
+        "south": "P5",
+        "west": "O4",
+        "east": "Q4"
       }
     },
     {
-      "row": 4,
-      "col": 17,
-      "color": null,
+      "id": "Q4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q3",
+        "south": "Q5",
+        "west": "P4",
+        "east": "R4"
       }
     },
     {
-      "row": 4,
-      "col": 18,
-      "color": null,
+      "id": "R4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R3",
+        "south": "R5",
+        "west": "Q4",
+        "east": "S4"
       }
     },
     {
-      "row": 4,
-      "col": 19,
-      "color": null,
+      "id": "S4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S3",
+        "south": "S5",
+        "west": "R4",
+        "east": "T4"
       }
     },
     {
-      "row": 4,
-      "col": 20,
-      "color": null,
+      "id": "T4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T3",
+        "south": "T5",
+        "west": "S4",
+        "east": "U4"
       }
     },
     {
-      "row": 4,
-      "col": 21,
-      "color": null,
+      "id": "U4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U3",
+        "south": "U5",
+        "west": "T4",
+        "east": "V4"
       }
     },
     {
-      "row": 4,
-      "col": 22,
-      "color": null,
+      "id": "V4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V3",
+        "south": "V5",
+        "west": "U4",
+        "east": "W4"
       }
     },
     {
-      "row": 4,
-      "col": 23,
-      "color": null,
+      "id": "W4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W3",
+        "south": "W5",
+        "west": "V4",
+        "east": "X4"
       }
     },
     {
-      "row": 4,
-      "col": 24,
-      "color": null,
+      "id": "X4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X3",
+        "south": "X5",
+        "west": "W4",
+        "east": "Y4"
       }
     },
     {
-      "row": 4,
-      "col": 25,
-      "color": null,
+      "id": "Y4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y3",
+        "south": "Y5",
+        "west": "X4",
+        "east": "Z4"
       }
     },
     {
-      "row": 4,
-      "col": 26,
-      "color": null,
+      "id": "Z4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z3",
+        "south": "Z5",
+        "west": "Y4",
+        "east": "AA4"
       }
     },
     {
-      "row": 4,
-      "col": 27,
-      "color": null,
+      "id": "AA4",
+      "terrain": "exit ogre",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA3",
+        "south": "AA5",
+        "west": "Z4",
+        "east": "AB4"
       }
     },
     {
-      "row": 4,
-      "col": 28,
-      "color": null,
+      "id": "AB4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB3",
+        "south": "AB5",
+        "west": "AA4",
+        "east": "AC4"
       }
     },
     {
-      "row": 4,
-      "col": 29,
-      "color": null,
+      "id": "AC4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC3",
+        "south": "AC5",
+        "west": "AB4",
+        "east": "AD4"
       }
     },
     {
-      "row": 4,
-      "col": 30,
-      "color": null,
+      "id": "AD4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD3",
+        "south": "AD5",
+        "west": "AC4",
+        "east": "AE4"
       }
     },
     {
-      "row": 4,
-      "col": 31,
-      "color": null,
+      "id": "AE4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE3",
+        "south": "AE5",
+        "west": "AD4",
+        "east": "AF4"
       }
     },
     {
-      "row": 4,
-      "col": 32,
-      "color": null,
+      "id": "AF4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF3",
+        "south": "AF5",
+        "west": "AE4",
+        "east": "AG4"
       }
     },
     {
-      "row": 4,
-      "col": 33,
-      "color": null,
+      "id": "AG4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG3",
+        "south": "AG5",
+        "west": "AF4",
+        "east": "AH4"
       }
     },
     {
-      "row": 4,
-      "col": 34,
-      "color": null,
+      "id": "AH4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH3",
+        "south": "AH5",
+        "west": "AG4",
+        "east": "AI4"
       }
     },
     {
-      "row": 4,
-      "col": 35,
-      "color": null,
+      "id": "AI4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI3",
+        "south": "AI5",
+        "west": "AH4",
+        "east": "AJ4"
       }
     },
     {
-      "row": 4,
-      "col": 36,
-      "color": null,
+      "id": "AJ4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ3",
+        "south": "AJ5",
+        "west": "AI4",
+        "east": "AK4"
       }
     },
     {
-      "row": 4,
-      "col": 37,
-      "color": null,
+      "id": "AK4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK3",
+        "south": "AK5",
+        "west": "AJ4",
+        "east": "AL4"
       }
     },
     {
-      "row": 4,
-      "col": 38,
-      "color": null,
+      "id": "AL4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL3",
+        "south": "AL5",
+        "west": "AK4",
+        "east": "AM4"
       }
     },
     {
-      "row": 4,
-      "col": 39,
-      "color": null,
+      "id": "AM4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM3",
+        "south": "AM5",
+        "west": "AL4",
+        "east": "AN4"
       }
     },
     {
-      "row": 4,
-      "col": 40,
-      "color": null,
+      "id": "AN4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN3",
+        "south": "AN5",
+        "west": "AM4",
+        "east": "AO4"
       }
     },
     {
-      "row": 4,
-      "col": 41,
-      "color": null,
+      "id": "AO4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO3",
+        "south": "AO5",
+        "west": "AN4",
+        "east": "AP4"
       }
     },
     {
-      "row": 4,
-      "col": 42,
-      "color": null,
+      "id": "AP4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP3",
+        "south": "AP5",
+        "west": "AO4",
+        "east": "AQ4"
       }
     },
     {
-      "row": 4,
-      "col": 43,
-      "color": null,
+      "id": "AQ4",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ3",
+        "south": "AQ5",
+        "west": "AP4",
+        "east": "AR4"
       }
     },
     {
-      "row": 4,
-      "col": 44,
-      "color": null,
+      "id": "AR4",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR3",
+        "south": "AR5",
+        "west": "AQ4",
+        "east": "AS4"
       }
     },
     {
-      "row": 4,
-      "col": 45,
-      "color": null,
+      "id": "AS4",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS3",
+        "south": "AS5",
+        "west": "AR4",
+        "east": "AT4"
       }
     },
     {
-      "row": 4,
-      "col": 46,
-      "color": null,
+      "id": "AT4",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT3",
+        "south": "AT5",
+        "west": "AS4",
+        "east": "AU4"
       }
     },
     {
-      "row": 4,
-      "col": 47,
-      "color": null,
+      "id": "AU4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU3",
+        "south": "AU5",
+        "west": "AT4",
+        "east": "AV4"
       }
     },
     {
-      "row": 4,
-      "col": 48,
-      "color": null,
+      "id": "AV4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV3",
+        "south": "AV5",
+        "west": "AU4",
+        "east": "AW4"
       }
     },
     {
-      "row": 4,
-      "col": 49,
-      "color": null,
+      "id": "AW4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW3",
+        "south": "AW5",
+        "west": "AV4",
+        "east": "AX4"
       }
     },
     {
-      "row": 4,
-      "col": 50,
-      "color": null,
+      "id": "AX4",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX3",
+        "south": "AX5",
+        "west": "AW4"
       }
     },
     {
-      "row": 5,
-      "col": 1,
-      "color": null,
+      "id": "A5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A4",
+        "south": "A6",
+        "east": "B5"
       }
     },
     {
-      "row": 5,
-      "col": 2,
-      "color": null,
+      "id": "B5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B4",
+        "south": "B6",
+        "west": "A5",
+        "east": "C5"
       }
     },
     {
-      "row": 5,
-      "col": 3,
-      "color": null,
+      "id": "C5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C4",
+        "south": "C6",
+        "west": "B5",
+        "east": "D5"
       }
     },
     {
-      "row": 5,
-      "col": 4,
-      "color": null,
+      "id": "D5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D4",
+        "south": "D6",
+        "west": "C5",
+        "east": "E5"
       }
     },
     {
-      "row": 5,
-      "col": 5,
-      "color": null,
+      "id": "E5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E4",
+        "south": "E6",
+        "west": "D5",
+        "east": "F5"
       }
     },
     {
-      "row": 5,
-      "col": 6,
-      "color": null,
+      "id": "F5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F4",
+        "south": "F6",
+        "west": "E5",
+        "east": "G5"
       }
     },
     {
-      "row": 5,
-      "col": 7,
-      "color": null,
+      "id": "G5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G4",
+        "south": "G6",
+        "west": "F5",
+        "east": "H5"
       }
     },
     {
-      "row": 5,
-      "col": 8,
-      "color": null,
+      "id": "H5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H4",
+        "south": "H6",
+        "west": "G5",
+        "east": "I5"
       }
     },
     {
-      "row": 5,
-      "col": 9,
-      "color": null,
+      "id": "I5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I4",
+        "south": "I6",
+        "west": "H5",
+        "east": "J5"
       }
     },
     {
-      "row": 5,
-      "col": 10,
-      "color": null,
+      "id": "J5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J4",
+        "south": "J6",
+        "west": "I5",
+        "east": "K5"
       }
     },
     {
-      "row": 5,
-      "col": 11,
-      "color": null,
+      "id": "K5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K4",
+        "south": "K6",
+        "west": "J5",
+        "east": "L5"
       }
     },
     {
-      "row": 5,
-      "col": 12,
-      "color": null,
+      "id": "L5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L4",
+        "south": "L6",
+        "west": "K5",
+        "east": "M5"
       }
     },
     {
-      "row": 5,
-      "col": 13,
-      "color": null,
+      "id": "M5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M4",
+        "south": "M6",
+        "west": "L5",
+        "east": "N5"
       }
     },
     {
-      "row": 5,
-      "col": 14,
-      "color": null,
+      "id": "N5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N4",
+        "south": "N6",
+        "west": "M5",
+        "east": "O5"
       }
     },
     {
-      "row": 5,
-      "col": 15,
-      "color": null,
+      "id": "O5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O4",
+        "south": "O6",
+        "west": "N5",
+        "east": "P5"
       }
     },
     {
-      "row": 5,
-      "col": 16,
-      "color": null,
+      "id": "P5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P4",
+        "south": "P6",
+        "west": "O5",
+        "east": "Q5"
       }
     },
     {
-      "row": 5,
-      "col": 17,
-      "color": null,
+      "id": "Q5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q4",
+        "south": "Q6",
+        "west": "P5",
+        "east": "R5"
       }
     },
     {
-      "row": 5,
-      "col": 18,
-      "color": null,
+      "id": "R5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R4",
+        "south": "R6",
+        "west": "Q5",
+        "east": "S5"
       }
     },
     {
-      "row": 5,
-      "col": 19,
-      "color": null,
+      "id": "S5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S4",
+        "south": "S6",
+        "west": "R5",
+        "east": "T5"
       }
     },
     {
-      "row": 5,
-      "col": 20,
-      "color": null,
+      "id": "T5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T4",
+        "south": "T6",
+        "west": "S5",
+        "east": "U5"
       }
     },
     {
-      "row": 5,
-      "col": 21,
-      "color": null,
+      "id": "U5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U4",
+        "south": "U6",
+        "west": "T5",
+        "east": "V5"
       }
     },
     {
-      "row": 5,
-      "col": 22,
-      "color": null,
+      "id": "V5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V4",
+        "south": "V6",
+        "west": "U5",
+        "east": "W5"
       }
     },
     {
-      "row": 5,
-      "col": 23,
-      "color": null,
+      "id": "W5",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W4",
+        "south": "W6",
+        "west": "V5",
+        "east": "X5"
       }
     },
     {
-      "row": 5,
-      "col": 24,
-      "color": null,
+      "id": "X5",
+      "terrain": "na",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X4",
+        "south": "X6",
+        "west": "W5",
+        "east": "Y5"
       }
     },
     {
-      "row": 5,
-      "col": 25,
-      "color": null,
+      "id": "Y5",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y4",
+        "south": "Y6",
+        "west": "X5",
+        "east": "Z5"
       }
     },
     {
-      "row": 5,
-      "col": 26,
-      "color": null,
+      "id": "Z5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z4",
+        "south": "Z6",
+        "west": "Y5",
+        "east": "AA5"
       }
     },
     {
-      "row": 5,
-      "col": 27,
-      "color": null,
+      "id": "AA5",
+      "terrain": "bridge",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA4",
+        "south": "AA6",
+        "west": "Z5",
+        "east": "AB5"
       }
     },
     {
-      "row": 5,
-      "col": 28,
-      "color": null,
+      "id": "AB5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB4",
+        "south": "AB6",
+        "west": "AA5",
+        "east": "AC5"
       }
     },
     {
-      "row": 5,
-      "col": 29,
-      "color": null,
+      "id": "AC5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC4",
+        "south": "AC6",
+        "west": "AB5",
+        "east": "AD5"
       }
     },
     {
-      "row": 5,
-      "col": 30,
-      "color": null,
+      "id": "AD5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD4",
+        "south": "AD6",
+        "west": "AC5",
+        "east": "AE5"
       }
     },
     {
-      "row": 5,
-      "col": 31,
-      "color": null,
+      "id": "AE5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE4",
+        "south": "AE6",
+        "west": "AD5",
+        "east": "AF5"
       }
     },
     {
-      "row": 5,
-      "col": 32,
-      "color": null,
+      "id": "AF5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF4",
+        "south": "AF6",
+        "west": "AE5",
+        "east": "AG5"
       }
     },
     {
-      "row": 5,
-      "col": 33,
-      "color": null,
+      "id": "AG5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG4",
+        "south": "AG6",
+        "west": "AF5",
+        "east": "AH5"
       }
     },
     {
-      "row": 5,
-      "col": 34,
-      "color": null,
+      "id": "AH5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH4",
+        "south": "AH6",
+        "west": "AG5",
+        "east": "AI5"
       }
     },
     {
-      "row": 5,
-      "col": 35,
-      "color": null,
+      "id": "AI5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI4",
+        "south": "AI6",
+        "west": "AH5",
+        "east": "AJ5"
       }
     },
     {
-      "row": 5,
-      "col": 36,
-      "color": null,
+      "id": "AJ5",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ4",
+        "south": "AJ6",
+        "west": "AI5",
+        "east": "AK5"
       }
     },
     {
-      "row": 5,
-      "col": 37,
-      "color": null,
+      "id": "AK5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK4",
+        "south": "AK6",
+        "west": "AJ5",
+        "east": "AL5"
       }
     },
     {
-      "row": 5,
-      "col": 38,
-      "color": null,
+      "id": "AL5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL4",
+        "south": "AL6",
+        "west": "AK5",
+        "east": "AM5"
       }
     },
     {
-      "row": 5,
-      "col": 39,
-      "color": null,
+      "id": "AM5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM4",
+        "south": "AM6",
+        "west": "AL5",
+        "east": "AN5"
       }
     },
     {
-      "row": 5,
-      "col": 40,
-      "color": null,
+      "id": "AN5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN4",
+        "south": "AN6",
+        "west": "AM5",
+        "east": "AO5"
       }
     },
     {
-      "row": 5,
-      "col": 41,
-      "color": null,
+      "id": "AO5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO4",
+        "south": "AO6",
+        "west": "AN5",
+        "east": "AP5"
       }
     },
     {
-      "row": 5,
-      "col": 42,
-      "color": null,
+      "id": "AP5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP4",
+        "south": "AP6",
+        "west": "AO5",
+        "east": "AQ5"
       }
     },
     {
-      "row": 5,
-      "col": 43,
-      "color": null,
+      "id": "AQ5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ4",
+        "south": "AQ6",
+        "west": "AP5",
+        "east": "AR5"
       }
     },
     {
-      "row": 5,
-      "col": 44,
-      "color": null,
+      "id": "AR5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR4",
+        "south": "AR6",
+        "west": "AQ5",
+        "east": "AS5"
       }
     },
     {
-      "row": 5,
-      "col": 45,
-      "color": null,
+      "id": "AS5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS4",
+        "south": "AS6",
+        "west": "AR5",
+        "east": "AT5"
       }
     },
     {
-      "row": 5,
-      "col": 46,
-      "color": null,
+      "id": "AT5",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT4",
+        "south": "AT6",
+        "west": "AS5",
+        "east": "AU5"
       }
     },
     {
-      "row": 5,
-      "col": 47,
-      "color": null,
+      "id": "AU5",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU4",
+        "south": "AU6",
+        "west": "AT5",
+        "east": "AV5"
       }
     },
     {
-      "row": 5,
-      "col": 48,
-      "color": null,
+      "id": "AV5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV4",
+        "south": "AV6",
+        "west": "AU5",
+        "east": "AW5"
       }
     },
     {
-      "row": 5,
-      "col": 49,
-      "color": null,
+      "id": "AW5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW4",
+        "south": "AW6",
+        "west": "AV5",
+        "east": "AX5"
       }
     },
     {
-      "row": 5,
-      "col": 50,
-      "color": null,
+      "id": "AX5",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX4",
+        "south": "AX6",
+        "west": "AW5"
       }
     },
     {
-      "row": 6,
-      "col": 1,
-      "color": null,
+      "id": "A6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A5",
+        "south": "A7",
+        "east": "B6"
       }
     },
     {
-      "row": 6,
-      "col": 2,
-      "color": null,
+      "id": "B6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B5",
+        "south": "B7",
+        "west": "A6",
+        "east": "C6"
       }
     },
     {
-      "row": 6,
-      "col": 3,
-      "color": null,
+      "id": "C6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C5",
+        "south": "C7",
+        "west": "B6",
+        "east": "D6"
       }
     },
     {
-      "row": 6,
-      "col": 4,
-      "color": null,
+      "id": "D6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D5",
+        "south": "D7",
+        "west": "C6",
+        "east": "E6"
       }
     },
     {
-      "row": 6,
-      "col": 5,
-      "color": null,
+      "id": "E6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E5",
+        "south": "E7",
+        "west": "D6",
+        "east": "F6"
       }
     },
     {
-      "row": 6,
-      "col": 6,
-      "color": null,
+      "id": "F6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F5",
+        "south": "F7",
+        "west": "E6",
+        "east": "G6"
       }
     },
     {
-      "row": 6,
-      "col": 7,
-      "color": null,
+      "id": "G6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G5",
+        "south": "G7",
+        "west": "F6",
+        "east": "H6"
       }
     },
     {
-      "row": 6,
-      "col": 8,
-      "color": null,
+      "id": "H6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H5",
+        "south": "H7",
+        "west": "G6",
+        "east": "I6"
       }
     },
     {
-      "row": 6,
-      "col": 9,
-      "color": null,
+      "id": "I6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I5",
+        "south": "I7",
+        "west": "H6",
+        "east": "J6"
       }
     },
     {
-      "row": 6,
-      "col": 10,
-      "color": null,
+      "id": "J6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J5",
+        "south": "J7",
+        "west": "I6",
+        "east": "K6"
       }
     },
     {
-      "row": 6,
-      "col": 11,
-      "color": null,
+      "id": "K6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K5",
+        "south": "K7",
+        "west": "J6",
+        "east": "L6"
       }
     },
     {
-      "row": 6,
-      "col": 12,
-      "color": null,
+      "id": "L6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L5",
+        "south": "L7",
+        "west": "K6",
+        "east": "M6"
       }
     },
     {
-      "row": 6,
-      "col": 13,
-      "color": null,
+      "id": "M6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M5",
+        "south": "M7",
+        "west": "L6",
+        "east": "N6"
       }
     },
     {
-      "row": 6,
-      "col": 14,
-      "color": null,
+      "id": "N6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N5",
+        "south": "N7",
+        "west": "M6",
+        "east": "O6"
       }
     },
     {
-      "row": 6,
-      "col": 15,
-      "color": null,
+      "id": "O6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O5",
+        "south": "O7",
+        "west": "N6",
+        "east": "P6"
       }
     },
     {
-      "row": 6,
-      "col": 16,
-      "color": null,
+      "id": "P6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P5",
+        "south": "P7",
+        "west": "O6",
+        "east": "Q6"
       }
     },
     {
-      "row": 6,
-      "col": 17,
-      "color": null,
+      "id": "Q6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q5",
+        "south": "Q7",
+        "west": "P6",
+        "east": "R6"
       }
     },
     {
-      "row": 6,
-      "col": 18,
-      "color": null,
+      "id": "R6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R5",
+        "south": "R7",
+        "west": "Q6",
+        "east": "S6"
       }
     },
     {
-      "row": 6,
-      "col": 19,
-      "color": null,
+      "id": "S6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S5",
+        "south": "S7",
+        "west": "R6",
+        "east": "T6"
       }
     },
     {
-      "row": 6,
-      "col": 20,
-      "color": null,
+      "id": "T6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T5",
+        "south": "T7",
+        "west": "S6",
+        "east": "U6"
       }
     },
     {
-      "row": 6,
-      "col": 21,
-      "color": null,
+      "id": "U6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U5",
+        "south": "U7",
+        "west": "T6",
+        "east": "V6"
       }
     },
     {
-      "row": 6,
-      "col": 22,
-      "color": null,
+      "id": "V6",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V5",
+        "south": "V7",
+        "west": "U6",
+        "east": "W6"
       }
     },
     {
-      "row": 6,
-      "col": 23,
-      "color": null,
+      "id": "W6",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W5",
+        "south": "W7",
+        "west": "V6",
+        "east": "X6"
       }
     },
     {
-      "row": 6,
-      "col": 24,
-      "color": null,
+      "id": "X6",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X5",
+        "south": "X7",
+        "west": "W6",
+        "east": "Y6"
       }
     },
     {
-      "row": 6,
-      "col": 25,
-      "color": null,
+      "id": "Y6",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y5",
+        "south": "Y7",
+        "west": "X6",
+        "east": "Z6"
       }
     },
     {
-      "row": 6,
-      "col": 26,
-      "color": null,
+      "id": "Z6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z5",
+        "south": "Z7",
+        "west": "Y6",
+        "east": "AA6"
       }
     },
     {
-      "row": 6,
-      "col": 27,
-      "color": null,
+      "id": "AA6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA5",
+        "south": "AA7",
+        "west": "Z6",
+        "east": "AB6"
       }
     },
     {
-      "row": 6,
-      "col": 28,
-      "color": null,
+      "id": "AB6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB5",
+        "south": "AB7",
+        "west": "AA6",
+        "east": "AC6"
       }
     },
     {
-      "row": 6,
-      "col": 29,
-      "color": null,
+      "id": "AC6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC5",
+        "south": "AC7",
+        "west": "AB6",
+        "east": "AD6"
       }
     },
     {
-      "row": 6,
-      "col": 30,
-      "color": null,
+      "id": "AD6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD5",
+        "south": "AD7",
+        "west": "AC6",
+        "east": "AE6"
       }
     },
     {
-      "row": 6,
-      "col": 31,
-      "color": null,
+      "id": "AE6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE5",
+        "south": "AE7",
+        "west": "AD6",
+        "east": "AF6"
       }
     },
     {
-      "row": 6,
-      "col": 32,
-      "color": null,
+      "id": "AF6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF5",
+        "south": "AF7",
+        "west": "AE6",
+        "east": "AG6"
       }
     },
     {
-      "row": 6,
-      "col": 33,
-      "color": null,
+      "id": "AG6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG5",
+        "south": "AG7",
+        "west": "AF6",
+        "east": "AH6"
       }
     },
     {
-      "row": 6,
-      "col": 34,
-      "color": null,
+      "id": "AH6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH5",
+        "south": "AH7",
+        "west": "AG6",
+        "east": "AI6"
       }
     },
     {
-      "row": 6,
-      "col": 35,
-      "color": null,
+      "id": "AI6",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI5",
+        "south": "AI7",
+        "west": "AH6",
+        "east": "AJ6"
       }
     },
     {
-      "row": 6,
-      "col": 36,
-      "color": null,
+      "id": "AJ6",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ5",
+        "south": "AJ7",
+        "west": "AI6",
+        "east": "AK6"
       }
     },
     {
-      "row": 6,
-      "col": 37,
-      "color": null,
+      "id": "AK6",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK5",
+        "south": "AK7",
+        "west": "AJ6",
+        "east": "AL6"
       }
     },
     {
-      "row": 6,
-      "col": 38,
-      "color": null,
+      "id": "AL6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL5",
+        "south": "AL7",
+        "west": "AK6",
+        "east": "AM6"
       }
     },
     {
-      "row": 6,
-      "col": 39,
-      "color": null,
+      "id": "AM6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM5",
+        "south": "AM7",
+        "west": "AL6",
+        "east": "AN6"
       }
     },
     {
-      "row": 6,
-      "col": 40,
-      "color": null,
+      "id": "AN6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN5",
+        "south": "AN7",
+        "west": "AM6",
+        "east": "AO6"
       }
     },
     {
-      "row": 6,
-      "col": 41,
-      "color": null,
+      "id": "AO6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO5",
+        "south": "AO7",
+        "west": "AN6",
+        "east": "AP6"
       }
     },
     {
-      "row": 6,
-      "col": 42,
-      "color": null,
+      "id": "AP6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP5",
+        "south": "AP7",
+        "west": "AO6",
+        "east": "AQ6"
       }
     },
     {
-      "row": 6,
-      "col": 43,
-      "color": null,
+      "id": "AQ6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ5",
+        "south": "AQ7",
+        "west": "AP6",
+        "east": "AR6"
       }
     },
     {
-      "row": 6,
-      "col": 44,
-      "color": null,
+      "id": "AR6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR5",
+        "south": "AR7",
+        "west": "AQ6",
+        "east": "AS6"
       }
     },
     {
-      "row": 6,
-      "col": 45,
-      "color": null,
+      "id": "AS6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS5",
+        "south": "AS7",
+        "west": "AR6",
+        "east": "AT6"
       }
     },
     {
-      "row": 6,
-      "col": 46,
-      "color": null,
+      "id": "AT6",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT5",
+        "south": "AT7",
+        "west": "AS6",
+        "east": "AU6"
       }
     },
     {
-      "row": 6,
-      "col": 47,
-      "color": null,
+      "id": "AU6",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU5",
+        "south": "AU7",
+        "west": "AT6",
+        "east": "AV6"
       }
     },
     {
-      "row": 6,
-      "col": 48,
-      "color": null,
+      "id": "AV6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV5",
+        "south": "AV7",
+        "west": "AU6",
+        "east": "AW6"
       }
     },
     {
-      "row": 6,
-      "col": 49,
-      "color": null,
+      "id": "AW6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW5",
+        "south": "AW7",
+        "west": "AV6",
+        "east": "AX6"
       }
     },
     {
-      "row": 6,
-      "col": 50,
-      "color": null,
+      "id": "AX6",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX5",
+        "south": "AX7",
+        "west": "AW6"
       }
     },
     {
-      "row": 7,
-      "col": 1,
-      "color": null,
+      "id": "A7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A6",
+        "south": "A8",
+        "east": "B7"
       }
     },
     {
-      "row": 7,
-      "col": 2,
-      "color": null,
+      "id": "B7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B6",
+        "south": "B8",
+        "west": "A7",
+        "east": "C7"
       }
     },
     {
-      "row": 7,
-      "col": 3,
-      "color": null,
+      "id": "C7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C6",
+        "south": "C8",
+        "west": "B7",
+        "east": "D7"
       }
     },
     {
-      "row": 7,
-      "col": 4,
-      "color": null,
+      "id": "D7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D6",
+        "south": "D8",
+        "west": "C7",
+        "east": "E7"
       }
     },
     {
-      "row": 7,
-      "col": 5,
-      "color": null,
+      "id": "E7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E6",
+        "south": "E8",
+        "west": "D7",
+        "east": "F7"
       }
     },
     {
-      "row": 7,
-      "col": 6,
-      "color": null,
+      "id": "F7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F6",
+        "south": "F8",
+        "west": "E7",
+        "east": "G7"
       }
     },
     {
-      "row": 7,
-      "col": 7,
-      "color": null,
+      "id": "G7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G6",
+        "south": "G8",
+        "west": "F7",
+        "east": "H7"
       }
     },
     {
-      "row": 7,
-      "col": 8,
-      "color": null,
+      "id": "H7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H6",
+        "south": "H8",
+        "west": "G7",
+        "east": "I7"
       }
     },
     {
-      "row": 7,
-      "col": 9,
-      "color": null,
+      "id": "I7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I6",
+        "south": "I8",
+        "west": "H7",
+        "east": "J7"
       }
     },
     {
-      "row": 7,
-      "col": 10,
-      "color": null,
+      "id": "J7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J6",
+        "south": "J8",
+        "west": "I7",
+        "east": "K7"
       }
     },
     {
-      "row": 7,
-      "col": 11,
-      "color": null,
+      "id": "K7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K6",
+        "south": "K8",
+        "west": "J7",
+        "east": "L7"
       }
     },
     {
-      "row": 7,
-      "col": 12,
-      "color": null,
+      "id": "L7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L6",
+        "south": "L8",
+        "west": "K7",
+        "east": "M7"
       }
     },
     {
-      "row": 7,
-      "col": 13,
-      "color": null,
+      "id": "M7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M6",
+        "south": "M8",
+        "west": "L7",
+        "east": "N7"
       }
     },
     {
-      "row": 7,
-      "col": 14,
-      "color": null,
+      "id": "N7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N6",
+        "south": "N8",
+        "west": "M7",
+        "east": "O7"
       }
     },
     {
-      "row": 7,
-      "col": 15,
-      "color": null,
+      "id": "O7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O6",
+        "south": "O8",
+        "west": "N7",
+        "east": "P7"
       }
     },
     {
-      "row": 7,
-      "col": 16,
-      "color": null,
+      "id": "P7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P6",
+        "south": "P8",
+        "west": "O7",
+        "east": "Q7"
       }
     },
     {
-      "row": 7,
-      "col": 17,
-      "color": null,
+      "id": "Q7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q6",
+        "south": "Q8",
+        "west": "P7",
+        "east": "R7"
       }
     },
     {
-      "row": 7,
-      "col": 18,
-      "color": null,
+      "id": "R7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R6",
+        "south": "R8",
+        "west": "Q7",
+        "east": "S7"
       }
     },
     {
-      "row": 7,
-      "col": 19,
-      "color": null,
+      "id": "S7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S6",
+        "south": "S8",
+        "west": "R7",
+        "east": "T7"
       }
     },
     {
-      "row": 7,
-      "col": 20,
-      "color": null,
+      "id": "T7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T6",
+        "south": "T8",
+        "west": "S7",
+        "east": "U7"
       }
     },
     {
-      "row": 7,
-      "col": 21,
-      "color": null,
+      "id": "U7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U6",
+        "south": "U8",
+        "west": "T7",
+        "east": "V7"
       }
     },
     {
-      "row": 7,
-      "col": 22,
-      "color": null,
+      "id": "V7",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V6",
+        "south": "V8",
+        "west": "U7",
+        "east": "W7"
       }
     },
     {
-      "row": 7,
-      "col": 23,
-      "color": null,
+      "id": "W7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W6",
+        "south": "W8",
+        "west": "V7",
+        "east": "X7"
       }
     },
     {
-      "row": 7,
-      "col": 24,
-      "color": null,
+      "id": "X7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X6",
+        "south": "X8",
+        "west": "W7",
+        "east": "Y7"
       }
     },
     {
-      "row": 7,
-      "col": 25,
-      "color": null,
+      "id": "Y7",
+      "terrain": "Anshelm",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y6",
+        "south": "Y8",
+        "west": "X7",
+        "east": "Z7"
       }
     },
     {
-      "row": 7,
-      "col": 26,
-      "color": null,
+      "id": "Z7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z6",
+        "south": "Z8",
+        "west": "Y7",
+        "east": "AA7"
       }
     },
     {
-      "row": 7,
-      "col": 27,
-      "color": null,
+      "id": "AA7",
+      "terrain": "gorge",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA6",
+        "south": "AA8",
+        "west": "Z7",
+        "east": "AB7"
       }
     },
     {
-      "row": 7,
-      "col": 28,
-      "color": null,
+      "id": "AB7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB6",
+        "south": "AB8",
+        "west": "AA7",
+        "east": "AC7"
       }
     },
     {
-      "row": 7,
-      "col": 29,
-      "color": null,
+      "id": "AC7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC6",
+        "south": "AC8",
+        "west": "AB7",
+        "east": "AD7"
       }
     },
     {
-      "row": 7,
-      "col": 30,
-      "color": null,
+      "id": "AD7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD6",
+        "south": "AD8",
+        "west": "AC7",
+        "east": "AE7"
       }
     },
     {
-      "row": 7,
-      "col": 31,
-      "color": null,
+      "id": "AE7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE6",
+        "south": "AE8",
+        "west": "AD7",
+        "east": "AF7"
       }
     },
     {
-      "row": 7,
-      "col": 32,
-      "color": null,
+      "id": "AF7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF6",
+        "south": "AF8",
+        "west": "AE7",
+        "east": "AG7"
       }
     },
     {
-      "row": 7,
-      "col": 33,
-      "color": null,
+      "id": "AG7",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG6",
+        "south": "AG8",
+        "west": "AF7",
+        "east": "AH7"
       }
     },
     {
-      "row": 7,
-      "col": 34,
-      "color": null,
+      "id": "AH7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH6",
+        "south": "AH8",
+        "west": "AG7",
+        "east": "AI7"
       }
     },
     {
-      "row": 7,
-      "col": 35,
-      "color": null,
+      "id": "AI7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI6",
+        "south": "AI8",
+        "west": "AH7",
+        "east": "AJ7"
       }
     },
     {
-      "row": 7,
-      "col": 36,
-      "color": null,
+      "id": "AJ7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ6",
+        "south": "AJ8",
+        "west": "AI7",
+        "east": "AK7"
       }
     },
     {
-      "row": 7,
-      "col": 37,
-      "color": null,
+      "id": "AK7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK6",
+        "south": "AK8",
+        "west": "AJ7",
+        "east": "AL7"
       }
     },
     {
-      "row": 7,
-      "col": 38,
-      "color": null,
+      "id": "AL7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL6",
+        "south": "AL8",
+        "west": "AK7",
+        "east": "AM7"
       }
     },
     {
-      "row": 7,
-      "col": 39,
-      "color": null,
+      "id": "AM7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM6",
+        "south": "AM8",
+        "west": "AL7",
+        "east": "AN7"
       }
     },
     {
-      "row": 7,
-      "col": 40,
-      "color": null,
+      "id": "AN7",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN6",
+        "south": "AN8",
+        "west": "AM7",
+        "east": "AO7"
       }
     },
     {
-      "row": 7,
-      "col": 41,
-      "color": null,
+      "id": "AO7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO6",
+        "south": "AO8",
+        "west": "AN7",
+        "east": "AP7"
       }
     },
     {
-      "row": 7,
-      "col": 42,
-      "color": null,
+      "id": "AP7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP6",
+        "south": "AP8",
+        "west": "AO7",
+        "east": "AQ7"
       }
     },
     {
-      "row": 7,
-      "col": 43,
-      "color": null,
+      "id": "AQ7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ6",
+        "south": "AQ8",
+        "west": "AP7",
+        "east": "AR7"
       }
     },
     {
-      "row": 7,
-      "col": 44,
-      "color": null,
+      "id": "AR7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR6",
+        "south": "AR8",
+        "west": "AQ7",
+        "east": "AS7"
       }
     },
     {
-      "row": 7,
-      "col": 45,
-      "color": null,
+      "id": "AS7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS6",
+        "south": "AS8",
+        "west": "AR7",
+        "east": "AT7"
       }
     },
     {
-      "row": 7,
-      "col": 46,
-      "color": null,
+      "id": "AT7",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT6",
+        "south": "AT8",
+        "west": "AS7",
+        "east": "AU7"
       }
     },
     {
-      "row": 7,
-      "col": 47,
-      "color": null,
+      "id": "AU7",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU6",
+        "south": "AU8",
+        "west": "AT7",
+        "east": "AV7"
       }
     },
     {
-      "row": 7,
-      "col": 48,
-      "color": null,
+      "id": "AV7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV6",
+        "south": "AV8",
+        "west": "AU7",
+        "east": "AW7"
       }
     },
     {
-      "row": 7,
-      "col": 49,
-      "color": null,
+      "id": "AW7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW6",
+        "south": "AW8",
+        "west": "AV7",
+        "east": "AX7"
       }
     },
     {
-      "row": 7,
-      "col": 50,
-      "color": null,
+      "id": "AX7",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX6",
+        "south": "AX8",
+        "west": "AW7"
       }
     },
     {
-      "row": 8,
-      "col": 1,
-      "color": null,
+      "id": "A8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A7",
+        "south": "A9",
+        "east": "B8"
       }
     },
     {
-      "row": 8,
-      "col": 2,
-      "color": null,
+      "id": "B8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B7",
+        "south": "B9",
+        "west": "A8",
+        "east": "C8"
       }
     },
     {
-      "row": 8,
-      "col": 3,
-      "color": null,
+      "id": "C8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C7",
+        "south": "C9",
+        "west": "B8",
+        "east": "D8"
       }
     },
     {
-      "row": 8,
-      "col": 4,
-      "color": null,
+      "id": "D8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D7",
+        "south": "D9",
+        "west": "C8",
+        "east": "E8"
       }
     },
     {
-      "row": 8,
-      "col": 5,
-      "color": null,
+      "id": "E8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E7",
+        "south": "E9",
+        "west": "D8",
+        "east": "F8"
       }
     },
     {
-      "row": 8,
-      "col": 6,
-      "color": null,
+      "id": "F8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F7",
+        "south": "F9",
+        "west": "E8",
+        "east": "G8"
       }
     },
     {
-      "row": 8,
-      "col": 7,
-      "color": null,
+      "id": "G8",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G7",
+        "south": "G9",
+        "west": "F8",
+        "east": "H8"
       }
     },
     {
-      "row": 8,
-      "col": 8,
-      "color": null,
+      "id": "H8",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H7",
+        "south": "H9",
+        "west": "G8",
+        "east": "I8"
       }
     },
     {
-      "row": 8,
-      "col": 9,
-      "color": null,
+      "id": "I8",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I7",
+        "south": "I9",
+        "west": "H8",
+        "east": "J8"
       }
     },
     {
-      "row": 8,
-      "col": 10,
-      "color": null,
+      "id": "J8",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J7",
+        "south": "J9",
+        "west": "I8",
+        "east": "K8"
       }
     },
     {
-      "row": 8,
-      "col": 11,
-      "color": null,
+      "id": "K8",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K7",
+        "south": "K9",
+        "west": "J8",
+        "east": "L8"
       }
     },
     {
-      "row": 8,
-      "col": 12,
-      "color": null,
+      "id": "L8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L7",
+        "south": "L9",
+        "west": "K8",
+        "east": "M8"
       }
     },
     {
-      "row": 8,
-      "col": 13,
-      "color": null,
+      "id": "M8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M7",
+        "south": "M9",
+        "west": "L8",
+        "east": "N8"
       }
     },
     {
-      "row": 8,
-      "col": 14,
-      "color": null,
+      "id": "N8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N7",
+        "south": "N9",
+        "west": "M8",
+        "east": "O8"
       }
     },
     {
-      "row": 8,
-      "col": 15,
-      "color": null,
+      "id": "O8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O7",
+        "south": "O9",
+        "west": "N8",
+        "east": "P8"
       }
     },
     {
-      "row": 8,
-      "col": 16,
-      "color": null,
+      "id": "P8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P7",
+        "south": "P9",
+        "west": "O8",
+        "east": "Q8"
       }
     },
     {
-      "row": 8,
-      "col": 17,
-      "color": null,
+      "id": "Q8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q7",
+        "south": "Q9",
+        "west": "P8",
+        "east": "R8"
       }
     },
     {
-      "row": 8,
-      "col": 18,
-      "color": null,
+      "id": "R8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R7",
+        "south": "R9",
+        "west": "Q8",
+        "east": "S8"
       }
     },
     {
-      "row": 8,
-      "col": 19,
-      "color": null,
+      "id": "S8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S7",
+        "south": "S9",
+        "west": "R8",
+        "east": "T8"
       }
     },
     {
-      "row": 8,
-      "col": 20,
-      "color": null,
+      "id": "T8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T7",
+        "south": "T9",
+        "west": "S8",
+        "east": "U8"
       }
     },
     {
-      "row": 8,
-      "col": 21,
-      "color": null,
+      "id": "U8",
+      "terrain": "castle",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U7",
+        "south": "U9",
+        "west": "T8",
+        "east": "V8"
       }
     },
     {
-      "row": 8,
-      "col": 22,
-      "color": null,
+      "id": "V8",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V7",
+        "south": "V9",
+        "west": "U8",
+        "east": "W8"
       }
     },
     {
-      "row": 8,
-      "col": 23,
-      "color": null,
+      "id": "W8",
+      "terrain": "tower",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W7",
+        "south": "W9",
+        "west": "V8",
+        "east": "X8"
       }
     },
     {
-      "row": 8,
-      "col": 24,
-      "color": null,
+      "id": "X8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X7",
+        "south": "X9",
+        "west": "W8",
+        "east": "Y8"
       }
     },
     {
-      "row": 8,
-      "col": 25,
-      "color": null,
+      "id": "Y8",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y7",
+        "south": "Y9",
+        "west": "X8",
+        "east": "Z8"
       }
     },
     {
-      "row": 8,
-      "col": 26,
-      "color": null,
+      "id": "Z8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z7",
+        "south": "Z9",
+        "west": "Y8",
+        "east": "AA8"
       }
     },
     {
-      "row": 8,
-      "col": 27,
-      "color": null,
+      "id": "AA8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA7",
+        "south": "AA9",
+        "west": "Z8",
+        "east": "AB8"
       }
     },
     {
-      "row": 8,
-      "col": 28,
-      "color": null,
+      "id": "AB8",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB7",
+        "south": "AB9",
+        "west": "AA8",
+        "east": "AC8"
       }
     },
     {
-      "row": 8,
-      "col": 29,
-      "color": null,
+      "id": "AC8",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC7",
+        "south": "AC9",
+        "west": "AB8",
+        "east": "AD8"
       }
     },
     {
-      "row": 8,
-      "col": 30,
-      "color": null,
+      "id": "AD8",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD7",
+        "south": "AD9",
+        "west": "AC8",
+        "east": "AE8"
       }
     },
     {
-      "row": 8,
-      "col": 31,
-      "color": null,
+      "id": "AE8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE7",
+        "south": "AE9",
+        "west": "AD8",
+        "east": "AF8"
       }
     },
     {
-      "row": 8,
-      "col": 32,
-      "color": null,
+      "id": "AF8",
+      "terrain": "valley",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF7",
+        "south": "AF9",
+        "west": "AE8",
+        "east": "AG8"
       }
     },
     {
-      "row": 8,
-      "col": 33,
-      "color": null,
+      "id": "AG8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG7",
+        "south": "AG9",
+        "west": "AF8",
+        "east": "AH8"
       }
     },
     {
-      "row": 8,
-      "col": 34,
-      "color": null,
+      "id": "AH8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH7",
+        "south": "AH9",
+        "west": "AG8",
+        "east": "AI8"
       }
     },
     {
-      "row": 8,
-      "col": 35,
-      "color": null,
+      "id": "AI8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI7",
+        "south": "AI9",
+        "west": "AH8",
+        "east": "AJ8"
       }
     },
     {
-      "row": 8,
-      "col": 36,
-      "color": null,
+      "id": "AJ8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ7",
+        "south": "AJ9",
+        "west": "AI8",
+        "east": "AK8"
       }
     },
     {
-      "row": 8,
-      "col": 37,
-      "color": null,
+      "id": "AK8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK7",
+        "south": "AK9",
+        "west": "AJ8",
+        "east": "AL8"
       }
     },
     {
-      "row": 8,
-      "col": 38,
-      "color": null,
+      "id": "AL8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL7",
+        "south": "AL9",
+        "west": "AK8",
+        "east": "AM8"
       }
     },
     {
-      "row": 8,
-      "col": 39,
-      "color": null,
+      "id": "AM8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM7",
+        "south": "AM9",
+        "west": "AL8",
+        "east": "AN8"
       }
     },
     {
-      "row": 8,
-      "col": 40,
-      "color": null,
+      "id": "AN8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN7",
+        "south": "AN9",
+        "west": "AM8",
+        "east": "AO8"
       }
     },
     {
-      "row": 8,
-      "col": 41,
-      "color": null,
+      "id": "AO8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO7",
+        "south": "AO9",
+        "west": "AN8",
+        "east": "AP8"
       }
     },
     {
-      "row": 8,
-      "col": 42,
-      "color": null,
+      "id": "AP8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP7",
+        "south": "AP9",
+        "west": "AO8",
+        "east": "AQ8"
       }
     },
     {
-      "row": 8,
-      "col": 43,
-      "color": null,
+      "id": "AQ8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ7",
+        "south": "AQ9",
+        "west": "AP8",
+        "east": "AR8"
       }
     },
     {
-      "row": 8,
-      "col": 44,
-      "color": null,
+      "id": "AR8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR7",
+        "south": "AR9",
+        "west": "AQ8",
+        "east": "AS8"
       }
     },
     {
-      "row": 8,
-      "col": 45,
-      "color": null,
+      "id": "AS8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS7",
+        "south": "AS9",
+        "west": "AR8",
+        "east": "AT8"
       }
     },
     {
-      "row": 8,
-      "col": 46,
-      "color": null,
+      "id": "AT8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT7",
+        "south": "AT9",
+        "west": "AS8",
+        "east": "AU8"
       }
     },
     {
-      "row": 8,
-      "col": 47,
-      "color": null,
+      "id": "AU8",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU7",
+        "south": "AU9",
+        "west": "AT8",
+        "east": "AV8"
       }
     },
     {
-      "row": 8,
-      "col": 48,
-      "color": null,
+      "id": "AV8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV7",
+        "south": "AV9",
+        "west": "AU8",
+        "east": "AW8"
       }
     },
     {
-      "row": 8,
-      "col": 49,
-      "color": null,
+      "id": "AW8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW7",
+        "south": "AW9",
+        "west": "AV8",
+        "east": "AX8"
       }
     },
     {
-      "row": 8,
-      "col": 50,
-      "color": null,
+      "id": "AX8",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX7",
+        "south": "AX9",
+        "west": "AW8"
       }
     },
     {
-      "row": 9,
-      "col": 1,
-      "color": null,
+      "id": "A9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A8",
+        "south": "A10",
+        "east": "B9"
       }
     },
     {
-      "row": 9,
-      "col": 2,
-      "color": null,
+      "id": "B9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B8",
+        "south": "B10",
+        "west": "A9",
+        "east": "C9"
       }
     },
     {
-      "row": 9,
-      "col": 3,
-      "color": null,
+      "id": "C9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C8",
+        "south": "C10",
+        "west": "B9",
+        "east": "D9"
       }
     },
     {
-      "row": 9,
-      "col": 4,
-      "color": null,
+      "id": "D9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D8",
+        "south": "D10",
+        "west": "C9",
+        "east": "E9"
       }
     },
     {
-      "row": 9,
-      "col": 5,
-      "color": null,
+      "id": "E9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E8",
+        "south": "E10",
+        "west": "D9",
+        "east": "F9"
       }
     },
     {
-      "row": 9,
-      "col": 6,
-      "color": null,
+      "id": "F9",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F8",
+        "south": "F10",
+        "west": "E9",
+        "east": "G9"
       }
     },
     {
-      "row": 9,
-      "col": 7,
-      "color": null,
+      "id": "G9",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G8",
+        "south": "G10",
+        "west": "F9",
+        "east": "H9"
       }
     },
     {
-      "row": 9,
-      "col": 8,
-      "color": null,
+      "id": "H9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H8",
+        "south": "H10",
+        "west": "G9",
+        "east": "I9"
       }
     },
     {
-      "row": 9,
-      "col": 9,
-      "color": null,
+      "id": "I9",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I8",
+        "south": "I10",
+        "west": "H9",
+        "east": "J9"
       }
     },
     {
-      "row": 9,
-      "col": 10,
-      "color": null,
+      "id": "J9",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J8",
+        "south": "J10",
+        "west": "I9",
+        "east": "K9"
       }
     },
     {
-      "row": 9,
-      "col": 11,
-      "color": null,
+      "id": "K9",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K8",
+        "south": "K10",
+        "west": "J9",
+        "east": "L9"
       }
     },
     {
-      "row": 9,
-      "col": 12,
-      "color": null,
+      "id": "L9",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L8",
+        "south": "L10",
+        "west": "K9",
+        "east": "M9"
       }
     },
     {
-      "row": 9,
-      "col": 13,
-      "color": null,
+      "id": "M9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M8",
+        "south": "M10",
+        "west": "L9",
+        "east": "N9"
       }
     },
     {
-      "row": 9,
-      "col": 14,
-      "color": null,
+      "id": "N9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N8",
+        "south": "N10",
+        "west": "M9",
+        "east": "O9"
       }
     },
     {
-      "row": 9,
-      "col": 15,
-      "color": null,
+      "id": "O9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O8",
+        "south": "O10",
+        "west": "N9",
+        "east": "P9"
       }
     },
     {
-      "row": 9,
-      "col": 16,
-      "color": null,
+      "id": "P9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P8",
+        "south": "P10",
+        "west": "O9",
+        "east": "Q9"
       }
     },
     {
-      "row": 9,
-      "col": 17,
-      "color": null,
+      "id": "Q9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q8",
+        "south": "Q10",
+        "west": "P9",
+        "east": "R9"
       }
     },
     {
-      "row": 9,
-      "col": 18,
-      "color": null,
+      "id": "R9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R8",
+        "south": "R10",
+        "west": "Q9",
+        "east": "S9"
       }
     },
     {
-      "row": 9,
-      "col": 19,
-      "color": null,
+      "id": "S9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S8",
+        "south": "S10",
+        "west": "R9",
+        "east": "T9"
       }
     },
     {
-      "row": 9,
-      "col": 20,
-      "color": null,
+      "id": "T9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T8",
+        "south": "T10",
+        "west": "S9",
+        "east": "U9"
       }
     },
     {
-      "row": 9,
-      "col": 21,
-      "color": null,
+      "id": "U9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U8",
+        "south": "U10",
+        "west": "T9",
+        "east": "V9"
       }
     },
     {
-      "row": 9,
-      "col": 22,
-      "color": null,
+      "id": "V9",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V8",
+        "south": "V10",
+        "west": "U9",
+        "east": "W9"
       }
     },
     {
-      "row": 9,
-      "col": 23,
-      "color": null,
+      "id": "W9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W8",
+        "south": "W10",
+        "west": "V9",
+        "east": "X9"
       }
     },
     {
-      "row": 9,
-      "col": 24,
-      "color": null,
+      "id": "X9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X8",
+        "south": "X10",
+        "west": "W9",
+        "east": "Y9"
       }
     },
     {
-      "row": 9,
-      "col": 25,
-      "color": null,
+      "id": "Y9",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y8",
+        "south": "Y10",
+        "west": "X9",
+        "east": "Z9"
       }
     },
     {
-      "row": 9,
-      "col": 26,
-      "color": null,
+      "id": "Z9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z8",
+        "south": "Z10",
+        "west": "Y9",
+        "east": "AA9"
       }
     },
     {
-      "row": 9,
-      "col": 27,
-      "color": null,
+      "id": "AA9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA8",
+        "south": "AA10",
+        "west": "Z9",
+        "east": "AB9"
       }
     },
     {
-      "row": 9,
-      "col": 28,
-      "color": null,
+      "id": "AB9",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB8",
+        "south": "AB10",
+        "west": "AA9",
+        "east": "AC9"
       }
     },
     {
-      "row": 9,
-      "col": 29,
-      "color": null,
+      "id": "AC9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC8",
+        "south": "AC10",
+        "west": "AB9",
+        "east": "AD9"
       }
     },
     {
-      "row": 9,
-      "col": 30,
-      "color": null,
+      "id": "AD9",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD8",
+        "south": "AD10",
+        "west": "AC9",
+        "east": "AE9"
       }
     },
     {
-      "row": 9,
-      "col": 31,
-      "color": null,
+      "id": "AE9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE8",
+        "south": "AE10",
+        "west": "AD9",
+        "east": "AF9"
       }
     },
     {
-      "row": 9,
-      "col": 32,
-      "color": null,
+      "id": "AF9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF8",
+        "south": "AF10",
+        "west": "AE9",
+        "east": "AG9"
       }
     },
     {
-      "row": 9,
-      "col": 33,
-      "color": null,
+      "id": "AG9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG8",
+        "south": "AG10",
+        "west": "AF9",
+        "east": "AH9"
       }
     },
     {
-      "row": 9,
-      "col": 34,
-      "color": null,
+      "id": "AH9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH8",
+        "south": "AH10",
+        "west": "AG9",
+        "east": "AI9"
       }
     },
     {
-      "row": 9,
-      "col": 35,
-      "color": null,
+      "id": "AI9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI8",
+        "south": "AI10",
+        "west": "AH9",
+        "east": "AJ9"
       }
     },
     {
-      "row": 9,
-      "col": 36,
-      "color": null,
+      "id": "AJ9",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ8",
+        "south": "AJ10",
+        "west": "AI9",
+        "east": "AK9"
       }
     },
     {
-      "row": 9,
-      "col": 37,
-      "color": null,
+      "id": "AK9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK8",
+        "south": "AK10",
+        "west": "AJ9",
+        "east": "AL9"
       }
     },
     {
-      "row": 9,
-      "col": 38,
-      "color": null,
+      "id": "AL9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL8",
+        "south": "AL10",
+        "west": "AK9",
+        "east": "AM9"
       }
     },
     {
-      "row": 9,
-      "col": 39,
-      "color": null,
+      "id": "AM9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM8",
+        "south": "AM10",
+        "west": "AL9",
+        "east": "AN9"
       }
     },
     {
-      "row": 9,
-      "col": 40,
-      "color": null,
+      "id": "AN9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN8",
+        "south": "AN10",
+        "west": "AM9",
+        "east": "AO9"
       }
     },
     {
-      "row": 9,
-      "col": 41,
-      "color": null,
+      "id": "AO9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO8",
+        "south": "AO10",
+        "west": "AN9",
+        "east": "AP9"
       }
     },
     {
-      "row": 9,
-      "col": 42,
-      "color": null,
+      "id": "AP9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP8",
+        "south": "AP10",
+        "west": "AO9",
+        "east": "AQ9"
       }
     },
     {
-      "row": 9,
-      "col": 43,
-      "color": null,
+      "id": "AQ9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ8",
+        "south": "AQ10",
+        "west": "AP9",
+        "east": "AR9"
       }
     },
     {
-      "row": 9,
-      "col": 44,
-      "color": null,
+      "id": "AR9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR8",
+        "south": "AR10",
+        "west": "AQ9",
+        "east": "AS9"
       }
     },
     {
-      "row": 9,
-      "col": 45,
-      "color": null,
+      "id": "AS9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS8",
+        "south": "AS10",
+        "west": "AR9",
+        "east": "AT9"
       }
     },
     {
-      "row": 9,
-      "col": 46,
-      "color": null,
+      "id": "AT9",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT8",
+        "south": "AT10",
+        "west": "AS9",
+        "east": "AU9"
       }
     },
     {
-      "row": 9,
-      "col": 47,
-      "color": null,
+      "id": "AU9",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU8",
+        "south": "AU10",
+        "west": "AT9",
+        "east": "AV9"
       }
     },
     {
-      "row": 9,
-      "col": 48,
-      "color": null,
+      "id": "AV9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV8",
+        "south": "AV10",
+        "west": "AU9",
+        "east": "AW9"
       }
     },
     {
-      "row": 9,
-      "col": 49,
-      "color": null,
+      "id": "AW9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW8",
+        "south": "AW10",
+        "west": "AV9",
+        "east": "AX9"
       }
     },
     {
-      "row": 9,
-      "col": 50,
-      "color": null,
+      "id": "AX9",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX8",
+        "south": "AX10",
+        "west": "AW9"
       }
     },
     {
-      "row": 10,
-      "col": 1,
-      "color": null,
+      "id": "A10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A9",
+        "south": "A11",
+        "east": "B10"
       }
     },
     {
-      "row": 10,
-      "col": 2,
-      "color": null,
+      "id": "B10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B9",
+        "south": "B11",
+        "west": "A10",
+        "east": "C10"
       }
     },
     {
-      "row": 10,
-      "col": 3,
-      "color": null,
+      "id": "C10",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C9",
+        "south": "C11",
+        "west": "B10",
+        "east": "D10"
       }
     },
     {
-      "row": 10,
-      "col": 4,
-      "color": null,
+      "id": "D10",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D9",
+        "south": "D11",
+        "west": "C10",
+        "east": "E10"
       }
     },
     {
-      "row": 10,
-      "col": 5,
-      "color": null,
+      "id": "E10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E9",
+        "south": "E11",
+        "west": "D10",
+        "east": "F10"
       }
     },
     {
-      "row": 10,
-      "col": 6,
-      "color": null,
+      "id": "F10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F9",
+        "south": "F11",
+        "west": "E10",
+        "east": "G10"
       }
     },
     {
-      "row": 10,
-      "col": 7,
-      "color": null,
+      "id": "G10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G9",
+        "south": "G11",
+        "west": "F10",
+        "east": "H10"
       }
     },
     {
-      "row": 10,
-      "col": 8,
-      "color": null,
+      "id": "H10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H9",
+        "south": "H11",
+        "west": "G10",
+        "east": "I10"
       }
     },
     {
-      "row": 10,
-      "col": 9,
-      "color": null,
+      "id": "I10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I9",
+        "south": "I11",
+        "west": "H10",
+        "east": "J10"
       }
     },
     {
-      "row": 10,
-      "col": 10,
-      "color": null,
+      "id": "J10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J9",
+        "south": "J11",
+        "west": "I10",
+        "east": "K10"
       }
     },
     {
-      "row": 10,
-      "col": 11,
-      "color": null,
+      "id": "K10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K9",
+        "south": "K11",
+        "west": "J10",
+        "east": "L10"
       }
     },
     {
-      "row": 10,
-      "col": 12,
-      "color": null,
+      "id": "L10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L9",
+        "south": "L11",
+        "west": "K10",
+        "east": "M10"
       }
     },
     {
-      "row": 10,
-      "col": 13,
-      "color": null,
+      "id": "M10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M9",
+        "south": "M11",
+        "west": "L10",
+        "east": "N10"
       }
     },
     {
-      "row": 10,
-      "col": 14,
-      "color": null,
+      "id": "N10",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N9",
+        "south": "N11",
+        "west": "M10",
+        "east": "O10"
       }
     },
     {
-      "row": 10,
-      "col": 15,
-      "color": null,
+      "id": "O10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O9",
+        "south": "O11",
+        "west": "N10",
+        "east": "P10"
       }
     },
     {
-      "row": 10,
-      "col": 16,
-      "color": null,
+      "id": "P10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P9",
+        "south": "P11",
+        "west": "O10",
+        "east": "Q10"
       }
     },
     {
-      "row": 10,
-      "col": 17,
-      "color": null,
+      "id": "Q10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q9",
+        "south": "Q11",
+        "west": "P10",
+        "east": "R10"
       }
     },
     {
-      "row": 10,
-      "col": 18,
-      "color": null,
+      "id": "R10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R9",
+        "south": "R11",
+        "west": "Q10",
+        "east": "S10"
       }
     },
     {
-      "row": 10,
-      "col": 19,
-      "color": null,
+      "id": "S10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S9",
+        "south": "S11",
+        "west": "R10",
+        "east": "T10"
       }
     },
     {
-      "row": 10,
-      "col": 20,
-      "color": null,
+      "id": "T10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T9",
+        "south": "T11",
+        "west": "S10",
+        "east": "U10"
       }
     },
     {
-      "row": 10,
-      "col": 21,
-      "color": null,
+      "id": "U10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U9",
+        "south": "U11",
+        "west": "T10",
+        "east": "V10"
       }
     },
     {
-      "row": 10,
-      "col": 22,
-      "color": null,
+      "id": "V10",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V9",
+        "south": "V11",
+        "west": "U10",
+        "east": "W10"
       }
     },
     {
-      "row": 10,
-      "col": 23,
-      "color": null,
+      "id": "W10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W9",
+        "south": "W11",
+        "west": "V10",
+        "east": "X10"
       }
     },
     {
-      "row": 10,
-      "col": 24,
-      "color": null,
+      "id": "X10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X9",
+        "south": "X11",
+        "west": "W10",
+        "east": "Y10"
       }
     },
     {
-      "row": 10,
-      "col": 25,
-      "color": null,
+      "id": "Y10",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y9",
+        "south": "Y11",
+        "west": "X10",
+        "east": "Z10"
       }
     },
     {
-      "row": 10,
-      "col": 26,
-      "color": null,
+      "id": "Z10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z9",
+        "south": "Z11",
+        "west": "Y10",
+        "east": "AA10"
       }
     },
     {
-      "row": 10,
-      "col": 27,
-      "color": null,
+      "id": "AA10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA9",
+        "south": "AA11",
+        "west": "Z10",
+        "east": "AB10"
       }
     },
     {
-      "row": 10,
-      "col": 28,
-      "color": null,
+      "id": "AB10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB9",
+        "south": "AB11",
+        "west": "AA10",
+        "east": "AC10"
       }
     },
     {
-      "row": 10,
-      "col": 29,
-      "color": null,
+      "id": "AC10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC9",
+        "south": "AC11",
+        "west": "AB10",
+        "east": "AD10"
       }
     },
     {
-      "row": 10,
-      "col": 30,
-      "color": null,
+      "id": "AD10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD9",
+        "south": "AD11",
+        "west": "AC10",
+        "east": "AE10"
       }
     },
     {
-      "row": 10,
-      "col": 31,
-      "color": null,
+      "id": "AE10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE9",
+        "south": "AE11",
+        "west": "AD10",
+        "east": "AF10"
       }
     },
     {
-      "row": 10,
-      "col": 32,
-      "color": null,
+      "id": "AF10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF9",
+        "south": "AF11",
+        "west": "AE10",
+        "east": "AG10"
       }
     },
     {
-      "row": 10,
-      "col": 33,
-      "color": null,
+      "id": "AG10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG9",
+        "south": "AG11",
+        "west": "AF10",
+        "east": "AH10"
       }
     },
     {
-      "row": 10,
-      "col": 34,
-      "color": null,
+      "id": "AH10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH9",
+        "south": "AH11",
+        "west": "AG10",
+        "east": "AI10"
       }
     },
     {
-      "row": 10,
-      "col": 35,
-      "color": null,
+      "id": "AI10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI9",
+        "south": "AI11",
+        "west": "AH10",
+        "east": "AJ10"
       }
     },
     {
-      "row": 10,
-      "col": 36,
-      "color": null,
+      "id": "AJ10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ9",
+        "south": "AJ11",
+        "west": "AI10",
+        "east": "AK10"
       }
     },
     {
-      "row": 10,
-      "col": 37,
-      "color": null,
+      "id": "AK10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK9",
+        "south": "AK11",
+        "west": "AJ10",
+        "east": "AL10"
       }
     },
     {
-      "row": 10,
-      "col": 38,
-      "color": null,
+      "id": "AL10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL9",
+        "south": "AL11",
+        "west": "AK10",
+        "east": "AM10"
       }
     },
     {
-      "row": 10,
-      "col": 39,
-      "color": null,
+      "id": "AM10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM9",
+        "south": "AM11",
+        "west": "AL10",
+        "east": "AN10"
       }
     },
     {
-      "row": 10,
-      "col": 40,
-      "color": null,
+      "id": "AN10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN9",
+        "south": "AN11",
+        "west": "AM10",
+        "east": "AO10"
       }
     },
     {
-      "row": 10,
-      "col": 41,
-      "color": null,
+      "id": "AO10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO9",
+        "south": "AO11",
+        "west": "AN10",
+        "east": "AP10"
       }
     },
     {
-      "row": 10,
-      "col": 42,
-      "color": null,
+      "id": "AP10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP9",
+        "south": "AP11",
+        "west": "AO10",
+        "east": "AQ10"
       }
     },
     {
-      "row": 10,
-      "col": 43,
-      "color": null,
+      "id": "AQ10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ9",
+        "south": "AQ11",
+        "west": "AP10",
+        "east": "AR10"
       }
     },
     {
-      "row": 10,
-      "col": 44,
-      "color": null,
+      "id": "AR10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR9",
+        "south": "AR11",
+        "west": "AQ10",
+        "east": "AS10"
       }
     },
     {
-      "row": 10,
-      "col": 45,
-      "color": null,
+      "id": "AS10",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS9",
+        "south": "AS11",
+        "west": "AR10",
+        "east": "AT10"
       }
     },
     {
-      "row": 10,
-      "col": 46,
-      "color": null,
+      "id": "AT10",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT9",
+        "south": "AT11",
+        "west": "AS10",
+        "east": "AU10"
       }
     },
     {
-      "row": 10,
-      "col": 47,
-      "color": null,
+      "id": "AU10",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU9",
+        "south": "AU11",
+        "west": "AT10",
+        "east": "AV10"
       }
     },
     {
-      "row": 10,
-      "col": 48,
-      "color": null,
+      "id": "AV10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV9",
+        "south": "AV11",
+        "west": "AU10",
+        "east": "AW10"
       }
     },
     {
-      "row": 10,
-      "col": 49,
-      "color": null,
+      "id": "AW10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW9",
+        "south": "AW11",
+        "west": "AV10",
+        "east": "AX10"
       }
     },
     {
-      "row": 10,
-      "col": 50,
-      "color": null,
+      "id": "AX10",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX9",
+        "south": "AX11",
+        "west": "AW10"
       }
     },
     {
-      "row": 11,
-      "col": 1,
-      "color": null,
+      "id": "A11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A10",
+        "south": "A12",
+        "east": "B11"
       }
     },
     {
-      "row": 11,
-      "col": 2,
-      "color": null,
+      "id": "B11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B10",
+        "south": "B12",
+        "west": "A11",
+        "east": "C11"
       }
     },
     {
-      "row": 11,
-      "col": 3,
-      "color": null,
+      "id": "C11",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C10",
+        "south": "C12",
+        "west": "B11",
+        "east": "D11"
       }
     },
     {
-      "row": 11,
-      "col": 4,
-      "color": null,
+      "id": "D11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D10",
+        "south": "D12",
+        "west": "C11",
+        "east": "E11"
       }
     },
     {
-      "row": 11,
-      "col": 5,
-      "color": null,
+      "id": "E11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E10",
+        "south": "E12",
+        "west": "D11",
+        "east": "F11"
       }
     },
     {
-      "row": 11,
-      "col": 6,
-      "color": null,
+      "id": "F11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F10",
+        "south": "F12",
+        "west": "E11",
+        "east": "G11"
       }
     },
     {
-      "row": 11,
-      "col": 7,
-      "color": null,
+      "id": "G11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G10",
+        "south": "G12",
+        "west": "F11",
+        "east": "H11"
       }
     },
     {
-      "row": 11,
-      "col": 8,
-      "color": null,
+      "id": "H11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H10",
+        "south": "H12",
+        "west": "G11",
+        "east": "I11"
       }
     },
     {
-      "row": 11,
-      "col": 9,
-      "color": null,
+      "id": "I11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I10",
+        "south": "I12",
+        "west": "H11",
+        "east": "J11"
       }
     },
     {
-      "row": 11,
-      "col": 10,
-      "color": null,
+      "id": "J11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J10",
+        "south": "J12",
+        "west": "I11",
+        "east": "K11"
       }
     },
     {
-      "row": 11,
-      "col": 11,
-      "color": null,
+      "id": "K11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K10",
+        "south": "K12",
+        "west": "J11",
+        "east": "L11"
       }
     },
     {
-      "row": 11,
-      "col": 12,
-      "color": null,
+      "id": "L11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L10",
+        "south": "L12",
+        "west": "K11",
+        "east": "M11"
       }
     },
     {
-      "row": 11,
-      "col": 13,
-      "color": null,
+      "id": "M11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M10",
+        "south": "M12",
+        "west": "L11",
+        "east": "N11"
       }
     },
     {
-      "row": 11,
-      "col": 14,
-      "color": null,
+      "id": "N11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N10",
+        "south": "N12",
+        "west": "M11",
+        "east": "O11"
       }
     },
     {
-      "row": 11,
-      "col": 15,
-      "color": null,
+      "id": "O11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O10",
+        "south": "O12",
+        "west": "N11",
+        "east": "P11"
       }
     },
     {
-      "row": 11,
-      "col": 16,
-      "color": null,
+      "id": "P11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P10",
+        "south": "P12",
+        "west": "O11",
+        "east": "Q11"
       }
     },
     {
-      "row": 11,
-      "col": 17,
-      "color": null,
+      "id": "Q11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q10",
+        "south": "Q12",
+        "west": "P11",
+        "east": "R11"
       }
     },
     {
-      "row": 11,
-      "col": 18,
-      "color": null,
+      "id": "R11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R10",
+        "south": "R12",
+        "west": "Q11",
+        "east": "S11"
       }
     },
     {
-      "row": 11,
-      "col": 19,
-      "color": null,
+      "id": "S11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S10",
+        "south": "S12",
+        "west": "R11",
+        "east": "T11"
       }
     },
     {
-      "row": 11,
-      "col": 20,
-      "color": null,
+      "id": "T11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T10",
+        "south": "T12",
+        "west": "S11",
+        "east": "U11"
       }
     },
     {
-      "row": 11,
-      "col": 21,
-      "color": null,
+      "id": "U11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U10",
+        "south": "U12",
+        "west": "T11",
+        "east": "V11"
       }
     },
     {
-      "row": 11,
-      "col": 22,
-      "color": null,
+      "id": "V11",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V10",
+        "south": "V12",
+        "west": "U11",
+        "east": "W11"
       }
     },
     {
-      "row": 11,
-      "col": 23,
-      "color": null,
+      "id": "W11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W10",
+        "south": "W12",
+        "west": "V11",
+        "east": "X11"
       }
     },
     {
-      "row": 11,
-      "col": 24,
-      "color": null,
+      "id": "X11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X10",
+        "south": "X12",
+        "west": "W11",
+        "east": "Y11"
       }
     },
     {
-      "row": 11,
-      "col": 25,
-      "color": null,
+      "id": "Y11",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y10",
+        "south": "Y12",
+        "west": "X11",
+        "east": "Z11"
       }
     },
     {
-      "row": 11,
-      "col": 26,
-      "color": null,
+      "id": "Z11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z10",
+        "south": "Z12",
+        "west": "Y11",
+        "east": "AA11"
       }
     },
     {
-      "row": 11,
-      "col": 27,
-      "color": null,
+      "id": "AA11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA10",
+        "south": "AA12",
+        "west": "Z11",
+        "east": "AB11"
       }
     },
     {
-      "row": 11,
-      "col": 28,
-      "color": null,
+      "id": "AB11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB10",
+        "south": "AB12",
+        "west": "AA11",
+        "east": "AC11"
       }
     },
     {
-      "row": 11,
-      "col": 29,
-      "color": null,
+      "id": "AC11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC10",
+        "south": "AC12",
+        "west": "AB11",
+        "east": "AD11"
       }
     },
     {
-      "row": 11,
-      "col": 30,
-      "color": null,
+      "id": "AD11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD10",
+        "south": "AD12",
+        "west": "AC11",
+        "east": "AE11"
       }
     },
     {
-      "row": 11,
-      "col": 31,
-      "color": null,
+      "id": "AE11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE10",
+        "south": "AE12",
+        "west": "AD11",
+        "east": "AF11"
       }
     },
     {
-      "row": 11,
-      "col": 32,
-      "color": null,
+      "id": "AF11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF10",
+        "south": "AF12",
+        "west": "AE11",
+        "east": "AG11"
       }
     },
     {
-      "row": 11,
-      "col": 33,
-      "color": null,
+      "id": "AG11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG10",
+        "south": "AG12",
+        "west": "AF11",
+        "east": "AH11"
       }
     },
     {
-      "row": 11,
-      "col": 34,
-      "color": null,
+      "id": "AH11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH10",
+        "south": "AH12",
+        "west": "AG11",
+        "east": "AI11"
       }
     },
     {
-      "row": 11,
-      "col": 35,
-      "color": null,
+      "id": "AI11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI10",
+        "south": "AI12",
+        "west": "AH11",
+        "east": "AJ11"
       }
     },
     {
-      "row": 11,
-      "col": 36,
-      "color": null,
+      "id": "AJ11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ10",
+        "south": "AJ12",
+        "west": "AI11",
+        "east": "AK11"
       }
     },
     {
-      "row": 11,
-      "col": 37,
-      "color": null,
+      "id": "AK11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK10",
+        "south": "AK12",
+        "west": "AJ11",
+        "east": "AL11"
       }
     },
     {
-      "row": 11,
-      "col": 38,
-      "color": null,
+      "id": "AL11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL10",
+        "south": "AL12",
+        "west": "AK11",
+        "east": "AM11"
       }
     },
     {
-      "row": 11,
-      "col": 39,
-      "color": null,
+      "id": "AM11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM10",
+        "south": "AM12",
+        "west": "AL11",
+        "east": "AN11"
       }
     },
     {
-      "row": 11,
-      "col": 40,
-      "color": null,
+      "id": "AN11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN10",
+        "south": "AN12",
+        "west": "AM11",
+        "east": "AO11"
       }
     },
     {
-      "row": 11,
-      "col": 41,
-      "color": null,
+      "id": "AO11",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO10",
+        "south": "AO12",
+        "west": "AN11",
+        "east": "AP11"
       }
     },
     {
-      "row": 11,
-      "col": 42,
-      "color": null,
+      "id": "AP11",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP10",
+        "south": "AP12",
+        "west": "AO11",
+        "east": "AQ11"
       }
     },
     {
-      "row": 11,
-      "col": 43,
-      "color": null,
+      "id": "AQ11",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ10",
+        "south": "AQ12",
+        "west": "AP11",
+        "east": "AR11"
       }
     },
     {
-      "row": 11,
-      "col": 44,
-      "color": null,
+      "id": "AR11",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR10",
+        "south": "AR12",
+        "west": "AQ11",
+        "east": "AS11"
       }
     },
     {
-      "row": 11,
-      "col": 45,
-      "color": null,
+      "id": "AS11",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS10",
+        "south": "AS12",
+        "west": "AR11",
+        "east": "AT11"
       }
     },
     {
-      "row": 11,
-      "col": 46,
-      "color": null,
+      "id": "AT11",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT10",
+        "south": "AT12",
+        "west": "AS11",
+        "east": "AU11"
       }
     },
     {
-      "row": 11,
-      "col": 47,
-      "color": null,
+      "id": "AU11",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU10",
+        "south": "AU12",
+        "west": "AT11",
+        "east": "AV11"
       }
     },
     {
-      "row": 11,
-      "col": 48,
-      "color": null,
+      "id": "AV11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV10",
+        "south": "AV12",
+        "west": "AU11",
+        "east": "AW11"
       }
     },
     {
-      "row": 11,
-      "col": 49,
-      "color": null,
+      "id": "AW11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW10",
+        "south": "AW12",
+        "west": "AV11",
+        "east": "AX11"
       }
     },
     {
-      "row": 11,
-      "col": 50,
-      "color": null,
+      "id": "AX11",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX10",
+        "south": "AX12",
+        "west": "AW11"
       }
     },
     {
-      "row": 12,
-      "col": 1,
-      "color": null,
+      "id": "A12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A11",
+        "south": "A13",
+        "east": "B12"
       }
     },
     {
-      "row": 12,
-      "col": 2,
-      "color": null,
+      "id": "B12",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B11",
+        "south": "B13",
+        "west": "A12",
+        "east": "C12"
       }
     },
     {
-      "row": 12,
-      "col": 3,
-      "color": null,
+      "id": "C12",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C11",
+        "south": "C13",
+        "west": "B12",
+        "east": "D12"
       }
     },
     {
-      "row": 12,
-      "col": 4,
-      "color": null,
+      "id": "D12",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D11",
+        "south": "D13",
+        "west": "C12",
+        "east": "E12"
       }
     },
     {
-      "row": 12,
-      "col": 5,
-      "color": null,
+      "id": "E12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E11",
+        "south": "E13",
+        "west": "D12",
+        "east": "F12"
       }
     },
     {
-      "row": 12,
-      "col": 6,
-      "color": null,
+      "id": "F12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F11",
+        "south": "F13",
+        "west": "E12",
+        "east": "G12"
       }
     },
     {
-      "row": 12,
-      "col": 7,
-      "color": null,
+      "id": "G12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G11",
+        "south": "G13",
+        "west": "F12",
+        "east": "H12"
       }
     },
     {
-      "row": 12,
-      "col": 8,
-      "color": null,
+      "id": "H12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H11",
+        "south": "H13",
+        "west": "G12",
+        "east": "I12"
       }
     },
     {
-      "row": 12,
-      "col": 9,
-      "color": null,
+      "id": "I12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I11",
+        "south": "I13",
+        "west": "H12",
+        "east": "J12"
       }
     },
     {
-      "row": 12,
-      "col": 10,
-      "color": null,
+      "id": "J12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J11",
+        "south": "J13",
+        "west": "I12",
+        "east": "K12"
       }
     },
     {
-      "row": 12,
-      "col": 11,
-      "color": null,
+      "id": "K12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K11",
+        "south": "K13",
+        "west": "J12",
+        "east": "L12"
       }
     },
     {
-      "row": 12,
-      "col": 12,
-      "color": null,
+      "id": "L12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L11",
+        "south": "L13",
+        "west": "K12",
+        "east": "M12"
       }
     },
     {
-      "row": 12,
-      "col": 13,
-      "color": null,
+      "id": "M12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M11",
+        "south": "M13",
+        "west": "L12",
+        "east": "N12"
       }
     },
     {
-      "row": 12,
-      "col": 14,
-      "color": null,
+      "id": "N12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N11",
+        "south": "N13",
+        "west": "M12",
+        "east": "O12"
       }
     },
     {
-      "row": 12,
-      "col": 15,
-      "color": null,
+      "id": "O12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O11",
+        "south": "O13",
+        "west": "N12",
+        "east": "P12"
       }
     },
     {
-      "row": 12,
-      "col": 16,
-      "color": null,
+      "id": "P12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P11",
+        "south": "P13",
+        "west": "O12",
+        "east": "Q12"
       }
     },
     {
-      "row": 12,
-      "col": 17,
-      "color": null,
+      "id": "Q12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q11",
+        "south": "Q13",
+        "west": "P12",
+        "east": "R12"
       }
     },
     {
-      "row": 12,
-      "col": 18,
-      "color": null,
+      "id": "R12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R11",
+        "south": "R13",
+        "west": "Q12",
+        "east": "S12"
       }
     },
     {
-      "row": 12,
-      "col": 19,
-      "color": null,
+      "id": "S12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S11",
+        "south": "S13",
+        "west": "R12",
+        "east": "T12"
       }
     },
     {
-      "row": 12,
-      "col": 20,
-      "color": null,
+      "id": "T12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T11",
+        "south": "T13",
+        "west": "S12",
+        "east": "U12"
       }
     },
     {
-      "row": 12,
-      "col": 21,
-      "color": null,
+      "id": "U12",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U11",
+        "south": "U13",
+        "west": "T12",
+        "east": "V12"
       }
     },
     {
-      "row": 12,
-      "col": 22,
-      "color": null,
+      "id": "V12",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V11",
+        "south": "V13",
+        "west": "U12",
+        "east": "W12"
       }
     },
     {
-      "row": 12,
-      "col": 23,
-      "color": null,
+      "id": "W12",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W11",
+        "south": "W13",
+        "west": "V12",
+        "east": "X12"
       }
     },
     {
-      "row": 12,
-      "col": 24,
-      "color": null,
+      "id": "X12",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X11",
+        "south": "X13",
+        "west": "W12",
+        "east": "Y12"
       }
     },
     {
-      "row": 12,
-      "col": 25,
-      "color": null,
+      "id": "Y12",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y11",
+        "south": "Y13",
+        "west": "X12",
+        "east": "Z12"
       }
     },
     {
-      "row": 12,
-      "col": 26,
-      "color": null,
+      "id": "Z12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z11",
+        "south": "Z13",
+        "west": "Y12",
+        "east": "AA12"
       }
     },
     {
-      "row": 12,
-      "col": 27,
-      "color": null,
+      "id": "AA12",
+      "terrain": "keep",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA11",
+        "south": "AA13",
+        "west": "Z12",
+        "east": "AB12"
       }
     },
     {
-      "row": 12,
-      "col": 28,
-      "color": null,
+      "id": "AB12",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB11",
+        "south": "AB13",
+        "west": "AA12",
+        "east": "AC12"
       }
     },
     {
-      "row": 12,
-      "col": 29,
-      "color": null,
+      "id": "AC12",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC11",
+        "south": "AC13",
+        "west": "AB12",
+        "east": "AD12"
       }
     },
     {
-      "row": 12,
-      "col": 30,
-      "color": null,
+      "id": "AD12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD11",
+        "south": "AD13",
+        "west": "AC12",
+        "east": "AE12"
       }
     },
     {
-      "row": 12,
-      "col": 31,
-      "color": null,
+      "id": "AE12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE11",
+        "south": "AE13",
+        "west": "AD12",
+        "east": "AF12"
       }
     },
     {
-      "row": 12,
-      "col": 32,
-      "color": null,
+      "id": "AF12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF11",
+        "south": "AF13",
+        "west": "AE12",
+        "east": "AG12"
       }
     },
     {
-      "row": 12,
-      "col": 33,
-      "color": null,
+      "id": "AG12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG11",
+        "south": "AG13",
+        "west": "AF12",
+        "east": "AH12"
       }
     },
     {
-      "row": 12,
-      "col": 34,
-      "color": null,
+      "id": "AH12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH11",
+        "south": "AH13",
+        "west": "AG12",
+        "east": "AI12"
       }
     },
     {
-      "row": 12,
-      "col": 35,
-      "color": null,
+      "id": "AI12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI11",
+        "south": "AI13",
+        "west": "AH12",
+        "east": "AJ12"
       }
     },
     {
-      "row": 12,
-      "col": 36,
-      "color": null,
+      "id": "AJ12",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ11",
+        "south": "AJ13",
+        "west": "AI12",
+        "east": "AK12"
       }
     },
     {
-      "row": 12,
-      "col": 37,
-      "color": null,
+      "id": "AK12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK11",
+        "south": "AK13",
+        "west": "AJ12",
+        "east": "AL12"
       }
     },
     {
-      "row": 12,
-      "col": 38,
-      "color": null,
+      "id": "AL12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL11",
+        "south": "AL13",
+        "west": "AK12",
+        "east": "AM12"
       }
     },
     {
-      "row": 12,
-      "col": 39,
-      "color": null,
+      "id": "AM12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM11",
+        "south": "AM13",
+        "west": "AL12",
+        "east": "AN12"
       }
     },
     {
-      "row": 12,
-      "col": 40,
-      "color": null,
+      "id": "AN12",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN11",
+        "south": "AN13",
+        "west": "AM12",
+        "east": "AO12"
       }
     },
     {
-      "row": 12,
-      "col": 41,
-      "color": null,
+      "id": "AO12",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO11",
+        "south": "AO13",
+        "west": "AN12",
+        "east": "AP12"
       }
     },
     {
-      "row": 12,
-      "col": 42,
-      "color": null,
+      "id": "AP12",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP11",
+        "south": "AP13",
+        "west": "AO12",
+        "east": "AQ12"
       }
     },
     {
-      "row": 12,
-      "col": 43,
-      "color": null,
+      "id": "AQ12",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ11",
+        "south": "AQ13",
+        "west": "AP12",
+        "east": "AR12"
       }
     },
     {
-      "row": 12,
-      "col": 44,
-      "color": null,
+      "id": "AR12",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR11",
+        "south": "AR13",
+        "west": "AQ12",
+        "east": "AS12"
       }
     },
     {
-      "row": 12,
-      "col": 45,
-      "color": null,
+      "id": "AS12",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS11",
+        "south": "AS13",
+        "west": "AR12",
+        "east": "AT12"
       }
     },
     {
-      "row": 12,
-      "col": 46,
-      "color": null,
+      "id": "AT12",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT11",
+        "south": "AT13",
+        "west": "AS12",
+        "east": "AU12"
       }
     },
     {
-      "row": 12,
-      "col": 47,
-      "color": null,
+      "id": "AU12",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU11",
+        "south": "AU13",
+        "west": "AT12",
+        "east": "AV12"
       }
     },
     {
-      "row": 12,
-      "col": 48,
-      "color": null,
+      "id": "AV12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV11",
+        "south": "AV13",
+        "west": "AU12",
+        "east": "AW12"
       }
     },
     {
-      "row": 12,
-      "col": 49,
-      "color": null,
+      "id": "AW12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW11",
+        "south": "AW13",
+        "west": "AV12",
+        "east": "AX12"
       }
     },
     {
-      "row": 12,
-      "col": 50,
-      "color": null,
+      "id": "AX12",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX11",
+        "south": "AX13",
+        "west": "AW12"
       }
     },
     {
-      "row": 13,
-      "col": 1,
-      "color": null,
+      "id": "A13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A12",
+        "south": "A14",
+        "east": "B13"
       }
     },
     {
-      "row": 13,
-      "col": 2,
-      "color": null,
+      "id": "B13",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B12",
+        "south": "B14",
+        "west": "A13",
+        "east": "C13"
       }
     },
     {
-      "row": 13,
-      "col": 3,
-      "color": null,
+      "id": "C13",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C12",
+        "south": "C14",
+        "west": "B13",
+        "east": "D13"
       }
     },
     {
-      "row": 13,
-      "col": 4,
-      "color": null,
+      "id": "D13",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D12",
+        "south": "D14",
+        "west": "C13",
+        "east": "E13"
       }
     },
     {
-      "row": 13,
-      "col": 5,
-      "color": null,
+      "id": "E13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E12",
+        "south": "E14",
+        "west": "D13",
+        "east": "F13"
       }
     },
     {
-      "row": 13,
-      "col": 6,
-      "color": null,
+      "id": "F13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F12",
+        "south": "F14",
+        "west": "E13",
+        "east": "G13"
       }
     },
     {
-      "row": 13,
-      "col": 7,
-      "color": null,
+      "id": "G13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G12",
+        "south": "G14",
+        "west": "F13",
+        "east": "H13"
       }
     },
     {
-      "row": 13,
-      "col": 8,
-      "color": null,
+      "id": "H13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H12",
+        "south": "H14",
+        "west": "G13",
+        "east": "I13"
       }
     },
     {
-      "row": 13,
-      "col": 9,
-      "color": null,
+      "id": "I13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I12",
+        "south": "I14",
+        "west": "H13",
+        "east": "J13"
       }
     },
     {
-      "row": 13,
-      "col": 10,
-      "color": null,
+      "id": "J13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J12",
+        "south": "J14",
+        "west": "I13",
+        "east": "K13"
       }
     },
     {
-      "row": 13,
-      "col": 11,
-      "color": null,
+      "id": "K13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K12",
+        "south": "K14",
+        "west": "J13",
+        "east": "L13"
       }
     },
     {
-      "row": 13,
-      "col": 12,
-      "color": null,
+      "id": "L13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L12",
+        "south": "L14",
+        "west": "K13",
+        "east": "M13"
       }
     },
     {
-      "row": 13,
-      "col": 13,
-      "color": null,
+      "id": "M13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M12",
+        "south": "M14",
+        "west": "L13",
+        "east": "N13"
       }
     },
     {
-      "row": 13,
-      "col": 14,
-      "color": null,
+      "id": "N13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N12",
+        "south": "N14",
+        "west": "M13",
+        "east": "O13"
       }
     },
     {
-      "row": 13,
-      "col": 15,
-      "color": null,
+      "id": "O13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O12",
+        "south": "O14",
+        "west": "N13",
+        "east": "P13"
       }
     },
     {
-      "row": 13,
-      "col": 16,
-      "color": null,
+      "id": "P13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P12",
+        "south": "P14",
+        "west": "O13",
+        "east": "Q13"
       }
     },
     {
-      "row": 13,
-      "col": 17,
-      "color": null,
+      "id": "Q13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q12",
+        "south": "Q14",
+        "west": "P13",
+        "east": "R13"
       }
     },
     {
-      "row": 13,
-      "col": 18,
-      "color": null,
+      "id": "R13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R12",
+        "south": "R14",
+        "west": "Q13",
+        "east": "S13"
       }
     },
     {
-      "row": 13,
-      "col": 19,
-      "color": null,
+      "id": "S13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S12",
+        "south": "S14",
+        "west": "R13",
+        "east": "T13"
       }
     },
     {
-      "row": 13,
-      "col": 20,
-      "color": null,
+      "id": "T13",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T12",
+        "south": "T14",
+        "west": "S13",
+        "east": "U13"
       }
     },
     {
-      "row": 13,
-      "col": 21,
-      "color": null,
+      "id": "U13",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U12",
+        "south": "U14",
+        "west": "T13",
+        "east": "V13"
       }
     },
     {
-      "row": 13,
-      "col": 22,
-      "color": null,
+      "id": "V13",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V12",
+        "south": "V14",
+        "west": "U13",
+        "east": "W13"
       }
     },
     {
-      "row": 13,
-      "col": 23,
-      "color": null,
+      "id": "W13",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W12",
+        "south": "W14",
+        "west": "V13",
+        "east": "X13"
       }
     },
     {
-      "row": 13,
-      "col": 24,
-      "color": null,
+      "id": "X13",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X12",
+        "south": "X14",
+        "west": "W13",
+        "east": "Y13"
       }
     },
     {
-      "row": 13,
-      "col": 25,
-      "color": null,
+      "id": "Y13",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y12",
+        "south": "Y14",
+        "west": "X13",
+        "east": "Z13"
       }
     },
     {
-      "row": 13,
-      "col": 26,
-      "color": null,
+      "id": "Z13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z12",
+        "south": "Z14",
+        "west": "Y13",
+        "east": "AA13"
       }
     },
     {
-      "row": 13,
-      "col": 27,
-      "color": null,
+      "id": "AA13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA12",
+        "south": "AA14",
+        "west": "Z13",
+        "east": "AB13"
       }
     },
     {
-      "row": 13,
-      "col": 28,
-      "color": null,
+      "id": "AB13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB12",
+        "south": "AB14",
+        "west": "AA13",
+        "east": "AC13"
       }
     },
     {
-      "row": 13,
-      "col": 29,
-      "color": null,
+      "id": "AC13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC12",
+        "south": "AC14",
+        "west": "AB13",
+        "east": "AD13"
       }
     },
     {
-      "row": 13,
-      "col": 30,
-      "color": null,
+      "id": "AD13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD12",
+        "south": "AD14",
+        "west": "AC13",
+        "east": "AE13"
       }
     },
     {
-      "row": 13,
-      "col": 31,
-      "color": null,
+      "id": "AE13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE12",
+        "south": "AE14",
+        "west": "AD13",
+        "east": "AF13"
       }
     },
     {
-      "row": 13,
-      "col": 32,
-      "color": null,
+      "id": "AF13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF12",
+        "south": "AF14",
+        "west": "AE13",
+        "east": "AG13"
       }
     },
     {
-      "row": 13,
-      "col": 33,
-      "color": null,
+      "id": "AG13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG12",
+        "south": "AG14",
+        "west": "AF13",
+        "east": "AH13"
       }
     },
     {
-      "row": 13,
-      "col": 34,
-      "color": null,
+      "id": "AH13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH12",
+        "south": "AH14",
+        "west": "AG13",
+        "east": "AI13"
       }
     },
     {
-      "row": 13,
-      "col": 35,
-      "color": null,
+      "id": "AI13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI12",
+        "south": "AI14",
+        "west": "AH13",
+        "east": "AJ13"
       }
     },
     {
-      "row": 13,
-      "col": 36,
-      "color": null,
+      "id": "AJ13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ12",
+        "south": "AJ14",
+        "west": "AI13",
+        "east": "AK13"
       }
     },
     {
-      "row": 13,
-      "col": 37,
-      "color": null,
+      "id": "AK13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK12",
+        "south": "AK14",
+        "west": "AJ13",
+        "east": "AL13"
       }
     },
     {
-      "row": 13,
-      "col": 38,
-      "color": null,
+      "id": "AL13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL12",
+        "south": "AL14",
+        "west": "AK13",
+        "east": "AM13"
       }
     },
     {
-      "row": 13,
-      "col": 39,
-      "color": null,
+      "id": "AM13",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM12",
+        "south": "AM14",
+        "west": "AL13",
+        "east": "AN13"
       }
     },
     {
-      "row": 13,
-      "col": 40,
-      "color": null,
+      "id": "AN13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN12",
+        "south": "AN14",
+        "west": "AM13",
+        "east": "AO13"
       }
     },
     {
-      "row": 13,
-      "col": 41,
-      "color": null,
+      "id": "AO13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO12",
+        "south": "AO14",
+        "west": "AN13",
+        "east": "AP13"
       }
     },
     {
-      "row": 13,
-      "col": 42,
-      "color": null,
+      "id": "AP13",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP12",
+        "south": "AP14",
+        "west": "AO13",
+        "east": "AQ13"
       }
     },
     {
-      "row": 13,
-      "col": 43,
-      "color": null,
+      "id": "AQ13",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ12",
+        "south": "AQ14",
+        "west": "AP13",
+        "east": "AR13"
       }
     },
     {
-      "row": 13,
-      "col": 44,
-      "color": null,
+      "id": "AR13",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR12",
+        "south": "AR14",
+        "west": "AQ13",
+        "east": "AS13"
       }
     },
     {
-      "row": 13,
-      "col": 45,
-      "color": null,
+      "id": "AS13",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS12",
+        "south": "AS14",
+        "west": "AR13",
+        "east": "AT13"
       }
     },
     {
-      "row": 13,
-      "col": 46,
-      "color": null,
+      "id": "AT13",
+      "terrain": "Dark F",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT12",
+        "south": "AT14",
+        "west": "AS13",
+        "east": "AU13"
       }
     },
     {
-      "row": 13,
-      "col": 47,
-      "color": null,
+      "id": "AU13",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU12",
+        "south": "AU14",
+        "west": "AT13",
+        "east": "AV13"
       }
     },
     {
-      "row": 13,
-      "col": 48,
-      "color": null,
+      "id": "AV13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV12",
+        "south": "AV14",
+        "west": "AU13",
+        "east": "AW13"
       }
     },
     {
-      "row": 13,
-      "col": 49,
-      "color": null,
+      "id": "AW13",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW12",
+        "south": "AW14",
+        "west": "AV13",
+        "east": "AX13"
       }
     },
     {
-      "row": 13,
-      "col": 50,
-      "color": null,
+      "id": "AX13",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX12",
+        "south": "AX14",
+        "west": "AW13"
       }
     },
     {
-      "row": 14,
-      "col": 1,
-      "color": null,
+      "id": "A14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A13",
+        "south": "A15",
+        "east": "B14"
       }
     },
     {
-      "row": 14,
-      "col": 2,
-      "color": null,
+      "id": "B14",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B13",
+        "south": "B15",
+        "west": "A14",
+        "east": "C14"
       }
     },
     {
-      "row": 14,
-      "col": 3,
-      "color": null,
+      "id": "C14",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C13",
+        "south": "C15",
+        "west": "B14",
+        "east": "D14"
       }
     },
     {
-      "row": 14,
-      "col": 4,
-      "color": null,
+      "id": "D14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D13",
+        "south": "D15",
+        "west": "C14",
+        "east": "E14"
       }
     },
     {
-      "row": 14,
-      "col": 5,
-      "color": null,
+      "id": "E14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E13",
+        "south": "E15",
+        "west": "D14",
+        "east": "F14"
       }
     },
     {
-      "row": 14,
-      "col": 6,
-      "color": null,
+      "id": "F14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F13",
+        "south": "F15",
+        "west": "E14",
+        "east": "G14"
       }
     },
     {
-      "row": 14,
-      "col": 7,
-      "color": null,
+      "id": "G14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G13",
+        "south": "G15",
+        "west": "F14",
+        "east": "H14"
       }
     },
     {
-      "row": 14,
-      "col": 8,
-      "color": null,
+      "id": "H14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H13",
+        "south": "H15",
+        "west": "G14",
+        "east": "I14"
       }
     },
     {
-      "row": 14,
-      "col": 9,
-      "color": null,
+      "id": "I14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I13",
+        "south": "I15",
+        "west": "H14",
+        "east": "J14"
       }
     },
     {
-      "row": 14,
-      "col": 10,
-      "color": null,
+      "id": "J14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J13",
+        "south": "J15",
+        "west": "I14",
+        "east": "K14"
       }
     },
     {
-      "row": 14,
-      "col": 11,
-      "color": null,
+      "id": "K14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K13",
+        "south": "K15",
+        "west": "J14",
+        "east": "L14"
       }
     },
     {
-      "row": 14,
-      "col": 12,
-      "color": null,
+      "id": "L14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L13",
+        "south": "L15",
+        "west": "K14",
+        "east": "M14"
       }
     },
     {
-      "row": 14,
-      "col": 13,
-      "color": null,
+      "id": "M14",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M13",
+        "south": "M15",
+        "west": "L14",
+        "east": "N14"
       }
     },
     {
-      "row": 14,
-      "col": 14,
-      "color": null,
+      "id": "N14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N13",
+        "south": "N15",
+        "west": "M14",
+        "east": "O14"
       }
     },
     {
-      "row": 14,
-      "col": 15,
-      "color": null,
+      "id": "O14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O13",
+        "south": "O15",
+        "west": "N14",
+        "east": "P14"
       }
     },
     {
-      "row": 14,
-      "col": 16,
-      "color": null,
+      "id": "P14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P13",
+        "south": "P15",
+        "west": "O14",
+        "east": "Q14"
       }
     },
     {
-      "row": 14,
-      "col": 17,
-      "color": null,
+      "id": "Q14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q13",
+        "south": "Q15",
+        "west": "P14",
+        "east": "R14"
       }
     },
     {
-      "row": 14,
-      "col": 18,
-      "color": null,
+      "id": "R14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R13",
+        "south": "R15",
+        "west": "Q14",
+        "east": "S14"
       }
     },
     {
-      "row": 14,
-      "col": 19,
-      "color": null,
+      "id": "S14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S13",
+        "south": "S15",
+        "west": "R14",
+        "east": "T14"
       }
     },
     {
-      "row": 14,
-      "col": 20,
-      "color": null,
+      "id": "T14",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T13",
+        "south": "T15",
+        "west": "S14",
+        "east": "U14"
       }
     },
     {
-      "row": 14,
-      "col": 21,
-      "color": null,
+      "id": "U14",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U13",
+        "south": "U15",
+        "west": "T14",
+        "east": "V14"
       }
     },
     {
-      "row": 14,
-      "col": 22,
-      "color": null,
+      "id": "V14",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V13",
+        "south": "V15",
+        "west": "U14",
+        "east": "W14"
       }
     },
     {
-      "row": 14,
-      "col": 23,
-      "color": null,
+      "id": "W14",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W13",
+        "south": "W15",
+        "west": "V14",
+        "east": "X14"
       }
     },
     {
-      "row": 14,
-      "col": 24,
-      "color": null,
+      "id": "X14",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X13",
+        "south": "X15",
+        "west": "W14",
+        "east": "Y14"
       }
     },
     {
-      "row": 14,
-      "col": 25,
-      "color": null,
+      "id": "Y14",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y13",
+        "south": "Y15",
+        "west": "X14",
+        "east": "Z14"
       }
     },
     {
-      "row": 14,
-      "col": 26,
-      "color": null,
+      "id": "Z14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z13",
+        "south": "Z15",
+        "west": "Y14",
+        "east": "AA14"
       }
     },
     {
-      "row": 14,
-      "col": 27,
-      "color": null,
+      "id": "AA14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA13",
+        "south": "AA15",
+        "west": "Z14",
+        "east": "AB14"
       }
     },
     {
-      "row": 14,
-      "col": 28,
-      "color": null,
+      "id": "AB14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB13",
+        "south": "AB15",
+        "west": "AA14",
+        "east": "AC14"
       }
     },
     {
-      "row": 14,
-      "col": 29,
-      "color": null,
+      "id": "AC14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC13",
+        "south": "AC15",
+        "west": "AB14",
+        "east": "AD14"
       }
     },
     {
-      "row": 14,
-      "col": 30,
-      "color": null,
+      "id": "AD14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD13",
+        "south": "AD15",
+        "west": "AC14",
+        "east": "AE14"
       }
     },
     {
-      "row": 14,
-      "col": 31,
-      "color": null,
+      "id": "AE14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE13",
+        "south": "AE15",
+        "west": "AD14",
+        "east": "AF14"
       }
     },
     {
-      "row": 14,
-      "col": 32,
-      "color": null,
+      "id": "AF14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF13",
+        "south": "AF15",
+        "west": "AE14",
+        "east": "AG14"
       }
     },
     {
-      "row": 14,
-      "col": 33,
-      "color": null,
+      "id": "AG14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG13",
+        "south": "AG15",
+        "west": "AF14",
+        "east": "AH14"
       }
     },
     {
-      "row": 14,
-      "col": 34,
-      "color": null,
+      "id": "AH14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH13",
+        "south": "AH15",
+        "west": "AG14",
+        "east": "AI14"
       }
     },
     {
-      "row": 14,
-      "col": 35,
-      "color": null,
+      "id": "AI14",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI13",
+        "south": "AI15",
+        "west": "AH14",
+        "east": "AJ14"
       }
     },
     {
-      "row": 14,
-      "col": 36,
-      "color": null,
+      "id": "AJ14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ13",
+        "south": "AJ15",
+        "west": "AI14",
+        "east": "AK14"
       }
     },
     {
-      "row": 14,
-      "col": 37,
-      "color": null,
+      "id": "AK14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK13",
+        "south": "AK15",
+        "west": "AJ14",
+        "east": "AL14"
       }
     },
     {
-      "row": 14,
-      "col": 38,
-      "color": null,
+      "id": "AL14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL13",
+        "south": "AL15",
+        "west": "AK14",
+        "east": "AM14"
       }
     },
     {
-      "row": 14,
-      "col": 39,
-      "color": null,
+      "id": "AM14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM13",
+        "south": "AM15",
+        "west": "AL14",
+        "east": "AN14"
       }
     },
     {
-      "row": 14,
-      "col": 40,
-      "color": null,
+      "id": "AN14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN13",
+        "south": "AN15",
+        "west": "AM14",
+        "east": "AO14"
       }
     },
     {
-      "row": 14,
-      "col": 41,
-      "color": null,
+      "id": "AO14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO13",
+        "south": "AO15",
+        "west": "AN14",
+        "east": "AP14"
       }
     },
     {
-      "row": 14,
-      "col": 42,
-      "color": null,
+      "id": "AP14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP13",
+        "south": "AP15",
+        "west": "AO14",
+        "east": "AQ14"
       }
     },
     {
-      "row": 14,
-      "col": 43,
-      "color": null,
+      "id": "AQ14",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ13",
+        "south": "AQ15",
+        "west": "AP14",
+        "east": "AR14"
       }
     },
     {
-      "row": 14,
-      "col": 44,
-      "color": null,
+      "id": "AR14",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR13",
+        "south": "AR15",
+        "west": "AQ14",
+        "east": "AS14"
       }
     },
     {
-      "row": 14,
-      "col": 45,
-      "color": null,
+      "id": "AS14",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS13",
+        "south": "AS15",
+        "west": "AR14",
+        "east": "AT14"
       }
     },
     {
-      "row": 14,
-      "col": 46,
-      "color": null,
+      "id": "AT14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT13",
+        "south": "AT15",
+        "west": "AS14",
+        "east": "AU14"
       }
     },
     {
-      "row": 14,
-      "col": 47,
-      "color": null,
+      "id": "AU14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU13",
+        "south": "AU15",
+        "west": "AT14",
+        "east": "AV14"
       }
     },
     {
-      "row": 14,
-      "col": 48,
-      "color": null,
+      "id": "AV14",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV13",
+        "south": "AV15",
+        "west": "AU14",
+        "east": "AW14"
       }
     },
     {
-      "row": 14,
-      "col": 49,
-      "color": null,
+      "id": "AW14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW13",
+        "south": "AW15",
+        "west": "AV14",
+        "east": "AX14"
       }
     },
     {
-      "row": 14,
-      "col": 50,
-      "color": null,
+      "id": "AX14",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX13",
+        "south": "AX15",
+        "west": "AW14"
       }
     },
     {
-      "row": 15,
-      "col": 1,
-      "color": null,
+      "id": "A15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A14",
+        "south": "A16",
+        "east": "B15"
       }
     },
     {
-      "row": 15,
-      "col": 2,
-      "color": null,
+      "id": "B15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B14",
+        "south": "B16",
+        "west": "A15",
+        "east": "C15"
       }
     },
     {
-      "row": 15,
-      "col": 3,
-      "color": null,
+      "id": "C15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C14",
+        "south": "C16",
+        "west": "B15",
+        "east": "D15"
       }
     },
     {
-      "row": 15,
-      "col": 4,
-      "color": null,
+      "id": "D15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D14",
+        "south": "D16",
+        "west": "C15",
+        "east": "E15"
       }
     },
     {
-      "row": 15,
-      "col": 5,
-      "color": null,
+      "id": "E15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E14",
+        "south": "E16",
+        "west": "D15",
+        "east": "F15"
       }
     },
     {
-      "row": 15,
-      "col": 6,
-      "color": null,
+      "id": "F15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F14",
+        "south": "F16",
+        "west": "E15",
+        "east": "G15"
       }
     },
     {
-      "row": 15,
-      "col": 7,
-      "color": null,
+      "id": "G15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G14",
+        "south": "G16",
+        "west": "F15",
+        "east": "H15"
       }
     },
     {
-      "row": 15,
-      "col": 8,
-      "color": null,
+      "id": "H15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H14",
+        "south": "H16",
+        "west": "G15",
+        "east": "I15"
       }
     },
     {
-      "row": 15,
-      "col": 9,
-      "color": null,
+      "id": "I15",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I14",
+        "south": "I16",
+        "west": "H15",
+        "east": "J15"
       }
     },
     {
-      "row": 15,
-      "col": 10,
-      "color": null,
+      "id": "J15",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J14",
+        "south": "J16",
+        "west": "I15",
+        "east": "K15"
       }
     },
     {
-      "row": 15,
-      "col": 11,
-      "color": null,
+      "id": "K15",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K14",
+        "south": "K16",
+        "west": "J15",
+        "east": "L15"
       }
     },
     {
-      "row": 15,
-      "col": 12,
-      "color": null,
+      "id": "L15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L14",
+        "south": "L16",
+        "west": "K15",
+        "east": "M15"
       }
     },
     {
-      "row": 15,
-      "col": 13,
-      "color": null,
+      "id": "M15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M14",
+        "south": "M16",
+        "west": "L15",
+        "east": "N15"
       }
     },
     {
-      "row": 15,
-      "col": 14,
-      "color": null,
+      "id": "N15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N14",
+        "south": "N16",
+        "west": "M15",
+        "east": "O15"
       }
     },
     {
-      "row": 15,
-      "col": 15,
-      "color": null,
+      "id": "O15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O14",
+        "south": "O16",
+        "west": "N15",
+        "east": "P15"
       }
     },
     {
-      "row": 15,
-      "col": 16,
-      "color": null,
+      "id": "P15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P14",
+        "south": "P16",
+        "west": "O15",
+        "east": "Q15"
       }
     },
     {
-      "row": 15,
-      "col": 17,
-      "color": null,
+      "id": "Q15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q14",
+        "south": "Q16",
+        "west": "P15",
+        "east": "R15"
       }
     },
     {
-      "row": 15,
-      "col": 18,
-      "color": null,
+      "id": "R15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R14",
+        "south": "R16",
+        "west": "Q15",
+        "east": "S15"
       }
     },
     {
-      "row": 15,
-      "col": 19,
-      "color": null,
+      "id": "S15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S14",
+        "south": "S16",
+        "west": "R15",
+        "east": "T15"
       }
     },
     {
-      "row": 15,
-      "col": 20,
-      "color": null,
+      "id": "T15",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T14",
+        "south": "T16",
+        "west": "S15",
+        "east": "U15"
       }
     },
     {
-      "row": 15,
-      "col": 21,
-      "color": null,
+      "id": "U15",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U14",
+        "south": "U16",
+        "west": "T15",
+        "east": "V15"
       }
     },
     {
-      "row": 15,
-      "col": 22,
-      "color": null,
+      "id": "V15",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V14",
+        "south": "V16",
+        "west": "U15",
+        "east": "W15"
       }
     },
     {
-      "row": 15,
-      "col": 23,
-      "color": null,
+      "id": "W15",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W14",
+        "south": "W16",
+        "west": "V15",
+        "east": "X15"
       }
     },
     {
-      "row": 15,
-      "col": 24,
-      "color": null,
+      "id": "X15",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X14",
+        "south": "X16",
+        "west": "W15",
+        "east": "Y15"
       }
     },
     {
-      "row": 15,
-      "col": 25,
-      "color": null,
+      "id": "Y15",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y14",
+        "south": "Y16",
+        "west": "X15",
+        "east": "Z15"
       }
     },
     {
-      "row": 15,
-      "col": 26,
-      "color": null,
+      "id": "Z15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z14",
+        "south": "Z16",
+        "west": "Y15",
+        "east": "AA15"
       }
     },
     {
-      "row": 15,
-      "col": 27,
-      "color": null,
+      "id": "AA15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA14",
+        "south": "AA16",
+        "west": "Z15",
+        "east": "AB15"
       }
     },
     {
-      "row": 15,
-      "col": 28,
-      "color": null,
+      "id": "AB15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB14",
+        "south": "AB16",
+        "west": "AA15",
+        "east": "AC15"
       }
     },
     {
-      "row": 15,
-      "col": 29,
-      "color": null,
+      "id": "AC15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC14",
+        "south": "AC16",
+        "west": "AB15",
+        "east": "AD15"
       }
     },
     {
-      "row": 15,
-      "col": 30,
-      "color": null,
+      "id": "AD15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD14",
+        "south": "AD16",
+        "west": "AC15",
+        "east": "AE15"
       }
     },
     {
-      "row": 15,
-      "col": 31,
-      "color": null,
+      "id": "AE15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE14",
+        "south": "AE16",
+        "west": "AD15",
+        "east": "AF15"
       }
     },
     {
-      "row": 15,
-      "col": 32,
-      "color": null,
+      "id": "AF15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF14",
+        "south": "AF16",
+        "west": "AE15",
+        "east": "AG15"
       }
     },
     {
-      "row": 15,
-      "col": 33,
-      "color": null,
+      "id": "AG15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG14",
+        "south": "AG16",
+        "west": "AF15",
+        "east": "AH15"
       }
     },
     {
-      "row": 15,
-      "col": 34,
-      "color": null,
+      "id": "AH15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH14",
+        "south": "AH16",
+        "west": "AG15",
+        "east": "AI15"
       }
     },
     {
-      "row": 15,
-      "col": 35,
-      "color": null,
+      "id": "AI15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI14",
+        "south": "AI16",
+        "west": "AH15",
+        "east": "AJ15"
       }
     },
     {
-      "row": 15,
-      "col": 36,
-      "color": null,
+      "id": "AJ15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ14",
+        "south": "AJ16",
+        "west": "AI15",
+        "east": "AK15"
       }
     },
     {
-      "row": 15,
-      "col": 37,
-      "color": null,
+      "id": "AK15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK14",
+        "south": "AK16",
+        "west": "AJ15",
+        "east": "AL15"
       }
     },
     {
-      "row": 15,
-      "col": 38,
-      "color": null,
+      "id": "AL15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL14",
+        "south": "AL16",
+        "west": "AK15",
+        "east": "AM15"
       }
     },
     {
-      "row": 15,
-      "col": 39,
-      "color": null,
+      "id": "AM15",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM14",
+        "south": "AM16",
+        "west": "AL15",
+        "east": "AN15"
       }
     },
     {
-      "row": 15,
-      "col": 40,
-      "color": null,
+      "id": "AN15",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN14",
+        "south": "AN16",
+        "west": "AM15",
+        "east": "AO15"
       }
     },
     {
-      "row": 15,
-      "col": 41,
-      "color": null,
+      "id": "AO15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO14",
+        "south": "AO16",
+        "west": "AN15",
+        "east": "AP15"
       }
     },
     {
-      "row": 15,
-      "col": 42,
-      "color": null,
+      "id": "AP15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP14",
+        "south": "AP16",
+        "west": "AO15",
+        "east": "AQ15"
       }
     },
     {
-      "row": 15,
-      "col": 43,
-      "color": null,
+      "id": "AQ15",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ14",
+        "south": "AQ16",
+        "west": "AP15",
+        "east": "AR15"
       }
     },
     {
-      "row": 15,
-      "col": 44,
-      "color": null,
+      "id": "AR15",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR14",
+        "south": "AR16",
+        "west": "AQ15",
+        "east": "AS15"
       }
     },
     {
-      "row": 15,
-      "col": 45,
-      "color": null,
+      "id": "AS15",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS14",
+        "south": "AS16",
+        "west": "AR15",
+        "east": "AT15"
       }
     },
     {
-      "row": 15,
-      "col": 46,
-      "color": null,
+      "id": "AT15",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT14",
+        "south": "AT16",
+        "west": "AS15",
+        "east": "AU15"
       }
     },
     {
-      "row": 15,
-      "col": 47,
-      "color": null,
+      "id": "AU15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU14",
+        "south": "AU16",
+        "west": "AT15",
+        "east": "AV15"
       }
     },
     {
-      "row": 15,
-      "col": 48,
-      "color": null,
+      "id": "AV15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV14",
+        "south": "AV16",
+        "west": "AU15",
+        "east": "AW15"
       }
     },
     {
-      "row": 15,
-      "col": 49,
-      "color": null,
+      "id": "AW15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW14",
+        "south": "AW16",
+        "west": "AV15",
+        "east": "AX15"
       }
     },
     {
-      "row": 15,
-      "col": 50,
-      "color": null,
+      "id": "AX15",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX14",
+        "south": "AX16",
+        "west": "AW15"
       }
     },
     {
-      "row": 16,
-      "col": 1,
-      "color": null,
+      "id": "A16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A15",
+        "south": "A17",
+        "east": "B16"
       }
     },
     {
-      "row": 16,
-      "col": 2,
-      "color": null,
+      "id": "B16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B15",
+        "south": "B17",
+        "west": "A16",
+        "east": "C16"
       }
     },
     {
-      "row": 16,
-      "col": 3,
-      "color": null,
+      "id": "C16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C15",
+        "south": "C17",
+        "west": "B16",
+        "east": "D16"
       }
     },
     {
-      "row": 16,
-      "col": 4,
-      "color": null,
+      "id": "D16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D15",
+        "south": "D17",
+        "west": "C16",
+        "east": "E16"
       }
     },
     {
-      "row": 16,
-      "col": 5,
-      "color": null,
+      "id": "E16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E15",
+        "south": "E17",
+        "west": "D16",
+        "east": "F16"
       }
     },
     {
-      "row": 16,
-      "col": 6,
-      "color": null,
+      "id": "F16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F15",
+        "south": "F17",
+        "west": "E16",
+        "east": "G16"
       }
     },
     {
-      "row": 16,
-      "col": 7,
-      "color": null,
+      "id": "G16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G15",
+        "south": "G17",
+        "west": "F16",
+        "east": "H16"
       }
     },
     {
-      "row": 16,
-      "col": 8,
-      "color": null,
+      "id": "H16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H15",
+        "south": "H17",
+        "west": "G16",
+        "east": "I16"
       }
     },
     {
-      "row": 16,
-      "col": 9,
-      "color": null,
+      "id": "I16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I15",
+        "south": "I17",
+        "west": "H16",
+        "east": "J16"
       }
     },
     {
-      "row": 16,
-      "col": 10,
-      "color": null,
+      "id": "J16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J15",
+        "south": "J17",
+        "west": "I16",
+        "east": "K16"
       }
     },
     {
-      "row": 16,
-      "col": 11,
-      "color": null,
+      "id": "K16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K15",
+        "south": "K17",
+        "west": "J16",
+        "east": "L16"
       }
     },
     {
-      "row": 16,
-      "col": 12,
-      "color": null,
+      "id": "L16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L15",
+        "south": "L17",
+        "west": "K16",
+        "east": "M16"
       }
     },
     {
-      "row": 16,
-      "col": 13,
-      "color": null,
+      "id": "M16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M15",
+        "south": "M17",
+        "west": "L16",
+        "east": "N16"
       }
     },
     {
-      "row": 16,
-      "col": 14,
-      "color": null,
+      "id": "N16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N15",
+        "south": "N17",
+        "west": "M16",
+        "east": "O16"
       }
     },
     {
-      "row": 16,
-      "col": 15,
-      "color": null,
+      "id": "O16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O15",
+        "south": "O17",
+        "west": "N16",
+        "east": "P16"
       }
     },
     {
-      "row": 16,
-      "col": 16,
-      "color": null,
+      "id": "P16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P15",
+        "south": "P17",
+        "west": "O16",
+        "east": "Q16"
       }
     },
     {
-      "row": 16,
-      "col": 17,
-      "color": null,
+      "id": "Q16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q15",
+        "south": "Q17",
+        "west": "P16",
+        "east": "R16"
       }
     },
     {
-      "row": 16,
-      "col": 18,
-      "color": null,
+      "id": "R16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R15",
+        "south": "R17",
+        "west": "Q16",
+        "east": "S16"
       }
     },
     {
-      "row": 16,
-      "col": 19,
-      "color": null,
+      "id": "S16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S15",
+        "south": "S17",
+        "west": "R16",
+        "east": "T16"
       }
     },
     {
-      "row": 16,
-      "col": 20,
-      "color": null,
+      "id": "T16",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T15",
+        "south": "T17",
+        "west": "S16",
+        "east": "U16"
       }
     },
     {
-      "row": 16,
-      "col": 21,
-      "color": null,
+      "id": "U16",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U15",
+        "south": "U17",
+        "west": "T16",
+        "east": "V16"
       }
     },
     {
-      "row": 16,
-      "col": 22,
-      "color": null,
+      "id": "V16",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V15",
+        "south": "V17",
+        "west": "U16",
+        "east": "W16"
       }
     },
     {
-      "row": 16,
-      "col": 23,
-      "color": null,
+      "id": "W16",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W15",
+        "south": "W17",
+        "west": "V16",
+        "east": "X16"
       }
     },
     {
-      "row": 16,
-      "col": 24,
-      "color": null,
+      "id": "X16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X15",
+        "south": "X17",
+        "west": "W16",
+        "east": "Y16"
       }
     },
     {
-      "row": 16,
-      "col": 25,
-      "color": null,
+      "id": "Y16",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y15",
+        "south": "Y17",
+        "west": "X16",
+        "east": "Z16"
       }
     },
     {
-      "row": 16,
-      "col": 26,
-      "color": null,
+      "id": "Z16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z15",
+        "south": "Z17",
+        "west": "Y16",
+        "east": "AA16"
       }
     },
     {
-      "row": 16,
-      "col": 27,
-      "color": null,
+      "id": "AA16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA15",
+        "south": "AA17",
+        "west": "Z16",
+        "east": "AB16"
       }
     },
     {
-      "row": 16,
-      "col": 28,
-      "color": null,
+      "id": "AB16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB15",
+        "south": "AB17",
+        "west": "AA16",
+        "east": "AC16"
       }
     },
     {
-      "row": 16,
-      "col": 29,
-      "color": null,
+      "id": "AC16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC15",
+        "south": "AC17",
+        "west": "AB16",
+        "east": "AD16"
       }
     },
     {
-      "row": 16,
-      "col": 30,
-      "color": null,
+      "id": "AD16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD15",
+        "south": "AD17",
+        "west": "AC16",
+        "east": "AE16"
       }
     },
     {
-      "row": 16,
-      "col": 31,
-      "color": null,
+      "id": "AE16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE15",
+        "south": "AE17",
+        "west": "AD16",
+        "east": "AF16"
       }
     },
     {
-      "row": 16,
-      "col": 32,
-      "color": null,
+      "id": "AF16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF15",
+        "south": "AF17",
+        "west": "AE16",
+        "east": "AG16"
       }
     },
     {
-      "row": 16,
-      "col": 33,
-      "color": null,
+      "id": "AG16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG15",
+        "south": "AG17",
+        "west": "AF16",
+        "east": "AH16"
       }
     },
     {
-      "row": 16,
-      "col": 34,
-      "color": null,
+      "id": "AH16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH15",
+        "south": "AH17",
+        "west": "AG16",
+        "east": "AI16"
       }
     },
     {
-      "row": 16,
-      "col": 35,
-      "color": null,
+      "id": "AI16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI15",
+        "south": "AI17",
+        "west": "AH16",
+        "east": "AJ16"
       }
     },
     {
-      "row": 16,
-      "col": 36,
-      "color": null,
+      "id": "AJ16",
+      "terrain": "M",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ15",
+        "south": "AJ17",
+        "west": "AI16",
+        "east": "AK16"
       }
     },
     {
-      "row": 16,
-      "col": 37,
-      "color": null,
+      "id": "AK16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK15",
+        "south": "AK17",
+        "west": "AJ16",
+        "east": "AL16"
       }
     },
     {
-      "row": 16,
-      "col": 38,
-      "color": null,
+      "id": "AL16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL15",
+        "south": "AL17",
+        "west": "AK16",
+        "east": "AM16"
       }
     },
     {
-      "row": 16,
-      "col": 39,
-      "color": null,
+      "id": "AM16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM15",
+        "south": "AM17",
+        "west": "AL16",
+        "east": "AN16"
       }
     },
     {
-      "row": 16,
-      "col": 40,
-      "color": null,
+      "id": "AN16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN15",
+        "south": "AN17",
+        "west": "AM16",
+        "east": "AO16"
       }
     },
     {
-      "row": 16,
-      "col": 41,
-      "color": null,
+      "id": "AO16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO15",
+        "south": "AO17",
+        "west": "AN16",
+        "east": "AP16"
       }
     },
     {
-      "row": 16,
-      "col": 42,
-      "color": null,
+      "id": "AP16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP15",
+        "south": "AP17",
+        "west": "AO16",
+        "east": "AQ16"
       }
     },
     {
-      "row": 16,
-      "col": 43,
-      "color": null,
+      "id": "AQ16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ15",
+        "south": "AQ17",
+        "west": "AP16",
+        "east": "AR16"
       }
     },
     {
-      "row": 16,
-      "col": 44,
-      "color": null,
+      "id": "AR16",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR15",
+        "south": "AR17",
+        "west": "AQ16",
+        "east": "AS16"
       }
     },
     {
-      "row": 16,
-      "col": 45,
-      "color": null,
+      "id": "AS16",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS15",
+        "south": "AS17",
+        "west": "AR16",
+        "east": "AT16"
       }
     },
     {
-      "row": 16,
-      "col": 46,
-      "color": null,
+      "id": "AT16",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT15",
+        "south": "AT17",
+        "west": "AS16",
+        "east": "AU16"
       }
     },
     {
-      "row": 16,
-      "col": 47,
-      "color": null,
+      "id": "AU16",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU15",
+        "south": "AU17",
+        "west": "AT16",
+        "east": "AV16"
       }
     },
     {
-      "row": 16,
-      "col": 48,
-      "color": null,
+      "id": "AV16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV15",
+        "south": "AV17",
+        "west": "AU16",
+        "east": "AW16"
       }
     },
     {
-      "row": 16,
-      "col": 49,
-      "color": null,
+      "id": "AW16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW15",
+        "south": "AW17",
+        "west": "AV16",
+        "east": "AX16"
       }
     },
     {
-      "row": 16,
-      "col": 50,
-      "color": null,
+      "id": "AX16",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX15",
+        "south": "AX17",
+        "west": "AW16"
       }
     },
     {
-      "row": 17,
-      "col": 1,
-      "color": null,
+      "id": "A17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A16",
+        "south": "A18",
+        "east": "B17"
       }
     },
     {
-      "row": 17,
-      "col": 2,
-      "color": null,
+      "id": "B17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B16",
+        "south": "B18",
+        "west": "A17",
+        "east": "C17"
       }
     },
     {
-      "row": 17,
-      "col": 3,
-      "color": null,
+      "id": "C17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C16",
+        "south": "C18",
+        "west": "B17",
+        "east": "D17"
       }
     },
     {
-      "row": 17,
-      "col": 4,
-      "color": null,
+      "id": "D17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D16",
+        "south": "D18",
+        "west": "C17",
+        "east": "E17"
       }
     },
     {
-      "row": 17,
-      "col": 5,
-      "color": null,
+      "id": "E17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E16",
+        "south": "E18",
+        "west": "D17",
+        "east": "F17"
       }
     },
     {
-      "row": 17,
-      "col": 6,
-      "color": null,
+      "id": "F17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F16",
+        "south": "F18",
+        "west": "E17",
+        "east": "G17"
       }
     },
     {
-      "row": 17,
-      "col": 7,
-      "color": null,
+      "id": "G17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G16",
+        "south": "G18",
+        "west": "F17",
+        "east": "H17"
       }
     },
     {
-      "row": 17,
-      "col": 8,
-      "color": null,
+      "id": "H17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H16",
+        "south": "H18",
+        "west": "G17",
+        "east": "I17"
       }
     },
     {
-      "row": 17,
-      "col": 9,
-      "color": null,
+      "id": "I17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I16",
+        "south": "I18",
+        "west": "H17",
+        "east": "J17"
       }
     },
     {
-      "row": 17,
-      "col": 10,
-      "color": null,
+      "id": "J17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J16",
+        "south": "J18",
+        "west": "I17",
+        "east": "K17"
       }
     },
     {
-      "row": 17,
-      "col": 11,
-      "color": null,
+      "id": "K17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K16",
+        "south": "K18",
+        "west": "J17",
+        "east": "L17"
       }
     },
     {
-      "row": 17,
-      "col": 12,
-      "color": null,
+      "id": "L17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L16",
+        "south": "L18",
+        "west": "K17",
+        "east": "M17"
       }
     },
     {
-      "row": 17,
-      "col": 13,
-      "color": null,
+      "id": "M17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M16",
+        "south": "M18",
+        "west": "L17",
+        "east": "N17"
       }
     },
     {
-      "row": 17,
-      "col": 14,
-      "color": null,
+      "id": "N17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N16",
+        "south": "N18",
+        "west": "M17",
+        "east": "O17"
       }
     },
     {
-      "row": 17,
-      "col": 15,
-      "color": null,
+      "id": "O17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O16",
+        "south": "O18",
+        "west": "N17",
+        "east": "P17"
       }
     },
     {
-      "row": 17,
-      "col": 16,
-      "color": null,
+      "id": "P17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P16",
+        "south": "P18",
+        "west": "O17",
+        "east": "Q17"
       }
     },
     {
-      "row": 17,
-      "col": 17,
-      "color": null,
+      "id": "Q17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q16",
+        "south": "Q18",
+        "west": "P17",
+        "east": "R17"
       }
     },
     {
-      "row": 17,
-      "col": 18,
-      "color": null,
+      "id": "R17",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R16",
+        "south": "R18",
+        "west": "Q17",
+        "east": "S17"
       }
     },
     {
-      "row": 17,
-      "col": 19,
-      "color": null,
+      "id": "S17",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S16",
+        "south": "S18",
+        "west": "R17",
+        "east": "T17"
       }
     },
     {
-      "row": 17,
-      "col": 20,
-      "color": null,
+      "id": "T17",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T16",
+        "south": "T18",
+        "west": "S17",
+        "east": "U17"
       }
     },
     {
-      "row": 17,
-      "col": 21,
-      "color": null,
+      "id": "U17",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U16",
+        "south": "U18",
+        "west": "T17",
+        "east": "V17"
       }
     },
     {
-      "row": 17,
-      "col": 22,
-      "color": null,
+      "id": "V17",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V16",
+        "south": "V18",
+        "west": "U17",
+        "east": "W17"
       }
     },
     {
-      "row": 17,
-      "col": 23,
-      "color": null,
+      "id": "W17",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W16",
+        "south": "W18",
+        "west": "V17",
+        "east": "X17"
       }
     },
     {
-      "row": 17,
-      "col": 24,
-      "color": null,
+      "id": "X17",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X16",
+        "south": "X18",
+        "west": "W17",
+        "east": "Y17"
       }
     },
     {
-      "row": 17,
-      "col": 25,
-      "color": null,
+      "id": "Y17",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y16",
+        "south": "Y18",
+        "west": "X17",
+        "east": "Z17"
       }
     },
     {
-      "row": 17,
-      "col": 26,
-      "color": null,
+      "id": "Z17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z16",
+        "south": "Z18",
+        "west": "Y17",
+        "east": "AA17"
       }
     },
     {
-      "row": 17,
-      "col": 27,
-      "color": null,
+      "id": "AA17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA16",
+        "south": "AA18",
+        "west": "Z17",
+        "east": "AB17"
       }
     },
     {
-      "row": 17,
-      "col": 28,
-      "color": null,
+      "id": "AB17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB16",
+        "south": "AB18",
+        "west": "AA17",
+        "east": "AC17"
       }
     },
     {
-      "row": 17,
-      "col": 29,
-      "color": null,
+      "id": "AC17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC16",
+        "south": "AC18",
+        "west": "AB17",
+        "east": "AD17"
       }
     },
     {
-      "row": 17,
-      "col": 30,
-      "color": null,
+      "id": "AD17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD16",
+        "south": "AD18",
+        "west": "AC17",
+        "east": "AE17"
       }
     },
     {
-      "row": 17,
-      "col": 31,
-      "color": null,
+      "id": "AE17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE16",
+        "south": "AE18",
+        "west": "AD17",
+        "east": "AF17"
       }
     },
     {
-      "row": 17,
-      "col": 32,
-      "color": null,
+      "id": "AF17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF16",
+        "south": "AF18",
+        "west": "AE17",
+        "east": "AG17"
       }
     },
     {
-      "row": 17,
-      "col": 33,
-      "color": null,
+      "id": "AG17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG16",
+        "south": "AG18",
+        "west": "AF17",
+        "east": "AH17"
       }
     },
     {
-      "row": 17,
-      "col": 34,
-      "color": null,
+      "id": "AH17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH16",
+        "south": "AH18",
+        "west": "AG17",
+        "east": "AI17"
       }
     },
     {
-      "row": 17,
-      "col": 35,
-      "color": null,
+      "id": "AI17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI16",
+        "south": "AI18",
+        "west": "AH17",
+        "east": "AJ17"
       }
     },
     {
-      "row": 17,
-      "col": 36,
-      "color": null,
+      "id": "AJ17",
+      "terrain": "M",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ16",
+        "south": "AJ18",
+        "west": "AI17",
+        "east": "AK17"
       }
     },
     {
-      "row": 17,
-      "col": 37,
-      "color": null,
+      "id": "AK17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK16",
+        "south": "AK18",
+        "west": "AJ17",
+        "east": "AL17"
       }
     },
     {
-      "row": 17,
-      "col": 38,
-      "color": null,
+      "id": "AL17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL16",
+        "south": "AL18",
+        "west": "AK17",
+        "east": "AM17"
       }
     },
     {
-      "row": 17,
-      "col": 39,
-      "color": null,
+      "id": "AM17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM16",
+        "south": "AM18",
+        "west": "AL17",
+        "east": "AN17"
       }
     },
     {
-      "row": 17,
-      "col": 40,
-      "color": null,
+      "id": "AN17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN16",
+        "south": "AN18",
+        "west": "AM17",
+        "east": "AO17"
       }
     },
     {
-      "row": 17,
-      "col": 41,
-      "color": null,
+      "id": "AO17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO16",
+        "south": "AO18",
+        "west": "AN17",
+        "east": "AP17"
       }
     },
     {
-      "row": 17,
-      "col": 42,
-      "color": null,
+      "id": "AP17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP16",
+        "south": "AP18",
+        "west": "AO17",
+        "east": "AQ17"
       }
     },
     {
-      "row": 17,
-      "col": 43,
-      "color": null,
+      "id": "AQ17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ16",
+        "south": "AQ18",
+        "west": "AP17",
+        "east": "AR17"
       }
     },
     {
-      "row": 17,
-      "col": 44,
-      "color": null,
+      "id": "AR17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR16",
+        "south": "AR18",
+        "west": "AQ17",
+        "east": "AS17"
       }
     },
     {
-      "row": 17,
-      "col": 45,
-      "color": null,
+      "id": "AS17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS16",
+        "south": "AS18",
+        "west": "AR17",
+        "east": "AT17"
       }
     },
     {
-      "row": 17,
-      "col": 46,
-      "color": null,
+      "id": "AT17",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT16",
+        "south": "AT18",
+        "west": "AS17",
+        "east": "AU17"
       }
     },
     {
-      "row": 17,
-      "col": 47,
-      "color": null,
+      "id": "AU17",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU16",
+        "south": "AU18",
+        "west": "AT17",
+        "east": "AV17"
       }
     },
     {
-      "row": 17,
-      "col": 48,
-      "color": null,
+      "id": "AV17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV16",
+        "south": "AV18",
+        "west": "AU17",
+        "east": "AW17"
       }
     },
     {
-      "row": 17,
-      "col": 49,
-      "color": null,
+      "id": "AW17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW16",
+        "south": "AW18",
+        "west": "AV17",
+        "east": "AX17"
       }
     },
     {
-      "row": 17,
-      "col": 50,
-      "color": null,
+      "id": "AX17",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX16",
+        "south": "AX18",
+        "west": "AW17"
       }
     },
     {
-      "row": 18,
-      "col": 1,
-      "color": null,
+      "id": "A18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A17",
+        "south": "A19",
+        "east": "B18"
       }
     },
     {
-      "row": 18,
-      "col": 2,
-      "color": null,
+      "id": "B18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B17",
+        "south": "B19",
+        "west": "A18",
+        "east": "C18"
       }
     },
     {
-      "row": 18,
-      "col": 3,
-      "color": null,
+      "id": "C18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C17",
+        "south": "C19",
+        "west": "B18",
+        "east": "D18"
       }
     },
     {
-      "row": 18,
-      "col": 4,
-      "color": null,
+      "id": "D18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D17",
+        "south": "D19",
+        "west": "C18",
+        "east": "E18"
       }
     },
     {
-      "row": 18,
-      "col": 5,
-      "color": null,
+      "id": "E18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E17",
+        "south": "E19",
+        "west": "D18",
+        "east": "F18"
       }
     },
     {
-      "row": 18,
-      "col": 6,
-      "color": null,
+      "id": "F18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F17",
+        "south": "F19",
+        "west": "E18",
+        "east": "G18"
       }
     },
     {
-      "row": 18,
-      "col": 7,
-      "color": null,
+      "id": "G18",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G17",
+        "south": "G19",
+        "west": "F18",
+        "east": "H18"
       }
     },
     {
-      "row": 18,
-      "col": 8,
-      "color": null,
+      "id": "H18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H17",
+        "south": "H19",
+        "west": "G18",
+        "east": "I18"
       }
     },
     {
-      "row": 18,
-      "col": 9,
-      "color": null,
+      "id": "I18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I17",
+        "south": "I19",
+        "west": "H18",
+        "east": "J18"
       }
     },
     {
-      "row": 18,
-      "col": 10,
-      "color": null,
+      "id": "J18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J17",
+        "south": "J19",
+        "west": "I18",
+        "east": "K18"
       }
     },
     {
-      "row": 18,
-      "col": 11,
-      "color": null,
+      "id": "K18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K17",
+        "south": "K19",
+        "west": "J18",
+        "east": "L18"
       }
     },
     {
-      "row": 18,
-      "col": 12,
-      "color": null,
+      "id": "L18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L17",
+        "south": "L19",
+        "west": "K18",
+        "east": "M18"
       }
     },
     {
-      "row": 18,
-      "col": 13,
-      "color": null,
+      "id": "M18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M17",
+        "south": "M19",
+        "west": "L18",
+        "east": "N18"
       }
     },
     {
-      "row": 18,
-      "col": 14,
-      "color": null,
+      "id": "N18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N17",
+        "south": "N19",
+        "west": "M18",
+        "east": "O18"
       }
     },
     {
-      "row": 18,
-      "col": 15,
-      "color": null,
+      "id": "O18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O17",
+        "south": "O19",
+        "west": "N18",
+        "east": "P18"
       }
     },
     {
-      "row": 18,
-      "col": 16,
-      "color": null,
+      "id": "P18",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P17",
+        "south": "P19",
+        "west": "O18",
+        "east": "Q18"
       }
     },
     {
-      "row": 18,
-      "col": 17,
-      "color": null,
+      "id": "Q18",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q17",
+        "south": "Q19",
+        "west": "P18",
+        "east": "R18"
       }
     },
     {
-      "row": 18,
-      "col": 18,
-      "color": null,
+      "id": "R18",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R17",
+        "south": "R19",
+        "west": "Q18",
+        "east": "S18"
       }
     },
     {
-      "row": 18,
-      "col": 19,
-      "color": null,
+      "id": "S18",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S17",
+        "south": "S19",
+        "west": "R18",
+        "east": "T18"
       }
     },
     {
-      "row": 18,
-      "col": 20,
-      "color": null,
+      "id": "T18",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T17",
+        "south": "T19",
+        "west": "S18",
+        "east": "U18"
       }
     },
     {
-      "row": 18,
-      "col": 21,
-      "color": null,
+      "id": "U18",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U17",
+        "south": "U19",
+        "west": "T18",
+        "east": "V18"
       }
     },
     {
-      "row": 18,
-      "col": 22,
-      "color": null,
+      "id": "V18",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V17",
+        "south": "V19",
+        "west": "U18",
+        "east": "W18"
       }
     },
     {
-      "row": 18,
-      "col": 23,
-      "color": null,
+      "id": "W18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W17",
+        "south": "W19",
+        "west": "V18",
+        "east": "X18"
       }
     },
     {
-      "row": 18,
-      "col": 24,
-      "color": null,
+      "id": "X18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X17",
+        "south": "X19",
+        "west": "W18",
+        "east": "Y18"
       }
     },
     {
-      "row": 18,
-      "col": 25,
-      "color": null,
+      "id": "Y18",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y17",
+        "south": "Y19",
+        "west": "X18",
+        "east": "Z18"
       }
     },
     {
-      "row": 18,
-      "col": 26,
-      "color": null,
+      "id": "Z18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z17",
+        "south": "Z19",
+        "west": "Y18",
+        "east": "AA18"
       }
     },
     {
-      "row": 18,
-      "col": 27,
-      "color": null,
+      "id": "AA18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA17",
+        "south": "AA19",
+        "west": "Z18",
+        "east": "AB18"
       }
     },
     {
-      "row": 18,
-      "col": 28,
-      "color": null,
+      "id": "AB18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB17",
+        "south": "AB19",
+        "west": "AA18",
+        "east": "AC18"
       }
     },
     {
-      "row": 18,
-      "col": 29,
-      "color": null,
+      "id": "AC18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC17",
+        "south": "AC19",
+        "west": "AB18",
+        "east": "AD18"
       }
     },
     {
-      "row": 18,
-      "col": 30,
-      "color": null,
+      "id": "AD18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD17",
+        "south": "AD19",
+        "west": "AC18",
+        "east": "AE18"
       }
     },
     {
-      "row": 18,
-      "col": 31,
-      "color": null,
+      "id": "AE18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE17",
+        "south": "AE19",
+        "west": "AD18",
+        "east": "AF18"
       }
     },
     {
-      "row": 18,
-      "col": 32,
-      "color": null,
+      "id": "AF18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF17",
+        "south": "AF19",
+        "west": "AE18",
+        "east": "AG18"
       }
     },
     {
-      "row": 18,
-      "col": 33,
-      "color": null,
+      "id": "AG18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG17",
+        "south": "AG19",
+        "west": "AF18",
+        "east": "AH18"
       }
     },
     {
-      "row": 18,
-      "col": 34,
-      "color": null,
+      "id": "AH18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH17",
+        "south": "AH19",
+        "west": "AG18",
+        "east": "AI18"
       }
     },
     {
-      "row": 18,
-      "col": 35,
-      "color": null,
+      "id": "AI18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI17",
+        "south": "AI19",
+        "west": "AH18",
+        "east": "AJ18"
       }
     },
     {
-      "row": 18,
-      "col": 36,
-      "color": null,
+      "id": "AJ18",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ17",
+        "south": "AJ19",
+        "west": "AI18",
+        "east": "AK18"
       }
     },
     {
-      "row": 18,
-      "col": 37,
-      "color": null,
+      "id": "AK18",
+      "terrain": "M",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK17",
+        "south": "AK19",
+        "west": "AJ18",
+        "east": "AL18"
       }
     },
     {
-      "row": 18,
-      "col": 38,
-      "color": null,
+      "id": "AL18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL17",
+        "south": "AL19",
+        "west": "AK18",
+        "east": "AM18"
       }
     },
     {
-      "row": 18,
-      "col": 39,
-      "color": null,
+      "id": "AM18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM17",
+        "south": "AM19",
+        "west": "AL18",
+        "east": "AN18"
       }
     },
     {
-      "row": 18,
-      "col": 40,
-      "color": null,
+      "id": "AN18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN17",
+        "south": "AN19",
+        "west": "AM18",
+        "east": "AO18"
       }
     },
     {
-      "row": 18,
-      "col": 41,
-      "color": null,
+      "id": "AO18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO17",
+        "south": "AO19",
+        "west": "AN18",
+        "east": "AP18"
       }
     },
     {
-      "row": 18,
-      "col": 42,
-      "color": null,
+      "id": "AP18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP17",
+        "south": "AP19",
+        "west": "AO18",
+        "east": "AQ18"
       }
     },
     {
-      "row": 18,
-      "col": 43,
-      "color": null,
+      "id": "AQ18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ17",
+        "south": "AQ19",
+        "west": "AP18",
+        "east": "AR18"
       }
     },
     {
-      "row": 18,
-      "col": 44,
-      "color": null,
+      "id": "AR18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR17",
+        "south": "AR19",
+        "west": "AQ18",
+        "east": "AS18"
       }
     },
     {
-      "row": 18,
-      "col": 45,
-      "color": null,
+      "id": "AS18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS17",
+        "south": "AS19",
+        "west": "AR18",
+        "east": "AT18"
       }
     },
     {
-      "row": 18,
-      "col": 46,
-      "color": null,
+      "id": "AT18",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT17",
+        "south": "AT19",
+        "west": "AS18",
+        "east": "AU18"
       }
     },
     {
-      "row": 18,
-      "col": 47,
-      "color": null,
+      "id": "AU18",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU17",
+        "south": "AU19",
+        "west": "AT18",
+        "east": "AV18"
       }
     },
     {
-      "row": 18,
-      "col": 48,
-      "color": null,
+      "id": "AV18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV17",
+        "south": "AV19",
+        "west": "AU18",
+        "east": "AW18"
       }
     },
     {
-      "row": 18,
-      "col": 49,
-      "color": null,
+      "id": "AW18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW17",
+        "south": "AW19",
+        "west": "AV18",
+        "east": "AX18"
       }
     },
     {
-      "row": 18,
-      "col": 50,
-      "color": null,
+      "id": "AX18",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX17",
+        "south": "AX19",
+        "west": "AW18"
       }
     },
     {
-      "row": 19,
-      "col": 1,
-      "color": null,
+      "id": "A19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A18",
+        "south": "A20",
+        "east": "B19"
       }
     },
     {
-      "row": 19,
-      "col": 2,
-      "color": null,
+      "id": "B19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B18",
+        "south": "B20",
+        "west": "A19",
+        "east": "C19"
       }
     },
     {
-      "row": 19,
-      "col": 3,
-      "color": null,
+      "id": "C19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C18",
+        "south": "C20",
+        "west": "B19",
+        "east": "D19"
       }
     },
     {
-      "row": 19,
-      "col": 4,
-      "color": null,
+      "id": "D19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D18",
+        "south": "D20",
+        "west": "C19",
+        "east": "E19"
       }
     },
     {
-      "row": 19,
-      "col": 5,
-      "color": null,
+      "id": "E19",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E18",
+        "south": "E20",
+        "west": "D19",
+        "east": "F19"
       }
     },
     {
-      "row": 19,
-      "col": 6,
-      "color": null,
+      "id": "F19",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F18",
+        "south": "F20",
+        "west": "E19",
+        "east": "G19"
       }
     },
     {
-      "row": 19,
-      "col": 7,
-      "color": null,
+      "id": "G19",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G18",
+        "south": "G20",
+        "west": "F19",
+        "east": "H19"
       }
     },
     {
-      "row": 19,
-      "col": 8,
-      "color": null,
+      "id": "H19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H18",
+        "south": "H20",
+        "west": "G19",
+        "east": "I19"
       }
     },
     {
-      "row": 19,
-      "col": 9,
-      "color": null,
+      "id": "I19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I18",
+        "south": "I20",
+        "west": "H19",
+        "east": "J19"
       }
     },
     {
-      "row": 19,
-      "col": 10,
-      "color": null,
+      "id": "J19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J18",
+        "south": "J20",
+        "west": "I19",
+        "east": "K19"
       }
     },
     {
-      "row": 19,
-      "col": 11,
-      "color": null,
+      "id": "K19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K18",
+        "south": "K20",
+        "west": "J19",
+        "east": "L19"
       }
     },
     {
-      "row": 19,
-      "col": 12,
-      "color": null,
+      "id": "L19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L18",
+        "south": "L20",
+        "west": "K19",
+        "east": "M19"
       }
     },
     {
-      "row": 19,
-      "col": 13,
-      "color": null,
+      "id": "M19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M18",
+        "south": "M20",
+        "west": "L19",
+        "east": "N19"
       }
     },
     {
-      "row": 19,
-      "col": 14,
-      "color": null,
+      "id": "N19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N18",
+        "south": "N20",
+        "west": "M19",
+        "east": "O19"
       }
     },
     {
-      "row": 19,
-      "col": 15,
-      "color": null,
+      "id": "O19",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O18",
+        "south": "O20",
+        "west": "N19",
+        "east": "P19"
       }
     },
     {
-      "row": 19,
-      "col": 16,
-      "color": null,
+      "id": "P19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P18",
+        "south": "P20",
+        "west": "O19",
+        "east": "Q19"
       }
     },
     {
-      "row": 19,
-      "col": 17,
-      "color": null,
+      "id": "Q19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q18",
+        "south": "Q20",
+        "west": "P19",
+        "east": "R19"
       }
     },
     {
-      "row": 19,
-      "col": 18,
-      "color": null,
+      "id": "R19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R18",
+        "south": "R20",
+        "west": "Q19",
+        "east": "S19"
       }
     },
     {
-      "row": 19,
-      "col": 19,
-      "color": null,
+      "id": "S19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S18",
+        "south": "S20",
+        "west": "R19",
+        "east": "T19"
       }
     },
     {
-      "row": 19,
-      "col": 20,
-      "color": null,
+      "id": "T19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T18",
+        "south": "T20",
+        "west": "S19",
+        "east": "U19"
       }
     },
     {
-      "row": 19,
-      "col": 21,
-      "color": null,
+      "id": "U19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U18",
+        "south": "U20",
+        "west": "T19",
+        "east": "V19"
       }
     },
     {
-      "row": 19,
-      "col": 22,
-      "color": null,
+      "id": "V19",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V18",
+        "south": "V20",
+        "west": "U19",
+        "east": "W19"
       }
     },
     {
-      "row": 19,
-      "col": 23,
-      "color": null,
+      "id": "W19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W18",
+        "south": "W20",
+        "west": "V19",
+        "east": "X19"
       }
     },
     {
-      "row": 19,
-      "col": 24,
-      "color": null,
+      "id": "X19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X18",
+        "south": "X20",
+        "west": "W19",
+        "east": "Y19"
       }
     },
     {
-      "row": 19,
-      "col": 25,
-      "color": null,
+      "id": "Y19",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y18",
+        "south": "Y20",
+        "west": "X19",
+        "east": "Z19"
       }
     },
     {
-      "row": 19,
-      "col": 26,
-      "color": null,
+      "id": "Z19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z18",
+        "south": "Z20",
+        "west": "Y19",
+        "east": "AA19"
       }
     },
     {
-      "row": 19,
-      "col": 27,
-      "color": null,
+      "id": "AA19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA18",
+        "south": "AA20",
+        "west": "Z19",
+        "east": "AB19"
       }
     },
     {
-      "row": 19,
-      "col": 28,
-      "color": null,
+      "id": "AB19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB18",
+        "south": "AB20",
+        "west": "AA19",
+        "east": "AC19"
       }
     },
     {
-      "row": 19,
-      "col": 29,
-      "color": null,
+      "id": "AC19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC18",
+        "south": "AC20",
+        "west": "AB19",
+        "east": "AD19"
       }
     },
     {
-      "row": 19,
-      "col": 30,
-      "color": null,
+      "id": "AD19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD18",
+        "south": "AD20",
+        "west": "AC19",
+        "east": "AE19"
       }
     },
     {
-      "row": 19,
-      "col": 31,
-      "color": null,
+      "id": "AE19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE18",
+        "south": "AE20",
+        "west": "AD19",
+        "east": "AF19"
       }
     },
     {
-      "row": 19,
-      "col": 32,
-      "color": null,
+      "id": "AF19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF18",
+        "south": "AF20",
+        "west": "AE19",
+        "east": "AG19"
       }
     },
     {
-      "row": 19,
-      "col": 33,
-      "color": null,
+      "id": "AG19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG18",
+        "south": "AG20",
+        "west": "AF19",
+        "east": "AH19"
       }
     },
     {
-      "row": 19,
-      "col": 34,
-      "color": null,
+      "id": "AH19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH18",
+        "south": "AH20",
+        "west": "AG19",
+        "east": "AI19"
       }
     },
     {
-      "row": 19,
-      "col": 35,
-      "color": null,
+      "id": "AI19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI18",
+        "south": "AI20",
+        "west": "AH19",
+        "east": "AJ19"
       }
     },
     {
-      "row": 19,
-      "col": 36,
-      "color": null,
+      "id": "AJ19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ18",
+        "south": "AJ20",
+        "west": "AI19",
+        "east": "AK19"
       }
     },
     {
-      "row": 19,
-      "col": 37,
-      "color": null,
+      "id": "AK19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK18",
+        "south": "AK20",
+        "west": "AJ19",
+        "east": "AL19"
       }
     },
     {
-      "row": 19,
-      "col": 38,
-      "color": null,
+      "id": "AL19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL18",
+        "south": "AL20",
+        "west": "AK19",
+        "east": "AM19"
       }
     },
     {
-      "row": 19,
-      "col": 39,
-      "color": null,
+      "id": "AM19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM18",
+        "south": "AM20",
+        "west": "AL19",
+        "east": "AN19"
       }
     },
     {
-      "row": 19,
-      "col": 40,
-      "color": null,
+      "id": "AN19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN18",
+        "south": "AN20",
+        "west": "AM19",
+        "east": "AO19"
       }
     },
     {
-      "row": 19,
-      "col": 41,
-      "color": null,
+      "id": "AO19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO18",
+        "south": "AO20",
+        "west": "AN19",
+        "east": "AP19"
       }
     },
     {
-      "row": 19,
-      "col": 42,
-      "color": null,
+      "id": "AP19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP18",
+        "south": "AP20",
+        "west": "AO19",
+        "east": "AQ19"
       }
     },
     {
-      "row": 19,
-      "col": 43,
-      "color": null,
+      "id": "AQ19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ18",
+        "south": "AQ20",
+        "west": "AP19",
+        "east": "AR19"
       }
     },
     {
-      "row": 19,
-      "col": 44,
-      "color": null,
+      "id": "AR19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR18",
+        "south": "AR20",
+        "west": "AQ19",
+        "east": "AS19"
       }
     },
     {
-      "row": 19,
-      "col": 45,
-      "color": null,
+      "id": "AS19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS18",
+        "south": "AS20",
+        "west": "AR19",
+        "east": "AT19"
       }
     },
     {
-      "row": 19,
-      "col": 46,
-      "color": null,
+      "id": "AT19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT18",
+        "south": "AT20",
+        "west": "AS19",
+        "east": "AU19"
       }
     },
     {
-      "row": 19,
-      "col": 47,
-      "color": null,
+      "id": "AU19",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU18",
+        "south": "AU20",
+        "west": "AT19",
+        "east": "AV19"
       }
     },
     {
-      "row": 19,
-      "col": 48,
-      "color": null,
+      "id": "AV19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV18",
+        "south": "AV20",
+        "west": "AU19",
+        "east": "AW19"
       }
     },
     {
-      "row": 19,
-      "col": 49,
-      "color": null,
+      "id": "AW19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW18",
+        "south": "AW20",
+        "west": "AV19",
+        "east": "AX19"
       }
     },
     {
-      "row": 19,
-      "col": 50,
-      "color": null,
+      "id": "AX19",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX18",
+        "south": "AX20",
+        "west": "AW19"
       }
     },
     {
-      "row": 20,
-      "col": 1,
-      "color": null,
+      "id": "A20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A19",
+        "south": "A21",
+        "east": "B20"
       }
     },
     {
-      "row": 20,
-      "col": 2,
-      "color": null,
+      "id": "B20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B19",
+        "south": "B21",
+        "west": "A20",
+        "east": "C20"
       }
     },
     {
-      "row": 20,
-      "col": 3,
-      "color": null,
+      "id": "C20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C19",
+        "south": "C21",
+        "west": "B20",
+        "east": "D20"
       }
     },
     {
-      "row": 20,
-      "col": 4,
-      "color": null,
+      "id": "D20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D19",
+        "south": "D21",
+        "west": "C20",
+        "east": "E20"
       }
     },
     {
-      "row": 20,
-      "col": 5,
-      "color": null,
+      "id": "E20",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E19",
+        "south": "E21",
+        "west": "D20",
+        "east": "F20"
       }
     },
     {
-      "row": 20,
-      "col": 6,
-      "color": null,
+      "id": "F20",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F19",
+        "south": "F21",
+        "west": "E20",
+        "east": "G20"
       }
     },
     {
-      "row": 20,
-      "col": 7,
-      "color": null,
+      "id": "G20",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G19",
+        "south": "G21",
+        "west": "F20",
+        "east": "H20"
       }
     },
     {
-      "row": 20,
-      "col": 8,
-      "color": null,
+      "id": "H20",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H19",
+        "south": "H21",
+        "west": "G20",
+        "east": "I20"
       }
     },
     {
-      "row": 20,
-      "col": 9,
-      "color": null,
+      "id": "I20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I19",
+        "south": "I21",
+        "west": "H20",
+        "east": "J20"
       }
     },
     {
-      "row": 20,
-      "col": 10,
-      "color": null,
+      "id": "J20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J19",
+        "south": "J21",
+        "west": "I20",
+        "east": "K20"
       }
     },
     {
-      "row": 20,
-      "col": 11,
-      "color": null,
+      "id": "K20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K19",
+        "south": "K21",
+        "west": "J20",
+        "east": "L20"
       }
     },
     {
-      "row": 20,
-      "col": 12,
-      "color": null,
+      "id": "L20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L19",
+        "south": "L21",
+        "west": "K20",
+        "east": "M20"
       }
     },
     {
-      "row": 20,
-      "col": 13,
-      "color": null,
+      "id": "M20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M19",
+        "south": "M21",
+        "west": "L20",
+        "east": "N20"
       }
     },
     {
-      "row": 20,
-      "col": 14,
-      "color": null,
+      "id": "N20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N19",
+        "south": "N21",
+        "west": "M20",
+        "east": "O20"
       }
     },
     {
-      "row": 20,
-      "col": 15,
-      "color": null,
+      "id": "O20",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O19",
+        "south": "O21",
+        "west": "N20",
+        "east": "P20"
       }
     },
     {
-      "row": 20,
-      "col": 16,
-      "color": null,
+      "id": "P20",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P19",
+        "south": "P21",
+        "west": "O20",
+        "east": "Q20"
       }
     },
     {
-      "row": 20,
-      "col": 17,
-      "color": null,
+      "id": "Q20",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q19",
+        "south": "Q21",
+        "west": "P20",
+        "east": "R20"
       }
     },
     {
-      "row": 20,
-      "col": 18,
-      "color": null,
+      "id": "R20",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R19",
+        "south": "R21",
+        "west": "Q20",
+        "east": "S20"
       }
     },
     {
-      "row": 20,
-      "col": 19,
-      "color": null,
+      "id": "S20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S19",
+        "south": "S21",
+        "west": "R20",
+        "east": "T20"
       }
     },
     {
-      "row": 20,
-      "col": 20,
-      "color": null,
+      "id": "T20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T19",
+        "south": "T21",
+        "west": "S20",
+        "east": "U20"
       }
     },
     {
-      "row": 20,
-      "col": 21,
-      "color": null,
+      "id": "U20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U19",
+        "south": "U21",
+        "west": "T20",
+        "east": "V20"
       }
     },
     {
-      "row": 20,
-      "col": 22,
-      "color": null,
+      "id": "V20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V19",
+        "south": "V21",
+        "west": "U20",
+        "east": "W20"
       }
     },
     {
-      "row": 20,
-      "col": 23,
-      "color": null,
+      "id": "W20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W19",
+        "south": "W21",
+        "west": "V20",
+        "east": "X20"
       }
     },
     {
-      "row": 20,
-      "col": 24,
-      "color": null,
+      "id": "X20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X19",
+        "south": "X21",
+        "west": "W20",
+        "east": "Y20"
       }
     },
     {
-      "row": 20,
-      "col": 25,
-      "color": null,
+      "id": "Y20",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y19",
+        "south": "Y21",
+        "west": "X20",
+        "east": "Z20"
       }
     },
     {
-      "row": 20,
-      "col": 26,
-      "color": null,
+      "id": "Z20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z19",
+        "south": "Z21",
+        "west": "Y20",
+        "east": "AA20"
       }
     },
     {
-      "row": 20,
-      "col": 27,
-      "color": null,
+      "id": "AA20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA19",
+        "south": "AA21",
+        "west": "Z20",
+        "east": "AB20"
       }
     },
     {
-      "row": 20,
-      "col": 28,
-      "color": null,
+      "id": "AB20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB19",
+        "south": "AB21",
+        "west": "AA20",
+        "east": "AC20"
       }
     },
     {
-      "row": 20,
-      "col": 29,
-      "color": null,
+      "id": "AC20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC19",
+        "south": "AC21",
+        "west": "AB20",
+        "east": "AD20"
       }
     },
     {
-      "row": 20,
-      "col": 30,
-      "color": null,
+      "id": "AD20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD19",
+        "south": "AD21",
+        "west": "AC20",
+        "east": "AE20"
       }
     },
     {
-      "row": 20,
-      "col": 31,
-      "color": null,
+      "id": "AE20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE19",
+        "south": "AE21",
+        "west": "AD20",
+        "east": "AF20"
       }
     },
     {
-      "row": 20,
-      "col": 32,
-      "color": null,
+      "id": "AF20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF19",
+        "south": "AF21",
+        "west": "AE20",
+        "east": "AG20"
       }
     },
     {
-      "row": 20,
-      "col": 33,
-      "color": null,
+      "id": "AG20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG19",
+        "south": "AG21",
+        "west": "AF20",
+        "east": "AH20"
       }
     },
     {
-      "row": 20,
-      "col": 34,
-      "color": null,
+      "id": "AH20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH19",
+        "south": "AH21",
+        "west": "AG20",
+        "east": "AI20"
       }
     },
     {
-      "row": 20,
-      "col": 35,
-      "color": null,
+      "id": "AI20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI19",
+        "south": "AI21",
+        "west": "AH20",
+        "east": "AJ20"
       }
     },
     {
-      "row": 20,
-      "col": 36,
-      "color": null,
+      "id": "AJ20",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ19",
+        "south": "AJ21",
+        "west": "AI20",
+        "east": "AK20"
       }
     },
     {
-      "row": 20,
-      "col": 37,
-      "color": null,
+      "id": "AK20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK19",
+        "south": "AK21",
+        "west": "AJ20",
+        "east": "AL20"
       }
     },
     {
-      "row": 20,
-      "col": 38,
-      "color": null,
+      "id": "AL20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL19",
+        "south": "AL21",
+        "west": "AK20",
+        "east": "AM20"
       }
     },
     {
-      "row": 20,
-      "col": 39,
-      "color": null,
+      "id": "AM20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM19",
+        "south": "AM21",
+        "west": "AL20",
+        "east": "AN20"
       }
     },
     {
-      "row": 20,
-      "col": 40,
-      "color": null,
+      "id": "AN20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN19",
+        "south": "AN21",
+        "west": "AM20",
+        "east": "AO20"
       }
     },
     {
-      "row": 20,
-      "col": 41,
-      "color": null,
+      "id": "AO20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO19",
+        "south": "AO21",
+        "west": "AN20",
+        "east": "AP20"
       }
     },
     {
-      "row": 20,
-      "col": 42,
-      "color": null,
+      "id": "AP20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP19",
+        "south": "AP21",
+        "west": "AO20",
+        "east": "AQ20"
       }
     },
     {
-      "row": 20,
-      "col": 43,
-      "color": null,
+      "id": "AQ20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ19",
+        "south": "AQ21",
+        "west": "AP20",
+        "east": "AR20"
       }
     },
     {
-      "row": 20,
-      "col": 44,
-      "color": null,
+      "id": "AR20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR19",
+        "south": "AR21",
+        "west": "AQ20",
+        "east": "AS20"
       }
     },
     {
-      "row": 20,
-      "col": 45,
-      "color": null,
+      "id": "AS20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS19",
+        "south": "AS21",
+        "west": "AR20",
+        "east": "AT20"
       }
     },
     {
-      "row": 20,
-      "col": 46,
-      "color": null,
+      "id": "AT20",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT19",
+        "south": "AT21",
+        "west": "AS20",
+        "east": "AU20"
       }
     },
     {
-      "row": 20,
-      "col": 47,
-      "color": null,
+      "id": "AU20",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU19",
+        "south": "AU21",
+        "west": "AT20",
+        "east": "AV20"
       }
     },
     {
-      "row": 20,
-      "col": 48,
-      "color": null,
+      "id": "AV20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV19",
+        "south": "AV21",
+        "west": "AU20",
+        "east": "AW20"
       }
     },
     {
-      "row": 20,
-      "col": 49,
-      "color": null,
+      "id": "AW20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW19",
+        "south": "AW21",
+        "west": "AV20",
+        "east": "AX20"
       }
     },
     {
-      "row": 20,
-      "col": 50,
-      "color": null,
+      "id": "AX20",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX19",
+        "south": "AX21",
+        "west": "AW20"
       }
     },
     {
-      "row": 21,
-      "col": 1,
-      "color": null,
+      "id": "A21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A20",
+        "south": "A22",
+        "east": "B21"
       }
     },
     {
-      "row": 21,
-      "col": 2,
-      "color": null,
+      "id": "B21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B20",
+        "south": "B22",
+        "west": "A21",
+        "east": "C21"
       }
     },
     {
-      "row": 21,
-      "col": 3,
-      "color": null,
+      "id": "C21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C20",
+        "south": "C22",
+        "west": "B21",
+        "east": "D21"
       }
     },
     {
-      "row": 21,
-      "col": 4,
-      "color": null,
+      "id": "D21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D20",
+        "south": "D22",
+        "west": "C21",
+        "east": "E21"
       }
     },
     {
-      "row": 21,
-      "col": 5,
-      "color": null,
+      "id": "E21",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E20",
+        "south": "E22",
+        "west": "D21",
+        "east": "F21"
       }
     },
     {
-      "row": 21,
-      "col": 6,
-      "color": null,
+      "id": "F21",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F20",
+        "south": "F22",
+        "west": "E21",
+        "east": "G21"
       }
     },
     {
-      "row": 21,
-      "col": 7,
-      "color": null,
+      "id": "G21",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G20",
+        "south": "G22",
+        "west": "F21",
+        "east": "H21"
       }
     },
     {
-      "row": 21,
-      "col": 8,
-      "color": null,
+      "id": "H21",
+      "terrain": "gap",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H20",
+        "south": "H22",
+        "west": "G21",
+        "east": "I21"
       }
     },
     {
-      "row": 21,
-      "col": 9,
-      "color": null,
+      "id": "I21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I20",
+        "south": "I22",
+        "west": "H21",
+        "east": "J21"
       }
     },
     {
-      "row": 21,
-      "col": 10,
-      "color": null,
+      "id": "J21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J20",
+        "south": "J22",
+        "west": "I21",
+        "east": "K21"
       }
     },
     {
-      "row": 21,
-      "col": 11,
-      "color": null,
+      "id": "K21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K20",
+        "south": "K22",
+        "west": "J21",
+        "east": "L21"
       }
     },
     {
-      "row": 21,
-      "col": 12,
-      "color": null,
+      "id": "L21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L20",
+        "south": "L22",
+        "west": "K21",
+        "east": "M21"
       }
     },
     {
-      "row": 21,
-      "col": 13,
-      "color": null,
+      "id": "M21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M20",
+        "south": "M22",
+        "west": "L21",
+        "east": "N21"
       }
     },
     {
-      "row": 21,
-      "col": 14,
-      "color": null,
+      "id": "N21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N20",
+        "south": "N22",
+        "west": "M21",
+        "east": "O21"
       }
     },
     {
-      "row": 21,
-      "col": 15,
-      "color": null,
+      "id": "O21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O20",
+        "south": "O22",
+        "west": "N21",
+        "east": "P21"
       }
     },
     {
-      "row": 21,
-      "col": 16,
-      "color": null,
+      "id": "P21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P20",
+        "south": "P22",
+        "west": "O21",
+        "east": "Q21"
       }
     },
     {
-      "row": 21,
-      "col": 17,
-      "color": null,
+      "id": "Q21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q20",
+        "south": "Q22",
+        "west": "P21",
+        "east": "R21"
       }
     },
     {
-      "row": 21,
-      "col": 18,
-      "color": null,
+      "id": "R21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R20",
+        "south": "R22",
+        "west": "Q21",
+        "east": "S21"
       }
     },
     {
-      "row": 21,
-      "col": 19,
-      "color": null,
+      "id": "S21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S20",
+        "south": "S22",
+        "west": "R21",
+        "east": "T21"
       }
     },
     {
-      "row": 21,
-      "col": 20,
-      "color": null,
+      "id": "T21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T20",
+        "south": "T22",
+        "west": "S21",
+        "east": "U21"
       }
     },
     {
-      "row": 21,
-      "col": 21,
-      "color": null,
+      "id": "U21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U20",
+        "south": "U22",
+        "west": "T21",
+        "east": "V21"
       }
     },
     {
-      "row": 21,
-      "col": 22,
-      "color": null,
+      "id": "V21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V20",
+        "south": "V22",
+        "west": "U21",
+        "east": "W21"
       }
     },
     {
-      "row": 21,
-      "col": 23,
-      "color": null,
+      "id": "W21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W20",
+        "south": "W22",
+        "west": "V21",
+        "east": "X21"
       }
     },
     {
-      "row": 21,
-      "col": 24,
-      "color": null,
+      "id": "X21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X20",
+        "south": "X22",
+        "west": "W21",
+        "east": "Y21"
       }
     },
     {
-      "row": 21,
-      "col": 25,
-      "color": null,
+      "id": "Y21",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y20",
+        "south": "Y22",
+        "west": "X21",
+        "east": "Z21"
       }
     },
     {
-      "row": 21,
-      "col": 26,
-      "color": null,
+      "id": "Z21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z20",
+        "south": "Z22",
+        "west": "Y21",
+        "east": "AA21"
       }
     },
     {
-      "row": 21,
-      "col": 27,
-      "color": null,
+      "id": "AA21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA20",
+        "south": "AA22",
+        "west": "Z21",
+        "east": "AB21"
       }
     },
     {
-      "row": 21,
-      "col": 28,
-      "color": null,
+      "id": "AB21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB20",
+        "south": "AB22",
+        "west": "AA21",
+        "east": "AC21"
       }
     },
     {
-      "row": 21,
-      "col": 29,
-      "color": null,
+      "id": "AC21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC20",
+        "south": "AC22",
+        "west": "AB21",
+        "east": "AD21"
       }
     },
     {
-      "row": 21,
-      "col": 30,
-      "color": null,
+      "id": "AD21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD20",
+        "south": "AD22",
+        "west": "AC21",
+        "east": "AE21"
       }
     },
     {
-      "row": 21,
-      "col": 31,
-      "color": null,
+      "id": "AE21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE20",
+        "south": "AE22",
+        "west": "AD21",
+        "east": "AF21"
       }
     },
     {
-      "row": 21,
-      "col": 32,
-      "color": null,
+      "id": "AF21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF20",
+        "south": "AF22",
+        "west": "AE21",
+        "east": "AG21"
       }
     },
     {
-      "row": 21,
-      "col": 33,
-      "color": null,
+      "id": "AG21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG20",
+        "south": "AG22",
+        "west": "AF21",
+        "east": "AH21"
       }
     },
     {
-      "row": 21,
-      "col": 34,
-      "color": null,
+      "id": "AH21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH20",
+        "south": "AH22",
+        "west": "AG21",
+        "east": "AI21"
       }
     },
     {
-      "row": 21,
-      "col": 35,
-      "color": null,
+      "id": "AI21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI20",
+        "south": "AI22",
+        "west": "AH21",
+        "east": "AJ21"
       }
     },
     {
-      "row": 21,
-      "col": 36,
-      "color": null,
+      "id": "AJ21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ20",
+        "south": "AJ22",
+        "west": "AI21",
+        "east": "AK21"
       }
     },
     {
-      "row": 21,
-      "col": 37,
-      "color": null,
+      "id": "AK21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK20",
+        "south": "AK22",
+        "west": "AJ21",
+        "east": "AL21"
       }
     },
     {
-      "row": 21,
-      "col": 38,
-      "color": null,
+      "id": "AL21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL20",
+        "south": "AL22",
+        "west": "AK21",
+        "east": "AM21"
       }
     },
     {
-      "row": 21,
-      "col": 39,
-      "color": null,
+      "id": "AM21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM20",
+        "south": "AM22",
+        "west": "AL21",
+        "east": "AN21"
       }
     },
     {
-      "row": 21,
-      "col": 40,
-      "color": null,
+      "id": "AN21",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN20",
+        "south": "AN22",
+        "west": "AM21",
+        "east": "AO21"
       }
     },
     {
-      "row": 21,
-      "col": 41,
-      "color": null,
+      "id": "AO21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO20",
+        "south": "AO22",
+        "west": "AN21",
+        "east": "AP21"
       }
     },
     {
-      "row": 21,
-      "col": 42,
-      "color": null,
+      "id": "AP21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP20",
+        "south": "AP22",
+        "west": "AO21",
+        "east": "AQ21"
       }
     },
     {
-      "row": 21,
-      "col": 43,
-      "color": null,
+      "id": "AQ21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ20",
+        "south": "AQ22",
+        "west": "AP21",
+        "east": "AR21"
       }
     },
     {
-      "row": 21,
-      "col": 44,
-      "color": null,
+      "id": "AR21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR20",
+        "south": "AR22",
+        "west": "AQ21",
+        "east": "AS21"
       }
     },
     {
-      "row": 21,
-      "col": 45,
-      "color": null,
+      "id": "AS21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS20",
+        "south": "AS22",
+        "west": "AR21",
+        "east": "AT21"
       }
     },
     {
-      "row": 21,
-      "col": 46,
-      "color": null,
+      "id": "AT21",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT20",
+        "south": "AT22",
+        "west": "AS21",
+        "east": "AU21"
       }
     },
     {
-      "row": 21,
-      "col": 47,
-      "color": null,
+      "id": "AU21",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU20",
+        "south": "AU22",
+        "west": "AT21",
+        "east": "AV21"
       }
     },
     {
-      "row": 21,
-      "col": 48,
-      "color": null,
+      "id": "AV21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV20",
+        "south": "AV22",
+        "west": "AU21",
+        "east": "AW21"
       }
     },
     {
-      "row": 21,
-      "col": 49,
-      "color": null,
+      "id": "AW21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW20",
+        "south": "AW22",
+        "west": "AV21",
+        "east": "AX21"
       }
     },
     {
-      "row": 21,
-      "col": 50,
-      "color": null,
+      "id": "AX21",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX20",
+        "south": "AX22",
+        "west": "AW21"
       }
     },
     {
-      "row": 22,
-      "col": 1,
-      "color": null,
+      "id": "A22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A21",
+        "south": "A23",
+        "east": "B22"
       }
     },
     {
-      "row": 22,
-      "col": 2,
-      "color": null,
+      "id": "B22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B21",
+        "south": "B23",
+        "west": "A22",
+        "east": "C22"
       }
     },
     {
-      "row": 22,
-      "col": 3,
-      "color": null,
+      "id": "C22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C21",
+        "south": "C23",
+        "west": "B22",
+        "east": "D22"
       }
     },
     {
-      "row": 22,
-      "col": 4,
-      "color": null,
+      "id": "D22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D21",
+        "south": "D23",
+        "west": "C22",
+        "east": "E22"
       }
     },
     {
-      "row": 22,
-      "col": 5,
-      "color": null,
+      "id": "E22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E21",
+        "south": "E23",
+        "west": "D22",
+        "east": "F22"
       }
     },
     {
-      "row": 22,
-      "col": 6,
-      "color": null,
+      "id": "F22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F21",
+        "south": "F23",
+        "west": "E22",
+        "east": "G22"
       }
     },
     {
-      "row": 22,
-      "col": 7,
-      "color": null,
+      "id": "G22",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G21",
+        "south": "G23",
+        "west": "F22",
+        "east": "H22"
       }
     },
     {
-      "row": 22,
-      "col": 8,
-      "color": null,
+      "id": "H22",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H21",
+        "south": "H23",
+        "west": "G22",
+        "east": "I22"
       }
     },
     {
-      "row": 22,
-      "col": 9,
-      "color": null,
+      "id": "I22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I21",
+        "south": "I23",
+        "west": "H22",
+        "east": "J22"
       }
     },
     {
-      "row": 22,
-      "col": 10,
-      "color": null,
+      "id": "J22",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J21",
+        "south": "J23",
+        "west": "I22",
+        "east": "K22"
       }
     },
     {
-      "row": 22,
-      "col": 11,
-      "color": null,
+      "id": "K22",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K21",
+        "south": "K23",
+        "west": "J22",
+        "east": "L22"
       }
     },
     {
-      "row": 22,
-      "col": 12,
-      "color": null,
+      "id": "L22",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L21",
+        "south": "L23",
+        "west": "K22",
+        "east": "M22"
       }
     },
     {
-      "row": 22,
-      "col": 13,
-      "color": null,
+      "id": "M22",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M21",
+        "south": "M23",
+        "west": "L22",
+        "east": "N22"
       }
     },
     {
-      "row": 22,
-      "col": 14,
-      "color": null,
+      "id": "N22",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N21",
+        "south": "N23",
+        "west": "M22",
+        "east": "O22"
       }
     },
     {
-      "row": 22,
-      "col": 15,
-      "color": null,
+      "id": "O22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O21",
+        "south": "O23",
+        "west": "N22",
+        "east": "P22"
       }
     },
     {
-      "row": 22,
-      "col": 16,
-      "color": null,
+      "id": "P22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P21",
+        "south": "P23",
+        "west": "O22",
+        "east": "Q22"
       }
     },
     {
-      "row": 22,
-      "col": 17,
-      "color": null,
+      "id": "Q22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q21",
+        "south": "Q23",
+        "west": "P22",
+        "east": "R22"
       }
     },
     {
-      "row": 22,
-      "col": 18,
-      "color": null,
+      "id": "R22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R21",
+        "south": "R23",
+        "west": "Q22",
+        "east": "S22"
       }
     },
     {
-      "row": 22,
-      "col": 19,
-      "color": null,
+      "id": "S22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S21",
+        "south": "S23",
+        "west": "R22",
+        "east": "T22"
       }
     },
     {
-      "row": 22,
-      "col": 20,
-      "color": null,
+      "id": "T22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T21",
+        "south": "T23",
+        "west": "S22",
+        "east": "U22"
       }
     },
     {
-      "row": 22,
-      "col": 21,
-      "color": null,
+      "id": "U22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U21",
+        "south": "U23",
+        "west": "T22",
+        "east": "V22"
       }
     },
     {
-      "row": 22,
-      "col": 22,
-      "color": null,
+      "id": "V22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V21",
+        "south": "V23",
+        "west": "U22",
+        "east": "W22"
       }
     },
     {
-      "row": 22,
-      "col": 23,
-      "color": null,
+      "id": "W22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W21",
+        "south": "W23",
+        "west": "V22",
+        "east": "X22"
       }
     },
     {
-      "row": 22,
-      "col": 24,
-      "color": null,
+      "id": "X22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X21",
+        "south": "X23",
+        "west": "W22",
+        "east": "Y22"
       }
     },
     {
-      "row": 22,
-      "col": 25,
-      "color": null,
+      "id": "Y22",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y21",
+        "south": "Y23",
+        "west": "X22",
+        "east": "Z22"
       }
     },
     {
-      "row": 22,
-      "col": 26,
-      "color": null,
+      "id": "Z22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z21",
+        "south": "Z23",
+        "west": "Y22",
+        "east": "AA22"
       }
     },
     {
-      "row": 22,
-      "col": 27,
-      "color": null,
+      "id": "AA22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA21",
+        "south": "AA23",
+        "west": "Z22",
+        "east": "AB22"
       }
     },
     {
-      "row": 22,
-      "col": 28,
-      "color": null,
+      "id": "AB22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB21",
+        "south": "AB23",
+        "west": "AA22",
+        "east": "AC22"
       }
     },
     {
-      "row": 22,
-      "col": 29,
-      "color": null,
+      "id": "AC22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC21",
+        "south": "AC23",
+        "west": "AB22",
+        "east": "AD22"
       }
     },
     {
-      "row": 22,
-      "col": 30,
-      "color": null,
+      "id": "AD22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD21",
+        "south": "AD23",
+        "west": "AC22",
+        "east": "AE22"
       }
     },
     {
-      "row": 22,
-      "col": 31,
-      "color": null,
+      "id": "AE22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE21",
+        "south": "AE23",
+        "west": "AD22",
+        "east": "AF22"
       }
     },
     {
-      "row": 22,
-      "col": 32,
-      "color": null,
+      "id": "AF22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF21",
+        "south": "AF23",
+        "west": "AE22",
+        "east": "AG22"
       }
     },
     {
-      "row": 22,
-      "col": 33,
-      "color": null,
+      "id": "AG22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG21",
+        "south": "AG23",
+        "west": "AF22",
+        "east": "AH22"
       }
     },
     {
-      "row": 22,
-      "col": 34,
-      "color": null,
+      "id": "AH22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH21",
+        "south": "AH23",
+        "west": "AG22",
+        "east": "AI22"
       }
     },
     {
-      "row": 22,
-      "col": 35,
-      "color": null,
+      "id": "AI22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI21",
+        "south": "AI23",
+        "west": "AH22",
+        "east": "AJ22"
       }
     },
     {
-      "row": 22,
-      "col": 36,
-      "color": null,
+      "id": "AJ22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ21",
+        "south": "AJ23",
+        "west": "AI22",
+        "east": "AK22"
       }
     },
     {
-      "row": 22,
-      "col": 37,
-      "color": null,
+      "id": "AK22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK21",
+        "south": "AK23",
+        "west": "AJ22",
+        "east": "AL22"
       }
     },
     {
-      "row": 22,
-      "col": 38,
-      "color": null,
+      "id": "AL22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL21",
+        "south": "AL23",
+        "west": "AK22",
+        "east": "AM22"
       }
     },
     {
-      "row": 22,
-      "col": 39,
-      "color": null,
+      "id": "AM22",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM21",
+        "south": "AM23",
+        "west": "AL22",
+        "east": "AN22"
       }
     },
     {
-      "row": 22,
-      "col": 40,
-      "color": null,
+      "id": "AN22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN21",
+        "south": "AN23",
+        "west": "AM22",
+        "east": "AO22"
       }
     },
     {
-      "row": 22,
-      "col": 41,
-      "color": null,
+      "id": "AO22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO21",
+        "south": "AO23",
+        "west": "AN22",
+        "east": "AP22"
       }
     },
     {
-      "row": 22,
-      "col": 42,
-      "color": null,
+      "id": "AP22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP21",
+        "south": "AP23",
+        "west": "AO22",
+        "east": "AQ22"
       }
     },
     {
-      "row": 22,
-      "col": 43,
-      "color": null,
+      "id": "AQ22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ21",
+        "south": "AQ23",
+        "west": "AP22",
+        "east": "AR22"
       }
     },
     {
-      "row": 22,
-      "col": 44,
-      "color": null,
+      "id": "AR22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR21",
+        "south": "AR23",
+        "west": "AQ22",
+        "east": "AS22"
       }
     },
     {
-      "row": 22,
-      "col": 45,
-      "color": null,
+      "id": "AS22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS21",
+        "south": "AS23",
+        "west": "AR22",
+        "east": "AT22"
       }
     },
     {
-      "row": 22,
-      "col": 46,
-      "color": null,
+      "id": "AT22",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT21",
+        "south": "AT23",
+        "west": "AS22",
+        "east": "AU22"
       }
     },
     {
-      "row": 22,
-      "col": 47,
-      "color": null,
+      "id": "AU22",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU21",
+        "south": "AU23",
+        "west": "AT22",
+        "east": "AV22"
       }
     },
     {
-      "row": 22,
-      "col": 48,
-      "color": null,
+      "id": "AV22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV21",
+        "south": "AV23",
+        "west": "AU22",
+        "east": "AW22"
       }
     },
     {
-      "row": 22,
-      "col": 49,
-      "color": null,
+      "id": "AW22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW21",
+        "south": "AW23",
+        "west": "AV22",
+        "east": "AX22"
       }
     },
     {
-      "row": 22,
-      "col": 50,
-      "color": null,
+      "id": "AX22",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX21",
+        "south": "AX23",
+        "west": "AW22"
       }
     },
     {
-      "row": 23,
-      "col": 1,
-      "color": null,
+      "id": "A23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A22",
+        "south": "A24",
+        "east": "B23"
       }
     },
     {
-      "row": 23,
-      "col": 2,
-      "color": null,
+      "id": "B23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B22",
+        "south": "B24",
+        "west": "A23",
+        "east": "C23"
       }
     },
     {
-      "row": 23,
-      "col": 3,
-      "color": null,
+      "id": "C23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C22",
+        "south": "C24",
+        "west": "B23",
+        "east": "D23"
       }
     },
     {
-      "row": 23,
-      "col": 4,
-      "color": null,
+      "id": "D23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D22",
+        "south": "D24",
+        "west": "C23",
+        "east": "E23"
       }
     },
     {
-      "row": 23,
-      "col": 5,
-      "color": null,
+      "id": "E23",
+      "terrain": "burrows",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E22",
+        "south": "E24",
+        "west": "D23",
+        "east": "F23"
       }
     },
     {
-      "row": 23,
-      "col": 6,
-      "color": null,
+      "id": "F23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F22",
+        "south": "F24",
+        "west": "E23",
+        "east": "G23"
       }
     },
     {
-      "row": 23,
-      "col": 7,
-      "color": null,
+      "id": "G23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G22",
+        "south": "G24",
+        "west": "F23",
+        "east": "H23"
       }
     },
     {
-      "row": 23,
-      "col": 8,
-      "color": null,
+      "id": "H23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H22",
+        "south": "H24",
+        "west": "G23",
+        "east": "I23"
       }
     },
     {
-      "row": 23,
-      "col": 9,
-      "color": null,
+      "id": "I23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I22",
+        "south": "I24",
+        "west": "H23",
+        "east": "J23"
       }
     },
     {
-      "row": 23,
-      "col": 10,
-      "color": null,
+      "id": "J23",
+      "terrain": "cave",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J22",
+        "south": "J24",
+        "west": "I23",
+        "east": "K23"
       }
     },
     {
-      "row": 23,
-      "col": 11,
-      "color": null,
+      "id": "K23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K22",
+        "south": "K24",
+        "west": "J23",
+        "east": "L23"
       }
     },
     {
-      "row": 23,
-      "col": 12,
-      "color": null,
+      "id": "L23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L22",
+        "south": "L24",
+        "west": "K23",
+        "east": "M23"
       }
     },
     {
-      "row": 23,
-      "col": 13,
-      "color": null,
+      "id": "M23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M22",
+        "south": "M24",
+        "west": "L23",
+        "east": "N23"
       }
     },
     {
-      "row": 23,
-      "col": 14,
-      "color": null,
+      "id": "N23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N22",
+        "south": "N24",
+        "west": "M23",
+        "east": "O23"
       }
     },
     {
-      "row": 23,
-      "col": 15,
-      "color": null,
+      "id": "O23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O22",
+        "south": "O24",
+        "west": "N23",
+        "east": "P23"
       }
     },
     {
-      "row": 23,
-      "col": 16,
-      "color": null,
+      "id": "P23",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P22",
+        "south": "P24",
+        "west": "O23",
+        "east": "Q23"
       }
     },
     {
-      "row": 23,
-      "col": 17,
-      "color": null,
+      "id": "Q23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q22",
+        "south": "Q24",
+        "west": "P23",
+        "east": "R23"
       }
     },
     {
-      "row": 23,
-      "col": 18,
-      "color": null,
+      "id": "R23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R22",
+        "south": "R24",
+        "west": "Q23",
+        "east": "S23"
       }
     },
     {
-      "row": 23,
-      "col": 19,
-      "color": null,
+      "id": "S23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S22",
+        "south": "S24",
+        "west": "R23",
+        "east": "T23"
       }
     },
     {
-      "row": 23,
-      "col": 20,
-      "color": null,
+      "id": "T23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T22",
+        "south": "T24",
+        "west": "S23",
+        "east": "U23"
       }
     },
     {
-      "row": 23,
-      "col": 21,
-      "color": null,
+      "id": "U23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U22",
+        "south": "U24",
+        "west": "T23",
+        "east": "V23"
       }
     },
     {
-      "row": 23,
-      "col": 22,
-      "color": null,
+      "id": "V23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V22",
+        "south": "V24",
+        "west": "U23",
+        "east": "W23"
       }
     },
     {
-      "row": 23,
-      "col": 23,
-      "color": null,
+      "id": "W23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W22",
+        "south": "W24",
+        "west": "V23",
+        "east": "X23"
       }
     },
     {
-      "row": 23,
-      "col": 24,
-      "color": null,
+      "id": "X23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X22",
+        "south": "X24",
+        "west": "W23",
+        "east": "Y23"
       }
     },
     {
-      "row": 23,
-      "col": 25,
-      "color": null,
+      "id": "Y23",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y22",
+        "south": "Y24",
+        "west": "X23",
+        "east": "Z23"
       }
     },
     {
-      "row": 23,
-      "col": 26,
-      "color": null,
+      "id": "Z23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z22",
+        "south": "Z24",
+        "west": "Y23",
+        "east": "AA23"
       }
     },
     {
-      "row": 23,
-      "col": 27,
-      "color": null,
+      "id": "AA23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA22",
+        "south": "AA24",
+        "west": "Z23",
+        "east": "AB23"
       }
     },
     {
-      "row": 23,
-      "col": 28,
-      "color": null,
+      "id": "AB23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB22",
+        "south": "AB24",
+        "west": "AA23",
+        "east": "AC23"
       }
     },
     {
-      "row": 23,
-      "col": 29,
-      "color": null,
+      "id": "AC23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC22",
+        "south": "AC24",
+        "west": "AB23",
+        "east": "AD23"
       }
     },
     {
-      "row": 23,
-      "col": 30,
-      "color": null,
+      "id": "AD23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD22",
+        "south": "AD24",
+        "west": "AC23",
+        "east": "AE23"
       }
     },
     {
-      "row": 23,
-      "col": 31,
-      "color": null,
+      "id": "AE23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE22",
+        "south": "AE24",
+        "west": "AD23",
+        "east": "AF23"
       }
     },
     {
-      "row": 23,
-      "col": 32,
-      "color": null,
+      "id": "AF23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF22",
+        "south": "AF24",
+        "west": "AE23",
+        "east": "AG23"
       }
     },
     {
-      "row": 23,
-      "col": 33,
-      "color": null,
+      "id": "AG23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG22",
+        "south": "AG24",
+        "west": "AF23",
+        "east": "AH23"
       }
     },
     {
-      "row": 23,
-      "col": 34,
-      "color": null,
+      "id": "AH23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH22",
+        "south": "AH24",
+        "west": "AG23",
+        "east": "AI23"
       }
     },
     {
-      "row": 23,
-      "col": 35,
-      "color": null,
+      "id": "AI23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI22",
+        "south": "AI24",
+        "west": "AH23",
+        "east": "AJ23"
       }
     },
     {
-      "row": 23,
-      "col": 36,
-      "color": null,
+      "id": "AJ23",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ22",
+        "south": "AJ24",
+        "west": "AI23",
+        "east": "AK23"
       }
     },
     {
-      "row": 23,
-      "col": 37,
-      "color": null,
+      "id": "AK23",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK22",
+        "south": "AK24",
+        "west": "AJ23",
+        "east": "AL23"
       }
     },
     {
-      "row": 23,
-      "col": 38,
-      "color": null,
+      "id": "AL23",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL22",
+        "south": "AL24",
+        "west": "AK23",
+        "east": "AM23"
       }
     },
     {
-      "row": 23,
-      "col": 39,
-      "color": null,
+      "id": "AM23",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM22",
+        "south": "AM24",
+        "west": "AL23",
+        "east": "AN23"
       }
     },
     {
-      "row": 23,
-      "col": 40,
-      "color": null,
+      "id": "AN23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN22",
+        "south": "AN24",
+        "west": "AM23",
+        "east": "AO23"
       }
     },
     {
-      "row": 23,
-      "col": 41,
-      "color": null,
+      "id": "AO23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO22",
+        "south": "AO24",
+        "west": "AN23",
+        "east": "AP23"
       }
     },
     {
-      "row": 23,
-      "col": 42,
-      "color": null,
+      "id": "AP23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP22",
+        "south": "AP24",
+        "west": "AO23",
+        "east": "AQ23"
       }
     },
     {
-      "row": 23,
-      "col": 43,
-      "color": null,
+      "id": "AQ23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ22",
+        "south": "AQ24",
+        "west": "AP23",
+        "east": "AR23"
       }
     },
     {
-      "row": 23,
-      "col": 44,
-      "color": null,
+      "id": "AR23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR22",
+        "south": "AR24",
+        "west": "AQ23",
+        "east": "AS23"
       }
     },
     {
-      "row": 23,
-      "col": 45,
-      "color": null,
+      "id": "AS23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS22",
+        "south": "AS24",
+        "west": "AR23",
+        "east": "AT23"
       }
     },
     {
-      "row": 23,
-      "col": 46,
-      "color": null,
+      "id": "AT23",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT22",
+        "south": "AT24",
+        "west": "AS23",
+        "east": "AU23"
       }
     },
     {
-      "row": 23,
-      "col": 47,
-      "color": null,
+      "id": "AU23",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU22",
+        "south": "AU24",
+        "west": "AT23",
+        "east": "AV23"
       }
     },
     {
-      "row": 23,
-      "col": 48,
-      "color": null,
+      "id": "AV23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV22",
+        "south": "AV24",
+        "west": "AU23",
+        "east": "AW23"
       }
     },
     {
-      "row": 23,
-      "col": 49,
-      "color": null,
+      "id": "AW23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW22",
+        "south": "AW24",
+        "west": "AV23",
+        "east": "AX23"
       }
     },
     {
-      "row": 23,
-      "col": 50,
-      "color": null,
+      "id": "AX23",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX22",
+        "south": "AX24",
+        "west": "AW23"
       }
     },
     {
-      "row": 24,
-      "col": 1,
-      "color": null,
+      "id": "A24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A23",
+        "south": "A25",
+        "east": "B24"
       }
     },
     {
-      "row": 24,
-      "col": 2,
-      "color": null,
+      "id": "B24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B23",
+        "south": "B25",
+        "west": "A24",
+        "east": "C24"
       }
     },
     {
-      "row": 24,
-      "col": 3,
-      "color": null,
+      "id": "C24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C23",
+        "south": "C25",
+        "west": "B24",
+        "east": "D24"
       }
     },
     {
-      "row": 24,
-      "col": 4,
-      "color": null,
+      "id": "D24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D23",
+        "south": "D25",
+        "west": "C24",
+        "east": "E24"
       }
     },
     {
-      "row": 24,
-      "col": 5,
-      "color": null,
+      "id": "E24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E23",
+        "south": "E25",
+        "west": "D24",
+        "east": "F24"
       }
     },
     {
-      "row": 24,
-      "col": 6,
-      "color": null,
+      "id": "F24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F23",
+        "south": "F25",
+        "west": "E24",
+        "east": "G24"
       }
     },
     {
-      "row": 24,
-      "col": 7,
-      "color": null,
+      "id": "G24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G23",
+        "south": "G25",
+        "west": "F24",
+        "east": "H24"
       }
     },
     {
-      "row": 24,
-      "col": 8,
-      "color": null,
+      "id": "H24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H23",
+        "south": "H25",
+        "west": "G24",
+        "east": "I24"
       }
     },
     {
-      "row": 24,
-      "col": 9,
-      "color": null,
+      "id": "I24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I23",
+        "south": "I25",
+        "west": "H24",
+        "east": "J24"
       }
     },
     {
-      "row": 24,
-      "col": 10,
-      "color": null,
+      "id": "J24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J23",
+        "south": "J25",
+        "west": "I24",
+        "east": "K24"
       }
     },
     {
-      "row": 24,
-      "col": 11,
-      "color": null,
+      "id": "K24",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K23",
+        "south": "K25",
+        "west": "J24",
+        "east": "L24"
       }
     },
     {
-      "row": 24,
-      "col": 12,
-      "color": null,
+      "id": "L24",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L23",
+        "south": "L25",
+        "west": "K24",
+        "east": "M24"
       }
     },
     {
-      "row": 24,
-      "col": 13,
-      "color": null,
+      "id": "M24",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M23",
+        "south": "M25",
+        "west": "L24",
+        "east": "N24"
       }
     },
     {
-      "row": 24,
-      "col": 14,
-      "color": null,
+      "id": "N24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N23",
+        "south": "N25",
+        "west": "M24",
+        "east": "O24"
       }
     },
     {
-      "row": 24,
-      "col": 15,
-      "color": null,
+      "id": "O24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O23",
+        "south": "O25",
+        "west": "N24",
+        "east": "P24"
       }
     },
     {
-      "row": 24,
-      "col": 16,
-      "color": null,
+      "id": "P24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P23",
+        "south": "P25",
+        "west": "O24",
+        "east": "Q24"
       }
     },
     {
-      "row": 24,
-      "col": 17,
-      "color": null,
+      "id": "Q24",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q23",
+        "south": "Q25",
+        "west": "P24",
+        "east": "R24"
       }
     },
     {
-      "row": 24,
-      "col": 18,
-      "color": null,
+      "id": "R24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R23",
+        "south": "R25",
+        "west": "Q24",
+        "east": "S24"
       }
     },
     {
-      "row": 24,
-      "col": 19,
-      "color": null,
+      "id": "S24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S23",
+        "south": "S25",
+        "west": "R24",
+        "east": "T24"
       }
     },
     {
-      "row": 24,
-      "col": 20,
-      "color": null,
+      "id": "T24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T23",
+        "south": "T25",
+        "west": "S24",
+        "east": "U24"
       }
     },
     {
-      "row": 24,
-      "col": 21,
-      "color": null,
+      "id": "U24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U23",
+        "south": "U25",
+        "west": "T24",
+        "east": "V24"
       }
     },
     {
-      "row": 24,
-      "col": 22,
-      "color": null,
+      "id": "V24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V23",
+        "south": "V25",
+        "west": "U24",
+        "east": "W24"
       }
     },
     {
-      "row": 24,
-      "col": 23,
-      "color": null,
+      "id": "W24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W23",
+        "south": "W25",
+        "west": "V24",
+        "east": "X24"
       }
     },
     {
-      "row": 24,
-      "col": 24,
-      "color": null,
+      "id": "X24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X23",
+        "south": "X25",
+        "west": "W24",
+        "east": "Y24"
       }
     },
     {
-      "row": 24,
-      "col": 25,
-      "color": null,
+      "id": "Y24",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y23",
+        "south": "Y25",
+        "west": "X24",
+        "east": "Z24"
       }
     },
     {
-      "row": 24,
-      "col": 26,
-      "color": null,
+      "id": "Z24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z23",
+        "south": "Z25",
+        "west": "Y24",
+        "east": "AA24"
       }
     },
     {
-      "row": 24,
-      "col": 27,
-      "color": null,
+      "id": "AA24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA23",
+        "south": "AA25",
+        "west": "Z24",
+        "east": "AB24"
       }
     },
     {
-      "row": 24,
-      "col": 28,
-      "color": null,
+      "id": "AB24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB23",
+        "south": "AB25",
+        "west": "AA24",
+        "east": "AC24"
       }
     },
     {
-      "row": 24,
-      "col": 29,
-      "color": null,
+      "id": "AC24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC23",
+        "south": "AC25",
+        "west": "AB24",
+        "east": "AD24"
       }
     },
     {
-      "row": 24,
-      "col": 30,
-      "color": null,
+      "id": "AD24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD23",
+        "south": "AD25",
+        "west": "AC24",
+        "east": "AE24"
       }
     },
     {
-      "row": 24,
-      "col": 31,
-      "color": null,
+      "id": "AE24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE23",
+        "south": "AE25",
+        "west": "AD24",
+        "east": "AF24"
       }
     },
     {
-      "row": 24,
-      "col": 32,
-      "color": null,
+      "id": "AF24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF23",
+        "south": "AF25",
+        "west": "AE24",
+        "east": "AG24"
       }
     },
     {
-      "row": 24,
-      "col": 33,
-      "color": null,
+      "id": "AG24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG23",
+        "south": "AG25",
+        "west": "AF24",
+        "east": "AH24"
       }
     },
     {
-      "row": 24,
-      "col": 34,
-      "color": null,
+      "id": "AH24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH23",
+        "south": "AH25",
+        "west": "AG24",
+        "east": "AI24"
       }
     },
     {
-      "row": 24,
-      "col": 35,
-      "color": null,
+      "id": "AI24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI23",
+        "south": "AI25",
+        "west": "AH24",
+        "east": "AJ24"
       }
     },
     {
-      "row": 24,
-      "col": 36,
-      "color": null,
+      "id": "AJ24",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ23",
+        "south": "AJ25",
+        "west": "AI24",
+        "east": "AK24"
       }
     },
     {
-      "row": 24,
-      "col": 37,
-      "color": null,
+      "id": "AK24",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK23",
+        "south": "AK25",
+        "west": "AJ24",
+        "east": "AL24"
       }
     },
     {
-      "row": 24,
-      "col": 38,
-      "color": null,
+      "id": "AL24",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL23",
+        "south": "AL25",
+        "west": "AK24",
+        "east": "AM24"
       }
     },
     {
-      "row": 24,
-      "col": 39,
-      "color": null,
+      "id": "AM24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM23",
+        "south": "AM25",
+        "west": "AL24",
+        "east": "AN24"
       }
     },
     {
-      "row": 24,
-      "col": 40,
-      "color": null,
+      "id": "AN24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN23",
+        "south": "AN25",
+        "west": "AM24",
+        "east": "AO24"
       }
     },
     {
-      "row": 24,
-      "col": 41,
-      "color": null,
+      "id": "AO24",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO23",
+        "south": "AO25",
+        "west": "AN24",
+        "east": "AP24"
       }
     },
     {
-      "row": 24,
-      "col": 42,
-      "color": null,
+      "id": "AP24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP23",
+        "south": "AP25",
+        "west": "AO24",
+        "east": "AQ24"
       }
     },
     {
-      "row": 24,
-      "col": 43,
-      "color": null,
+      "id": "AQ24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ23",
+        "south": "AQ25",
+        "west": "AP24",
+        "east": "AR24"
       }
     },
     {
-      "row": 24,
-      "col": 44,
-      "color": null,
+      "id": "AR24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR23",
+        "south": "AR25",
+        "west": "AQ24",
+        "east": "AS24"
       }
     },
     {
-      "row": 24,
-      "col": 45,
-      "color": null,
+      "id": "AS24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS23",
+        "south": "AS25",
+        "west": "AR24",
+        "east": "AT24"
       }
     },
     {
-      "row": 24,
-      "col": 46,
-      "color": null,
+      "id": "AT24",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT23",
+        "south": "AT25",
+        "west": "AS24",
+        "east": "AU24"
       }
     },
     {
-      "row": 24,
-      "col": 47,
-      "color": null,
+      "id": "AU24",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU23",
+        "south": "AU25",
+        "west": "AT24",
+        "east": "AV24"
       }
     },
     {
-      "row": 24,
-      "col": 48,
-      "color": null,
+      "id": "AV24",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV23",
+        "south": "AV25",
+        "west": "AU24",
+        "east": "AW24"
       }
     },
     {
-      "row": 24,
-      "col": 49,
-      "color": null,
+      "id": "AW24",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW23",
+        "south": "AW25",
+        "west": "AV24",
+        "east": "AX24"
       }
     },
     {
-      "row": 24,
-      "col": 50,
-      "color": null,
+      "id": "AX24",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX23",
+        "south": "AX25",
+        "west": "AW24"
       }
     },
     {
-      "row": 25,
-      "col": 1,
-      "color": null,
+      "id": "A25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A24",
+        "south": "A26",
+        "east": "B25"
       }
     },
     {
-      "row": 25,
-      "col": 2,
-      "color": null,
+      "id": "B25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B24",
+        "south": "B26",
+        "west": "A25",
+        "east": "C25"
       }
     },
     {
-      "row": 25,
-      "col": 3,
-      "color": null,
+      "id": "C25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C24",
+        "south": "C26",
+        "west": "B25",
+        "east": "D25"
       }
     },
     {
-      "row": 25,
-      "col": 4,
-      "color": null,
+      "id": "D25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D24",
+        "south": "D26",
+        "west": "C25",
+        "east": "E25"
       }
     },
     {
-      "row": 25,
-      "col": 5,
-      "color": null,
+      "id": "E25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E24",
+        "south": "E26",
+        "west": "D25",
+        "east": "F25"
       }
     },
     {
-      "row": 25,
-      "col": 6,
-      "color": null,
+      "id": "F25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F24",
+        "south": "F26",
+        "west": "E25",
+        "east": "G25"
       }
     },
     {
-      "row": 25,
-      "col": 7,
-      "color": null,
+      "id": "G25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G24",
+        "south": "G26",
+        "west": "F25",
+        "east": "H25"
       }
     },
     {
-      "row": 25,
-      "col": 8,
-      "color": null,
+      "id": "H25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H24",
+        "south": "H26",
+        "west": "G25",
+        "east": "I25"
       }
     },
     {
-      "row": 25,
-      "col": 9,
-      "color": null,
+      "id": "I25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I24",
+        "south": "I26",
+        "west": "H25",
+        "east": "J25"
       }
     },
     {
-      "row": 25,
-      "col": 10,
-      "color": null,
+      "id": "J25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J24",
+        "south": "J26",
+        "west": "I25",
+        "east": "K25"
       }
     },
     {
-      "row": 25,
-      "col": 11,
-      "color": null,
+      "id": "K25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K24",
+        "south": "K26",
+        "west": "J25",
+        "east": "L25"
       }
     },
     {
-      "row": 25,
-      "col": 12,
-      "color": null,
+      "id": "L25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L24",
+        "south": "L26",
+        "west": "K25",
+        "east": "M25"
       }
     },
     {
-      "row": 25,
-      "col": 13,
-      "color": null,
+      "id": "M25",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M24",
+        "south": "M26",
+        "west": "L25",
+        "east": "N25"
       }
     },
     {
-      "row": 25,
-      "col": 14,
-      "color": null,
+      "id": "N25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N24",
+        "south": "N26",
+        "west": "M25",
+        "east": "O25"
       }
     },
     {
-      "row": 25,
-      "col": 15,
-      "color": null,
+      "id": "O25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O24",
+        "south": "O26",
+        "west": "N25",
+        "east": "P25"
       }
     },
     {
-      "row": 25,
-      "col": 16,
-      "color": null,
+      "id": "P25",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P24",
+        "south": "P26",
+        "west": "O25",
+        "east": "Q25"
       }
     },
     {
-      "row": 25,
-      "col": 17,
-      "color": null,
+      "id": "Q25",
+      "terrain": "crevice",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q24",
+        "south": "Q26",
+        "west": "P25",
+        "east": "R25"
       }
     },
     {
-      "row": 25,
-      "col": 18,
-      "color": null,
+      "id": "R25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R24",
+        "south": "R26",
+        "west": "Q25",
+        "east": "S25"
       }
     },
     {
-      "row": 25,
-      "col": 19,
-      "color": null,
+      "id": "S25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S24",
+        "south": "S26",
+        "west": "R25",
+        "east": "T25"
       }
     },
     {
-      "row": 25,
-      "col": 20,
-      "color": null,
+      "id": "T25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T24",
+        "south": "T26",
+        "west": "S25",
+        "east": "U25"
       }
     },
     {
-      "row": 25,
-      "col": 21,
-      "color": null,
+      "id": "U25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U24",
+        "south": "U26",
+        "west": "T25",
+        "east": "V25"
       }
     },
     {
-      "row": 25,
-      "col": 22,
-      "color": null,
+      "id": "V25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V24",
+        "south": "V26",
+        "west": "U25",
+        "east": "W25"
       }
     },
     {
-      "row": 25,
-      "col": 23,
-      "color": null,
+      "id": "W25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W24",
+        "south": "W26",
+        "west": "V25",
+        "east": "X25"
       }
     },
     {
-      "row": 25,
-      "col": 24,
-      "color": null,
+      "id": "X25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X24",
+        "south": "X26",
+        "west": "W25",
+        "east": "Y25"
       }
     },
     {
-      "row": 25,
-      "col": 25,
-      "color": null,
+      "id": "Y25",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y24",
+        "south": "Y26",
+        "west": "X25",
+        "east": "Z25"
       }
     },
     {
-      "row": 25,
-      "col": 26,
-      "color": null,
+      "id": "Z25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z24",
+        "south": "Z26",
+        "west": "Y25",
+        "east": "AA25"
       }
     },
     {
-      "row": 25,
-      "col": 27,
-      "color": null,
+      "id": "AA25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA24",
+        "south": "AA26",
+        "west": "Z25",
+        "east": "AB25"
       }
     },
     {
-      "row": 25,
-      "col": 28,
-      "color": null,
+      "id": "AB25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB24",
+        "south": "AB26",
+        "west": "AA25",
+        "east": "AC25"
       }
     },
     {
-      "row": 25,
-      "col": 29,
-      "color": null,
+      "id": "AC25",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC24",
+        "south": "AC26",
+        "west": "AB25",
+        "east": "AD25"
       }
     },
     {
-      "row": 25,
-      "col": 30,
-      "color": null,
+      "id": "AD25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD24",
+        "south": "AD26",
+        "west": "AC25",
+        "east": "AE25"
       }
     },
     {
-      "row": 25,
-      "col": 31,
-      "color": null,
+      "id": "AE25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE24",
+        "south": "AE26",
+        "west": "AD25",
+        "east": "AF25"
       }
     },
     {
-      "row": 25,
-      "col": 32,
-      "color": null,
+      "id": "AF25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF24",
+        "south": "AF26",
+        "west": "AE25",
+        "east": "AG25"
       }
     },
     {
-      "row": 25,
-      "col": 33,
-      "color": null,
+      "id": "AG25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG24",
+        "south": "AG26",
+        "west": "AF25",
+        "east": "AH25"
       }
     },
     {
-      "row": 25,
-      "col": 34,
-      "color": null,
+      "id": "AH25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH24",
+        "south": "AH26",
+        "west": "AG25",
+        "east": "AI25"
       }
     },
     {
-      "row": 25,
-      "col": 35,
-      "color": null,
+      "id": "AI25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI24",
+        "south": "AI26",
+        "west": "AH25",
+        "east": "AJ25"
       }
     },
     {
-      "row": 25,
-      "col": 36,
-      "color": null,
+      "id": "AJ25",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ24",
+        "south": "AJ26",
+        "west": "AI25",
+        "east": "AK25"
       }
     },
     {
-      "row": 25,
-      "col": 37,
-      "color": null,
+      "id": "AK25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK24",
+        "south": "AK26",
+        "west": "AJ25",
+        "east": "AL25"
       }
     },
     {
-      "row": 25,
-      "col": 38,
-      "color": null,
+      "id": "AL25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL24",
+        "south": "AL26",
+        "west": "AK25",
+        "east": "AM25"
       }
     },
     {
-      "row": 25,
-      "col": 39,
-      "color": null,
+      "id": "AM25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM24",
+        "south": "AM26",
+        "west": "AL25",
+        "east": "AN25"
       }
     },
     {
-      "row": 25,
-      "col": 40,
-      "color": null,
+      "id": "AN25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN24",
+        "south": "AN26",
+        "west": "AM25",
+        "east": "AO25"
       }
     },
     {
-      "row": 25,
-      "col": 41,
-      "color": null,
+      "id": "AO25",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO24",
+        "south": "AO26",
+        "west": "AN25",
+        "east": "AP25"
       }
     },
     {
-      "row": 25,
-      "col": 42,
-      "color": null,
+      "id": "AP25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP24",
+        "south": "AP26",
+        "west": "AO25",
+        "east": "AQ25"
       }
     },
     {
-      "row": 25,
-      "col": 43,
-      "color": null,
+      "id": "AQ25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ24",
+        "south": "AQ26",
+        "west": "AP25",
+        "east": "AR25"
       }
     },
     {
-      "row": 25,
-      "col": 44,
-      "color": null,
+      "id": "AR25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR24",
+        "south": "AR26",
+        "west": "AQ25",
+        "east": "AS25"
       }
     },
     {
-      "row": 25,
-      "col": 45,
-      "color": null,
+      "id": "AS25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS24",
+        "south": "AS26",
+        "west": "AR25",
+        "east": "AT25"
       }
     },
     {
-      "row": 25,
-      "col": 46,
-      "color": null,
+      "id": "AT25",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT24",
+        "south": "AT26",
+        "west": "AS25",
+        "east": "AU25"
       }
     },
     {
-      "row": 25,
-      "col": 47,
-      "color": null,
+      "id": "AU25",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU24",
+        "south": "AU26",
+        "west": "AT25",
+        "east": "AV25"
       }
     },
     {
-      "row": 25,
-      "col": 48,
-      "color": null,
+      "id": "AV25",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV24",
+        "south": "AV26",
+        "west": "AU25",
+        "east": "AW25"
       }
     },
     {
-      "row": 25,
-      "col": 49,
-      "color": null,
+      "id": "AW25",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW24",
+        "south": "AW26",
+        "west": "AV25",
+        "east": "AX25"
       }
     },
     {
-      "row": 25,
-      "col": 50,
-      "color": null,
+      "id": "AX25",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX24",
+        "south": "AX26",
+        "west": "AW25"
       }
     },
     {
-      "row": 26,
-      "col": 1,
-      "color": null,
+      "id": "A26",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A25",
+        "south": "A27",
+        "east": "B26"
       }
     },
     {
-      "row": 26,
-      "col": 2,
-      "color": null,
+      "id": "B26",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B25",
+        "south": "B27",
+        "west": "A26",
+        "east": "C26"
       }
     },
     {
-      "row": 26,
-      "col": 3,
-      "color": null,
+      "id": "C26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C25",
+        "south": "C27",
+        "west": "B26",
+        "east": "D26"
       }
     },
     {
-      "row": 26,
-      "col": 4,
-      "color": null,
+      "id": "D26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D25",
+        "south": "D27",
+        "west": "C26",
+        "east": "E26"
       }
     },
     {
-      "row": 26,
-      "col": 5,
-      "color": null,
+      "id": "E26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E25",
+        "south": "E27",
+        "west": "D26",
+        "east": "F26"
       }
     },
     {
-      "row": 26,
-      "col": 6,
-      "color": null,
+      "id": "F26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F25",
+        "south": "F27",
+        "west": "E26",
+        "east": "G26"
       }
     },
     {
-      "row": 26,
-      "col": 7,
-      "color": null,
+      "id": "G26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G25",
+        "south": "G27",
+        "west": "F26",
+        "east": "H26"
       }
     },
     {
-      "row": 26,
-      "col": 8,
-      "color": null,
+      "id": "H26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H25",
+        "south": "H27",
+        "west": "G26",
+        "east": "I26"
       }
     },
     {
-      "row": 26,
-      "col": 9,
-      "color": null,
+      "id": "I26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I25",
+        "south": "I27",
+        "west": "H26",
+        "east": "J26"
       }
     },
     {
-      "row": 26,
-      "col": 10,
-      "color": null,
+      "id": "J26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J25",
+        "south": "J27",
+        "west": "I26",
+        "east": "K26"
       }
     },
     {
-      "row": 26,
-      "col": 11,
-      "color": null,
+      "id": "K26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K25",
+        "south": "K27",
+        "west": "J26",
+        "east": "L26"
       }
     },
     {
-      "row": 26,
-      "col": 12,
-      "color": null,
+      "id": "L26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L25",
+        "south": "L27",
+        "west": "K26",
+        "east": "M26"
       }
     },
     {
-      "row": 26,
-      "col": 13,
-      "color": null,
+      "id": "M26",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M25",
+        "south": "M27",
+        "west": "L26",
+        "east": "N26"
       }
     },
     {
-      "row": 26,
-      "col": 14,
-      "color": null,
+      "id": "N26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N25",
+        "south": "N27",
+        "west": "M26",
+        "east": "O26"
       }
     },
     {
-      "row": 26,
-      "col": 15,
-      "color": null,
+      "id": "O26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O25",
+        "south": "O27",
+        "west": "N26",
+        "east": "P26"
       }
     },
     {
-      "row": 26,
-      "col": 16,
-      "color": null,
+      "id": "P26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P25",
+        "south": "P27",
+        "west": "O26",
+        "east": "Q26"
       }
     },
     {
-      "row": 26,
-      "col": 17,
-      "color": null,
+      "id": "Q26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q25",
+        "south": "Q27",
+        "west": "P26",
+        "east": "R26"
       }
     },
     {
-      "row": 26,
-      "col": 18,
-      "color": null,
+      "id": "R26",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R25",
+        "south": "R27",
+        "west": "Q26",
+        "east": "S26"
       }
     },
     {
-      "row": 26,
-      "col": 19,
-      "color": null,
+      "id": "S26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S25",
+        "south": "S27",
+        "west": "R26",
+        "east": "T26"
       }
     },
     {
-      "row": 26,
-      "col": 20,
-      "color": null,
+      "id": "T26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T25",
+        "south": "T27",
+        "west": "S26",
+        "east": "U26"
       }
     },
     {
-      "row": 26,
-      "col": 21,
-      "color": null,
+      "id": "U26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U25",
+        "south": "U27",
+        "west": "T26",
+        "east": "V26"
       }
     },
     {
-      "row": 26,
-      "col": 22,
-      "color": null,
+      "id": "V26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V25",
+        "south": "V27",
+        "west": "U26",
+        "east": "W26"
       }
     },
     {
-      "row": 26,
-      "col": 23,
-      "color": null,
+      "id": "W26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W25",
+        "south": "W27",
+        "west": "V26",
+        "east": "X26"
       }
     },
     {
-      "row": 26,
-      "col": 24,
-      "color": null,
+      "id": "X26",
+      "terrain": "nv",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X25",
+        "south": "X27",
+        "west": "W26",
+        "east": "Y26"
       }
     },
     {
-      "row": 26,
-      "col": 25,
-      "color": null,
+      "id": "Y26",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y25",
+        "south": "Y27",
+        "west": "X26",
+        "east": "Z26"
       }
     },
     {
-      "row": 26,
-      "col": 26,
-      "color": null,
+      "id": "Z26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z25",
+        "south": "Z27",
+        "west": "Y26",
+        "east": "AA26"
       }
     },
     {
-      "row": 26,
-      "col": 27,
-      "color": null,
+      "id": "AA26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA25",
+        "south": "AA27",
+        "west": "Z26",
+        "east": "AB26"
       }
     },
     {
-      "row": 26,
-      "col": 28,
-      "color": null,
+      "id": "AB26",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB25",
+        "south": "AB27",
+        "west": "AA26",
+        "east": "AC26"
       }
     },
     {
-      "row": 26,
-      "col": 29,
-      "color": null,
+      "id": "AC26",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC25",
+        "south": "AC27",
+        "west": "AB26",
+        "east": "AD26"
       }
     },
     {
-      "row": 26,
-      "col": 30,
-      "color": null,
+      "id": "AD26",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD25",
+        "south": "AD27",
+        "west": "AC26",
+        "east": "AE26"
       }
     },
     {
-      "row": 26,
-      "col": 31,
-      "color": null,
+      "id": "AE26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE25",
+        "south": "AE27",
+        "west": "AD26",
+        "east": "AF26"
       }
     },
     {
-      "row": 26,
-      "col": 32,
-      "color": null,
+      "id": "AF26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF25",
+        "south": "AF27",
+        "west": "AE26",
+        "east": "AG26"
       }
     },
     {
-      "row": 26,
-      "col": 33,
-      "color": null,
+      "id": "AG26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG25",
+        "south": "AG27",
+        "west": "AF26",
+        "east": "AH26"
       }
     },
     {
-      "row": 26,
-      "col": 34,
-      "color": null,
+      "id": "AH26",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH25",
+        "south": "AH27",
+        "west": "AG26",
+        "east": "AI26"
       }
     },
     {
-      "row": 26,
-      "col": 35,
-      "color": null,
+      "id": "AI26",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI25",
+        "south": "AI27",
+        "west": "AH26",
+        "east": "AJ26"
       }
     },
     {
-      "row": 26,
-      "col": 36,
-      "color": null,
+      "id": "AJ26",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ25",
+        "south": "AJ27",
+        "west": "AI26",
+        "east": "AK26"
       }
     },
     {
-      "row": 26,
-      "col": 37,
-      "color": null,
+      "id": "AK26",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK25",
+        "south": "AK27",
+        "west": "AJ26",
+        "east": "AL26"
       }
     },
     {
-      "row": 26,
-      "col": 38,
-      "color": null,
+      "id": "AL26",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL25",
+        "south": "AL27",
+        "west": "AK26",
+        "east": "AM26"
       }
     },
     {
-      "row": 26,
-      "col": 39,
-      "color": null,
+      "id": "AM26",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM25",
+        "south": "AM27",
+        "west": "AL26",
+        "east": "AN26"
       }
     },
     {
-      "row": 26,
-      "col": 40,
-      "color": null,
+      "id": "AN26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN25",
+        "south": "AN27",
+        "west": "AM26",
+        "east": "AO26"
       }
     },
     {
-      "row": 26,
-      "col": 41,
-      "color": null,
+      "id": "AO26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO25",
+        "south": "AO27",
+        "west": "AN26",
+        "east": "AP26"
       }
     },
     {
-      "row": 26,
-      "col": 42,
-      "color": null,
+      "id": "AP26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP25",
+        "south": "AP27",
+        "west": "AO26",
+        "east": "AQ26"
       }
     },
     {
-      "row": 26,
-      "col": 43,
-      "color": null,
+      "id": "AQ26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ25",
+        "south": "AQ27",
+        "west": "AP26",
+        "east": "AR26"
       }
     },
     {
-      "row": 26,
-      "col": 44,
-      "color": null,
+      "id": "AR26",
+      "terrain": "cave",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR25",
+        "south": "AR27",
+        "west": "AQ26",
+        "east": "AS26"
       }
     },
     {
-      "row": 26,
-      "col": 45,
-      "color": null,
+      "id": "AS26",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS25",
+        "south": "AS27",
+        "west": "AR26",
+        "east": "AT26"
       }
     },
     {
-      "row": 26,
-      "col": 46,
-      "color": null,
+      "id": "AT26",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT25",
+        "south": "AT27",
+        "west": "AS26",
+        "east": "AU26"
       }
     },
     {
-      "row": 26,
-      "col": 47,
-      "color": null,
+      "id": "AU26",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU25",
+        "south": "AU27",
+        "west": "AT26",
+        "east": "AV26"
       }
     },
     {
-      "row": 26,
-      "col": 48,
-      "color": null,
+      "id": "AV26",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV25",
+        "south": "AV27",
+        "west": "AU26",
+        "east": "AW26"
       }
     },
     {
-      "row": 26,
-      "col": 49,
-      "color": null,
+      "id": "AW26",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW25",
+        "south": "AW27",
+        "west": "AV26",
+        "east": "AX26"
       }
     },
     {
-      "row": 26,
-      "col": 50,
-      "color": null,
+      "id": "AX26",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX25",
+        "south": "AX27",
+        "west": "AW26"
       }
     },
     {
-      "row": 27,
-      "col": 1,
-      "color": null,
+      "id": "A27",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A26",
+        "south": "A28",
+        "east": "B27"
       }
     },
     {
-      "row": 27,
-      "col": 2,
-      "color": null,
+      "id": "B27",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B26",
+        "south": "B28",
+        "west": "A27",
+        "east": "C27"
       }
     },
     {
-      "row": 27,
-      "col": 3,
-      "color": null,
+      "id": "C27",
+      "terrain": "swamp",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C26",
+        "south": "C28",
+        "west": "B27",
+        "east": "D27"
       }
     },
     {
-      "row": 27,
-      "col": 4,
-      "color": null,
+      "id": "D27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D26",
+        "south": "D28",
+        "west": "C27",
+        "east": "E27"
       }
     },
     {
-      "row": 27,
-      "col": 5,
-      "color": null,
+      "id": "E27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E26",
+        "south": "E28",
+        "west": "D27",
+        "east": "F27"
       }
     },
     {
-      "row": 27,
-      "col": 6,
-      "color": null,
+      "id": "F27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F26",
+        "south": "F28",
+        "west": "E27",
+        "east": "G27"
       }
     },
     {
-      "row": 27,
-      "col": 7,
-      "color": null,
+      "id": "G27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G26",
+        "south": "G28",
+        "west": "F27",
+        "east": "H27"
       }
     },
     {
-      "row": 27,
-      "col": 8,
-      "color": null,
+      "id": "H27",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H26",
+        "south": "H28",
+        "west": "G27",
+        "east": "I27"
       }
     },
     {
-      "row": 27,
-      "col": 9,
-      "color": null,
+      "id": "I27",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I26",
+        "south": "I28",
+        "west": "H27",
+        "east": "J27"
       }
     },
     {
-      "row": 27,
-      "col": 10,
-      "color": null,
+      "id": "J27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J26",
+        "south": "J28",
+        "west": "I27",
+        "east": "K27"
       }
     },
     {
-      "row": 27,
-      "col": 11,
-      "color": null,
+      "id": "K27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K26",
+        "south": "K28",
+        "west": "J27",
+        "east": "L27"
       }
     },
     {
-      "row": 27,
-      "col": 12,
-      "color": null,
+      "id": "L27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L26",
+        "south": "L28",
+        "west": "K27",
+        "east": "M27"
       }
     },
     {
-      "row": 27,
-      "col": 13,
-      "color": null,
+      "id": "M27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M26",
+        "south": "M28",
+        "west": "L27",
+        "east": "N27"
       }
     },
     {
-      "row": 27,
-      "col": 14,
-      "color": null,
+      "id": "N27",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N26",
+        "south": "N28",
+        "west": "M27",
+        "east": "O27"
       }
     },
     {
-      "row": 27,
-      "col": 15,
-      "color": null,
+      "id": "O27",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O26",
+        "south": "O28",
+        "west": "N27",
+        "east": "P27"
       }
     },
     {
-      "row": 27,
-      "col": 16,
-      "color": null,
+      "id": "P27",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P26",
+        "south": "P28",
+        "west": "O27",
+        "east": "Q27"
       }
     },
     {
-      "row": 27,
-      "col": 17,
-      "color": null,
+      "id": "Q27",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q26",
+        "south": "Q28",
+        "west": "P27",
+        "east": "R27"
       }
     },
     {
-      "row": 27,
-      "col": 18,
-      "color": null,
+      "id": "R27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R26",
+        "south": "R28",
+        "west": "Q27",
+        "east": "S27"
       }
     },
     {
-      "row": 27,
-      "col": 19,
-      "color": null,
+      "id": "S27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S26",
+        "south": "S28",
+        "west": "R27",
+        "east": "T27"
       }
     },
     {
-      "row": 27,
-      "col": 20,
-      "color": null,
+      "id": "T27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T26",
+        "south": "T28",
+        "west": "S27",
+        "east": "U27"
       }
     },
     {
-      "row": 27,
-      "col": 21,
-      "color": null,
+      "id": "U27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U26",
+        "south": "U28",
+        "west": "T27",
+        "east": "V27"
       }
     },
     {
-      "row": 27,
-      "col": 22,
-      "color": null,
+      "id": "V27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V26",
+        "south": "V28",
+        "west": "U27",
+        "east": "W27"
       }
     },
     {
-      "row": 27,
-      "col": 23,
-      "color": null,
+      "id": "W27",
+      "terrain": "wv",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W26",
+        "south": "W28",
+        "west": "V27",
+        "east": "X27"
       }
     },
     {
-      "row": 27,
-      "col": 24,
-      "color": null,
+      "id": "X27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X26",
+        "south": "X28",
+        "west": "W27",
+        "east": "Y27"
       }
     },
     {
-      "row": 27,
-      "col": 25,
-      "color": null,
+      "id": "Y27",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y26",
+        "south": "Y28",
+        "west": "X27",
+        "east": "Z27"
       }
     },
     {
-      "row": 27,
-      "col": 26,
-      "color": null,
+      "id": "Z27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z26",
+        "south": "Z28",
+        "west": "Y27",
+        "east": "AA27"
       }
     },
     {
-      "row": 27,
-      "col": 27,
-      "color": null,
+      "id": "AA27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA26",
+        "south": "AA28",
+        "west": "Z27",
+        "east": "AB27"
       }
     },
     {
-      "row": 27,
-      "col": 28,
-      "color": null,
+      "id": "AB27",
+      "terrain": "village",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB26",
+        "south": "AB28",
+        "west": "AA27",
+        "east": "AC27"
       }
     },
     {
-      "row": 27,
-      "col": 29,
-      "color": null,
+      "id": "AC27",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC26",
+        "south": "AC28",
+        "west": "AB27",
+        "east": "AD27"
       }
     },
     {
-      "row": 27,
-      "col": 30,
-      "color": null,
+      "id": "AD27",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD26",
+        "south": "AD28",
+        "west": "AC27",
+        "east": "AE27"
       }
     },
     {
-      "row": 27,
-      "col": 31,
-      "color": null,
+      "id": "AE27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE26",
+        "south": "AE28",
+        "west": "AD27",
+        "east": "AF27"
       }
     },
     {
-      "row": 27,
-      "col": 32,
-      "color": null,
+      "id": "AF27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF26",
+        "south": "AF28",
+        "west": "AE27",
+        "east": "AG27"
       }
     },
     {
-      "row": 27,
-      "col": 33,
-      "color": null,
+      "id": "AG27",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG26",
+        "south": "AG28",
+        "west": "AF27",
+        "east": "AH27"
       }
     },
     {
-      "row": 27,
-      "col": 34,
-      "color": null,
+      "id": "AH27",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH26",
+        "south": "AH28",
+        "west": "AG27",
+        "east": "AI27"
       }
     },
     {
-      "row": 27,
-      "col": 35,
-      "color": null,
+      "id": "AI27",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI26",
+        "south": "AI28",
+        "west": "AH27",
+        "east": "AJ27"
       }
     },
     {
-      "row": 27,
-      "col": 36,
-      "color": null,
+      "id": "AJ27",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ26",
+        "south": "AJ28",
+        "west": "AI27",
+        "east": "AK27"
       }
     },
     {
-      "row": 27,
-      "col": 37,
-      "color": null,
+      "id": "AK27",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK26",
+        "south": "AK28",
+        "west": "AJ27",
+        "east": "AL27"
       }
     },
     {
-      "row": 27,
-      "col": 38,
-      "color": null,
+      "id": "AL27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL26",
+        "south": "AL28",
+        "west": "AK27",
+        "east": "AM27"
       }
     },
     {
-      "row": 27,
-      "col": 39,
-      "color": null,
+      "id": "AM27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM26",
+        "south": "AM28",
+        "west": "AL27",
+        "east": "AN27"
       }
     },
     {
-      "row": 27,
-      "col": 40,
-      "color": null,
+      "id": "AN27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN26",
+        "south": "AN28",
+        "west": "AM27",
+        "east": "AO27"
       }
     },
     {
-      "row": 27,
-      "col": 41,
-      "color": null,
+      "id": "AO27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO26",
+        "south": "AO28",
+        "west": "AN27",
+        "east": "AP27"
       }
     },
     {
-      "row": 27,
-      "col": 42,
-      "color": null,
+      "id": "AP27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP26",
+        "south": "AP28",
+        "west": "AO27",
+        "east": "AQ27"
       }
     },
     {
-      "row": 27,
-      "col": 43,
-      "color": null,
+      "id": "AQ27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ26",
+        "south": "AQ28",
+        "west": "AP27",
+        "east": "AR27"
       }
     },
     {
-      "row": 27,
-      "col": 44,
-      "color": null,
+      "id": "AR27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR26",
+        "south": "AR28",
+        "west": "AQ27",
+        "east": "AS27"
       }
     },
     {
-      "row": 27,
-      "col": 45,
-      "color": null,
+      "id": "AS27",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS26",
+        "south": "AS28",
+        "west": "AR27",
+        "east": "AT27"
       }
     },
     {
-      "row": 27,
-      "col": 46,
-      "color": null,
+      "id": "AT27",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT26",
+        "south": "AT28",
+        "west": "AS27",
+        "east": "AU27"
       }
     },
     {
-      "row": 27,
-      "col": 47,
-      "color": null,
+      "id": "AU27",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU26",
+        "south": "AU28",
+        "west": "AT27",
+        "east": "AV27"
       }
     },
     {
-      "row": 27,
-      "col": 48,
-      "color": null,
+      "id": "AV27",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV26",
+        "south": "AV28",
+        "west": "AU27",
+        "east": "AW27"
       }
     },
     {
-      "row": 27,
-      "col": 49,
-      "color": null,
+      "id": "AW27",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW26",
+        "south": "AW28",
+        "west": "AV27",
+        "east": "AX27"
       }
     },
     {
-      "row": 27,
-      "col": 50,
-      "color": null,
+      "id": "AX27",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX26",
+        "south": "AX28",
+        "west": "AW27"
       }
     },
     {
-      "row": 28,
-      "col": 1,
-      "color": null,
+      "id": "A28",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A27",
+        "south": "A29",
+        "east": "B28"
       }
     },
     {
-      "row": 28,
-      "col": 2,
-      "color": null,
+      "id": "B28",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B27",
+        "south": "B29",
+        "west": "A28",
+        "east": "C28"
       }
     },
     {
-      "row": 28,
-      "col": 3,
-      "color": null,
+      "id": "C28",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C27",
+        "south": "C29",
+        "west": "B28",
+        "east": "D28"
       }
     },
     {
-      "row": 28,
-      "col": 4,
-      "color": null,
+      "id": "D28",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D27",
+        "south": "D29",
+        "west": "C28",
+        "east": "E28"
       }
     },
     {
-      "row": 28,
-      "col": 5,
-      "color": null,
+      "id": "E28",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E27",
+        "south": "E29",
+        "west": "D28",
+        "east": "F28"
       }
     },
     {
-      "row": 28,
-      "col": 6,
-      "color": null,
+      "id": "F28",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F27",
+        "south": "F29",
+        "west": "E28",
+        "east": "G28"
       }
     },
     {
-      "row": 28,
-      "col": 7,
-      "color": null,
+      "id": "G28",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G27",
+        "south": "G29",
+        "west": "F28",
+        "east": "H28"
       }
     },
     {
-      "row": 28,
-      "col": 8,
-      "color": null,
+      "id": "H28",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H27",
+        "south": "H29",
+        "west": "G28",
+        "east": "I28"
       }
     },
     {
-      "row": 28,
-      "col": 9,
-      "color": null,
+      "id": "I28",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I27",
+        "south": "I29",
+        "west": "H28",
+        "east": "J28"
       }
     },
     {
-      "row": 28,
-      "col": 10,
-      "color": null,
+      "id": "J28",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J27",
+        "south": "J29",
+        "west": "I28",
+        "east": "K28"
       }
     },
     {
-      "row": 28,
-      "col": 11,
-      "color": null,
+      "id": "K28",
+      "terrain": "Candera",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K27",
+        "south": "K29",
+        "west": "J28",
+        "east": "L28"
       }
     },
     {
-      "row": 28,
-      "col": 12,
-      "color": null,
+      "id": "L28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L27",
+        "south": "L29",
+        "west": "K28",
+        "east": "M28"
       }
     },
     {
-      "row": 28,
-      "col": 13,
-      "color": null,
+      "id": "M28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M27",
+        "south": "M29",
+        "west": "L28",
+        "east": "N28"
       }
     },
     {
-      "row": 28,
-      "col": 14,
-      "color": null,
+      "id": "N28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N27",
+        "south": "N29",
+        "west": "M28",
+        "east": "O28"
       }
     },
     {
-      "row": 28,
-      "col": 15,
-      "color": null,
+      "id": "O28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O27",
+        "south": "O29",
+        "west": "N28",
+        "east": "P28"
       }
     },
     {
-      "row": 28,
-      "col": 16,
-      "color": null,
+      "id": "P28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P27",
+        "south": "P29",
+        "west": "O28",
+        "east": "Q28"
       }
     },
     {
-      "row": 28,
-      "col": 17,
-      "color": null,
+      "id": "Q28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q27",
+        "south": "Q29",
+        "west": "P28",
+        "east": "R28"
       }
     },
     {
-      "row": 28,
-      "col": 18,
-      "color": null,
+      "id": "R28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R27",
+        "south": "R29",
+        "west": "Q28",
+        "east": "S28"
       }
     },
     {
-      "row": 28,
-      "col": 19,
-      "color": null,
+      "id": "S28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S27",
+        "south": "S29",
+        "west": "R28",
+        "east": "T28"
       }
     },
     {
-      "row": 28,
-      "col": 20,
-      "color": null,
+      "id": "T28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T27",
+        "south": "T29",
+        "west": "S28",
+        "east": "U28"
       }
     },
     {
-      "row": 28,
-      "col": 21,
-      "color": null,
+      "id": "U28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U27",
+        "south": "U29",
+        "west": "T28",
+        "east": "V28"
       }
     },
     {
-      "row": 28,
-      "col": 22,
-      "color": null,
+      "id": "V28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V27",
+        "south": "V29",
+        "west": "U28",
+        "east": "W28"
       }
     },
     {
-      "row": 28,
-      "col": 23,
-      "color": null,
+      "id": "W28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W27",
+        "south": "W29",
+        "west": "V28",
+        "east": "X28"
       }
     },
     {
-      "row": 28,
-      "col": 24,
-      "color": null,
+      "id": "X28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X27",
+        "south": "X29",
+        "west": "W28",
+        "east": "Y28"
       }
     },
     {
-      "row": 28,
-      "col": 25,
-      "color": null,
+      "id": "Y28",
+      "terrain": "Vesla",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y27",
+        "south": "Y29",
+        "west": "X28",
+        "east": "Z28"
       }
     },
     {
-      "row": 28,
-      "col": 26,
-      "color": null,
+      "id": "Z28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z27",
+        "south": "Z29",
+        "west": "Y28",
+        "east": "AA28"
       }
     },
     {
-      "row": 28,
-      "col": 27,
-      "color": null,
+      "id": "AA28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA27",
+        "south": "AA29",
+        "west": "Z28",
+        "east": "AB28"
       }
     },
     {
-      "row": 28,
-      "col": 28,
-      "color": null,
+      "id": "AB28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB27",
+        "south": "AB29",
+        "west": "AA28",
+        "east": "AC28"
       }
     },
     {
-      "row": 28,
-      "col": 29,
-      "color": null,
+      "id": "AC28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC27",
+        "south": "AC29",
+        "west": "AB28",
+        "east": "AD28"
       }
     },
     {
-      "row": 28,
-      "col": 30,
-      "color": null,
+      "id": "AD28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD27",
+        "south": "AD29",
+        "west": "AC28",
+        "east": "AE28"
       }
     },
     {
-      "row": 28,
-      "col": 31,
-      "color": null,
+      "id": "AE28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE27",
+        "south": "AE29",
+        "west": "AD28",
+        "east": "AF28"
       }
     },
     {
-      "row": 28,
-      "col": 32,
-      "color": null,
+      "id": "AF28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF27",
+        "south": "AF29",
+        "west": "AE28",
+        "east": "AG28"
       }
     },
     {
-      "row": 28,
-      "col": 33,
-      "color": null,
+      "id": "AG28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG27",
+        "south": "AG29",
+        "west": "AF28",
+        "east": "AH28"
       }
     },
     {
-      "row": 28,
-      "col": 34,
-      "color": null,
+      "id": "AH28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH27",
+        "south": "AH29",
+        "west": "AG28",
+        "east": "AI28"
       }
     },
     {
-      "row": 28,
-      "col": 35,
-      "color": null,
+      "id": "AI28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI27",
+        "south": "AI29",
+        "west": "AH28",
+        "east": "AJ28"
       }
     },
     {
-      "row": 28,
-      "col": 36,
-      "color": null,
+      "id": "AJ28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ27",
+        "south": "AJ29",
+        "west": "AI28",
+        "east": "AK28"
       }
     },
     {
-      "row": 28,
-      "col": 37,
-      "color": null,
+      "id": "AK28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK27",
+        "south": "AK29",
+        "west": "AJ28",
+        "east": "AL28"
       }
     },
     {
-      "row": 28,
-      "col": 38,
-      "color": null,
+      "id": "AL28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL27",
+        "south": "AL29",
+        "west": "AK28",
+        "east": "AM28"
       }
     },
     {
-      "row": 28,
-      "col": 39,
-      "color": null,
+      "id": "AM28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM27",
+        "south": "AM29",
+        "west": "AL28",
+        "east": "AN28"
       }
     },
     {
-      "row": 28,
-      "col": 40,
-      "color": null,
+      "id": "AN28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN27",
+        "south": "AN29",
+        "west": "AM28",
+        "east": "AO28"
       }
     },
     {
-      "row": 28,
-      "col": 41,
-      "color": null,
+      "id": "AO28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO27",
+        "south": "AO29",
+        "west": "AN28",
+        "east": "AP28"
       }
     },
     {
-      "row": 28,
-      "col": 42,
-      "color": null,
+      "id": "AP28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP27",
+        "south": "AP29",
+        "west": "AO28",
+        "east": "AQ28"
       }
     },
     {
-      "row": 28,
-      "col": 43,
-      "color": null,
+      "id": "AQ28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ27",
+        "south": "AQ29",
+        "west": "AP28",
+        "east": "AR28"
       }
     },
     {
-      "row": 28,
-      "col": 44,
-      "color": null,
+      "id": "AR28",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR27",
+        "south": "AR29",
+        "west": "AQ28",
+        "east": "AS28"
       }
     },
     {
-      "row": 28,
-      "col": 45,
-      "color": null,
+      "id": "AS28",
+      "terrain": "Exedoria",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS27",
+        "south": "AS29",
+        "west": "AR28",
+        "east": "AT28"
       }
     },
     {
-      "row": 28,
-      "col": 46,
-      "color": null,
+      "id": "AT28",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT27",
+        "south": "AT29",
+        "west": "AS28",
+        "east": "AU28"
       }
     },
     {
-      "row": 28,
-      "col": 47,
-      "color": null,
+      "id": "AU28",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU27",
+        "south": "AU29",
+        "west": "AT28",
+        "east": "AV28"
       }
     },
     {
-      "row": 28,
-      "col": 48,
-      "color": null,
+      "id": "AV28",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV27",
+        "south": "AV29",
+        "west": "AU28",
+        "east": "AW28"
       }
     },
     {
-      "row": 28,
-      "col": 49,
-      "color": null,
+      "id": "AW28",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW27",
+        "south": "AW29",
+        "west": "AV28",
+        "east": "AX28"
       }
     },
     {
-      "row": 28,
-      "col": 50,
-      "color": null,
+      "id": "AX28",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX27",
+        "south": "AX29",
+        "west": "AW28"
       }
     },
     {
-      "row": 29,
-      "col": 1,
-      "color": null,
+      "id": "A29",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A28",
+        "south": "A30",
+        "east": "B29"
       }
     },
     {
-      "row": 29,
-      "col": 2,
-      "color": null,
+      "id": "B29",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B28",
+        "south": "B30",
+        "west": "A29",
+        "east": "C29"
       }
     },
     {
-      "row": 29,
-      "col": 3,
-      "color": null,
+      "id": "C29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C28",
+        "south": "C30",
+        "west": "B29",
+        "east": "D29"
       }
     },
     {
-      "row": 29,
-      "col": 4,
-      "color": null,
+      "id": "D29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D28",
+        "south": "D30",
+        "west": "C29",
+        "east": "E29"
       }
     },
     {
-      "row": 29,
-      "col": 5,
-      "color": null,
+      "id": "E29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E28",
+        "south": "E30",
+        "west": "D29",
+        "east": "F29"
       }
     },
     {
-      "row": 29,
-      "col": 6,
-      "color": null,
+      "id": "F29",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F28",
+        "south": "F30",
+        "west": "E29",
+        "east": "G29"
       }
     },
     {
-      "row": 29,
-      "col": 7,
-      "color": null,
+      "id": "G29",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G28",
+        "south": "G30",
+        "west": "F29",
+        "east": "H29"
       }
     },
     {
-      "row": 29,
-      "col": 8,
-      "color": null,
+      "id": "H29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H28",
+        "south": "H30",
+        "west": "G29",
+        "east": "I29"
       }
     },
     {
-      "row": 29,
-      "col": 9,
-      "color": null,
+      "id": "I29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I28",
+        "south": "I30",
+        "west": "H29",
+        "east": "J29"
       }
     },
     {
-      "row": 29,
-      "col": 10,
-      "color": null,
+      "id": "J29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J28",
+        "south": "J30",
+        "west": "I29",
+        "east": "K29"
       }
     },
     {
-      "row": 29,
-      "col": 11,
-      "color": null,
+      "id": "K29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K28",
+        "south": "K30",
+        "west": "J29",
+        "east": "L29"
       }
     },
     {
-      "row": 29,
-      "col": 12,
-      "color": null,
+      "id": "L29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L28",
+        "south": "L30",
+        "west": "K29",
+        "east": "M29"
       }
     },
     {
-      "row": 29,
-      "col": 13,
-      "color": null,
+      "id": "M29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M28",
+        "south": "M30",
+        "west": "L29",
+        "east": "N29"
       }
     },
     {
-      "row": 29,
-      "col": 14,
-      "color": null,
+      "id": "N29",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N28",
+        "south": "N30",
+        "west": "M29",
+        "east": "O29"
       }
     },
     {
-      "row": 29,
-      "col": 15,
-      "color": null,
+      "id": "O29",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O28",
+        "south": "O30",
+        "west": "N29",
+        "east": "P29"
       }
     },
     {
-      "row": 29,
-      "col": 16,
-      "color": null,
+      "id": "P29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P28",
+        "south": "P30",
+        "west": "O29",
+        "east": "Q29"
       }
     },
     {
-      "row": 29,
-      "col": 17,
-      "color": null,
+      "id": "Q29",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q28",
+        "south": "Q30",
+        "west": "P29",
+        "east": "R29"
       }
     },
     {
-      "row": 29,
-      "col": 18,
-      "color": null,
+      "id": "R29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R28",
+        "south": "R30",
+        "west": "Q29",
+        "east": "S29"
       }
     },
     {
-      "row": 29,
-      "col": 19,
-      "color": null,
+      "id": "S29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S28",
+        "south": "S30",
+        "west": "R29",
+        "east": "T29"
       }
     },
     {
-      "row": 29,
-      "col": 20,
-      "color": null,
+      "id": "T29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T28",
+        "south": "T30",
+        "west": "S29",
+        "east": "U29"
       }
     },
     {
-      "row": 29,
-      "col": 21,
-      "color": null,
+      "id": "U29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U28",
+        "south": "U30",
+        "west": "T29",
+        "east": "V29"
       }
     },
     {
-      "row": 29,
-      "col": 22,
-      "color": null,
+      "id": "V29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V28",
+        "south": "V30",
+        "west": "U29",
+        "east": "W29"
       }
     },
     {
-      "row": 29,
-      "col": 23,
-      "color": null,
+      "id": "W29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W28",
+        "south": "W30",
+        "west": "V29",
+        "east": "X29"
       }
     },
     {
-      "row": 29,
-      "col": 24,
-      "color": null,
+      "id": "X29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X28",
+        "south": "X30",
+        "west": "W29",
+        "east": "Y29"
       }
     },
     {
-      "row": 29,
-      "col": 25,
-      "color": null,
+      "id": "Y29",
+      "terrain": "Nature P",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y28",
+        "south": "Y30",
+        "west": "X29",
+        "east": "Z29"
       }
     },
     {
-      "row": 29,
-      "col": 26,
-      "color": null,
+      "id": "Z29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z28",
+        "south": "Z30",
+        "west": "Y29",
+        "east": "AA29"
       }
     },
     {
-      "row": 29,
-      "col": 27,
-      "color": null,
+      "id": "AA29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA28",
+        "south": "AA30",
+        "west": "Z29",
+        "east": "AB29"
       }
     },
     {
-      "row": 29,
-      "col": 28,
-      "color": null,
+      "id": "AB29",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB28",
+        "south": "AB30",
+        "west": "AA29",
+        "east": "AC29"
       }
     },
     {
-      "row": 29,
-      "col": 29,
-      "color": null,
+      "id": "AC29",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC28",
+        "south": "AC30",
+        "west": "AB29",
+        "east": "AD29"
       }
     },
     {
-      "row": 29,
-      "col": 30,
-      "color": null,
+      "id": "AD29",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD28",
+        "south": "AD30",
+        "west": "AC29",
+        "east": "AE29"
       }
     },
     {
-      "row": 29,
-      "col": 31,
-      "color": null,
+      "id": "AE29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE28",
+        "south": "AE30",
+        "west": "AD29",
+        "east": "AF29"
       }
     },
     {
-      "row": 29,
-      "col": 32,
-      "color": null,
+      "id": "AF29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF28",
+        "south": "AF30",
+        "west": "AE29",
+        "east": "AG29"
       }
     },
     {
-      "row": 29,
-      "col": 33,
-      "color": null,
+      "id": "AG29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG28",
+        "south": "AG30",
+        "west": "AF29",
+        "east": "AH29"
       }
     },
     {
-      "row": 29,
-      "col": 34,
-      "color": null,
+      "id": "AH29",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH28",
+        "south": "AH30",
+        "west": "AG29",
+        "east": "AI29"
       }
     },
     {
-      "row": 29,
-      "col": 35,
-      "color": null,
+      "id": "AI29",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI28",
+        "south": "AI30",
+        "west": "AH29",
+        "east": "AJ29"
       }
     },
     {
-      "row": 29,
-      "col": 36,
-      "color": null,
+      "id": "AJ29",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ28",
+        "south": "AJ30",
+        "west": "AI29",
+        "east": "AK29"
       }
     },
     {
-      "row": 29,
-      "col": 37,
-      "color": null,
+      "id": "AK29",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK28",
+        "south": "AK30",
+        "west": "AJ29",
+        "east": "AL29"
       }
     },
     {
-      "row": 29,
-      "col": 38,
-      "color": null,
+      "id": "AL29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL28",
+        "south": "AL30",
+        "west": "AK29",
+        "east": "AM29"
       }
     },
     {
-      "row": 29,
-      "col": 39,
-      "color": null,
+      "id": "AM29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM28",
+        "south": "AM30",
+        "west": "AL29",
+        "east": "AN29"
       }
     },
     {
-      "row": 29,
-      "col": 40,
-      "color": null,
+      "id": "AN29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN28",
+        "south": "AN30",
+        "west": "AM29",
+        "east": "AO29"
       }
     },
     {
-      "row": 29,
-      "col": 41,
-      "color": null,
+      "id": "AO29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO28",
+        "south": "AO30",
+        "west": "AN29",
+        "east": "AP29"
       }
     },
     {
-      "row": 29,
-      "col": 42,
-      "color": null,
+      "id": "AP29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP28",
+        "south": "AP30",
+        "west": "AO29",
+        "east": "AQ29"
       }
     },
     {
-      "row": 29,
-      "col": 43,
-      "color": null,
+      "id": "AQ29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ28",
+        "south": "AQ30",
+        "west": "AP29",
+        "east": "AR29"
       }
     },
     {
-      "row": 29,
-      "col": 44,
-      "color": null,
+      "id": "AR29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR28",
+        "south": "AR30",
+        "west": "AQ29",
+        "east": "AS29"
       }
     },
     {
-      "row": 29,
-      "col": 45,
-      "color": null,
+      "id": "AS29",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS28",
+        "south": "AS30",
+        "west": "AR29",
+        "east": "AT29"
       }
     },
     {
-      "row": 29,
-      "col": 46,
-      "color": null,
+      "id": "AT29",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT28",
+        "south": "AT30",
+        "west": "AS29",
+        "east": "AU29"
       }
     },
     {
-      "row": 29,
-      "col": 47,
-      "color": null,
+      "id": "AU29",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU28",
+        "south": "AU30",
+        "west": "AT29",
+        "east": "AV29"
       }
     },
     {
-      "row": 29,
-      "col": 48,
-      "color": null,
+      "id": "AV29",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV28",
+        "south": "AV30",
+        "west": "AU29",
+        "east": "AW29"
       }
     },
     {
-      "row": 29,
-      "col": 49,
-      "color": null,
+      "id": "AW29",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW28",
+        "south": "AW30",
+        "west": "AV29",
+        "east": "AX29"
       }
     },
     {
-      "row": 29,
-      "col": 50,
-      "color": null,
+      "id": "AX29",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX28",
+        "south": "AX30",
+        "west": "AW29"
       }
     },
     {
-      "row": 30,
-      "col": 1,
-      "color": null,
+      "id": "A30",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A29",
+        "south": "A31",
+        "east": "B30"
       }
     },
     {
-      "row": 30,
-      "col": 2,
-      "color": null,
+      "id": "B30",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B29",
+        "south": "B31",
+        "west": "A30",
+        "east": "C30"
       }
     },
     {
-      "row": 30,
-      "col": 3,
-      "color": null,
+      "id": "C30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C29",
+        "south": "C31",
+        "west": "B30",
+        "east": "D30"
       }
     },
     {
-      "row": 30,
-      "col": 4,
-      "color": null,
+      "id": "D30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D29",
+        "south": "D31",
+        "west": "C30",
+        "east": "E30"
       }
     },
     {
-      "row": 30,
-      "col": 5,
-      "color": null,
+      "id": "E30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E29",
+        "south": "E31",
+        "west": "D30",
+        "east": "F30"
       }
     },
     {
-      "row": 30,
-      "col": 6,
-      "color": null,
+      "id": "F30",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F29",
+        "south": "F31",
+        "west": "E30",
+        "east": "G30"
       }
     },
     {
-      "row": 30,
-      "col": 7,
-      "color": null,
+      "id": "G30",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G29",
+        "south": "G31",
+        "west": "F30",
+        "east": "H30"
       }
     },
     {
-      "row": 30,
-      "col": 8,
-      "color": null,
+      "id": "H30",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H29",
+        "south": "H31",
+        "west": "G30",
+        "east": "I30"
       }
     },
     {
-      "row": 30,
-      "col": 9,
-      "color": null,
+      "id": "I30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I29",
+        "south": "I31",
+        "west": "H30",
+        "east": "J30"
       }
     },
     {
-      "row": 30,
-      "col": 10,
-      "color": null,
+      "id": "J30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J29",
+        "south": "J31",
+        "west": "I30",
+        "east": "K30"
       }
     },
     {
-      "row": 30,
-      "col": 11,
-      "color": null,
+      "id": "K30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K29",
+        "south": "K31",
+        "west": "J30",
+        "east": "L30"
       }
     },
     {
-      "row": 30,
-      "col": 12,
-      "color": null,
+      "id": "L30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L29",
+        "south": "L31",
+        "west": "K30",
+        "east": "M30"
       }
     },
     {
-      "row": 30,
-      "col": 13,
-      "color": null,
+      "id": "M30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M29",
+        "south": "M31",
+        "west": "L30",
+        "east": "N30"
       }
     },
     {
-      "row": 30,
-      "col": 14,
-      "color": null,
+      "id": "N30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N29",
+        "south": "N31",
+        "west": "M30",
+        "east": "O30"
       }
     },
     {
-      "row": 30,
-      "col": 15,
-      "color": null,
+      "id": "O30",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O29",
+        "south": "O31",
+        "west": "N30",
+        "east": "P30"
       }
     },
     {
-      "row": 30,
-      "col": 16,
-      "color": null,
+      "id": "P30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P29",
+        "south": "P31",
+        "west": "O30",
+        "east": "Q30"
       }
     },
     {
-      "row": 30,
-      "col": 17,
-      "color": null,
+      "id": "Q30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q29",
+        "south": "Q31",
+        "west": "P30",
+        "east": "R30"
       }
     },
     {
-      "row": 30,
-      "col": 18,
-      "color": null,
+      "id": "R30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R29",
+        "south": "R31",
+        "west": "Q30",
+        "east": "S30"
       }
     },
     {
-      "row": 30,
-      "col": 19,
-      "color": null,
+      "id": "S30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S29",
+        "south": "S31",
+        "west": "R30",
+        "east": "T30"
       }
     },
     {
-      "row": 30,
-      "col": 20,
-      "color": null,
+      "id": "T30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T29",
+        "south": "T31",
+        "west": "S30",
+        "east": "U30"
       }
     },
     {
-      "row": 30,
-      "col": 21,
-      "color": null,
+      "id": "U30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U29",
+        "south": "U31",
+        "west": "T30",
+        "east": "V30"
       }
     },
     {
-      "row": 30,
-      "col": 22,
-      "color": null,
+      "id": "V30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V29",
+        "south": "V31",
+        "west": "U30",
+        "east": "W30"
       }
     },
     {
-      "row": 30,
-      "col": 23,
-      "color": null,
+      "id": "W30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W29",
+        "south": "W31",
+        "west": "V30",
+        "east": "X30"
       }
     },
     {
-      "row": 30,
-      "col": 24,
-      "color": null,
+      "id": "X30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X29",
+        "south": "X31",
+        "west": "W30",
+        "east": "Y30"
       }
     },
     {
-      "row": 30,
-      "col": 25,
-      "color": null,
+      "id": "Y30",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y29",
+        "south": "Y31",
+        "west": "X30",
+        "east": "Z30"
       }
     },
     {
-      "row": 30,
-      "col": 26,
-      "color": null,
+      "id": "Z30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z29",
+        "south": "Z31",
+        "west": "Y30",
+        "east": "AA30"
       }
     },
     {
-      "row": 30,
-      "col": 27,
-      "color": null,
+      "id": "AA30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA29",
+        "south": "AA31",
+        "west": "Z30",
+        "east": "AB30"
       }
     },
     {
-      "row": 30,
-      "col": 28,
-      "color": null,
+      "id": "AB30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB29",
+        "south": "AB31",
+        "west": "AA30",
+        "east": "AC30"
       }
     },
     {
-      "row": 30,
-      "col": 29,
-      "color": null,
+      "id": "AC30",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC29",
+        "south": "AC31",
+        "west": "AB30",
+        "east": "AD30"
       }
     },
     {
-      "row": 30,
-      "col": 30,
-      "color": null,
+      "id": "AD30",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD29",
+        "south": "AD31",
+        "west": "AC30",
+        "east": "AE30"
       }
     },
     {
-      "row": 30,
-      "col": 31,
-      "color": null,
+      "id": "AE30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE29",
+        "south": "AE31",
+        "west": "AD30",
+        "east": "AF30"
       }
     },
     {
-      "row": 30,
-      "col": 32,
-      "color": null,
+      "id": "AF30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF29",
+        "south": "AF31",
+        "west": "AE30",
+        "east": "AG30"
       }
     },
     {
-      "row": 30,
-      "col": 33,
-      "color": null,
+      "id": "AG30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG29",
+        "south": "AG31",
+        "west": "AF30",
+        "east": "AH30"
       }
     },
     {
-      "row": 30,
-      "col": 34,
-      "color": null,
+      "id": "AH30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH29",
+        "south": "AH31",
+        "west": "AG30",
+        "east": "AI30"
       }
     },
     {
-      "row": 30,
-      "col": 35,
-      "color": null,
+      "id": "AI30",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI29",
+        "south": "AI31",
+        "west": "AH30",
+        "east": "AJ30"
       }
     },
     {
-      "row": 30,
-      "col": 36,
-      "color": null,
+      "id": "AJ30",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ29",
+        "south": "AJ31",
+        "west": "AI30",
+        "east": "AK30"
       }
     },
     {
-      "row": 30,
-      "col": 37,
-      "color": null,
+      "id": "AK30",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK29",
+        "south": "AK31",
+        "west": "AJ30",
+        "east": "AL30"
       }
     },
     {
-      "row": 30,
-      "col": 38,
-      "color": null,
+      "id": "AL30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL29",
+        "south": "AL31",
+        "west": "AK30",
+        "east": "AM30"
       }
     },
     {
-      "row": 30,
-      "col": 39,
-      "color": null,
+      "id": "AM30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM29",
+        "south": "AM31",
+        "west": "AL30",
+        "east": "AN30"
       }
     },
     {
-      "row": 30,
-      "col": 40,
-      "color": null,
+      "id": "AN30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN29",
+        "south": "AN31",
+        "west": "AM30",
+        "east": "AO30"
       }
     },
     {
-      "row": 30,
-      "col": 41,
-      "color": null,
+      "id": "AO30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO29",
+        "south": "AO31",
+        "west": "AN30",
+        "east": "AP30"
       }
     },
     {
-      "row": 30,
-      "col": 42,
-      "color": null,
+      "id": "AP30",
+      "terrain": "Pylus",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP29",
+        "south": "AP31",
+        "west": "AO30",
+        "east": "AQ30"
       }
     },
     {
-      "row": 30,
-      "col": 43,
-      "color": null,
+      "id": "AQ30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ29",
+        "south": "AQ31",
+        "west": "AP30",
+        "east": "AR30"
       }
     },
     {
-      "row": 30,
-      "col": 44,
-      "color": null,
+      "id": "AR30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR29",
+        "south": "AR31",
+        "west": "AQ30",
+        "east": "AS30"
       }
     },
     {
-      "row": 30,
-      "col": 45,
-      "color": null,
+      "id": "AS30",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS29",
+        "south": "AS31",
+        "west": "AR30",
+        "east": "AT30"
       }
     },
     {
-      "row": 30,
-      "col": 46,
-      "color": null,
+      "id": "AT30",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT29",
+        "south": "AT31",
+        "west": "AS30",
+        "east": "AU30"
       }
     },
     {
-      "row": 30,
-      "col": 47,
-      "color": null,
+      "id": "AU30",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU29",
+        "south": "AU31",
+        "west": "AT30",
+        "east": "AV30"
       }
     },
     {
-      "row": 30,
-      "col": 48,
-      "color": null,
+      "id": "AV30",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV29",
+        "south": "AV31",
+        "west": "AU30",
+        "east": "AW30"
       }
     },
     {
-      "row": 30,
-      "col": 49,
-      "color": null,
+      "id": "AW30",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW29",
+        "south": "AW31",
+        "west": "AV30",
+        "east": "AX30"
       }
     },
     {
-      "row": 30,
-      "col": 50,
-      "color": null,
+      "id": "AX30",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX29",
+        "south": "AX31",
+        "west": "AW30"
       }
     },
     {
-      "row": 31,
-      "col": 1,
-      "color": null,
+      "id": "A31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A30",
+        "south": "A32",
+        "east": "B31"
       }
     },
     {
-      "row": 31,
-      "col": 2,
-      "color": null,
+      "id": "B31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B30",
+        "south": "B32",
+        "west": "A31",
+        "east": "C31"
       }
     },
     {
-      "row": 31,
-      "col": 3,
-      "color": null,
+      "id": "C31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C30",
+        "south": "C32",
+        "west": "B31",
+        "east": "D31"
       }
     },
     {
-      "row": 31,
-      "col": 4,
-      "color": null,
+      "id": "D31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D30",
+        "south": "D32",
+        "west": "C31",
+        "east": "E31"
       }
     },
     {
-      "row": 31,
-      "col": 5,
-      "color": null,
+      "id": "E31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E30",
+        "south": "E32",
+        "west": "D31",
+        "east": "F31"
       }
     },
     {
-      "row": 31,
-      "col": 6,
-      "color": null,
+      "id": "F31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F30",
+        "south": "F32",
+        "west": "E31",
+        "east": "G31"
       }
     },
     {
-      "row": 31,
-      "col": 7,
-      "color": null,
+      "id": "G31",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G30",
+        "south": "G32",
+        "west": "F31",
+        "east": "H31"
       }
     },
     {
-      "row": 31,
-      "col": 8,
-      "color": null,
+      "id": "H31",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H30",
+        "south": "H32",
+        "west": "G31",
+        "east": "I31"
       }
     },
     {
-      "row": 31,
-      "col": 9,
-      "color": null,
+      "id": "I31",
+      "terrain": "dunes",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I30",
+        "south": "I32",
+        "west": "H31",
+        "east": "J31"
       }
     },
     {
-      "row": 31,
-      "col": 10,
-      "color": null,
+      "id": "J31",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J30",
+        "south": "J32",
+        "west": "I31",
+        "east": "K31"
       }
     },
     {
-      "row": 31,
-      "col": 11,
-      "color": null,
+      "id": "K31",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K30",
+        "south": "K32",
+        "west": "J31",
+        "east": "L31"
       }
     },
     {
-      "row": 31,
-      "col": 12,
-      "color": null,
+      "id": "L31",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L30",
+        "south": "L32",
+        "west": "K31",
+        "east": "M31"
       }
     },
     {
-      "row": 31,
-      "col": 13,
-      "color": null,
+      "id": "M31",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M30",
+        "south": "M32",
+        "west": "L31",
+        "east": "N31"
       }
     },
     {
-      "row": 31,
-      "col": 14,
-      "color": null,
+      "id": "N31",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N30",
+        "south": "N32",
+        "west": "M31",
+        "east": "O31"
       }
     },
     {
-      "row": 31,
-      "col": 15,
-      "color": null,
+      "id": "O31",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O30",
+        "south": "O32",
+        "west": "N31",
+        "east": "P31"
       }
     },
     {
-      "row": 31,
-      "col": 16,
-      "color": null,
+      "id": "P31",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P30",
+        "south": "P32",
+        "west": "O31",
+        "east": "Q31"
       }
     },
     {
-      "row": 31,
-      "col": 17,
-      "color": null,
+      "id": "Q31",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q30",
+        "south": "Q32",
+        "west": "P31",
+        "east": "R31"
       }
     },
     {
-      "row": 31,
-      "col": 18,
-      "color": null,
+      "id": "R31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R30",
+        "south": "R32",
+        "west": "Q31",
+        "east": "S31"
       }
     },
     {
-      "row": 31,
-      "col": 19,
-      "color": null,
+      "id": "S31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S30",
+        "south": "S32",
+        "west": "R31",
+        "east": "T31"
       }
     },
     {
-      "row": 31,
-      "col": 20,
-      "color": null,
+      "id": "T31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T30",
+        "south": "T32",
+        "west": "S31",
+        "east": "U31"
       }
     },
     {
-      "row": 31,
-      "col": 21,
-      "color": null,
+      "id": "U31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U30",
+        "south": "U32",
+        "west": "T31",
+        "east": "V31"
       }
     },
     {
-      "row": 31,
-      "col": 22,
-      "color": null,
+      "id": "V31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V30",
+        "south": "V32",
+        "west": "U31",
+        "east": "W31"
       }
     },
     {
-      "row": 31,
-      "col": 23,
-      "color": null,
+      "id": "W31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W30",
+        "south": "W32",
+        "west": "V31",
+        "east": "X31"
       }
     },
     {
-      "row": 31,
-      "col": 24,
-      "color": null,
+      "id": "X31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X30",
+        "south": "X32",
+        "west": "W31",
+        "east": "Y31"
       }
     },
     {
-      "row": 31,
-      "col": 25,
-      "color": null,
+      "id": "Y31",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y30",
+        "south": "Y32",
+        "west": "X31",
+        "east": "Z31"
       }
     },
     {
-      "row": 31,
-      "col": 26,
-      "color": null,
+      "id": "Z31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z30",
+        "south": "Z32",
+        "west": "Y31",
+        "east": "AA31"
       }
     },
     {
-      "row": 31,
-      "col": 27,
-      "color": null,
+      "id": "AA31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA30",
+        "south": "AA32",
+        "west": "Z31",
+        "east": "AB31"
       }
     },
     {
-      "row": 31,
-      "col": 28,
-      "color": null,
+      "id": "AB31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB30",
+        "south": "AB32",
+        "west": "AA31",
+        "east": "AC31"
       }
     },
     {
-      "row": 31,
-      "col": 29,
-      "color": null,
+      "id": "AC31",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC30",
+        "south": "AC32",
+        "west": "AB31",
+        "east": "AD31"
       }
     },
     {
-      "row": 31,
-      "col": 30,
-      "color": null,
+      "id": "AD31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD30",
+        "south": "AD32",
+        "west": "AC31",
+        "east": "AE31"
       }
     },
     {
-      "row": 31,
-      "col": 31,
-      "color": null,
+      "id": "AE31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE30",
+        "south": "AE32",
+        "west": "AD31",
+        "east": "AF31"
       }
     },
     {
-      "row": 31,
-      "col": 32,
-      "color": null,
+      "id": "AF31",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF30",
+        "south": "AF32",
+        "west": "AE31",
+        "east": "AG31"
       }
     },
     {
-      "row": 31,
-      "col": 33,
-      "color": null,
+      "id": "AG31",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG30",
+        "south": "AG32",
+        "west": "AF31",
+        "east": "AH31"
       }
     },
     {
-      "row": 31,
-      "col": 34,
-      "color": null,
+      "id": "AH31",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH30",
+        "south": "AH32",
+        "west": "AG31",
+        "east": "AI31"
       }
     },
     {
-      "row": 31,
-      "col": 35,
-      "color": null,
+      "id": "AI31",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI30",
+        "south": "AI32",
+        "west": "AH31",
+        "east": "AJ31"
       }
     },
     {
-      "row": 31,
-      "col": 36,
-      "color": null,
+      "id": "AJ31",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ30",
+        "south": "AJ32",
+        "west": "AI31",
+        "east": "AK31"
       }
     },
     {
-      "row": 31,
-      "col": 37,
-      "color": null,
+      "id": "AK31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK30",
+        "south": "AK32",
+        "west": "AJ31",
+        "east": "AL31"
       }
     },
     {
-      "row": 31,
-      "col": 38,
-      "color": null,
+      "id": "AL31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL30",
+        "south": "AL32",
+        "west": "AK31",
+        "east": "AM31"
       }
     },
     {
-      "row": 31,
-      "col": 39,
-      "color": null,
+      "id": "AM31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM30",
+        "south": "AM32",
+        "west": "AL31",
+        "east": "AN31"
       }
     },
     {
-      "row": 31,
-      "col": 40,
-      "color": null,
+      "id": "AN31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN30",
+        "south": "AN32",
+        "west": "AM31",
+        "east": "AO31"
       }
     },
     {
-      "row": 31,
-      "col": 41,
-      "color": null,
+      "id": "AO31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO30",
+        "south": "AO32",
+        "west": "AN31",
+        "east": "AP31"
       }
     },
     {
-      "row": 31,
-      "col": 42,
-      "color": null,
+      "id": "AP31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP30",
+        "south": "AP32",
+        "west": "AO31",
+        "east": "AQ31"
       }
     },
     {
-      "row": 31,
-      "col": 43,
-      "color": null,
+      "id": "AQ31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ30",
+        "south": "AQ32",
+        "west": "AP31",
+        "east": "AR31"
       }
     },
     {
-      "row": 31,
-      "col": 44,
-      "color": null,
+      "id": "AR31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR30",
+        "south": "AR32",
+        "west": "AQ31",
+        "east": "AS31"
       }
     },
     {
-      "row": 31,
-      "col": 45,
-      "color": null,
+      "id": "AS31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS30",
+        "south": "AS32",
+        "west": "AR31",
+        "east": "AT31"
       }
     },
     {
-      "row": 31,
-      "col": 46,
-      "color": null,
+      "id": "AT31",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT30",
+        "south": "AT32",
+        "west": "AS31",
+        "east": "AU31"
       }
     },
     {
-      "row": 31,
-      "col": 47,
-      "color": null,
+      "id": "AU31",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU30",
+        "south": "AU32",
+        "west": "AT31",
+        "east": "AV31"
       }
     },
     {
-      "row": 31,
-      "col": 48,
-      "color": null,
+      "id": "AV31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV30",
+        "south": "AV32",
+        "west": "AU31",
+        "east": "AW31"
       }
     },
     {
-      "row": 31,
-      "col": 49,
-      "color": null,
+      "id": "AW31",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW30",
+        "south": "AW32",
+        "west": "AV31",
+        "east": "AX31"
       }
     },
     {
-      "row": 31,
-      "col": 50,
-      "color": null,
+      "id": "AX31",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX30",
+        "south": "AX32",
+        "west": "AW31"
       }
     },
     {
-      "row": 32,
-      "col": 1,
-      "color": null,
+      "id": "A32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A31",
+        "south": "A33",
+        "east": "B32"
       }
     },
     {
-      "row": 32,
-      "col": 2,
-      "color": null,
+      "id": "B32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B31",
+        "south": "B33",
+        "west": "A32",
+        "east": "C32"
       }
     },
     {
-      "row": 32,
-      "col": 3,
-      "color": null,
+      "id": "C32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C31",
+        "south": "C33",
+        "west": "B32",
+        "east": "D32"
       }
     },
     {
-      "row": 32,
-      "col": 4,
-      "color": null,
+      "id": "D32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D31",
+        "south": "D33",
+        "west": "C32",
+        "east": "E32"
       }
     },
     {
-      "row": 32,
-      "col": 5,
-      "color": null,
+      "id": "E32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E31",
+        "south": "E33",
+        "west": "D32",
+        "east": "F32"
       }
     },
     {
-      "row": 32,
-      "col": 6,
-      "color": null,
+      "id": "F32",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F31",
+        "south": "F33",
+        "west": "E32",
+        "east": "G32"
       }
     },
     {
-      "row": 32,
-      "col": 7,
-      "color": null,
+      "id": "G32",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G31",
+        "south": "G33",
+        "west": "F32",
+        "east": "H32"
       }
     },
     {
-      "row": 32,
-      "col": 8,
-      "color": null,
+      "id": "H32",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H31",
+        "south": "H33",
+        "west": "G32",
+        "east": "I32"
       }
     },
     {
-      "row": 32,
-      "col": 9,
-      "color": null,
+      "id": "I32",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I31",
+        "south": "I33",
+        "west": "H32",
+        "east": "J32"
       }
     },
     {
-      "row": 32,
-      "col": 10,
-      "color": null,
+      "id": "J32",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J31",
+        "south": "J33",
+        "west": "I32",
+        "east": "K32"
       }
     },
     {
-      "row": 32,
-      "col": 11,
-      "color": null,
+      "id": "K32",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K31",
+        "south": "K33",
+        "west": "J32",
+        "east": "L32"
       }
     },
     {
-      "row": 32,
-      "col": 12,
-      "color": null,
+      "id": "L32",
+      "terrain": "d",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L31",
+        "south": "L33",
+        "west": "K32",
+        "east": "M32"
       }
     },
     {
-      "row": 32,
-      "col": 13,
-      "color": null,
+      "id": "M32",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M31",
+        "south": "M33",
+        "west": "L32",
+        "east": "N32"
       }
     },
     {
-      "row": 32,
-      "col": 14,
-      "color": null,
+      "id": "N32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N31",
+        "south": "N33",
+        "west": "M32",
+        "east": "O32"
       }
     },
     {
-      "row": 32,
-      "col": 15,
-      "color": null,
+      "id": "O32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O31",
+        "south": "O33",
+        "west": "N32",
+        "east": "P32"
       }
     },
     {
-      "row": 32,
-      "col": 16,
-      "color": null,
+      "id": "P32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P31",
+        "south": "P33",
+        "west": "O32",
+        "east": "Q32"
       }
     },
     {
-      "row": 32,
-      "col": 17,
-      "color": null,
+      "id": "Q32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q31",
+        "south": "Q33",
+        "west": "P32",
+        "east": "R32"
       }
     },
     {
-      "row": 32,
-      "col": 18,
-      "color": null,
+      "id": "R32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R31",
+        "south": "R33",
+        "west": "Q32",
+        "east": "S32"
       }
     },
     {
-      "row": 32,
-      "col": 19,
-      "color": null,
+      "id": "S32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S31",
+        "south": "S33",
+        "west": "R32",
+        "east": "T32"
       }
     },
     {
-      "row": 32,
-      "col": 20,
-      "color": null,
+      "id": "T32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T31",
+        "south": "T33",
+        "west": "S32",
+        "east": "U32"
       }
     },
     {
-      "row": 32,
-      "col": 21,
-      "color": null,
+      "id": "U32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U31",
+        "south": "U33",
+        "west": "T32",
+        "east": "V32"
       }
     },
     {
-      "row": 32,
-      "col": 22,
-      "color": null,
+      "id": "V32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V31",
+        "south": "V33",
+        "west": "U32",
+        "east": "W32"
       }
     },
     {
-      "row": 32,
-      "col": 23,
-      "color": null,
+      "id": "W32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W31",
+        "south": "W33",
+        "west": "V32",
+        "east": "X32"
       }
     },
     {
-      "row": 32,
-      "col": 24,
-      "color": null,
+      "id": "X32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X31",
+        "south": "X33",
+        "west": "W32",
+        "east": "Y32"
       }
     },
     {
-      "row": 32,
-      "col": 25,
-      "color": null,
+      "id": "Y32",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y31",
+        "south": "Y33",
+        "west": "X32",
+        "east": "Z32"
       }
     },
     {
-      "row": 32,
-      "col": 26,
-      "color": null,
+      "id": "Z32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z31",
+        "south": "Z33",
+        "west": "Y32",
+        "east": "AA32"
       }
     },
     {
-      "row": 32,
-      "col": 27,
-      "color": null,
+      "id": "AA32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA31",
+        "south": "AA33",
+        "west": "Z32",
+        "east": "AB32"
       }
     },
     {
-      "row": 32,
-      "col": 28,
-      "color": null,
+      "id": "AB32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB31",
+        "south": "AB33",
+        "west": "AA32",
+        "east": "AC32"
       }
     },
     {
-      "row": 32,
-      "col": 29,
-      "color": null,
+      "id": "AC32",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC31",
+        "south": "AC33",
+        "west": "AB32",
+        "east": "AD32"
       }
     },
     {
-      "row": 32,
-      "col": 30,
-      "color": null,
+      "id": "AD32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD31",
+        "south": "AD33",
+        "west": "AC32",
+        "east": "AE32"
       }
     },
     {
-      "row": 32,
-      "col": 31,
-      "color": null,
+      "id": "AE32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE31",
+        "south": "AE33",
+        "west": "AD32",
+        "east": "AF32"
       }
     },
     {
-      "row": 32,
-      "col": 32,
-      "color": null,
+      "id": "AF32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF31",
+        "south": "AF33",
+        "west": "AE32",
+        "east": "AG32"
       }
     },
     {
-      "row": 32,
-      "col": 33,
-      "color": null,
+      "id": "AG32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG31",
+        "south": "AG33",
+        "west": "AF32",
+        "east": "AH32"
       }
     },
     {
-      "row": 32,
-      "col": 34,
-      "color": null,
+      "id": "AH32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH31",
+        "south": "AH33",
+        "west": "AG32",
+        "east": "AI32"
       }
     },
     {
-      "row": 32,
-      "col": 35,
-      "color": null,
+      "id": "AI32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI31",
+        "south": "AI33",
+        "west": "AH32",
+        "east": "AJ32"
       }
     },
     {
-      "row": 32,
-      "col": 36,
-      "color": null,
+      "id": "AJ32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ31",
+        "south": "AJ33",
+        "west": "AI32",
+        "east": "AK32"
       }
     },
     {
-      "row": 32,
-      "col": 37,
-      "color": null,
+      "id": "AK32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK31",
+        "south": "AK33",
+        "west": "AJ32",
+        "east": "AL32"
       }
     },
     {
-      "row": 32,
-      "col": 38,
-      "color": null,
+      "id": "AL32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL31",
+        "south": "AL33",
+        "west": "AK32",
+        "east": "AM32"
       }
     },
     {
-      "row": 32,
-      "col": 39,
-      "color": null,
+      "id": "AM32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM31",
+        "south": "AM33",
+        "west": "AL32",
+        "east": "AN32"
       }
     },
     {
-      "row": 32,
-      "col": 40,
-      "color": null,
+      "id": "AN32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN31",
+        "south": "AN33",
+        "west": "AM32",
+        "east": "AO32"
       }
     },
     {
-      "row": 32,
-      "col": 41,
-      "color": null,
+      "id": "AO32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO31",
+        "south": "AO33",
+        "west": "AN32",
+        "east": "AP32"
       }
     },
     {
-      "row": 32,
-      "col": 42,
-      "color": null,
+      "id": "AP32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP31",
+        "south": "AP33",
+        "west": "AO32",
+        "east": "AQ32"
       }
     },
     {
-      "row": 32,
-      "col": 43,
-      "color": null,
+      "id": "AQ32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ31",
+        "south": "AQ33",
+        "west": "AP32",
+        "east": "AR32"
       }
     },
     {
-      "row": 32,
-      "col": 44,
-      "color": null,
+      "id": "AR32",
+      "terrain": "foothills",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR31",
+        "south": "AR33",
+        "west": "AQ32",
+        "east": "AS32"
       }
     },
     {
-      "row": 32,
-      "col": 45,
-      "color": null,
+      "id": "AS32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS31",
+        "south": "AS33",
+        "west": "AR32",
+        "east": "AT32"
       }
     },
     {
-      "row": 32,
-      "col": 46,
-      "color": null,
+      "id": "AT32",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT31",
+        "south": "AT33",
+        "west": "AS32",
+        "east": "AU32"
       }
     },
     {
-      "row": 32,
-      "col": 47,
-      "color": null,
+      "id": "AU32",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU31",
+        "south": "AU33",
+        "west": "AT32",
+        "east": "AV32"
       }
     },
     {
-      "row": 32,
-      "col": 48,
-      "color": null,
+      "id": "AV32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV31",
+        "south": "AV33",
+        "west": "AU32",
+        "east": "AW32"
       }
     },
     {
-      "row": 32,
-      "col": 49,
-      "color": null,
+      "id": "AW32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW31",
+        "south": "AW33",
+        "west": "AV32",
+        "east": "AX32"
       }
     },
     {
-      "row": 32,
-      "col": 50,
-      "color": null,
+      "id": "AX32",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX31",
+        "south": "AX33",
+        "west": "AW32"
       }
     },
     {
-      "row": 33,
-      "col": 1,
-      "color": null,
+      "id": "A33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A32",
+        "south": "A34",
+        "east": "B33"
       }
     },
     {
-      "row": 33,
-      "col": 2,
-      "color": null,
+      "id": "B33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B32",
+        "south": "B34",
+        "west": "A33",
+        "east": "C33"
       }
     },
     {
-      "row": 33,
-      "col": 3,
-      "color": null,
+      "id": "C33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C32",
+        "south": "C34",
+        "west": "B33",
+        "east": "D33"
       }
     },
     {
-      "row": 33,
-      "col": 4,
-      "color": null,
+      "id": "D33",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D32",
+        "south": "D34",
+        "west": "C33",
+        "east": "E33"
       }
     },
     {
-      "row": 33,
-      "col": 5,
-      "color": null,
+      "id": "E33",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E32",
+        "south": "E34",
+        "west": "D33",
+        "east": "F33"
       }
     },
     {
-      "row": 33,
-      "col": 6,
-      "color": null,
+      "id": "F33",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F32",
+        "south": "F34",
+        "west": "E33",
+        "east": "G33"
       }
     },
     {
-      "row": 33,
-      "col": 7,
-      "color": null,
+      "id": "G33",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G32",
+        "south": "G34",
+        "west": "F33",
+        "east": "H33"
       }
     },
     {
-      "row": 33,
-      "col": 8,
-      "color": null,
+      "id": "H33",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H32",
+        "south": "H34",
+        "west": "G33",
+        "east": "I33"
       }
     },
     {
-      "row": 33,
-      "col": 9,
-      "color": null,
+      "id": "I33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I32",
+        "south": "I34",
+        "west": "H33",
+        "east": "J33"
       }
     },
     {
-      "row": 33,
-      "col": 10,
-      "color": null,
+      "id": "J33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J32",
+        "south": "J34",
+        "west": "I33",
+        "east": "K33"
       }
     },
     {
-      "row": 33,
-      "col": 11,
-      "color": null,
+      "id": "K33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K32",
+        "south": "K34",
+        "west": "J33",
+        "east": "L33"
       }
     },
     {
-      "row": 33,
-      "col": 12,
-      "color": null,
+      "id": "L33",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L32",
+        "south": "L34",
+        "west": "K33",
+        "east": "M33"
       }
     },
     {
-      "row": 33,
-      "col": 13,
-      "color": null,
+      "id": "M33",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M32",
+        "south": "M34",
+        "west": "L33",
+        "east": "N33"
       }
     },
     {
-      "row": 33,
-      "col": 14,
-      "color": null,
+      "id": "N33",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N32",
+        "south": "N34",
+        "west": "M33",
+        "east": "O33"
       }
     },
     {
-      "row": 33,
-      "col": 15,
-      "color": null,
+      "id": "O33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O32",
+        "south": "O34",
+        "west": "N33",
+        "east": "P33"
       }
     },
     {
-      "row": 33,
-      "col": 16,
-      "color": null,
+      "id": "P33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P32",
+        "south": "P34",
+        "west": "O33",
+        "east": "Q33"
       }
     },
     {
-      "row": 33,
-      "col": 17,
-      "color": null,
+      "id": "Q33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q32",
+        "south": "Q34",
+        "west": "P33",
+        "east": "R33"
       }
     },
     {
-      "row": 33,
-      "col": 18,
-      "color": null,
+      "id": "R33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R32",
+        "south": "R34",
+        "west": "Q33",
+        "east": "S33"
       }
     },
     {
-      "row": 33,
-      "col": 19,
-      "color": null,
+      "id": "S33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S32",
+        "south": "S34",
+        "west": "R33",
+        "east": "T33"
       }
     },
     {
-      "row": 33,
-      "col": 20,
-      "color": null,
+      "id": "T33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T32",
+        "south": "T34",
+        "west": "S33",
+        "east": "U33"
       }
     },
     {
-      "row": 33,
-      "col": 21,
-      "color": null,
+      "id": "U33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U32",
+        "south": "U34",
+        "west": "T33",
+        "east": "V33"
       }
     },
     {
-      "row": 33,
-      "col": 22,
-      "color": null,
+      "id": "V33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V32",
+        "south": "V34",
+        "west": "U33",
+        "east": "W33"
       }
     },
     {
-      "row": 33,
-      "col": 23,
-      "color": null,
+      "id": "W33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W32",
+        "south": "W34",
+        "west": "V33",
+        "east": "X33"
       }
     },
     {
-      "row": 33,
-      "col": 24,
-      "color": null,
+      "id": "X33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X32",
+        "south": "X34",
+        "west": "W33",
+        "east": "Y33"
       }
     },
     {
-      "row": 33,
-      "col": 25,
-      "color": null,
+      "id": "Y33",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y32",
+        "south": "Y34",
+        "west": "X33",
+        "east": "Z33"
       }
     },
     {
-      "row": 33,
-      "col": 26,
-      "color": null,
+      "id": "Z33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z32",
+        "south": "Z34",
+        "west": "Y33",
+        "east": "AA33"
       }
     },
     {
-      "row": 33,
-      "col": 27,
-      "color": null,
+      "id": "AA33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA32",
+        "south": "AA34",
+        "west": "Z33",
+        "east": "AB33"
       }
     },
     {
-      "row": 33,
-      "col": 28,
-      "color": null,
+      "id": "AB33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB32",
+        "south": "AB34",
+        "west": "AA33",
+        "east": "AC33"
       }
     },
     {
-      "row": 33,
-      "col": 29,
-      "color": null,
+      "id": "AC33",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC32",
+        "south": "AC34",
+        "west": "AB33",
+        "east": "AD33"
       }
     },
     {
-      "row": 33,
-      "col": 30,
-      "color": null,
+      "id": "AD33",
+      "terrain": "V Green",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD32",
+        "south": "AD34",
+        "west": "AC33",
+        "east": "AE33"
       }
     },
     {
-      "row": 33,
-      "col": 31,
-      "color": null,
+      "id": "AE33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE32",
+        "south": "AE34",
+        "west": "AD33",
+        "east": "AF33"
       }
     },
     {
-      "row": 33,
-      "col": 32,
-      "color": null,
+      "id": "AF33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF32",
+        "south": "AF34",
+        "west": "AE33",
+        "east": "AG33"
       }
     },
     {
-      "row": 33,
-      "col": 33,
-      "color": null,
+      "id": "AG33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG32",
+        "south": "AG34",
+        "west": "AF33",
+        "east": "AH33"
       }
     },
     {
-      "row": 33,
-      "col": 34,
-      "color": null,
+      "id": "AH33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH32",
+        "south": "AH34",
+        "west": "AG33",
+        "east": "AI33"
       }
     },
     {
-      "row": 33,
-      "col": 35,
-      "color": null,
+      "id": "AI33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI32",
+        "south": "AI34",
+        "west": "AH33",
+        "east": "AJ33"
       }
     },
     {
-      "row": 33,
-      "col": 36,
-      "color": null,
+      "id": "AJ33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ32",
+        "south": "AJ34",
+        "west": "AI33",
+        "east": "AK33"
       }
     },
     {
-      "row": 33,
-      "col": 37,
-      "color": null,
+      "id": "AK33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK32",
+        "south": "AK34",
+        "west": "AJ33",
+        "east": "AL33"
       }
     },
     {
-      "row": 33,
-      "col": 38,
-      "color": null,
+      "id": "AL33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL32",
+        "south": "AL34",
+        "west": "AK33",
+        "east": "AM33"
       }
     },
     {
-      "row": 33,
-      "col": 39,
-      "color": null,
+      "id": "AM33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM32",
+        "south": "AM34",
+        "west": "AL33",
+        "east": "AN33"
       }
     },
     {
-      "row": 33,
-      "col": 40,
-      "color": null,
+      "id": "AN33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN32",
+        "south": "AN34",
+        "west": "AM33",
+        "east": "AO33"
       }
     },
     {
-      "row": 33,
-      "col": 41,
-      "color": null,
+      "id": "AO33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO32",
+        "south": "AO34",
+        "west": "AN33",
+        "east": "AP33"
       }
     },
     {
-      "row": 33,
-      "col": 42,
-      "color": null,
+      "id": "AP33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP32",
+        "south": "AP34",
+        "west": "AO33",
+        "east": "AQ33"
       }
     },
     {
-      "row": 33,
-      "col": 43,
-      "color": null,
+      "id": "AQ33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ32",
+        "south": "AQ34",
+        "west": "AP33",
+        "east": "AR33"
       }
     },
     {
-      "row": 33,
-      "col": 44,
-      "color": null,
+      "id": "AR33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR32",
+        "south": "AR34",
+        "west": "AQ33",
+        "east": "AS33"
       }
     },
     {
-      "row": 33,
-      "col": 45,
-      "color": null,
+      "id": "AS33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS32",
+        "south": "AS34",
+        "west": "AR33",
+        "east": "AT33"
       }
     },
     {
-      "row": 33,
-      "col": 46,
-      "color": null,
+      "id": "AT33",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT32",
+        "south": "AT34",
+        "west": "AS33",
+        "east": "AU33"
       }
     },
     {
-      "row": 33,
-      "col": 47,
-      "color": null,
+      "id": "AU33",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU32",
+        "south": "AU34",
+        "west": "AT33",
+        "east": "AV33"
       }
     },
     {
-      "row": 33,
-      "col": 48,
-      "color": null,
+      "id": "AV33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV32",
+        "south": "AV34",
+        "west": "AU33",
+        "east": "AW33"
       }
     },
     {
-      "row": 33,
-      "col": 49,
-      "color": null,
+      "id": "AW33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW32",
+        "south": "AW34",
+        "west": "AV33",
+        "east": "AX33"
       }
     },
     {
-      "row": 33,
-      "col": 50,
-      "color": null,
+      "id": "AX33",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX32",
+        "south": "AX34",
+        "west": "AW33"
       }
     },
     {
-      "row": 34,
-      "col": 1,
-      "color": null,
+      "id": "A34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A33",
+        "south": "A35",
+        "east": "B34"
       }
     },
     {
-      "row": 34,
-      "col": 2,
-      "color": null,
+      "id": "B34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B33",
+        "south": "B35",
+        "west": "A34",
+        "east": "C34"
       }
     },
     {
-      "row": 34,
-      "col": 3,
-      "color": null,
+      "id": "C34",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C33",
+        "south": "C35",
+        "west": "B34",
+        "east": "D34"
       }
     },
     {
-      "row": 34,
-      "col": 4,
-      "color": null,
+      "id": "D34",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D33",
+        "south": "D35",
+        "west": "C34",
+        "east": "E34"
       }
     },
     {
-      "row": 34,
-      "col": 5,
-      "color": null,
+      "id": "E34",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E33",
+        "south": "E35",
+        "west": "D34",
+        "east": "F34"
       }
     },
     {
-      "row": 34,
-      "col": 6,
-      "color": null,
+      "id": "F34",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F33",
+        "south": "F35",
+        "west": "E34",
+        "east": "G34"
       }
     },
     {
-      "row": 34,
-      "col": 7,
-      "color": null,
+      "id": "G34",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G33",
+        "south": "G35",
+        "west": "F34",
+        "east": "H34"
       }
     },
     {
-      "row": 34,
-      "col": 8,
-      "color": null,
+      "id": "H34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H33",
+        "south": "H35",
+        "west": "G34",
+        "east": "I34"
       }
     },
     {
-      "row": 34,
-      "col": 9,
-      "color": null,
+      "id": "I34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I33",
+        "south": "I35",
+        "west": "H34",
+        "east": "J34"
       }
     },
     {
-      "row": 34,
-      "col": 10,
-      "color": null,
+      "id": "J34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J33",
+        "south": "J35",
+        "west": "I34",
+        "east": "K34"
       }
     },
     {
-      "row": 34,
-      "col": 11,
-      "color": null,
+      "id": "K34",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K33",
+        "south": "K35",
+        "west": "J34",
+        "east": "L34"
       }
     },
     {
-      "row": 34,
-      "col": 12,
-      "color": null,
+      "id": "L34",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L33",
+        "south": "L35",
+        "west": "K34",
+        "east": "M34"
       }
     },
     {
-      "row": 34,
-      "col": 13,
-      "color": null,
+      "id": "M34",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M33",
+        "south": "M35",
+        "west": "L34",
+        "east": "N34"
       }
     },
     {
-      "row": 34,
-      "col": 14,
-      "color": null,
+      "id": "N34",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N33",
+        "south": "N35",
+        "west": "M34",
+        "east": "O34"
       }
     },
     {
-      "row": 34,
-      "col": 15,
-      "color": null,
+      "id": "O34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O33",
+        "south": "O35",
+        "west": "N34",
+        "east": "P34"
       }
     },
     {
-      "row": 34,
-      "col": 16,
-      "color": null,
+      "id": "P34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P33",
+        "south": "P35",
+        "west": "O34",
+        "east": "Q34"
       }
     },
     {
-      "row": 34,
-      "col": 17,
-      "color": null,
+      "id": "Q34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q33",
+        "south": "Q35",
+        "west": "P34",
+        "east": "R34"
       }
     },
     {
-      "row": 34,
-      "col": 18,
-      "color": null,
+      "id": "R34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R33",
+        "south": "R35",
+        "west": "Q34",
+        "east": "S34"
       }
     },
     {
-      "row": 34,
-      "col": 19,
-      "color": null,
+      "id": "S34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S33",
+        "south": "S35",
+        "west": "R34",
+        "east": "T34"
       }
     },
     {
-      "row": 34,
-      "col": 20,
-      "color": null,
+      "id": "T34",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T33",
+        "south": "T35",
+        "west": "S34",
+        "east": "U34"
       }
     },
     {
-      "row": 34,
-      "col": 21,
-      "color": null,
+      "id": "U34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U33",
+        "south": "U35",
+        "west": "T34",
+        "east": "V34"
       }
     },
     {
-      "row": 34,
-      "col": 22,
-      "color": null,
+      "id": "V34",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V33",
+        "south": "V35",
+        "west": "U34",
+        "east": "W34"
       }
     },
     {
-      "row": 34,
-      "col": 23,
-      "color": null,
+      "id": "W34",
+      "terrain": "path",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W33",
+        "south": "W35",
+        "west": "V34",
+        "east": "X34"
       }
     },
     {
-      "row": 34,
-      "col": 24,
-      "color": null,
+      "id": "X34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X33",
+        "south": "X35",
+        "west": "W34",
+        "east": "Y34"
       }
     },
     {
-      "row": 34,
-      "col": 25,
-      "color": null,
+      "id": "Y34",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y33",
+        "south": "Y35",
+        "west": "X34",
+        "east": "Z34"
       }
     },
     {
-      "row": 34,
-      "col": 26,
-      "color": null,
+      "id": "Z34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z33",
+        "south": "Z35",
+        "west": "Y34",
+        "east": "AA34"
       }
     },
     {
-      "row": 34,
-      "col": 27,
-      "color": null,
+      "id": "AA34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA33",
+        "south": "AA35",
+        "west": "Z34",
+        "east": "AB34"
       }
     },
     {
-      "row": 34,
-      "col": 28,
-      "color": null,
+      "id": "AB34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB33",
+        "south": "AB35",
+        "west": "AA34",
+        "east": "AC34"
       }
     },
     {
-      "row": 34,
-      "col": 29,
-      "color": null,
+      "id": "AC34",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC33",
+        "south": "AC35",
+        "west": "AB34",
+        "east": "AD34"
       }
     },
     {
-      "row": 34,
-      "col": 30,
-      "color": null,
+      "id": "AD34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD33",
+        "south": "AD35",
+        "west": "AC34",
+        "east": "AE34"
       }
     },
     {
-      "row": 34,
-      "col": 31,
-      "color": null,
+      "id": "AE34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE33",
+        "south": "AE35",
+        "west": "AD34",
+        "east": "AF34"
       }
     },
     {
-      "row": 34,
-      "col": 32,
-      "color": null,
+      "id": "AF34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF33",
+        "south": "AF35",
+        "west": "AE34",
+        "east": "AG34"
       }
     },
     {
-      "row": 34,
-      "col": 33,
-      "color": null,
+      "id": "AG34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG33",
+        "south": "AG35",
+        "west": "AF34",
+        "east": "AH34"
       }
     },
     {
-      "row": 34,
-      "col": 34,
-      "color": null,
+      "id": "AH34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH33",
+        "south": "AH35",
+        "west": "AG34",
+        "east": "AI34"
       }
     },
     {
-      "row": 34,
-      "col": 35,
-      "color": null,
+      "id": "AI34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI33",
+        "south": "AI35",
+        "west": "AH34",
+        "east": "AJ34"
       }
     },
     {
-      "row": 34,
-      "col": 36,
-      "color": null,
+      "id": "AJ34",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ33",
+        "south": "AJ35",
+        "west": "AI34",
+        "east": "AK34"
       }
     },
     {
-      "row": 34,
-      "col": 37,
-      "color": null,
+      "id": "AK34",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK33",
+        "south": "AK35",
+        "west": "AJ34",
+        "east": "AL34"
       }
     },
     {
-      "row": 34,
-      "col": 38,
-      "color": null,
+      "id": "AL34",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL33",
+        "south": "AL35",
+        "west": "AK34",
+        "east": "AM34"
       }
     },
     {
-      "row": 34,
-      "col": 39,
-      "color": null,
+      "id": "AM34",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM33",
+        "south": "AM35",
+        "west": "AL34",
+        "east": "AN34"
       }
     },
     {
-      "row": 34,
-      "col": 40,
-      "color": null,
+      "id": "AN34",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN33",
+        "south": "AN35",
+        "west": "AM34",
+        "east": "AO34"
       }
     },
     {
-      "row": 34,
-      "col": 41,
-      "color": null,
+      "id": "AO34",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO33",
+        "south": "AO35",
+        "west": "AN34",
+        "east": "AP34"
       }
     },
     {
-      "row": 34,
-      "col": 42,
-      "color": null,
+      "id": "AP34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP33",
+        "south": "AP35",
+        "west": "AO34",
+        "east": "AQ34"
       }
     },
     {
-      "row": 34,
-      "col": 43,
-      "color": null,
+      "id": "AQ34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ33",
+        "south": "AQ35",
+        "west": "AP34",
+        "east": "AR34"
       }
     },
     {
-      "row": 34,
-      "col": 44,
-      "color": null,
+      "id": "AR34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR33",
+        "south": "AR35",
+        "west": "AQ34",
+        "east": "AS34"
       }
     },
     {
-      "row": 34,
-      "col": 45,
-      "color": null,
+      "id": "AS34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS33",
+        "south": "AS35",
+        "west": "AR34",
+        "east": "AT34"
       }
     },
     {
-      "row": 34,
-      "col": 46,
-      "color": null,
+      "id": "AT34",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT33",
+        "south": "AT35",
+        "west": "AS34",
+        "east": "AU34"
       }
     },
     {
-      "row": 34,
-      "col": 47,
-      "color": null,
+      "id": "AU34",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU33",
+        "south": "AU35",
+        "west": "AT34",
+        "east": "AV34"
       }
     },
     {
-      "row": 34,
-      "col": 48,
-      "color": null,
+      "id": "AV34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV33",
+        "south": "AV35",
+        "west": "AU34",
+        "east": "AW34"
       }
     },
     {
-      "row": 34,
-      "col": 49,
-      "color": null,
+      "id": "AW34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW33",
+        "south": "AW35",
+        "west": "AV34",
+        "east": "AX34"
       }
     },
     {
-      "row": 34,
-      "col": 50,
-      "color": null,
+      "id": "AX34",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX33",
+        "south": "AX35",
+        "west": "AW34"
       }
     },
     {
-      "row": 35,
-      "col": 1,
-      "color": null,
+      "id": "A35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A34",
+        "south": "A36",
+        "east": "B35"
       }
     },
     {
-      "row": 35,
-      "col": 2,
-      "color": null,
+      "id": "B35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B34",
+        "south": "B36",
+        "west": "A35",
+        "east": "C35"
       }
     },
     {
-      "row": 35,
-      "col": 3,
-      "color": null,
+      "id": "C35",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C34",
+        "south": "C36",
+        "west": "B35",
+        "east": "D35"
       }
     },
     {
-      "row": 35,
-      "col": 4,
-      "color": null,
+      "id": "D35",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D34",
+        "south": "D36",
+        "west": "C35",
+        "east": "E35"
       }
     },
     {
-      "row": 35,
-      "col": 5,
-      "color": null,
+      "id": "E35",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E34",
+        "south": "E36",
+        "west": "D35",
+        "east": "F35"
       }
     },
     {
-      "row": 35,
-      "col": 6,
-      "color": null,
+      "id": "F35",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F34",
+        "south": "F36",
+        "west": "E35",
+        "east": "G35"
       }
     },
     {
-      "row": 35,
-      "col": 7,
-      "color": null,
+      "id": "G35",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G34",
+        "south": "G36",
+        "west": "F35",
+        "east": "H35"
       }
     },
     {
-      "row": 35,
-      "col": 8,
-      "color": null,
+      "id": "H35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H34",
+        "south": "H36",
+        "west": "G35",
+        "east": "I35"
       }
     },
     {
-      "row": 35,
-      "col": 9,
-      "color": null,
+      "id": "I35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I34",
+        "south": "I36",
+        "west": "H35",
+        "east": "J35"
       }
     },
     {
-      "row": 35,
-      "col": 10,
-      "color": null,
+      "id": "J35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J34",
+        "south": "J36",
+        "west": "I35",
+        "east": "K35"
       }
     },
     {
-      "row": 35,
-      "col": 11,
-      "color": null,
+      "id": "K35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K34",
+        "south": "K36",
+        "west": "J35",
+        "east": "L35"
       }
     },
     {
-      "row": 35,
-      "col": 12,
-      "color": null,
+      "id": "L35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L34",
+        "south": "L36",
+        "west": "K35",
+        "east": "M35"
       }
     },
     {
-      "row": 35,
-      "col": 13,
-      "color": null,
+      "id": "M35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M34",
+        "south": "M36",
+        "west": "L35",
+        "east": "N35"
       }
     },
     {
-      "row": 35,
-      "col": 14,
-      "color": null,
+      "id": "N35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N34",
+        "south": "N36",
+        "west": "M35",
+        "east": "O35"
       }
     },
     {
-      "row": 35,
-      "col": 15,
-      "color": null,
+      "id": "O35",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O34",
+        "south": "O36",
+        "west": "N35",
+        "east": "P35"
       }
     },
     {
-      "row": 35,
-      "col": 16,
-      "color": null,
+      "id": "P35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P34",
+        "south": "P36",
+        "west": "O35",
+        "east": "Q35"
       }
     },
     {
-      "row": 35,
-      "col": 17,
-      "color": null,
+      "id": "Q35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q34",
+        "south": "Q36",
+        "west": "P35",
+        "east": "R35"
       }
     },
     {
-      "row": 35,
-      "col": 18,
-      "color": null,
+      "id": "R35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R34",
+        "south": "R36",
+        "west": "Q35",
+        "east": "S35"
       }
     },
     {
-      "row": 35,
-      "col": 19,
-      "color": null,
+      "id": "S35",
+      "terrain": "hut",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S34",
+        "south": "S36",
+        "west": "R35",
+        "east": "T35"
       }
     },
     {
-      "row": 35,
-      "col": 20,
-      "color": null,
+      "id": "T35",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T34",
+        "south": "T36",
+        "west": "S35",
+        "east": "U35"
       }
     },
     {
-      "row": 35,
-      "col": 21,
-      "color": null,
+      "id": "U35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U34",
+        "south": "U36",
+        "west": "T35",
+        "east": "V35"
       }
     },
     {
-      "row": 35,
-      "col": 22,
-      "color": null,
+      "id": "V35",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V34",
+        "south": "V36",
+        "west": "U35",
+        "east": "W35"
       }
     },
     {
-      "row": 35,
-      "col": 23,
-      "color": null,
+      "id": "W35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W34",
+        "south": "W36",
+        "west": "V35",
+        "east": "X35"
       }
     },
     {
-      "row": 35,
-      "col": 24,
-      "color": null,
+      "id": "X35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X34",
+        "south": "X36",
+        "west": "W35",
+        "east": "Y35"
       }
     },
     {
-      "row": 35,
-      "col": 25,
-      "color": null,
+      "id": "Y35",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y34",
+        "south": "Y36",
+        "west": "X35",
+        "east": "Z35"
       }
     },
     {
-      "row": 35,
-      "col": 26,
-      "color": null,
+      "id": "Z35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z34",
+        "south": "Z36",
+        "west": "Y35",
+        "east": "AA35"
       }
     },
     {
-      "row": 35,
-      "col": 27,
-      "color": null,
+      "id": "AA35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA34",
+        "south": "AA36",
+        "west": "Z35",
+        "east": "AB35"
       }
     },
     {
-      "row": 35,
-      "col": 28,
-      "color": null,
+      "id": "AB35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB34",
+        "south": "AB36",
+        "west": "AA35",
+        "east": "AC35"
       }
     },
     {
-      "row": 35,
-      "col": 29,
-      "color": null,
+      "id": "AC35",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC34",
+        "south": "AC36",
+        "west": "AB35",
+        "east": "AD35"
       }
     },
     {
-      "row": 35,
-      "col": 30,
-      "color": null,
+      "id": "AD35",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD34",
+        "south": "AD36",
+        "west": "AC35",
+        "east": "AE35"
       }
     },
     {
-      "row": 35,
-      "col": 31,
-      "color": null,
+      "id": "AE35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE34",
+        "south": "AE36",
+        "west": "AD35",
+        "east": "AF35"
       }
     },
     {
-      "row": 35,
-      "col": 32,
-      "color": null,
+      "id": "AF35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF34",
+        "south": "AF36",
+        "west": "AE35",
+        "east": "AG35"
       }
     },
     {
-      "row": 35,
-      "col": 33,
-      "color": null,
+      "id": "AG35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG34",
+        "south": "AG36",
+        "west": "AF35",
+        "east": "AH35"
       }
     },
     {
-      "row": 35,
-      "col": 34,
-      "color": null,
+      "id": "AH35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH34",
+        "south": "AH36",
+        "west": "AG35",
+        "east": "AI35"
       }
     },
     {
-      "row": 35,
-      "col": 35,
-      "color": null,
+      "id": "AI35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI34",
+        "south": "AI36",
+        "west": "AH35",
+        "east": "AJ35"
       }
     },
     {
-      "row": 35,
-      "col": 36,
-      "color": null,
+      "id": "AJ35",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ34",
+        "south": "AJ36",
+        "west": "AI35",
+        "east": "AK35"
       }
     },
     {
-      "row": 35,
-      "col": 37,
-      "color": null,
+      "id": "AK35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK34",
+        "south": "AK36",
+        "west": "AJ35",
+        "east": "AL35"
       }
     },
     {
-      "row": 35,
-      "col": 38,
-      "color": null,
+      "id": "AL35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL34",
+        "south": "AL36",
+        "west": "AK35",
+        "east": "AM35"
       }
     },
     {
-      "row": 35,
-      "col": 39,
-      "color": null,
+      "id": "AM35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM34",
+        "south": "AM36",
+        "west": "AL35",
+        "east": "AN35"
       }
     },
     {
-      "row": 35,
-      "col": 40,
-      "color": null,
+      "id": "AN35",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN34",
+        "south": "AN36",
+        "west": "AM35",
+        "east": "AO35"
       }
     },
     {
-      "row": 35,
-      "col": 41,
-      "color": null,
+      "id": "AO35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO34",
+        "south": "AO36",
+        "west": "AN35",
+        "east": "AP35"
       }
     },
     {
-      "row": 35,
-      "col": 42,
-      "color": null,
+      "id": "AP35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP34",
+        "south": "AP36",
+        "west": "AO35",
+        "east": "AQ35"
       }
     },
     {
-      "row": 35,
-      "col": 43,
-      "color": null,
+      "id": "AQ35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ34",
+        "south": "AQ36",
+        "west": "AP35",
+        "east": "AR35"
       }
     },
     {
-      "row": 35,
-      "col": 44,
-      "color": null,
+      "id": "AR35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR34",
+        "south": "AR36",
+        "west": "AQ35",
+        "east": "AS35"
       }
     },
     {
-      "row": 35,
-      "col": 45,
-      "color": null,
+      "id": "AS35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS34",
+        "south": "AS36",
+        "west": "AR35",
+        "east": "AT35"
       }
     },
     {
-      "row": 35,
-      "col": 46,
-      "color": null,
+      "id": "AT35",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT34",
+        "south": "AT36",
+        "west": "AS35",
+        "east": "AU35"
       }
     },
     {
-      "row": 35,
-      "col": 47,
-      "color": null,
+      "id": "AU35",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU34",
+        "south": "AU36",
+        "west": "AT35",
+        "east": "AV35"
       }
     },
     {
-      "row": 35,
-      "col": 48,
-      "color": null,
+      "id": "AV35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV34",
+        "south": "AV36",
+        "west": "AU35",
+        "east": "AW35"
       }
     },
     {
-      "row": 35,
-      "col": 49,
-      "color": null,
+      "id": "AW35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW34",
+        "south": "AW36",
+        "west": "AV35",
+        "east": "AX35"
       }
     },
     {
-      "row": 35,
-      "col": 50,
-      "color": null,
+      "id": "AX35",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX34",
+        "south": "AX36",
+        "west": "AW35"
       }
     },
     {
-      "row": 36,
-      "col": 1,
-      "color": null,
+      "id": "A36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A35",
+        "south": "A37",
+        "east": "B36"
       }
     },
     {
-      "row": 36,
-      "col": 2,
-      "color": null,
+      "id": "B36",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B35",
+        "south": "B37",
+        "west": "A36",
+        "east": "C36"
       }
     },
     {
-      "row": 36,
-      "col": 3,
-      "color": null,
+      "id": "C36",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C35",
+        "south": "C37",
+        "west": "B36",
+        "east": "D36"
       }
     },
     {
-      "row": 36,
-      "col": 4,
-      "color": null,
+      "id": "D36",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D35",
+        "south": "D37",
+        "west": "C36",
+        "east": "E36"
       }
     },
     {
-      "row": 36,
-      "col": 5,
-      "color": null,
+      "id": "E36",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E35",
+        "south": "E37",
+        "west": "D36",
+        "east": "F36"
       }
     },
     {
-      "row": 36,
-      "col": 6,
-      "color": null,
+      "id": "F36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F35",
+        "south": "F37",
+        "west": "E36",
+        "east": "G36"
       }
     },
     {
-      "row": 36,
-      "col": 7,
-      "color": null,
+      "id": "G36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G35",
+        "south": "G37",
+        "west": "F36",
+        "east": "H36"
       }
     },
     {
-      "row": 36,
-      "col": 8,
-      "color": null,
+      "id": "H36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H35",
+        "south": "H37",
+        "west": "G36",
+        "east": "I36"
       }
     },
     {
-      "row": 36,
-      "col": 9,
-      "color": null,
+      "id": "I36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I35",
+        "south": "I37",
+        "west": "H36",
+        "east": "J36"
       }
     },
     {
-      "row": 36,
-      "col": 10,
-      "color": null,
+      "id": "J36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J35",
+        "south": "J37",
+        "west": "I36",
+        "east": "K36"
       }
     },
     {
-      "row": 36,
-      "col": 11,
-      "color": null,
+      "id": "K36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K35",
+        "south": "K37",
+        "west": "J36",
+        "east": "L36"
       }
     },
     {
-      "row": 36,
-      "col": 12,
-      "color": null,
+      "id": "L36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L35",
+        "south": "L37",
+        "west": "K36",
+        "east": "M36"
       }
     },
     {
-      "row": 36,
-      "col": 13,
-      "color": null,
+      "id": "M36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M35",
+        "south": "M37",
+        "west": "L36",
+        "east": "N36"
       }
     },
     {
-      "row": 36,
-      "col": 14,
-      "color": null,
+      "id": "N36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N35",
+        "south": "N37",
+        "west": "M36",
+        "east": "O36"
       }
     },
     {
-      "row": 36,
-      "col": 15,
-      "color": null,
+      "id": "O36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O35",
+        "south": "O37",
+        "west": "N36",
+        "east": "P36"
       }
     },
     {
-      "row": 36,
-      "col": 16,
-      "color": null,
+      "id": "P36",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P35",
+        "south": "P37",
+        "west": "O36",
+        "east": "Q36"
       }
     },
     {
-      "row": 36,
-      "col": 17,
-      "color": null,
+      "id": "Q36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q35",
+        "south": "Q37",
+        "west": "P36",
+        "east": "R36"
       }
     },
     {
-      "row": 36,
-      "col": 18,
-      "color": null,
+      "id": "R36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R35",
+        "south": "R37",
+        "west": "Q36",
+        "east": "S36"
       }
     },
     {
-      "row": 36,
-      "col": 19,
-      "color": null,
+      "id": "S36",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S35",
+        "south": "S37",
+        "west": "R36",
+        "east": "T36"
       }
     },
     {
-      "row": 36,
-      "col": 20,
-      "color": null,
+      "id": "T36",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T35",
+        "south": "T37",
+        "west": "S36",
+        "east": "U36"
       }
     },
     {
-      "row": 36,
-      "col": 21,
-      "color": null,
+      "id": "U36",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U35",
+        "south": "U37",
+        "west": "T36",
+        "east": "V36"
       }
     },
     {
-      "row": 36,
-      "col": 22,
-      "color": null,
+      "id": "V36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V35",
+        "south": "V37",
+        "west": "U36",
+        "east": "W36"
       }
     },
     {
-      "row": 36,
-      "col": 23,
-      "color": null,
+      "id": "W36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W35",
+        "south": "W37",
+        "west": "V36",
+        "east": "X36"
       }
     },
     {
-      "row": 36,
-      "col": 24,
-      "color": null,
+      "id": "X36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X35",
+        "south": "X37",
+        "west": "W36",
+        "east": "Y36"
       }
     },
     {
-      "row": 36,
-      "col": 25,
-      "color": null,
+      "id": "Y36",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y35",
+        "south": "Y37",
+        "west": "X36",
+        "east": "Z36"
       }
     },
     {
-      "row": 36,
-      "col": 26,
-      "color": null,
+      "id": "Z36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z35",
+        "south": "Z37",
+        "west": "Y36",
+        "east": "AA36"
       }
     },
     {
-      "row": 36,
-      "col": 27,
-      "color": null,
+      "id": "AA36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA35",
+        "south": "AA37",
+        "west": "Z36",
+        "east": "AB36"
       }
     },
     {
-      "row": 36,
-      "col": 28,
-      "color": null,
+      "id": "AB36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB35",
+        "south": "AB37",
+        "west": "AA36",
+        "east": "AC36"
       }
     },
     {
-      "row": 36,
-      "col": 29,
-      "color": null,
+      "id": "AC36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC35",
+        "south": "AC37",
+        "west": "AB36",
+        "east": "AD36"
       }
     },
     {
-      "row": 36,
-      "col": 30,
-      "color": null,
+      "id": "AD36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD35",
+        "south": "AD37",
+        "west": "AC36",
+        "east": "AE36"
       }
     },
     {
-      "row": 36,
-      "col": 31,
-      "color": null,
+      "id": "AE36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE35",
+        "south": "AE37",
+        "west": "AD36",
+        "east": "AF36"
       }
     },
     {
-      "row": 36,
-      "col": 32,
-      "color": null,
+      "id": "AF36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF35",
+        "south": "AF37",
+        "west": "AE36",
+        "east": "AG36"
       }
     },
     {
-      "row": 36,
-      "col": 33,
-      "color": null,
+      "id": "AG36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG35",
+        "south": "AG37",
+        "west": "AF36",
+        "east": "AH36"
       }
     },
     {
-      "row": 36,
-      "col": 34,
-      "color": null,
+      "id": "AH36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH35",
+        "south": "AH37",
+        "west": "AG36",
+        "east": "AI36"
       }
     },
     {
-      "row": 36,
-      "col": 35,
-      "color": null,
+      "id": "AI36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI35",
+        "south": "AI37",
+        "west": "AH36",
+        "east": "AJ36"
       }
     },
     {
-      "row": 36,
-      "col": 36,
-      "color": null,
+      "id": "AJ36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ35",
+        "south": "AJ37",
+        "west": "AI36",
+        "east": "AK36"
       }
     },
     {
-      "row": 36,
-      "col": 37,
-      "color": null,
+      "id": "AK36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK35",
+        "south": "AK37",
+        "west": "AJ36",
+        "east": "AL36"
       }
     },
     {
-      "row": 36,
-      "col": 38,
-      "color": null,
+      "id": "AL36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL35",
+        "south": "AL37",
+        "west": "AK36",
+        "east": "AM36"
       }
     },
     {
-      "row": 36,
-      "col": 39,
-      "color": null,
+      "id": "AM36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM35",
+        "south": "AM37",
+        "west": "AL36",
+        "east": "AN36"
       }
     },
     {
-      "row": 36,
-      "col": 40,
-      "color": null,
+      "id": "AN36",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN35",
+        "south": "AN37",
+        "west": "AM36",
+        "east": "AO36"
       }
     },
     {
-      "row": 36,
-      "col": 41,
-      "color": null,
+      "id": "AO36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO35",
+        "south": "AO37",
+        "west": "AN36",
+        "east": "AP36"
       }
     },
     {
-      "row": 36,
-      "col": 42,
-      "color": null,
+      "id": "AP36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP35",
+        "south": "AP37",
+        "west": "AO36",
+        "east": "AQ36"
       }
     },
     {
-      "row": 36,
-      "col": 43,
-      "color": null,
+      "id": "AQ36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ35",
+        "south": "AQ37",
+        "west": "AP36",
+        "east": "AR36"
       }
     },
     {
-      "row": 36,
-      "col": 44,
-      "color": null,
+      "id": "AR36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR35",
+        "south": "AR37",
+        "west": "AQ36",
+        "east": "AS36"
       }
     },
     {
-      "row": 36,
-      "col": 45,
-      "color": null,
+      "id": "AS36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS35",
+        "south": "AS37",
+        "west": "AR36",
+        "east": "AT36"
       }
     },
     {
-      "row": 36,
-      "col": 46,
-      "color": null,
+      "id": "AT36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT35",
+        "south": "AT37",
+        "west": "AS36",
+        "east": "AU36"
       }
     },
     {
-      "row": 36,
-      "col": 47,
-      "color": null,
+      "id": "AU36",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU35",
+        "south": "AU37",
+        "west": "AT36",
+        "east": "AV36"
       }
     },
     {
-      "row": 36,
-      "col": 48,
-      "color": null,
+      "id": "AV36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV35",
+        "south": "AV37",
+        "west": "AU36",
+        "east": "AW36"
       }
     },
     {
-      "row": 36,
-      "col": 49,
-      "color": null,
+      "id": "AW36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW35",
+        "south": "AW37",
+        "west": "AV36",
+        "east": "AX36"
       }
     },
     {
-      "row": 36,
-      "col": 50,
-      "color": null,
+      "id": "AX36",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX35",
+        "south": "AX37",
+        "west": "AW36"
       }
     },
     {
-      "row": 37,
-      "col": 1,
-      "color": null,
+      "id": "A37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A36",
+        "south": "A38",
+        "east": "B37"
       }
     },
     {
-      "row": 37,
-      "col": 2,
-      "color": null,
+      "id": "B37",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B36",
+        "south": "B38",
+        "west": "A37",
+        "east": "C37"
       }
     },
     {
-      "row": 37,
-      "col": 3,
-      "color": null,
+      "id": "C37",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C36",
+        "south": "C38",
+        "west": "B37",
+        "east": "D37"
       }
     },
     {
-      "row": 37,
-      "col": 4,
-      "color": null,
+      "id": "D37",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D36",
+        "south": "D38",
+        "west": "C37",
+        "east": "E37"
       }
     },
     {
-      "row": 37,
-      "col": 5,
-      "color": null,
+      "id": "E37",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E36",
+        "south": "E38",
+        "west": "D37",
+        "east": "F37"
       }
     },
     {
-      "row": 37,
-      "col": 6,
-      "color": null,
+      "id": "F37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F36",
+        "south": "F38",
+        "west": "E37",
+        "east": "G37"
       }
     },
     {
-      "row": 37,
-      "col": 7,
-      "color": null,
+      "id": "G37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G36",
+        "south": "G38",
+        "west": "F37",
+        "east": "H37"
       }
     },
     {
-      "row": 37,
-      "col": 8,
-      "color": null,
+      "id": "H37",
+      "terrain": "battlefld",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H36",
+        "south": "H38",
+        "west": "G37",
+        "east": "I37"
       }
     },
     {
-      "row": 37,
-      "col": 9,
-      "color": null,
+      "id": "I37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I36",
+        "south": "I38",
+        "west": "H37",
+        "east": "J37"
       }
     },
     {
-      "row": 37,
-      "col": 10,
-      "color": null,
+      "id": "J37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J36",
+        "south": "J38",
+        "west": "I37",
+        "east": "K37"
       }
     },
     {
-      "row": 37,
-      "col": 11,
-      "color": null,
+      "id": "K37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K36",
+        "south": "K38",
+        "west": "J37",
+        "east": "L37"
       }
     },
     {
-      "row": 37,
-      "col": 12,
-      "color": null,
+      "id": "L37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L36",
+        "south": "L38",
+        "west": "K37",
+        "east": "M37"
       }
     },
     {
-      "row": 37,
-      "col": 13,
-      "color": null,
+      "id": "M37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M36",
+        "south": "M38",
+        "west": "L37",
+        "east": "N37"
       }
     },
     {
-      "row": 37,
-      "col": 14,
-      "color": null,
+      "id": "N37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N36",
+        "south": "N38",
+        "west": "M37",
+        "east": "O37"
       }
     },
     {
-      "row": 37,
-      "col": 15,
-      "color": null,
+      "id": "O37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O36",
+        "south": "O38",
+        "west": "N37",
+        "east": "P37"
       }
     },
     {
-      "row": 37,
-      "col": 16,
-      "color": null,
+      "id": "P37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P36",
+        "south": "P38",
+        "west": "O37",
+        "east": "Q37"
       }
     },
     {
-      "row": 37,
-      "col": 17,
-      "color": null,
+      "id": "Q37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q36",
+        "south": "Q38",
+        "west": "P37",
+        "east": "R37"
       }
     },
     {
-      "row": 37,
-      "col": 18,
-      "color": null,
+      "id": "R37",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R36",
+        "south": "R38",
+        "west": "Q37",
+        "east": "S37"
       }
     },
     {
-      "row": 37,
-      "col": 19,
-      "color": null,
+      "id": "S37",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S36",
+        "south": "S38",
+        "west": "R37",
+        "east": "T37"
       }
     },
     {
-      "row": 37,
-      "col": 20,
-      "color": null,
+      "id": "T37",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T36",
+        "south": "T38",
+        "west": "S37",
+        "east": "U37"
       }
     },
     {
-      "row": 37,
-      "col": 21,
-      "color": null,
+      "id": "U37",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U36",
+        "south": "U38",
+        "west": "T37",
+        "east": "V37"
       }
     },
     {
-      "row": 37,
-      "col": 22,
-      "color": null,
+      "id": "V37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V36",
+        "south": "V38",
+        "west": "U37",
+        "east": "W37"
       }
     },
     {
-      "row": 37,
-      "col": 23,
-      "color": null,
+      "id": "W37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W36",
+        "south": "W38",
+        "west": "V37",
+        "east": "X37"
       }
     },
     {
-      "row": 37,
-      "col": 24,
-      "color": null,
+      "id": "X37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X36",
+        "south": "X38",
+        "west": "W37",
+        "east": "Y37"
       }
     },
     {
-      "row": 37,
-      "col": 25,
-      "color": null,
+      "id": "Y37",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y36",
+        "south": "Y38",
+        "west": "X37",
+        "east": "Z37"
       }
     },
     {
-      "row": 37,
-      "col": 26,
-      "color": null,
+      "id": "Z37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z36",
+        "south": "Z38",
+        "west": "Y37",
+        "east": "AA37"
       }
     },
     {
-      "row": 37,
-      "col": 27,
-      "color": null,
+      "id": "AA37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA36",
+        "south": "AA38",
+        "west": "Z37",
+        "east": "AB37"
       }
     },
     {
-      "row": 37,
-      "col": 28,
-      "color": null,
+      "id": "AB37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB36",
+        "south": "AB38",
+        "west": "AA37",
+        "east": "AC37"
       }
     },
     {
-      "row": 37,
-      "col": 29,
-      "color": null,
+      "id": "AC37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC36",
+        "south": "AC38",
+        "west": "AB37",
+        "east": "AD37"
       }
     },
     {
-      "row": 37,
-      "col": 30,
-      "color": null,
+      "id": "AD37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD36",
+        "south": "AD38",
+        "west": "AC37",
+        "east": "AE37"
       }
     },
     {
-      "row": 37,
-      "col": 31,
-      "color": null,
+      "id": "AE37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE36",
+        "south": "AE38",
+        "west": "AD37",
+        "east": "AF37"
       }
     },
     {
-      "row": 37,
-      "col": 32,
-      "color": null,
+      "id": "AF37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF36",
+        "south": "AF38",
+        "west": "AE37",
+        "east": "AG37"
       }
     },
     {
-      "row": 37,
-      "col": 33,
-      "color": null,
+      "id": "AG37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG36",
+        "south": "AG38",
+        "west": "AF37",
+        "east": "AH37"
       }
     },
     {
-      "row": 37,
-      "col": 34,
-      "color": null,
+      "id": "AH37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH36",
+        "south": "AH38",
+        "west": "AG37",
+        "east": "AI37"
       }
     },
     {
-      "row": 37,
-      "col": 35,
-      "color": null,
+      "id": "AI37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI36",
+        "south": "AI38",
+        "west": "AH37",
+        "east": "AJ37"
       }
     },
     {
-      "row": 37,
-      "col": 36,
-      "color": null,
+      "id": "AJ37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ36",
+        "south": "AJ38",
+        "west": "AI37",
+        "east": "AK37"
       }
     },
     {
-      "row": 37,
-      "col": 37,
-      "color": null,
+      "id": "AK37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK36",
+        "south": "AK38",
+        "west": "AJ37",
+        "east": "AL37"
       }
     },
     {
-      "row": 37,
-      "col": 38,
-      "color": null,
+      "id": "AL37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL36",
+        "south": "AL38",
+        "west": "AK37",
+        "east": "AM37"
       }
     },
     {
-      "row": 37,
-      "col": 39,
-      "color": null,
+      "id": "AM37",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM36",
+        "south": "AM38",
+        "west": "AL37",
+        "east": "AN37"
       }
     },
     {
-      "row": 37,
-      "col": 40,
-      "color": null,
+      "id": "AN37",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN36",
+        "south": "AN38",
+        "west": "AM37",
+        "east": "AO37"
       }
     },
     {
-      "row": 37,
-      "col": 41,
-      "color": null,
+      "id": "AO37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO36",
+        "south": "AO38",
+        "west": "AN37",
+        "east": "AP37"
       }
     },
     {
-      "row": 37,
-      "col": 42,
-      "color": null,
+      "id": "AP37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP36",
+        "south": "AP38",
+        "west": "AO37",
+        "east": "AQ37"
       }
     },
     {
-      "row": 37,
-      "col": 43,
-      "color": null,
+      "id": "AQ37",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ36",
+        "south": "AQ38",
+        "west": "AP37",
+        "east": "AR37"
       }
     },
     {
-      "row": 37,
-      "col": 44,
-      "color": null,
+      "id": "AR37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR36",
+        "south": "AR38",
+        "west": "AQ37",
+        "east": "AS37"
       }
     },
     {
-      "row": 37,
-      "col": 45,
-      "color": null,
+      "id": "AS37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS36",
+        "south": "AS38",
+        "west": "AR37",
+        "east": "AT37"
       }
     },
     {
-      "row": 37,
-      "col": 46,
-      "color": null,
+      "id": "AT37",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT36",
+        "south": "AT38",
+        "west": "AS37",
+        "east": "AU37"
       }
     },
     {
-      "row": 37,
-      "col": 47,
-      "color": null,
+      "id": "AU37",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU36",
+        "south": "AU38",
+        "west": "AT37",
+        "east": "AV37"
       }
     },
     {
-      "row": 37,
-      "col": 48,
-      "color": null,
+      "id": "AV37",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV36",
+        "south": "AV38",
+        "west": "AU37",
+        "east": "AW37"
       }
     },
     {
-      "row": 37,
-      "col": 49,
-      "color": null,
+      "id": "AW37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW36",
+        "south": "AW38",
+        "west": "AV37",
+        "east": "AX37"
       }
     },
     {
-      "row": 37,
-      "col": 50,
-      "color": null,
+      "id": "AX37",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX36",
+        "south": "AX38",
+        "west": "AW37"
       }
     },
     {
-      "row": 38,
-      "col": 1,
-      "color": null,
+      "id": "A38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A37",
+        "south": "A39",
+        "east": "B38"
       }
     },
     {
-      "row": 38,
-      "col": 2,
-      "color": null,
+      "id": "B38",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B37",
+        "south": "B39",
+        "west": "A38",
+        "east": "C38"
       }
     },
     {
-      "row": 38,
-      "col": 3,
-      "color": null,
+      "id": "C38",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C37",
+        "south": "C39",
+        "west": "B38",
+        "east": "D38"
       }
     },
     {
-      "row": 38,
-      "col": 4,
-      "color": null,
+      "id": "D38",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D37",
+        "south": "D39",
+        "west": "C38",
+        "east": "E38"
       }
     },
     {
-      "row": 38,
-      "col": 5,
-      "color": null,
+      "id": "E38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E37",
+        "south": "E39",
+        "west": "D38",
+        "east": "F38"
       }
     },
     {
-      "row": 38,
-      "col": 6,
-      "color": null,
+      "id": "F38",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F37",
+        "south": "F39",
+        "west": "E38",
+        "east": "G38"
       }
     },
     {
-      "row": 38,
-      "col": 7,
-      "color": null,
+      "id": "G38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G37",
+        "south": "G39",
+        "west": "F38",
+        "east": "H38"
       }
     },
     {
-      "row": 38,
-      "col": 8,
-      "color": null,
+      "id": "H38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H37",
+        "south": "H39",
+        "west": "G38",
+        "east": "I38"
       }
     },
     {
-      "row": 38,
-      "col": 9,
-      "color": null,
+      "id": "I38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I37",
+        "south": "I39",
+        "west": "H38",
+        "east": "J38"
       }
     },
     {
-      "row": 38,
-      "col": 10,
-      "color": null,
+      "id": "J38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J37",
+        "south": "J39",
+        "west": "I38",
+        "east": "K38"
       }
     },
     {
-      "row": 38,
-      "col": 11,
-      "color": null,
+      "id": "K38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K37",
+        "south": "K39",
+        "west": "J38",
+        "east": "L38"
       }
     },
     {
-      "row": 38,
-      "col": 12,
-      "color": null,
+      "id": "L38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L37",
+        "south": "L39",
+        "west": "K38",
+        "east": "M38"
       }
     },
     {
-      "row": 38,
-      "col": 13,
-      "color": null,
+      "id": "M38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M37",
+        "south": "M39",
+        "west": "L38",
+        "east": "N38"
       }
     },
     {
-      "row": 38,
-      "col": 14,
-      "color": null,
+      "id": "N38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N37",
+        "south": "N39",
+        "west": "M38",
+        "east": "O38"
       }
     },
     {
-      "row": 38,
-      "col": 15,
-      "color": null,
+      "id": "O38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O37",
+        "south": "O39",
+        "west": "N38",
+        "east": "P38"
       }
     },
     {
-      "row": 38,
-      "col": 16,
-      "color": null,
+      "id": "P38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P37",
+        "south": "P39",
+        "west": "O38",
+        "east": "Q38"
       }
     },
     {
-      "row": 38,
-      "col": 17,
-      "color": null,
+      "id": "Q38",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q37",
+        "south": "Q39",
+        "west": "P38",
+        "east": "R38"
       }
     },
     {
-      "row": 38,
-      "col": 18,
-      "color": null,
+      "id": "R38",
+      "terrain": "dock",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R37",
+        "south": "R39",
+        "west": "Q38",
+        "east": "S38"
       }
     },
     {
-      "row": 38,
-      "col": 19,
-      "color": null,
+      "id": "S38",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S37",
+        "south": "S39",
+        "west": "R38",
+        "east": "T38"
       }
     },
     {
-      "row": 38,
-      "col": 20,
-      "color": null,
+      "id": "T38",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T37",
+        "south": "T39",
+        "west": "S38",
+        "east": "U38"
       }
     },
     {
-      "row": 38,
-      "col": 21,
-      "color": null,
+      "id": "U38",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U37",
+        "south": "U39",
+        "west": "T38",
+        "east": "V38"
       }
     },
     {
-      "row": 38,
-      "col": 22,
-      "color": null,
+      "id": "V38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V37",
+        "south": "V39",
+        "west": "U38",
+        "east": "W38"
       }
     },
     {
-      "row": 38,
-      "col": 23,
-      "color": null,
+      "id": "W38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W37",
+        "south": "W39",
+        "west": "V38",
+        "east": "X38"
       }
     },
     {
-      "row": 38,
-      "col": 24,
-      "color": null,
+      "id": "X38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X37",
+        "south": "X39",
+        "west": "W38",
+        "east": "Y38"
       }
     },
     {
-      "row": 38,
-      "col": 25,
-      "color": null,
+      "id": "Y38",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y37",
+        "south": "Y39",
+        "west": "X38",
+        "east": "Z38"
       }
     },
     {
-      "row": 38,
-      "col": 26,
-      "color": null,
+      "id": "Z38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z37",
+        "south": "Z39",
+        "west": "Y38",
+        "east": "AA38"
       }
     },
     {
-      "row": 38,
-      "col": 27,
-      "color": null,
+      "id": "AA38",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA37",
+        "south": "AA39",
+        "west": "Z38",
+        "east": "AB38"
       }
     },
     {
-      "row": 38,
-      "col": 28,
-      "color": null,
+      "id": "AB38",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB37",
+        "south": "AB39",
+        "west": "AA38",
+        "east": "AC38"
       }
     },
     {
-      "row": 38,
-      "col": 29,
-      "color": null,
+      "id": "AC38",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC37",
+        "south": "AC39",
+        "west": "AB38",
+        "east": "AD38"
       }
     },
     {
-      "row": 38,
-      "col": 30,
-      "color": null,
+      "id": "AD38",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD37",
+        "south": "AD39",
+        "west": "AC38",
+        "east": "AE38"
       }
     },
     {
-      "row": 38,
-      "col": 31,
-      "color": null,
+      "id": "AE38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE37",
+        "south": "AE39",
+        "west": "AD38",
+        "east": "AF38"
       }
     },
     {
-      "row": 38,
-      "col": 32,
-      "color": null,
+      "id": "AF38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF37",
+        "south": "AF39",
+        "west": "AE38",
+        "east": "AG38"
       }
     },
     {
-      "row": 38,
-      "col": 33,
-      "color": null,
+      "id": "AG38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG37",
+        "south": "AG39",
+        "west": "AF38",
+        "east": "AH38"
       }
     },
     {
-      "row": 38,
-      "col": 34,
-      "color": null,
+      "id": "AH38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH37",
+        "south": "AH39",
+        "west": "AG38",
+        "east": "AI38"
       }
     },
     {
-      "row": 38,
-      "col": 35,
-      "color": null,
+      "id": "AI38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI37",
+        "south": "AI39",
+        "west": "AH38",
+        "east": "AJ38"
       }
     },
     {
-      "row": 38,
-      "col": 36,
-      "color": null,
+      "id": "AJ38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ37",
+        "south": "AJ39",
+        "west": "AI38",
+        "east": "AK38"
       }
     },
     {
-      "row": 38,
-      "col": 37,
-      "color": null,
+      "id": "AK38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK37",
+        "south": "AK39",
+        "west": "AJ38",
+        "east": "AL38"
       }
     },
     {
-      "row": 38,
-      "col": 38,
-      "color": null,
+      "id": "AL38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL37",
+        "south": "AL39",
+        "west": "AK38",
+        "east": "AM38"
       }
     },
     {
-      "row": 38,
-      "col": 39,
-      "color": null,
+      "id": "AM38",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM37",
+        "south": "AM39",
+        "west": "AL38",
+        "east": "AN38"
       }
     },
     {
-      "row": 38,
-      "col": 40,
-      "color": null,
+      "id": "AN38",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN37",
+        "south": "AN39",
+        "west": "AM38",
+        "east": "AO38"
       }
     },
     {
-      "row": 38,
-      "col": 41,
-      "color": null,
+      "id": "AO38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO37",
+        "south": "AO39",
+        "west": "AN38",
+        "east": "AP38"
       }
     },
     {
-      "row": 38,
-      "col": 42,
-      "color": null,
+      "id": "AP38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP37",
+        "south": "AP39",
+        "west": "AO38",
+        "east": "AQ38"
       }
     },
     {
-      "row": 38,
-      "col": 43,
-      "color": null,
+      "id": "AQ38",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ37",
+        "south": "AQ39",
+        "west": "AP38",
+        "east": "AR38"
       }
     },
     {
-      "row": 38,
-      "col": 44,
-      "color": null,
+      "id": "AR38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR37",
+        "south": "AR39",
+        "west": "AQ38",
+        "east": "AS38"
       }
     },
     {
-      "row": 38,
-      "col": 45,
-      "color": null,
+      "id": "AS38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS37",
+        "south": "AS39",
+        "west": "AR38",
+        "east": "AT38"
       }
     },
     {
-      "row": 38,
-      "col": 46,
-      "color": null,
+      "id": "AT38",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT37",
+        "south": "AT39",
+        "west": "AS38",
+        "east": "AU38"
       }
     },
     {
-      "row": 38,
-      "col": 47,
-      "color": null,
+      "id": "AU38",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU37",
+        "south": "AU39",
+        "west": "AT38",
+        "east": "AV38"
       }
     },
     {
-      "row": 38,
-      "col": 48,
-      "color": null,
+      "id": "AV38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV37",
+        "south": "AV39",
+        "west": "AU38",
+        "east": "AW38"
       }
     },
     {
-      "row": 38,
-      "col": 49,
-      "color": null,
+      "id": "AW38",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW37",
+        "south": "AW39",
+        "west": "AV38",
+        "east": "AX38"
       }
     },
     {
-      "row": 38,
-      "col": 50,
-      "color": null,
+      "id": "AX38",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX37",
+        "south": "AX39",
+        "west": "AW38"
       }
     },
     {
-      "row": 39,
-      "col": 1,
-      "color": null,
+      "id": "A39",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A38",
+        "south": "A40",
+        "east": "B39"
       }
     },
     {
-      "row": 39,
-      "col": 2,
-      "color": null,
+      "id": "B39",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B38",
+        "south": "B40",
+        "west": "A39",
+        "east": "C39"
       }
     },
     {
-      "row": 39,
-      "col": 3,
-      "color": null,
+      "id": "C39",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C38",
+        "south": "C40",
+        "west": "B39",
+        "east": "D39"
       }
     },
     {
-      "row": 39,
-      "col": 4,
-      "color": null,
+      "id": "D39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D38",
+        "south": "D40",
+        "west": "C39",
+        "east": "E39"
       }
     },
     {
-      "row": 39,
-      "col": 5,
-      "color": null,
+      "id": "E39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E38",
+        "south": "E40",
+        "west": "D39",
+        "east": "F39"
       }
     },
     {
-      "row": 39,
-      "col": 6,
-      "color": null,
+      "id": "F39",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F38",
+        "south": "F40",
+        "west": "E39",
+        "east": "G39"
       }
     },
     {
-      "row": 39,
-      "col": 7,
-      "color": null,
+      "id": "G39",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G38",
+        "south": "G40",
+        "west": "F39",
+        "east": "H39"
       }
     },
     {
-      "row": 39,
-      "col": 8,
-      "color": null,
+      "id": "H39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H38",
+        "south": "H40",
+        "west": "G39",
+        "east": "I39"
       }
     },
     {
-      "row": 39,
-      "col": 9,
-      "color": null,
+      "id": "I39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I38",
+        "south": "I40",
+        "west": "H39",
+        "east": "J39"
       }
     },
     {
-      "row": 39,
-      "col": 10,
-      "color": null,
+      "id": "J39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J38",
+        "south": "J40",
+        "west": "I39",
+        "east": "K39"
       }
     },
     {
-      "row": 39,
-      "col": 11,
-      "color": null,
+      "id": "K39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K38",
+        "south": "K40",
+        "west": "J39",
+        "east": "L39"
       }
     },
     {
-      "row": 39,
-      "col": 12,
-      "color": null,
+      "id": "L39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L38",
+        "south": "L40",
+        "west": "K39",
+        "east": "M39"
       }
     },
     {
-      "row": 39,
-      "col": 13,
-      "color": null,
+      "id": "M39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M38",
+        "south": "M40",
+        "west": "L39",
+        "east": "N39"
       }
     },
     {
-      "row": 39,
-      "col": 14,
-      "color": null,
+      "id": "N39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N38",
+        "south": "N40",
+        "west": "M39",
+        "east": "O39"
       }
     },
     {
-      "row": 39,
-      "col": 15,
-      "color": null,
+      "id": "O39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O38",
+        "south": "O40",
+        "west": "N39",
+        "east": "P39"
       }
     },
     {
-      "row": 39,
-      "col": 16,
-      "color": null,
+      "id": "P39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P38",
+        "south": "P40",
+        "west": "O39",
+        "east": "Q39"
       }
     },
     {
-      "row": 39,
-      "col": 17,
-      "color": null,
+      "id": "Q39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q38",
+        "south": "Q40",
+        "west": "P39",
+        "east": "R39"
       }
     },
     {
-      "row": 39,
-      "col": 18,
-      "color": null,
+      "id": "R39",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R38",
+        "south": "R40",
+        "west": "Q39",
+        "east": "S39"
       }
     },
     {
-      "row": 39,
-      "col": 19,
-      "color": null,
+      "id": "S39",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S38",
+        "south": "S40",
+        "west": "R39",
+        "east": "T39"
       }
     },
     {
-      "row": 39,
-      "col": 20,
-      "color": null,
+      "id": "T39",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T38",
+        "south": "T40",
+        "west": "S39",
+        "east": "U39"
       }
     },
     {
-      "row": 39,
-      "col": 21,
-      "color": null,
+      "id": "U39",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U38",
+        "south": "U40",
+        "west": "T39",
+        "east": "V39"
       }
     },
     {
-      "row": 39,
-      "col": 22,
-      "color": null,
+      "id": "V39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V38",
+        "south": "V40",
+        "west": "U39",
+        "east": "W39"
       }
     },
     {
-      "row": 39,
-      "col": 23,
-      "color": null,
+      "id": "W39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W38",
+        "south": "W40",
+        "west": "V39",
+        "east": "X39"
       }
     },
     {
-      "row": 39,
-      "col": 24,
-      "color": null,
+      "id": "X39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X38",
+        "south": "X40",
+        "west": "W39",
+        "east": "Y39"
       }
     },
     {
-      "row": 39,
-      "col": 25,
-      "color": null,
+      "id": "Y39",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y38",
+        "south": "Y40",
+        "west": "X39",
+        "east": "Z39"
       }
     },
     {
-      "row": 39,
-      "col": 26,
-      "color": null,
+      "id": "Z39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z38",
+        "south": "Z40",
+        "west": "Y39",
+        "east": "AA39"
       }
     },
     {
-      "row": 39,
-      "col": 27,
-      "color": null,
+      "id": "AA39",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA38",
+        "south": "AA40",
+        "west": "Z39",
+        "east": "AB39"
       }
     },
     {
-      "row": 39,
-      "col": 28,
-      "color": null,
+      "id": "AB39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB38",
+        "south": "AB40",
+        "west": "AA39",
+        "east": "AC39"
       }
     },
     {
-      "row": 39,
-      "col": 29,
-      "color": null,
+      "id": "AC39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC38",
+        "south": "AC40",
+        "west": "AB39",
+        "east": "AD39"
       }
     },
     {
-      "row": 39,
-      "col": 30,
-      "color": null,
+      "id": "AD39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD38",
+        "south": "AD40",
+        "west": "AC39",
+        "east": "AE39"
       }
     },
     {
-      "row": 39,
-      "col": 31,
-      "color": null,
+      "id": "AE39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE38",
+        "south": "AE40",
+        "west": "AD39",
+        "east": "AF39"
       }
     },
     {
-      "row": 39,
-      "col": 32,
-      "color": null,
+      "id": "AF39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF38",
+        "south": "AF40",
+        "west": "AE39",
+        "east": "AG39"
       }
     },
     {
-      "row": 39,
-      "col": 33,
-      "color": null,
+      "id": "AG39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG38",
+        "south": "AG40",
+        "west": "AF39",
+        "east": "AH39"
       }
     },
     {
-      "row": 39,
-      "col": 34,
-      "color": null,
+      "id": "AH39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH38",
+        "south": "AH40",
+        "west": "AG39",
+        "east": "AI39"
       }
     },
     {
-      "row": 39,
-      "col": 35,
-      "color": null,
+      "id": "AI39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI38",
+        "south": "AI40",
+        "west": "AH39",
+        "east": "AJ39"
       }
     },
     {
-      "row": 39,
-      "col": 36,
-      "color": null,
+      "id": "AJ39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ38",
+        "south": "AJ40",
+        "west": "AI39",
+        "east": "AK39"
       }
     },
     {
-      "row": 39,
-      "col": 37,
-      "color": null,
+      "id": "AK39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK38",
+        "south": "AK40",
+        "west": "AJ39",
+        "east": "AL39"
       }
     },
     {
-      "row": 39,
-      "col": 38,
-      "color": null,
+      "id": "AL39",
+      "terrain": "forest",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL38",
+        "south": "AL40",
+        "west": "AK39",
+        "east": "AM39"
       }
     },
     {
-      "row": 39,
-      "col": 39,
-      "color": null,
+      "id": "AM39",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM38",
+        "south": "AM40",
+        "west": "AL39",
+        "east": "AN39"
       }
     },
     {
-      "row": 39,
-      "col": 40,
-      "color": null,
+      "id": "AN39",
+      "terrain": "forest",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN38",
+        "south": "AN40",
+        "west": "AM39",
+        "east": "AO39"
       }
     },
     {
-      "row": 39,
-      "col": 41,
-      "color": null,
+      "id": "AO39",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO38",
+        "south": "AO40",
+        "west": "AN39",
+        "east": "AP39"
       }
     },
     {
-      "row": 39,
-      "col": 42,
-      "color": null,
+      "id": "AP39",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP38",
+        "south": "AP40",
+        "west": "AO39",
+        "east": "AQ39"
       }
     },
     {
-      "row": 39,
-      "col": 43,
-      "color": null,
+      "id": "AQ39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ38",
+        "south": "AQ40",
+        "west": "AP39",
+        "east": "AR39"
       }
     },
     {
-      "row": 39,
-      "col": 44,
-      "color": null,
+      "id": "AR39",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR38",
+        "south": "AR40",
+        "west": "AQ39",
+        "east": "AS39"
       }
     },
     {
-      "row": 39,
-      "col": 45,
-      "color": null,
+      "id": "AS39",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS38",
+        "south": "AS40",
+        "west": "AR39",
+        "east": "AT39"
       }
     },
     {
-      "row": 39,
-      "col": 46,
-      "color": null,
+      "id": "AT39",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT38",
+        "south": "AT40",
+        "west": "AS39",
+        "east": "AU39"
       }
     },
     {
-      "row": 39,
-      "col": 47,
-      "color": null,
+      "id": "AU39",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU38",
+        "south": "AU40",
+        "west": "AT39",
+        "east": "AV39"
       }
     },
     {
-      "row": 39,
-      "col": 48,
-      "color": null,
+      "id": "AV39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV38",
+        "south": "AV40",
+        "west": "AU39",
+        "east": "AW39"
       }
     },
     {
-      "row": 39,
-      "col": 49,
-      "color": null,
+      "id": "AW39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW38",
+        "south": "AW40",
+        "west": "AV39",
+        "east": "AX39"
       }
     },
     {
-      "row": 39,
-      "col": 50,
-      "color": null,
+      "id": "AX39",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX38",
+        "south": "AX40",
+        "west": "AW39"
       }
     },
     {
-      "row": 40,
-      "col": 1,
-      "color": null,
+      "id": "A40",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A39",
+        "south": "A41",
+        "east": "B40"
       }
     },
     {
-      "row": 40,
-      "col": 2,
-      "color": null,
+      "id": "B40",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B39",
+        "south": "B41",
+        "west": "A40",
+        "east": "C40"
       }
     },
     {
-      "row": 40,
-      "col": 3,
-      "color": null,
+      "id": "C40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C39",
+        "south": "C41",
+        "west": "B40",
+        "east": "D40"
       }
     },
     {
-      "row": 40,
-      "col": 4,
-      "color": null,
+      "id": "D40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D39",
+        "south": "D41",
+        "west": "C40",
+        "east": "E40"
       }
     },
     {
-      "row": 40,
-      "col": 5,
-      "color": null,
+      "id": "E40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E39",
+        "south": "E41",
+        "west": "D40",
+        "east": "F40"
       }
     },
     {
-      "row": 40,
-      "col": 6,
-      "color": null,
+      "id": "F40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F39",
+        "south": "F41",
+        "west": "E40",
+        "east": "G40"
       }
     },
     {
-      "row": 40,
-      "col": 7,
-      "color": null,
+      "id": "G40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G39",
+        "south": "G41",
+        "west": "F40",
+        "east": "H40"
       }
     },
     {
-      "row": 40,
-      "col": 8,
-      "color": null,
+      "id": "H40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H39",
+        "south": "H41",
+        "west": "G40",
+        "east": "I40"
       }
     },
     {
-      "row": 40,
-      "col": 9,
-      "color": null,
+      "id": "I40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I39",
+        "south": "I41",
+        "west": "H40",
+        "east": "J40"
       }
     },
     {
-      "row": 40,
-      "col": 10,
-      "color": null,
+      "id": "J40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J39",
+        "south": "J41",
+        "west": "I40",
+        "east": "K40"
       }
     },
     {
-      "row": 40,
-      "col": 11,
-      "color": null,
+      "id": "K40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K39",
+        "south": "K41",
+        "west": "J40",
+        "east": "L40"
       }
     },
     {
-      "row": 40,
-      "col": 12,
-      "color": null,
+      "id": "L40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L39",
+        "south": "L41",
+        "west": "K40",
+        "east": "M40"
       }
     },
     {
-      "row": 40,
-      "col": 13,
-      "color": null,
+      "id": "M40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M39",
+        "south": "M41",
+        "west": "L40",
+        "east": "N40"
       }
     },
     {
-      "row": 40,
-      "col": 14,
-      "color": null,
+      "id": "N40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N39",
+        "south": "N41",
+        "west": "M40",
+        "east": "O40"
       }
     },
     {
-      "row": 40,
-      "col": 15,
-      "color": null,
+      "id": "O40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O39",
+        "south": "O41",
+        "west": "N40",
+        "east": "P40"
       }
     },
     {
-      "row": 40,
-      "col": 16,
-      "color": null,
+      "id": "P40",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P39",
+        "south": "P41",
+        "west": "O40",
+        "east": "Q40"
       }
     },
     {
-      "row": 40,
-      "col": 17,
-      "color": null,
+      "id": "Q40",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q39",
+        "south": "Q41",
+        "west": "P40",
+        "east": "R40"
       }
     },
     {
-      "row": 40,
-      "col": 18,
-      "color": null,
+      "id": "R40",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R39",
+        "south": "R41",
+        "west": "Q40",
+        "east": "S40"
       }
     },
     {
-      "row": 40,
-      "col": 19,
-      "color": null,
+      "id": "S40",
+      "terrain": "Island",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S39",
+        "south": "S41",
+        "west": "R40",
+        "east": "T40"
       }
     },
     {
-      "row": 40,
-      "col": 20,
-      "color": null,
+      "id": "T40",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T39",
+        "south": "T41",
+        "west": "S40",
+        "east": "U40"
       }
     },
     {
-      "row": 40,
-      "col": 21,
-      "color": null,
+      "id": "U40",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U39",
+        "south": "U41",
+        "west": "T40",
+        "east": "V40"
       }
     },
     {
-      "row": 40,
-      "col": 22,
-      "color": null,
+      "id": "V40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V39",
+        "south": "V41",
+        "west": "U40",
+        "east": "W40"
       }
     },
     {
-      "row": 40,
-      "col": 23,
-      "color": null,
+      "id": "W40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W39",
+        "south": "W41",
+        "west": "V40",
+        "east": "X40"
       }
     },
     {
-      "row": 40,
-      "col": 24,
-      "color": null,
+      "id": "X40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X39",
+        "south": "X41",
+        "west": "W40",
+        "east": "Y40"
       }
     },
     {
-      "row": 40,
-      "col": 25,
-      "color": null,
+      "id": "Y40",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y39",
+        "south": "Y41",
+        "west": "X40",
+        "east": "Z40"
       }
     },
     {
-      "row": 40,
-      "col": 26,
-      "color": null,
+      "id": "Z40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z39",
+        "south": "Z41",
+        "west": "Y40",
+        "east": "AA40"
       }
     },
     {
-      "row": 40,
-      "col": 27,
-      "color": null,
+      "id": "AA40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA39",
+        "south": "AA41",
+        "west": "Z40",
+        "east": "AB40"
       }
     },
     {
-      "row": 40,
-      "col": 28,
-      "color": null,
+      "id": "AB40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB39",
+        "south": "AB41",
+        "west": "AA40",
+        "east": "AC40"
       }
     },
     {
-      "row": 40,
-      "col": 29,
-      "color": null,
+      "id": "AC40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC39",
+        "south": "AC41",
+        "west": "AB40",
+        "east": "AD40"
       }
     },
     {
-      "row": 40,
-      "col": 30,
-      "color": null,
+      "id": "AD40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD39",
+        "south": "AD41",
+        "west": "AC40",
+        "east": "AE40"
       }
     },
     {
-      "row": 40,
-      "col": 31,
-      "color": null,
+      "id": "AE40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE39",
+        "south": "AE41",
+        "west": "AD40",
+        "east": "AF40"
       }
     },
     {
-      "row": 40,
-      "col": 32,
-      "color": null,
+      "id": "AF40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF39",
+        "south": "AF41",
+        "west": "AE40",
+        "east": "AG40"
       }
     },
     {
-      "row": 40,
-      "col": 33,
-      "color": null,
+      "id": "AG40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG39",
+        "south": "AG41",
+        "west": "AF40",
+        "east": "AH40"
       }
     },
     {
-      "row": 40,
-      "col": 34,
-      "color": null,
+      "id": "AH40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH39",
+        "south": "AH41",
+        "west": "AG40",
+        "east": "AI40"
       }
     },
     {
-      "row": 40,
-      "col": 35,
-      "color": null,
+      "id": "AI40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI39",
+        "south": "AI41",
+        "west": "AH40",
+        "east": "AJ40"
       }
     },
     {
-      "row": 40,
-      "col": 36,
-      "color": null,
+      "id": "AJ40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ39",
+        "south": "AJ41",
+        "west": "AI40",
+        "east": "AK40"
       }
     },
     {
-      "row": 40,
-      "col": 37,
-      "color": null,
+      "id": "AK40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK39",
+        "south": "AK41",
+        "west": "AJ40",
+        "east": "AL40"
       }
     },
     {
-      "row": 40,
-      "col": 38,
-      "color": null,
+      "id": "AL40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL39",
+        "south": "AL41",
+        "west": "AK40",
+        "east": "AM40"
       }
     },
     {
-      "row": 40,
-      "col": 39,
-      "color": null,
+      "id": "AM40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM39",
+        "south": "AM41",
+        "west": "AL40",
+        "east": "AN40"
       }
     },
     {
-      "row": 40,
-      "col": 40,
-      "color": null,
+      "id": "AN40",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN39",
+        "south": "AN41",
+        "west": "AM40",
+        "east": "AO40"
       }
     },
     {
-      "row": 40,
-      "col": 41,
-      "color": null,
+      "id": "AO40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO39",
+        "south": "AO41",
+        "west": "AN40",
+        "east": "AP40"
       }
     },
     {
-      "row": 40,
-      "col": 42,
-      "color": null,
+      "id": "AP40",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP39",
+        "south": "AP41",
+        "west": "AO40",
+        "east": "AQ40"
       }
     },
     {
-      "row": 40,
-      "col": 43,
-      "color": null,
+      "id": "AQ40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ39",
+        "south": "AQ41",
+        "west": "AP40",
+        "east": "AR40"
       }
     },
     {
-      "row": 40,
-      "col": 44,
-      "color": null,
+      "id": "AR40",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR39",
+        "south": "AR41",
+        "west": "AQ40",
+        "east": "AS40"
       }
     },
     {
-      "row": 40,
-      "col": 45,
-      "color": null,
+      "id": "AS40",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS39",
+        "south": "AS41",
+        "west": "AR40",
+        "east": "AT40"
       }
     },
     {
-      "row": 40,
-      "col": 46,
-      "color": null,
+      "id": "AT40",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT39",
+        "south": "AT41",
+        "west": "AS40",
+        "east": "AU40"
       }
     },
     {
-      "row": 40,
-      "col": 47,
-      "color": null,
+      "id": "AU40",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU39",
+        "south": "AU41",
+        "west": "AT40",
+        "east": "AV40"
       }
     },
     {
-      "row": 40,
-      "col": 48,
-      "color": null,
+      "id": "AV40",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV39",
+        "south": "AV41",
+        "west": "AU40",
+        "east": "AW40"
       }
     },
     {
-      "row": 40,
-      "col": 49,
-      "color": null,
+      "id": "AW40",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW39",
+        "south": "AW41",
+        "west": "AV40",
+        "east": "AX40"
       }
     },
     {
-      "row": 40,
-      "col": 50,
-      "color": null,
+      "id": "AX40",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX39",
+        "south": "AX41",
+        "west": "AW40"
       }
     },
     {
-      "row": 41,
-      "col": 1,
-      "color": null,
+      "id": "A41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A40",
+        "south": "A42",
+        "east": "B41"
       }
     },
     {
-      "row": 41,
-      "col": 2,
-      "color": null,
+      "id": "B41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B40",
+        "south": "B42",
+        "west": "A41",
+        "east": "C41"
       }
     },
     {
-      "row": 41,
-      "col": 3,
-      "color": null,
+      "id": "C41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C40",
+        "south": "C42",
+        "west": "B41",
+        "east": "D41"
       }
     },
     {
-      "row": 41,
-      "col": 4,
-      "color": null,
+      "id": "D41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D40",
+        "south": "D42",
+        "west": "C41",
+        "east": "E41"
       }
     },
     {
-      "row": 41,
-      "col": 5,
-      "color": null,
+      "id": "E41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E40",
+        "south": "E42",
+        "west": "D41",
+        "east": "F41"
       }
     },
     {
-      "row": 41,
-      "col": 6,
-      "color": null,
+      "id": "F41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F40",
+        "south": "F42",
+        "west": "E41",
+        "east": "G41"
       }
     },
     {
-      "row": 41,
-      "col": 7,
-      "color": null,
+      "id": "G41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G40",
+        "south": "G42",
+        "west": "F41",
+        "east": "H41"
       }
     },
     {
-      "row": 41,
-      "col": 8,
-      "color": null,
+      "id": "H41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H40",
+        "south": "H42",
+        "west": "G41",
+        "east": "I41"
       }
     },
     {
-      "row": 41,
-      "col": 9,
-      "color": null,
+      "id": "I41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I40",
+        "south": "I42",
+        "west": "H41",
+        "east": "J41"
       }
     },
     {
-      "row": 41,
-      "col": 10,
-      "color": null,
+      "id": "J41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J40",
+        "south": "J42",
+        "west": "I41",
+        "east": "K41"
       }
     },
     {
-      "row": 41,
-      "col": 11,
-      "color": null,
+      "id": "K41",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K40",
+        "south": "K42",
+        "west": "J41",
+        "east": "L41"
       }
     },
     {
-      "row": 41,
-      "col": 12,
-      "color": null,
+      "id": "L41",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L40",
+        "south": "L42",
+        "west": "K41",
+        "east": "M41"
       }
     },
     {
-      "row": 41,
-      "col": 13,
-      "color": null,
+      "id": "M41",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M40",
+        "south": "M42",
+        "west": "L41",
+        "east": "N41"
       }
     },
     {
-      "row": 41,
-      "col": 14,
-      "color": null,
+      "id": "N41",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N40",
+        "south": "N42",
+        "west": "M41",
+        "east": "O41"
       }
     },
     {
-      "row": 41,
-      "col": 15,
-      "color": null,
+      "id": "O41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O40",
+        "south": "O42",
+        "west": "N41",
+        "east": "P41"
       }
     },
     {
-      "row": 41,
-      "col": 16,
-      "color": null,
+      "id": "P41",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P40",
+        "south": "P42",
+        "west": "O41",
+        "east": "Q41"
       }
     },
     {
-      "row": 41,
-      "col": 17,
-      "color": null,
+      "id": "Q41",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q40",
+        "south": "Q42",
+        "west": "P41",
+        "east": "R41"
       }
     },
     {
-      "row": 41,
-      "col": 18,
-      "color": null,
+      "id": "R41",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R40",
+        "south": "R42",
+        "west": "Q41",
+        "east": "S41"
       }
     },
     {
-      "row": 41,
-      "col": 19,
-      "color": null,
+      "id": "S41",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S40",
+        "south": "S42",
+        "west": "R41",
+        "east": "T41"
       }
     },
     {
-      "row": 41,
-      "col": 20,
-      "color": null,
+      "id": "T41",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T40",
+        "south": "T42",
+        "west": "S41",
+        "east": "U41"
       }
     },
     {
-      "row": 41,
-      "col": 21,
-      "color": null,
+      "id": "U41",
+      "terrain": "cove",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U40",
+        "south": "U42",
+        "west": "T41",
+        "east": "V41"
       }
     },
     {
-      "row": 41,
-      "col": 22,
-      "color": null,
+      "id": "V41",
+      "terrain": "path",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V40",
+        "south": "V42",
+        "west": "U41",
+        "east": "W41"
       }
     },
     {
-      "row": 41,
-      "col": 23,
-      "color": null,
+      "id": "W41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W40",
+        "south": "W42",
+        "west": "V41",
+        "east": "X41"
       }
     },
     {
-      "row": 41,
-      "col": 24,
-      "color": null,
+      "id": "X41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X40",
+        "south": "X42",
+        "west": "W41",
+        "east": "Y41"
       }
     },
     {
-      "row": 41,
-      "col": 25,
-      "color": null,
+      "id": "Y41",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y40",
+        "south": "Y42",
+        "west": "X41",
+        "east": "Z41"
       }
     },
     {
-      "row": 41,
-      "col": 26,
-      "color": null,
+      "id": "Z41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z40",
+        "south": "Z42",
+        "west": "Y41",
+        "east": "AA41"
       }
     },
     {
-      "row": 41,
-      "col": 27,
-      "color": null,
+      "id": "AA41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA40",
+        "south": "AA42",
+        "west": "Z41",
+        "east": "AB41"
       }
     },
     {
-      "row": 41,
-      "col": 28,
-      "color": null,
+      "id": "AB41",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB40",
+        "south": "AB42",
+        "west": "AA41",
+        "east": "AC41"
       }
     },
     {
-      "row": 41,
-      "col": 29,
-      "color": null,
+      "id": "AC41",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC40",
+        "south": "AC42",
+        "west": "AB41",
+        "east": "AD41"
       }
     },
     {
-      "row": 41,
-      "col": 30,
-      "color": null,
+      "id": "AD41",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD40",
+        "south": "AD42",
+        "west": "AC41",
+        "east": "AE41"
       }
     },
     {
-      "row": 41,
-      "col": 31,
-      "color": null,
+      "id": "AE41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE40",
+        "south": "AE42",
+        "west": "AD41",
+        "east": "AF41"
       }
     },
     {
-      "row": 41,
-      "col": 32,
-      "color": null,
+      "id": "AF41",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF40",
+        "south": "AF42",
+        "west": "AE41",
+        "east": "AG41"
       }
     },
     {
-      "row": 41,
-      "col": 33,
-      "color": null,
+      "id": "AG41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG40",
+        "south": "AG42",
+        "west": "AF41",
+        "east": "AH41"
       }
     },
     {
-      "row": 41,
-      "col": 34,
-      "color": null,
+      "id": "AH41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH40",
+        "south": "AH42",
+        "west": "AG41",
+        "east": "AI41"
       }
     },
     {
-      "row": 41,
-      "col": 35,
-      "color": null,
+      "id": "AI41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI40",
+        "south": "AI42",
+        "west": "AH41",
+        "east": "AJ41"
       }
     },
     {
-      "row": 41,
-      "col": 36,
-      "color": null,
+      "id": "AJ41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ40",
+        "south": "AJ42",
+        "west": "AI41",
+        "east": "AK41"
       }
     },
     {
-      "row": 41,
-      "col": 37,
-      "color": null,
+      "id": "AK41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK40",
+        "south": "AK42",
+        "west": "AJ41",
+        "east": "AL41"
       }
     },
     {
-      "row": 41,
-      "col": 38,
-      "color": null,
+      "id": "AL41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL40",
+        "south": "AL42",
+        "west": "AK41",
+        "east": "AM41"
       }
     },
     {
-      "row": 41,
-      "col": 39,
-      "color": null,
+      "id": "AM41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM40",
+        "south": "AM42",
+        "west": "AL41",
+        "east": "AN41"
       }
     },
     {
-      "row": 41,
-      "col": 40,
-      "color": null,
+      "id": "AN41",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN40",
+        "south": "AN42",
+        "west": "AM41",
+        "east": "AO41"
       }
     },
     {
-      "row": 41,
-      "col": 41,
-      "color": null,
+      "id": "AO41",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO40",
+        "south": "AO42",
+        "west": "AN41",
+        "east": "AP41"
       }
     },
     {
-      "row": 41,
-      "col": 42,
-      "color": null,
+      "id": "AP41",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP40",
+        "south": "AP42",
+        "west": "AO41",
+        "east": "AQ41"
       }
     },
     {
-      "row": 41,
-      "col": 43,
-      "color": null,
+      "id": "AQ41",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ40",
+        "south": "AQ42",
+        "west": "AP41",
+        "east": "AR41"
       }
     },
     {
-      "row": 41,
-      "col": 44,
-      "color": null,
+      "id": "AR41",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR40",
+        "south": "AR42",
+        "west": "AQ41",
+        "east": "AS41"
       }
     },
     {
-      "row": 41,
-      "col": 45,
-      "color": null,
+      "id": "AS41",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS40",
+        "south": "AS42",
+        "west": "AR41",
+        "east": "AT41"
       }
     },
     {
-      "row": 41,
-      "col": 46,
-      "color": null,
+      "id": "AT41",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT40",
+        "south": "AT42",
+        "west": "AS41",
+        "east": "AU41"
       }
     },
     {
-      "row": 41,
-      "col": 47,
-      "color": null,
+      "id": "AU41",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU40",
+        "south": "AU42",
+        "west": "AT41",
+        "east": "AV41"
       }
     },
     {
-      "row": 41,
-      "col": 48,
-      "color": null,
+      "id": "AV41",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV40",
+        "south": "AV42",
+        "west": "AU41",
+        "east": "AW41"
       }
     },
     {
-      "row": 41,
-      "col": 49,
-      "color": null,
+      "id": "AW41",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW40",
+        "south": "AW42",
+        "west": "AV41",
+        "east": "AX41"
       }
     },
     {
-      "row": 41,
-      "col": 50,
-      "color": null,
+      "id": "AX41",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX40",
+        "south": "AX42",
+        "west": "AW41"
       }
     },
     {
-      "row": 42,
-      "col": 1,
-      "color": null,
+      "id": "A42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A41",
+        "south": "A43",
+        "east": "B42"
       }
     },
     {
-      "row": 42,
-      "col": 2,
-      "color": null,
+      "id": "B42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B41",
+        "south": "B43",
+        "west": "A42",
+        "east": "C42"
       }
     },
     {
-      "row": 42,
-      "col": 3,
-      "color": null,
+      "id": "C42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C41",
+        "south": "C43",
+        "west": "B42",
+        "east": "D42"
       }
     },
     {
-      "row": 42,
-      "col": 4,
-      "color": null,
+      "id": "D42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D41",
+        "south": "D43",
+        "west": "C42",
+        "east": "E42"
       }
     },
     {
-      "row": 42,
-      "col": 5,
-      "color": null,
+      "id": "E42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E41",
+        "south": "E43",
+        "west": "D42",
+        "east": "F42"
       }
     },
     {
-      "row": 42,
-      "col": 6,
-      "color": null,
+      "id": "F42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F41",
+        "south": "F43",
+        "west": "E42",
+        "east": "G42"
       }
     },
     {
-      "row": 42,
-      "col": 7,
-      "color": null,
+      "id": "G42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G41",
+        "south": "G43",
+        "west": "F42",
+        "east": "H42"
       }
     },
     {
-      "row": 42,
-      "col": 8,
-      "color": null,
+      "id": "H42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H41",
+        "south": "H43",
+        "west": "G42",
+        "east": "I42"
       }
     },
     {
-      "row": 42,
-      "col": 9,
-      "color": null,
+      "id": "I42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I41",
+        "south": "I43",
+        "west": "H42",
+        "east": "J42"
       }
     },
     {
-      "row": 42,
-      "col": 10,
-      "color": null,
+      "id": "J42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J41",
+        "south": "J43",
+        "west": "I42",
+        "east": "K42"
       }
     },
     {
-      "row": 42,
-      "col": 11,
-      "color": null,
+      "id": "K42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K41",
+        "south": "K43",
+        "west": "J42",
+        "east": "L42"
       }
     },
     {
-      "row": 42,
-      "col": 12,
-      "color": null,
+      "id": "L42",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L41",
+        "south": "L43",
+        "west": "K42",
+        "east": "M42"
       }
     },
     {
-      "row": 42,
-      "col": 13,
-      "color": null,
+      "id": "M42",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M41",
+        "south": "M43",
+        "west": "L42",
+        "east": "N42"
       }
     },
     {
-      "row": 42,
-      "col": 14,
-      "color": null,
+      "id": "N42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N41",
+        "south": "N43",
+        "west": "M42",
+        "east": "O42"
       }
     },
     {
-      "row": 42,
-      "col": 15,
-      "color": null,
+      "id": "O42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O41",
+        "south": "O43",
+        "west": "N42",
+        "east": "P42"
       }
     },
     {
-      "row": 42,
-      "col": 16,
-      "color": null,
+      "id": "P42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P41",
+        "south": "P43",
+        "west": "O42",
+        "east": "Q42"
       }
     },
     {
-      "row": 42,
-      "col": 17,
-      "color": null,
+      "id": "Q42",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q41",
+        "south": "Q43",
+        "west": "P42",
+        "east": "R42"
       }
     },
     {
-      "row": 42,
-      "col": 18,
-      "color": null,
+      "id": "R42",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R41",
+        "south": "R43",
+        "west": "Q42",
+        "east": "S42"
       }
     },
     {
-      "row": 42,
-      "col": 19,
-      "color": null,
+      "id": "S42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S41",
+        "south": "S43",
+        "west": "R42",
+        "east": "T42"
       }
     },
     {
-      "row": 42,
-      "col": 20,
-      "color": null,
+      "id": "T42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T41",
+        "south": "T43",
+        "west": "S42",
+        "east": "U42"
       }
     },
     {
-      "row": 42,
-      "col": 21,
-      "color": null,
+      "id": "U42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U41",
+        "south": "U43",
+        "west": "T42",
+        "east": "V42"
       }
     },
     {
-      "row": 42,
-      "col": 22,
-      "color": null,
+      "id": "V42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V41",
+        "south": "V43",
+        "west": "U42",
+        "east": "W42"
       }
     },
     {
-      "row": 42,
-      "col": 23,
-      "color": null,
+      "id": "W42",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W41",
+        "south": "W43",
+        "west": "V42",
+        "east": "X42"
       }
     },
     {
-      "row": 42,
-      "col": 24,
-      "color": null,
+      "id": "X42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X41",
+        "south": "X43",
+        "west": "W42",
+        "east": "Y42"
       }
     },
     {
-      "row": 42,
-      "col": 25,
-      "color": null,
+      "id": "Y42",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y41",
+        "south": "Y43",
+        "west": "X42",
+        "east": "Z42"
       }
     },
     {
-      "row": 42,
-      "col": 26,
-      "color": null,
+      "id": "Z42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z41",
+        "south": "Z43",
+        "west": "Y42",
+        "east": "AA42"
       }
     },
     {
-      "row": 42,
-      "col": 27,
-      "color": null,
+      "id": "AA42",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA41",
+        "south": "AA43",
+        "west": "Z42",
+        "east": "AB42"
       }
     },
     {
-      "row": 42,
-      "col": 28,
-      "color": null,
+      "id": "AB42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB41",
+        "south": "AB43",
+        "west": "AA42",
+        "east": "AC42"
       }
     },
     {
-      "row": 42,
-      "col": 29,
-      "color": null,
+      "id": "AC42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC41",
+        "south": "AC43",
+        "west": "AB42",
+        "east": "AD42"
       }
     },
     {
-      "row": 42,
-      "col": 30,
-      "color": null,
+      "id": "AD42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD41",
+        "south": "AD43",
+        "west": "AC42",
+        "east": "AE42"
       }
     },
     {
-      "row": 42,
-      "col": 31,
-      "color": null,
+      "id": "AE42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE41",
+        "south": "AE43",
+        "west": "AD42",
+        "east": "AF42"
       }
     },
     {
-      "row": 42,
-      "col": 32,
-      "color": null,
+      "id": "AF42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF41",
+        "south": "AF43",
+        "west": "AE42",
+        "east": "AG42"
       }
     },
     {
-      "row": 42,
-      "col": 33,
-      "color": null,
+      "id": "AG42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG41",
+        "south": "AG43",
+        "west": "AF42",
+        "east": "AH42"
       }
     },
     {
-      "row": 42,
-      "col": 34,
-      "color": null,
+      "id": "AH42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH41",
+        "south": "AH43",
+        "west": "AG42",
+        "east": "AI42"
       }
     },
     {
-      "row": 42,
-      "col": 35,
-      "color": null,
+      "id": "AI42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI41",
+        "south": "AI43",
+        "west": "AH42",
+        "east": "AJ42"
       }
     },
     {
-      "row": 42,
-      "col": 36,
-      "color": null,
+      "id": "AJ42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ41",
+        "south": "AJ43",
+        "west": "AI42",
+        "east": "AK42"
       }
     },
     {
-      "row": 42,
-      "col": 37,
-      "color": null,
+      "id": "AK42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK41",
+        "south": "AK43",
+        "west": "AJ42",
+        "east": "AL42"
       }
     },
     {
-      "row": 42,
-      "col": 38,
-      "color": null,
+      "id": "AL42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL41",
+        "south": "AL43",
+        "west": "AK42",
+        "east": "AM42"
       }
     },
     {
-      "row": 42,
-      "col": 39,
-      "color": null,
+      "id": "AM42",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM41",
+        "south": "AM43",
+        "west": "AL42",
+        "east": "AN42"
       }
     },
     {
-      "row": 42,
-      "col": 40,
-      "color": null,
+      "id": "AN42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN41",
+        "south": "AN43",
+        "west": "AM42",
+        "east": "AO42"
       }
     },
     {
-      "row": 42,
-      "col": 41,
-      "color": null,
+      "id": "AO42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO41",
+        "south": "AO43",
+        "west": "AN42",
+        "east": "AP42"
       }
     },
     {
-      "row": 42,
-      "col": 42,
-      "color": null,
+      "id": "AP42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP41",
+        "south": "AP43",
+        "west": "AO42",
+        "east": "AQ42"
       }
     },
     {
-      "row": 42,
-      "col": 43,
-      "color": null,
+      "id": "AQ42",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ41",
+        "south": "AQ43",
+        "west": "AP42",
+        "east": "AR42"
       }
     },
     {
-      "row": 42,
-      "col": 44,
-      "color": null,
+      "id": "AR42",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR41",
+        "south": "AR43",
+        "west": "AQ42",
+        "east": "AS42"
       }
     },
     {
-      "row": 42,
-      "col": 45,
-      "color": null,
+      "id": "AS42",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS41",
+        "south": "AS43",
+        "west": "AR42",
+        "east": "AT42"
       }
     },
     {
-      "row": 42,
-      "col": 46,
-      "color": null,
+      "id": "AT42",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT41",
+        "south": "AT43",
+        "west": "AS42",
+        "east": "AU42"
       }
     },
     {
-      "row": 42,
-      "col": 47,
-      "color": null,
+      "id": "AU42",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU41",
+        "south": "AU43",
+        "west": "AT42",
+        "east": "AV42"
       }
     },
     {
-      "row": 42,
-      "col": 48,
-      "color": null,
+      "id": "AV42",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV41",
+        "south": "AV43",
+        "west": "AU42",
+        "east": "AW42"
       }
     },
     {
-      "row": 42,
-      "col": 49,
-      "color": null,
+      "id": "AW42",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW41",
+        "south": "AW43",
+        "west": "AV42",
+        "east": "AX42"
       }
     },
     {
-      "row": 42,
-      "col": 50,
-      "color": null,
+      "id": "AX42",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX41",
+        "south": "AX43",
+        "west": "AW42"
       }
     },
     {
-      "row": 43,
-      "col": 1,
-      "color": null,
+      "id": "A43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A42",
+        "south": "A44",
+        "east": "B43"
       }
     },
     {
-      "row": 43,
-      "col": 2,
-      "color": null,
+      "id": "B43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B42",
+        "south": "B44",
+        "west": "A43",
+        "east": "C43"
       }
     },
     {
-      "row": 43,
-      "col": 3,
-      "color": null,
+      "id": "C43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C42",
+        "south": "C44",
+        "west": "B43",
+        "east": "D43"
       }
     },
     {
-      "row": 43,
-      "col": 4,
-      "color": null,
+      "id": "D43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D42",
+        "south": "D44",
+        "west": "C43",
+        "east": "E43"
       }
     },
     {
-      "row": 43,
-      "col": 5,
-      "color": null,
+      "id": "E43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E42",
+        "south": "E44",
+        "west": "D43",
+        "east": "F43"
       }
     },
     {
-      "row": 43,
-      "col": 6,
-      "color": null,
+      "id": "F43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F42",
+        "south": "F44",
+        "west": "E43",
+        "east": "G43"
       }
     },
     {
-      "row": 43,
-      "col": 7,
-      "color": null,
+      "id": "G43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G42",
+        "south": "G44",
+        "west": "F43",
+        "east": "H43"
       }
     },
     {
-      "row": 43,
-      "col": 8,
-      "color": null,
+      "id": "H43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H42",
+        "south": "H44",
+        "west": "G43",
+        "east": "I43"
       }
     },
     {
-      "row": 43,
-      "col": 9,
-      "color": null,
+      "id": "I43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I42",
+        "south": "I44",
+        "west": "H43",
+        "east": "J43"
       }
     },
     {
-      "row": 43,
-      "col": 10,
-      "color": null,
+      "id": "J43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J42",
+        "south": "J44",
+        "west": "I43",
+        "east": "K43"
       }
     },
     {
-      "row": 43,
-      "col": 11,
-      "color": null,
+      "id": "K43",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K42",
+        "south": "K44",
+        "west": "J43",
+        "east": "L43"
       }
     },
     {
-      "row": 43,
-      "col": 12,
-      "color": null,
+      "id": "L43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L42",
+        "south": "L44",
+        "west": "K43",
+        "east": "M43"
       }
     },
     {
-      "row": 43,
-      "col": 13,
-      "color": null,
+      "id": "M43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M42",
+        "south": "M44",
+        "west": "L43",
+        "east": "N43"
       }
     },
     {
-      "row": 43,
-      "col": 14,
-      "color": null,
+      "id": "N43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N42",
+        "south": "N44",
+        "west": "M43",
+        "east": "O43"
       }
     },
     {
-      "row": 43,
-      "col": 15,
-      "color": null,
+      "id": "O43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O42",
+        "south": "O44",
+        "west": "N43",
+        "east": "P43"
       }
     },
     {
-      "row": 43,
-      "col": 16,
-      "color": null,
+      "id": "P43",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P42",
+        "south": "P44",
+        "west": "O43",
+        "east": "Q43"
       }
     },
     {
-      "row": 43,
-      "col": 17,
-      "color": null,
+      "id": "Q43",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q42",
+        "south": "Q44",
+        "west": "P43",
+        "east": "R43"
       }
     },
     {
-      "row": 43,
-      "col": 18,
-      "color": null,
+      "id": "R43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R42",
+        "south": "R44",
+        "west": "Q43",
+        "east": "S43"
       }
     },
     {
-      "row": 43,
-      "col": 19,
-      "color": null,
+      "id": "S43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S42",
+        "south": "S44",
+        "west": "R43",
+        "east": "T43"
       }
     },
     {
-      "row": 43,
-      "col": 20,
-      "color": null,
+      "id": "T43",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T42",
+        "south": "T44",
+        "west": "S43",
+        "east": "U43"
       }
     },
     {
-      "row": 43,
-      "col": 21,
-      "color": null,
+      "id": "U43",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U42",
+        "south": "U44",
+        "west": "T43",
+        "east": "V43"
       }
     },
     {
-      "row": 43,
-      "col": 22,
-      "color": null,
+      "id": "V43",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V42",
+        "south": "V44",
+        "west": "U43",
+        "east": "W43"
       }
     },
     {
-      "row": 43,
-      "col": 23,
-      "color": null,
+      "id": "W43",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W42",
+        "south": "W44",
+        "west": "V43",
+        "east": "X43"
       }
     },
     {
-      "row": 43,
-      "col": 24,
-      "color": null,
+      "id": "X43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X42",
+        "south": "X44",
+        "west": "W43",
+        "east": "Y43"
       }
     },
     {
-      "row": 43,
-      "col": 25,
-      "color": null,
+      "id": "Y43",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y42",
+        "south": "Y44",
+        "west": "X43",
+        "east": "Z43"
       }
     },
     {
-      "row": 43,
-      "col": 26,
-      "color": null,
+      "id": "Z43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z42",
+        "south": "Z44",
+        "west": "Y43",
+        "east": "AA43"
       }
     },
     {
-      "row": 43,
-      "col": 27,
-      "color": null,
+      "id": "AA43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA42",
+        "south": "AA44",
+        "west": "Z43",
+        "east": "AB43"
       }
     },
     {
-      "row": 43,
-      "col": 28,
-      "color": null,
+      "id": "AB43",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB42",
+        "south": "AB44",
+        "west": "AA43",
+        "east": "AC43"
       }
     },
     {
-      "row": 43,
-      "col": 29,
-      "color": null,
+      "id": "AC43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC42",
+        "south": "AC44",
+        "west": "AB43",
+        "east": "AD43"
       }
     },
     {
-      "row": 43,
-      "col": 30,
-      "color": null,
+      "id": "AD43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD42",
+        "south": "AD44",
+        "west": "AC43",
+        "east": "AE43"
       }
     },
     {
-      "row": 43,
-      "col": 31,
-      "color": null,
+      "id": "AE43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE42",
+        "south": "AE44",
+        "west": "AD43",
+        "east": "AF43"
       }
     },
     {
-      "row": 43,
-      "col": 32,
-      "color": null,
+      "id": "AF43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF42",
+        "south": "AF44",
+        "west": "AE43",
+        "east": "AG43"
       }
     },
     {
-      "row": 43,
-      "col": 33,
-      "color": null,
+      "id": "AG43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG42",
+        "south": "AG44",
+        "west": "AF43",
+        "east": "AH43"
       }
     },
     {
-      "row": 43,
-      "col": 34,
-      "color": null,
+      "id": "AH43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH42",
+        "south": "AH44",
+        "west": "AG43",
+        "east": "AI43"
       }
     },
     {
-      "row": 43,
-      "col": 35,
-      "color": null,
+      "id": "AI43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI42",
+        "south": "AI44",
+        "west": "AH43",
+        "east": "AJ43"
       }
     },
     {
-      "row": 43,
-      "col": 36,
-      "color": null,
+      "id": "AJ43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ42",
+        "south": "AJ44",
+        "west": "AI43",
+        "east": "AK43"
       }
     },
     {
-      "row": 43,
-      "col": 37,
-      "color": null,
+      "id": "AK43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK42",
+        "south": "AK44",
+        "west": "AJ43",
+        "east": "AL43"
       }
     },
     {
-      "row": 43,
-      "col": 38,
-      "color": null,
+      "id": "AL43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL42",
+        "south": "AL44",
+        "west": "AK43",
+        "east": "AM43"
       }
     },
     {
-      "row": 43,
-      "col": 39,
-      "color": null,
+      "id": "AM43",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM42",
+        "south": "AM44",
+        "west": "AL43",
+        "east": "AN43"
       }
     },
     {
-      "row": 43,
-      "col": 40,
-      "color": null,
+      "id": "AN43",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN42",
+        "south": "AN44",
+        "west": "AM43",
+        "east": "AO43"
       }
     },
     {
-      "row": 43,
-      "col": 41,
-      "color": null,
+      "id": "AO43",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO42",
+        "south": "AO44",
+        "west": "AN43",
+        "east": "AP43"
       }
     },
     {
-      "row": 43,
-      "col": 42,
-      "color": null,
+      "id": "AP43",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP42",
+        "south": "AP44",
+        "west": "AO43",
+        "east": "AQ43"
       }
     },
     {
-      "row": 43,
-      "col": 43,
-      "color": null,
+      "id": "AQ43",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ42",
+        "south": "AQ44",
+        "west": "AP43",
+        "east": "AR43"
       }
     },
     {
-      "row": 43,
-      "col": 44,
-      "color": null,
+      "id": "AR43",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR42",
+        "south": "AR44",
+        "west": "AQ43",
+        "east": "AS43"
       }
     },
     {
-      "row": 43,
-      "col": 45,
-      "color": null,
+      "id": "AS43",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS42",
+        "south": "AS44",
+        "west": "AR43",
+        "east": "AT43"
       }
     },
     {
-      "row": 43,
-      "col": 46,
-      "color": null,
+      "id": "AT43",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT42",
+        "south": "AT44",
+        "west": "AS43",
+        "east": "AU43"
       }
     },
     {
-      "row": 43,
-      "col": 47,
-      "color": null,
+      "id": "AU43",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU42",
+        "south": "AU44",
+        "west": "AT43",
+        "east": "AV43"
       }
     },
     {
-      "row": 43,
-      "col": 48,
-      "color": null,
+      "id": "AV43",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV42",
+        "south": "AV44",
+        "west": "AU43",
+        "east": "AW43"
       }
     },
     {
-      "row": 43,
-      "col": 49,
-      "color": null,
+      "id": "AW43",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW42",
+        "south": "AW44",
+        "west": "AV43",
+        "east": "AX43"
       }
     },
     {
-      "row": 43,
-      "col": 50,
-      "color": null,
+      "id": "AX43",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX42",
+        "south": "AX44",
+        "west": "AW43"
       }
     },
     {
-      "row": 44,
-      "col": 1,
-      "color": null,
+      "id": "A44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A43",
+        "south": "A45",
+        "east": "B44"
       }
     },
     {
-      "row": 44,
-      "col": 2,
-      "color": null,
+      "id": "B44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B43",
+        "south": "B45",
+        "west": "A44",
+        "east": "C44"
       }
     },
     {
-      "row": 44,
-      "col": 3,
-      "color": null,
+      "id": "C44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C43",
+        "south": "C45",
+        "west": "B44",
+        "east": "D44"
       }
     },
     {
-      "row": 44,
-      "col": 4,
-      "color": null,
+      "id": "D44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D43",
+        "south": "D45",
+        "west": "C44",
+        "east": "E44"
       }
     },
     {
-      "row": 44,
-      "col": 5,
-      "color": null,
+      "id": "E44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E43",
+        "south": "E45",
+        "west": "D44",
+        "east": "F44"
       }
     },
     {
-      "row": 44,
-      "col": 6,
-      "color": null,
+      "id": "F44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F43",
+        "south": "F45",
+        "west": "E44",
+        "east": "G44"
       }
     },
     {
-      "row": 44,
-      "col": 7,
-      "color": null,
+      "id": "G44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G43",
+        "south": "G45",
+        "west": "F44",
+        "east": "H44"
       }
     },
     {
-      "row": 44,
-      "col": 8,
-      "color": null,
+      "id": "H44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H43",
+        "south": "H45",
+        "west": "G44",
+        "east": "I44"
       }
     },
     {
-      "row": 44,
-      "col": 9,
-      "color": null,
+      "id": "I44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I43",
+        "south": "I45",
+        "west": "H44",
+        "east": "J44"
       }
     },
     {
-      "row": 44,
-      "col": 10,
-      "color": null,
+      "id": "J44",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J43",
+        "south": "J45",
+        "west": "I44",
+        "east": "K44"
       }
     },
     {
-      "row": 44,
-      "col": 11,
-      "color": null,
+      "id": "K44",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K43",
+        "south": "K45",
+        "west": "J44",
+        "east": "L44"
       }
     },
     {
-      "row": 44,
-      "col": 12,
-      "color": null,
+      "id": "L44",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L43",
+        "south": "L45",
+        "west": "K44",
+        "east": "M44"
       }
     },
     {
-      "row": 44,
-      "col": 13,
-      "color": null,
+      "id": "M44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M43",
+        "south": "M45",
+        "west": "L44",
+        "east": "N44"
       }
     },
     {
-      "row": 44,
-      "col": 14,
-      "color": null,
+      "id": "N44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N43",
+        "south": "N45",
+        "west": "M44",
+        "east": "O44"
       }
     },
     {
-      "row": 44,
-      "col": 15,
-      "color": null,
+      "id": "O44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O43",
+        "south": "O45",
+        "west": "N44",
+        "east": "P44"
       }
     },
     {
-      "row": 44,
-      "col": 16,
-      "color": null,
+      "id": "P44",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P43",
+        "south": "P45",
+        "west": "O44",
+        "east": "Q44"
       }
     },
     {
-      "row": 44,
-      "col": 17,
-      "color": null,
+      "id": "Q44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q43",
+        "south": "Q45",
+        "west": "P44",
+        "east": "R44"
       }
     },
     {
-      "row": 44,
-      "col": 18,
-      "color": null,
+      "id": "R44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R43",
+        "south": "R45",
+        "west": "Q44",
+        "east": "S44"
       }
     },
     {
-      "row": 44,
-      "col": 19,
-      "color": null,
+      "id": "S44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S43",
+        "south": "S45",
+        "west": "R44",
+        "east": "T44"
       }
     },
     {
-      "row": 44,
-      "col": 20,
-      "color": null,
+      "id": "T44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T43",
+        "south": "T45",
+        "west": "S44",
+        "east": "U44"
       }
     },
     {
-      "row": 44,
-      "col": 21,
-      "color": null,
+      "id": "U44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U43",
+        "south": "U45",
+        "west": "T44",
+        "east": "V44"
       }
     },
     {
-      "row": 44,
-      "col": 22,
-      "color": null,
+      "id": "V44",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V43",
+        "south": "V45",
+        "west": "U44",
+        "east": "W44"
       }
     },
     {
-      "row": 44,
-      "col": 23,
-      "color": null,
+      "id": "W44",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W43",
+        "south": "W45",
+        "west": "V44",
+        "east": "X44"
       }
     },
     {
-      "row": 44,
-      "col": 24,
-      "color": null,
+      "id": "X44",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X43",
+        "south": "X45",
+        "west": "W44",
+        "east": "Y44"
       }
     },
     {
-      "row": 44,
-      "col": 25,
-      "color": null,
+      "id": "Y44",
+      "terrain": "r",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y43",
+        "south": "Y45",
+        "west": "X44",
+        "east": "Z44"
       }
     },
     {
-      "row": 44,
-      "col": 26,
-      "color": null,
+      "id": "Z44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z43",
+        "south": "Z45",
+        "west": "Y44",
+        "east": "AA44"
       }
     },
     {
-      "row": 44,
-      "col": 27,
-      "color": null,
+      "id": "AA44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA43",
+        "south": "AA45",
+        "west": "Z44",
+        "east": "AB44"
       }
     },
     {
-      "row": 44,
-      "col": 28,
-      "color": null,
+      "id": "AB44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB43",
+        "south": "AB45",
+        "west": "AA44",
+        "east": "AC44"
       }
     },
     {
-      "row": 44,
-      "col": 29,
-      "color": null,
+      "id": "AC44",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC43",
+        "south": "AC45",
+        "west": "AB44",
+        "east": "AD44"
       }
     },
     {
-      "row": 44,
-      "col": 30,
-      "color": null,
+      "id": "AD44",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD43",
+        "south": "AD45",
+        "west": "AC44",
+        "east": "AE44"
       }
     },
     {
-      "row": 44,
-      "col": 31,
-      "color": null,
+      "id": "AE44",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE43",
+        "south": "AE45",
+        "west": "AD44",
+        "east": "AF44"
       }
     },
     {
-      "row": 44,
-      "col": 32,
-      "color": null,
+      "id": "AF44",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF43",
+        "south": "AF45",
+        "west": "AE44",
+        "east": "AG44"
       }
     },
     {
-      "row": 44,
-      "col": 33,
-      "color": null,
+      "id": "AG44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG43",
+        "south": "AG45",
+        "west": "AF44",
+        "east": "AH44"
       }
     },
     {
-      "row": 44,
-      "col": 34,
-      "color": null,
+      "id": "AH44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH43",
+        "south": "AH45",
+        "west": "AG44",
+        "east": "AI44"
       }
     },
     {
-      "row": 44,
-      "col": 35,
-      "color": null,
+      "id": "AI44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI43",
+        "south": "AI45",
+        "west": "AH44",
+        "east": "AJ44"
       }
     },
     {
-      "row": 44,
-      "col": 36,
-      "color": null,
+      "id": "AJ44",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ43",
+        "south": "AJ45",
+        "west": "AI44",
+        "east": "AK44"
       }
     },
     {
-      "row": 44,
-      "col": 37,
-      "color": null,
+      "id": "AK44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK43",
+        "south": "AK45",
+        "west": "AJ44",
+        "east": "AL44"
       }
     },
     {
-      "row": 44,
-      "col": 38,
-      "color": null,
+      "id": "AL44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL43",
+        "south": "AL45",
+        "west": "AK44",
+        "east": "AM44"
       }
     },
     {
-      "row": 44,
-      "col": 39,
-      "color": null,
+      "id": "AM44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM43",
+        "south": "AM45",
+        "west": "AL44",
+        "east": "AN44"
       }
     },
     {
-      "row": 44,
-      "col": 40,
-      "color": null,
+      "id": "AN44",
+      "terrain": "df",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN43",
+        "south": "AN45",
+        "west": "AM44",
+        "east": "AO44"
       }
     },
     {
-      "row": 44,
-      "col": 41,
-      "color": null,
+      "id": "AO44",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO43",
+        "south": "AO45",
+        "west": "AN44",
+        "east": "AP44"
       }
     },
     {
-      "row": 44,
-      "col": 42,
-      "color": null,
+      "id": "AP44",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP43",
+        "south": "AP45",
+        "west": "AO44",
+        "east": "AQ44"
       }
     },
     {
-      "row": 44,
-      "col": 43,
-      "color": null,
+      "id": "AQ44",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ43",
+        "south": "AQ45",
+        "west": "AP44",
+        "east": "AR44"
       }
     },
     {
-      "row": 44,
-      "col": 44,
-      "color": null,
+      "id": "AR44",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR43",
+        "south": "AR45",
+        "west": "AQ44",
+        "east": "AS44"
       }
     },
     {
-      "row": 44,
-      "col": 45,
-      "color": null,
+      "id": "AS44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS43",
+        "south": "AS45",
+        "west": "AR44",
+        "east": "AT44"
       }
     },
     {
-      "row": 44,
-      "col": 46,
-      "color": null,
+      "id": "AT44",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT43",
+        "south": "AT45",
+        "west": "AS44",
+        "east": "AU44"
       }
     },
     {
-      "row": 44,
-      "col": 47,
-      "color": null,
+      "id": "AU44",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU43",
+        "south": "AU45",
+        "west": "AT44",
+        "east": "AV44"
       }
     },
     {
-      "row": 44,
-      "col": 48,
-      "color": null,
+      "id": "AV44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV43",
+        "south": "AV45",
+        "west": "AU44",
+        "east": "AW44"
       }
     },
     {
-      "row": 44,
-      "col": 49,
-      "color": null,
+      "id": "AW44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW43",
+        "south": "AW45",
+        "west": "AV44",
+        "east": "AX44"
       }
     },
     {
-      "row": 44,
-      "col": 50,
-      "color": null,
+      "id": "AX44",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX43",
+        "south": "AX45",
+        "west": "AW44"
       }
     },
     {
-      "row": 45,
-      "col": 1,
-      "color": null,
+      "id": "A45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A44",
+        "south": "A46",
+        "east": "B45"
       }
     },
     {
-      "row": 45,
-      "col": 2,
-      "color": null,
+      "id": "B45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B44",
+        "south": "B46",
+        "west": "A45",
+        "east": "C45"
       }
     },
     {
-      "row": 45,
-      "col": 3,
-      "color": null,
+      "id": "C45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C44",
+        "south": "C46",
+        "west": "B45",
+        "east": "D45"
       }
     },
     {
-      "row": 45,
-      "col": 4,
-      "color": null,
+      "id": "D45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D44",
+        "south": "D46",
+        "west": "C45",
+        "east": "E45"
       }
     },
     {
-      "row": 45,
-      "col": 5,
-      "color": null,
+      "id": "E45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E44",
+        "south": "E46",
+        "west": "D45",
+        "east": "F45"
       }
     },
     {
-      "row": 45,
-      "col": 6,
-      "color": null,
+      "id": "F45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F44",
+        "south": "F46",
+        "west": "E45",
+        "east": "G45"
       }
     },
     {
-      "row": 45,
-      "col": 7,
-      "color": null,
+      "id": "G45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G44",
+        "south": "G46",
+        "west": "F45",
+        "east": "H45"
       }
     },
     {
-      "row": 45,
-      "col": 8,
-      "color": null,
+      "id": "H45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H44",
+        "south": "H46",
+        "west": "G45",
+        "east": "I45"
       }
     },
     {
-      "row": 45,
-      "col": 9,
-      "color": null,
+      "id": "I45",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I44",
+        "south": "I46",
+        "west": "H45",
+        "east": "J45"
       }
     },
     {
-      "row": 45,
-      "col": 10,
-      "color": null,
+      "id": "J45",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J44",
+        "south": "J46",
+        "west": "I45",
+        "east": "K45"
       }
     },
     {
-      "row": 45,
-      "col": 11,
-      "color": null,
+      "id": "K45",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K44",
+        "south": "K46",
+        "west": "J45",
+        "east": "L45"
       }
     },
     {
-      "row": 45,
-      "col": 12,
-      "color": null,
+      "id": "L45",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L44",
+        "south": "L46",
+        "west": "K45",
+        "east": "M45"
       }
     },
     {
-      "row": 45,
-      "col": 13,
-      "color": null,
+      "id": "M45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M44",
+        "south": "M46",
+        "west": "L45",
+        "east": "N45"
       }
     },
     {
-      "row": 45,
-      "col": 14,
-      "color": null,
+      "id": "N45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N44",
+        "south": "N46",
+        "west": "M45",
+        "east": "O45"
       }
     },
     {
-      "row": 45,
-      "col": 15,
-      "color": null,
+      "id": "O45",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O44",
+        "south": "O46",
+        "west": "N45",
+        "east": "P45"
       }
     },
     {
-      "row": 45,
-      "col": 16,
-      "color": null,
+      "id": "P45",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P44",
+        "south": "P46",
+        "west": "O45",
+        "east": "Q45"
       }
     },
     {
-      "row": 45,
-      "col": 17,
-      "color": null,
+      "id": "Q45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q44",
+        "south": "Q46",
+        "west": "P45",
+        "east": "R45"
       }
     },
     {
-      "row": 45,
-      "col": 18,
-      "color": null,
+      "id": "R45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R44",
+        "south": "R46",
+        "west": "Q45",
+        "east": "S45"
       }
     },
     {
-      "row": 45,
-      "col": 19,
-      "color": null,
+      "id": "S45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S44",
+        "south": "S46",
+        "west": "R45",
+        "east": "T45"
       }
     },
     {
-      "row": 45,
-      "col": 20,
-      "color": null,
+      "id": "T45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T44",
+        "south": "T46",
+        "west": "S45",
+        "east": "U45"
       }
     },
     {
-      "row": 45,
-      "col": 21,
-      "color": null,
+      "id": "U45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U44",
+        "south": "U46",
+        "west": "T45",
+        "east": "V45"
       }
     },
     {
-      "row": 45,
-      "col": 22,
-      "color": null,
+      "id": "V45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V44",
+        "south": "V46",
+        "west": "U45",
+        "east": "W45"
       }
     },
     {
-      "row": 45,
-      "col": 23,
-      "color": null,
+      "id": "W45",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W44",
+        "south": "W46",
+        "west": "V45",
+        "east": "X45"
       }
     },
     {
-      "row": 45,
-      "col": 24,
-      "color": null,
+      "id": "X45",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X44",
+        "south": "X46",
+        "west": "W45",
+        "east": "Y45"
       }
     },
     {
-      "row": 45,
-      "col": 25,
-      "color": null,
+      "id": "Y45",
+      "terrain": "Indel",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y44",
+        "south": "Y46",
+        "west": "X45",
+        "east": "Z45"
       }
     },
     {
-      "row": 45,
-      "col": 26,
-      "color": null,
+      "id": "Z45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z44",
+        "south": "Z46",
+        "west": "Y45",
+        "east": "AA45"
       }
     },
     {
-      "row": 45,
-      "col": 27,
-      "color": null,
+      "id": "AA45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA44",
+        "south": "AA46",
+        "west": "Z45",
+        "east": "AB45"
       }
     },
     {
-      "row": 45,
-      "col": 28,
-      "color": null,
+      "id": "AB45",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB44",
+        "south": "AB46",
+        "west": "AA45",
+        "east": "AC45"
       }
     },
     {
-      "row": 45,
-      "col": 29,
-      "color": null,
+      "id": "AC45",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC44",
+        "south": "AC46",
+        "west": "AB45",
+        "east": "AD45"
       }
     },
     {
-      "row": 45,
-      "col": 30,
-      "color": null,
+      "id": "AD45",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD44",
+        "south": "AD46",
+        "west": "AC45",
+        "east": "AE45"
       }
     },
     {
-      "row": 45,
-      "col": 31,
-      "color": null,
+      "id": "AE45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE44",
+        "south": "AE46",
+        "west": "AD45",
+        "east": "AF45"
       }
     },
     {
-      "row": 45,
-      "col": 32,
-      "color": null,
+      "id": "AF45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF44",
+        "south": "AF46",
+        "west": "AE45",
+        "east": "AG45"
       }
     },
     {
-      "row": 45,
-      "col": 33,
-      "color": null,
+      "id": "AG45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG44",
+        "south": "AG46",
+        "west": "AF45",
+        "east": "AH45"
       }
     },
     {
-      "row": 45,
-      "col": 34,
-      "color": null,
+      "id": "AH45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH44",
+        "south": "AH46",
+        "west": "AG45",
+        "east": "AI45"
       }
     },
     {
-      "row": 45,
-      "col": 35,
-      "color": null,
+      "id": "AI45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI44",
+        "south": "AI46",
+        "west": "AH45",
+        "east": "AJ45"
       }
     },
     {
-      "row": 45,
-      "col": 36,
-      "color": null,
+      "id": "AJ45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ44",
+        "south": "AJ46",
+        "west": "AI45",
+        "east": "AK45"
       }
     },
     {
-      "row": 45,
-      "col": 37,
-      "color": null,
+      "id": "AK45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK44",
+        "south": "AK46",
+        "west": "AJ45",
+        "east": "AL45"
       }
     },
     {
-      "row": 45,
-      "col": 38,
-      "color": null,
+      "id": "AL45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL44",
+        "south": "AL46",
+        "west": "AK45",
+        "east": "AM45"
       }
     },
     {
-      "row": 45,
-      "col": 39,
-      "color": null,
+      "id": "AM45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM44",
+        "south": "AM46",
+        "west": "AL45",
+        "east": "AN45"
       }
     },
     {
-      "row": 45,
-      "col": 40,
-      "color": null,
+      "id": "AN45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN44",
+        "south": "AN46",
+        "west": "AM45",
+        "east": "AO45"
       }
     },
     {
-      "row": 45,
-      "col": 41,
-      "color": null,
+      "id": "AO45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO44",
+        "south": "AO46",
+        "west": "AN45",
+        "east": "AP45"
       }
     },
     {
-      "row": 45,
-      "col": 42,
-      "color": null,
+      "id": "AP45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP44",
+        "south": "AP46",
+        "west": "AO45",
+        "east": "AQ45"
       }
     },
     {
-      "row": 45,
-      "col": 43,
-      "color": null,
+      "id": "AQ45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ44",
+        "south": "AQ46",
+        "west": "AP45",
+        "east": "AR45"
       }
     },
     {
-      "row": 45,
-      "col": 44,
-      "color": null,
+      "id": "AR45",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR44",
+        "south": "AR46",
+        "west": "AQ45",
+        "east": "AS45"
       }
     },
     {
-      "row": 45,
-      "col": 45,
-      "color": null,
+      "id": "AS45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS44",
+        "south": "AS46",
+        "west": "AR45",
+        "east": "AT45"
       }
     },
     {
-      "row": 45,
-      "col": 46,
-      "color": null,
+      "id": "AT45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT44",
+        "south": "AT46",
+        "west": "AS45",
+        "east": "AU45"
       }
     },
     {
-      "row": 45,
-      "col": 47,
-      "color": null,
+      "id": "AU45",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU44",
+        "south": "AU46",
+        "west": "AT45",
+        "east": "AV45"
       }
     },
     {
-      "row": 45,
-      "col": 48,
-      "color": null,
+      "id": "AV45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV44",
+        "south": "AV46",
+        "west": "AU45",
+        "east": "AW45"
       }
     },
     {
-      "row": 45,
-      "col": 49,
-      "color": null,
+      "id": "AW45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW44",
+        "south": "AW46",
+        "west": "AV45",
+        "east": "AX45"
       }
     },
     {
-      "row": 45,
-      "col": 50,
-      "color": null,
+      "id": "AX45",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX44",
+        "south": "AX46",
+        "west": "AW45"
       }
     },
     {
-      "row": 46,
-      "col": 1,
-      "color": null,
+      "id": "A46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A45",
+        "south": "A47",
+        "east": "B46"
       }
     },
     {
-      "row": 46,
-      "col": 2,
-      "color": null,
+      "id": "B46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B45",
+        "south": "B47",
+        "west": "A46",
+        "east": "C46"
       }
     },
     {
-      "row": 46,
-      "col": 3,
-      "color": null,
+      "id": "C46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C45",
+        "south": "C47",
+        "west": "B46",
+        "east": "D46"
       }
     },
     {
-      "row": 46,
-      "col": 4,
-      "color": null,
+      "id": "D46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D45",
+        "south": "D47",
+        "west": "C46",
+        "east": "E46"
       }
     },
     {
-      "row": 46,
-      "col": 5,
-      "color": null,
+      "id": "E46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E45",
+        "south": "E47",
+        "west": "D46",
+        "east": "F46"
       }
     },
     {
-      "row": 46,
-      "col": 6,
-      "color": null,
+      "id": "F46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F45",
+        "south": "F47",
+        "west": "E46",
+        "east": "G46"
       }
     },
     {
-      "row": 46,
-      "col": 7,
-      "color": null,
+      "id": "G46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G45",
+        "south": "G47",
+        "west": "F46",
+        "east": "H46"
       }
     },
     {
-      "row": 46,
-      "col": 8,
-      "color": null,
+      "id": "H46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H45",
+        "south": "H47",
+        "west": "G46",
+        "east": "I46"
       }
     },
     {
-      "row": 46,
-      "col": 9,
-      "color": null,
+      "id": "I46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I45",
+        "south": "I47",
+        "west": "H46",
+        "east": "J46"
       }
     },
     {
-      "row": 46,
-      "col": 10,
-      "color": null,
+      "id": "J46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J45",
+        "south": "J47",
+        "west": "I46",
+        "east": "K46"
       }
     },
     {
-      "row": 46,
-      "col": 11,
-      "color": null,
+      "id": "K46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K45",
+        "south": "K47",
+        "west": "J46",
+        "east": "L46"
       }
     },
     {
-      "row": 46,
-      "col": 12,
-      "color": null,
+      "id": "L46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L45",
+        "south": "L47",
+        "west": "K46",
+        "east": "M46"
       }
     },
     {
-      "row": 46,
-      "col": 13,
-      "color": null,
+      "id": "M46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M45",
+        "south": "M47",
+        "west": "L46",
+        "east": "N46"
       }
     },
     {
-      "row": 46,
-      "col": 14,
-      "color": null,
+      "id": "N46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N45",
+        "south": "N47",
+        "west": "M46",
+        "east": "O46"
       }
     },
     {
-      "row": 46,
-      "col": 15,
-      "color": null,
+      "id": "O46",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O45",
+        "south": "O47",
+        "west": "N46",
+        "east": "P46"
       }
     },
     {
-      "row": 46,
-      "col": 16,
-      "color": null,
+      "id": "P46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P45",
+        "south": "P47",
+        "west": "O46",
+        "east": "Q46"
       }
     },
     {
-      "row": 46,
-      "col": 17,
-      "color": null,
+      "id": "Q46",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q45",
+        "south": "Q47",
+        "west": "P46",
+        "east": "R46"
       }
     },
     {
-      "row": 46,
-      "col": 18,
-      "color": null,
+      "id": "R46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R45",
+        "south": "R47",
+        "west": "Q46",
+        "east": "S46"
       }
     },
     {
-      "row": 46,
-      "col": 19,
-      "color": null,
+      "id": "S46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S45",
+        "south": "S47",
+        "west": "R46",
+        "east": "T46"
       }
     },
     {
-      "row": 46,
-      "col": 20,
-      "color": null,
+      "id": "T46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T45",
+        "south": "T47",
+        "west": "S46",
+        "east": "U46"
       }
     },
     {
-      "row": 46,
-      "col": 21,
-      "color": null,
+      "id": "U46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U45",
+        "south": "U47",
+        "west": "T46",
+        "east": "V46"
       }
     },
     {
-      "row": 46,
-      "col": 22,
-      "color": null,
+      "id": "V46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V45",
+        "south": "V47",
+        "west": "U46",
+        "east": "W46"
       }
     },
     {
-      "row": 46,
-      "col": 23,
-      "color": null,
+      "id": "W46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W45",
+        "south": "W47",
+        "west": "V46",
+        "east": "X46"
       }
     },
     {
-      "row": 46,
-      "col": 24,
-      "color": null,
+      "id": "X46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X45",
+        "south": "X47",
+        "west": "W46",
+        "east": "Y46"
       }
     },
     {
-      "row": 46,
-      "col": 25,
-      "color": null,
+      "id": "Y46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y45",
+        "south": "Y47",
+        "west": "X46",
+        "east": "Z46"
       }
     },
     {
-      "row": 46,
-      "col": 26,
-      "color": null,
+      "id": "Z46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z45",
+        "south": "Z47",
+        "west": "Y46",
+        "east": "AA46"
       }
     },
     {
-      "row": 46,
-      "col": 27,
-      "color": null,
+      "id": "AA46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA45",
+        "south": "AA47",
+        "west": "Z46",
+        "east": "AB46"
       }
     },
     {
-      "row": 46,
-      "col": 28,
-      "color": null,
+      "id": "AB46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB45",
+        "south": "AB47",
+        "west": "AA46",
+        "east": "AC46"
       }
     },
     {
-      "row": 46,
-      "col": 29,
-      "color": null,
+      "id": "AC46",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC45",
+        "south": "AC47",
+        "west": "AB46",
+        "east": "AD46"
       }
     },
     {
-      "row": 46,
-      "col": 30,
-      "color": null,
+      "id": "AD46",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD45",
+        "south": "AD47",
+        "west": "AC46",
+        "east": "AE46"
       }
     },
     {
-      "row": 46,
-      "col": 31,
-      "color": null,
+      "id": "AE46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE45",
+        "south": "AE47",
+        "west": "AD46",
+        "east": "AF46"
       }
     },
     {
-      "row": 46,
-      "col": 32,
-      "color": null,
+      "id": "AF46",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF45",
+        "south": "AF47",
+        "west": "AE46",
+        "east": "AG46"
       }
     },
     {
-      "row": 46,
-      "col": 33,
-      "color": null,
+      "id": "AG46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG45",
+        "south": "AG47",
+        "west": "AF46",
+        "east": "AH46"
       }
     },
     {
-      "row": 46,
-      "col": 34,
-      "color": null,
+      "id": "AH46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH45",
+        "south": "AH47",
+        "west": "AG46",
+        "east": "AI46"
       }
     },
     {
-      "row": 46,
-      "col": 35,
-      "color": null,
+      "id": "AI46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI45",
+        "south": "AI47",
+        "west": "AH46",
+        "east": "AJ46"
       }
     },
     {
-      "row": 46,
-      "col": 36,
-      "color": null,
+      "id": "AJ46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ45",
+        "south": "AJ47",
+        "west": "AI46",
+        "east": "AK46"
       }
     },
     {
-      "row": 46,
-      "col": 37,
-      "color": null,
+      "id": "AK46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK45",
+        "south": "AK47",
+        "west": "AJ46",
+        "east": "AL46"
       }
     },
     {
-      "row": 46,
-      "col": 38,
-      "color": null,
+      "id": "AL46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL45",
+        "south": "AL47",
+        "west": "AK46",
+        "east": "AM46"
       }
     },
     {
-      "row": 46,
-      "col": 39,
-      "color": null,
+      "id": "AM46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM45",
+        "south": "AM47",
+        "west": "AL46",
+        "east": "AN46"
       }
     },
     {
-      "row": 46,
-      "col": 40,
-      "color": null,
+      "id": "AN46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN45",
+        "south": "AN47",
+        "west": "AM46",
+        "east": "AO46"
       }
     },
     {
-      "row": 46,
-      "col": 41,
-      "color": null,
+      "id": "AO46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO45",
+        "south": "AO47",
+        "west": "AN46",
+        "east": "AP46"
       }
     },
     {
-      "row": 46,
-      "col": 42,
-      "color": null,
+      "id": "AP46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP45",
+        "south": "AP47",
+        "west": "AO46",
+        "east": "AQ46"
       }
     },
     {
-      "row": 46,
-      "col": 43,
-      "color": null,
+      "id": "AQ46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ45",
+        "south": "AQ47",
+        "west": "AP46",
+        "east": "AR46"
       }
     },
     {
-      "row": 46,
-      "col": 44,
-      "color": null,
+      "id": "AR46",
+      "terrain": "f",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR45",
+        "south": "AR47",
+        "west": "AQ46",
+        "east": "AS46"
       }
     },
     {
-      "row": 46,
-      "col": 45,
-      "color": null,
+      "id": "AS46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS45",
+        "south": "AS47",
+        "west": "AR46",
+        "east": "AT46"
       }
     },
     {
-      "row": 46,
-      "col": 46,
-      "color": null,
+      "id": "AT46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT45",
+        "south": "AT47",
+        "west": "AS46",
+        "east": "AU46"
       }
     },
     {
-      "row": 46,
-      "col": 47,
-      "color": null,
+      "id": "AU46",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU45",
+        "south": "AU47",
+        "west": "AT46",
+        "east": "AV46"
       }
     },
     {
-      "row": 46,
-      "col": 48,
-      "color": null,
+      "id": "AV46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV45",
+        "south": "AV47",
+        "west": "AU46",
+        "east": "AW46"
       }
     },
     {
-      "row": 46,
-      "col": 49,
-      "color": null,
+      "id": "AW46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW45",
+        "south": "AW47",
+        "west": "AV46",
+        "east": "AX46"
       }
     },
     {
-      "row": 46,
-      "col": 50,
-      "color": null,
+      "id": "AX46",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX45",
+        "south": "AX47",
+        "west": "AW46"
       }
     },
     {
-      "row": 47,
-      "col": 1,
-      "color": null,
+      "id": "A47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A46",
+        "south": "A48",
+        "east": "B47"
       }
     },
     {
-      "row": 47,
-      "col": 2,
-      "color": null,
+      "id": "B47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B46",
+        "south": "B48",
+        "west": "A47",
+        "east": "C47"
       }
     },
     {
-      "row": 47,
-      "col": 3,
-      "color": null,
+      "id": "C47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C46",
+        "south": "C48",
+        "west": "B47",
+        "east": "D47"
       }
     },
     {
-      "row": 47,
-      "col": 4,
-      "color": null,
+      "id": "D47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D46",
+        "south": "D48",
+        "west": "C47",
+        "east": "E47"
       }
     },
     {
-      "row": 47,
-      "col": 5,
-      "color": null,
+      "id": "E47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E46",
+        "south": "E48",
+        "west": "D47",
+        "east": "F47"
       }
     },
     {
-      "row": 47,
-      "col": 6,
-      "color": null,
+      "id": "F47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F46",
+        "south": "F48",
+        "west": "E47",
+        "east": "G47"
       }
     },
     {
-      "row": 47,
-      "col": 7,
-      "color": null,
+      "id": "G47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G46",
+        "south": "G48",
+        "west": "F47",
+        "east": "H47"
       }
     },
     {
-      "row": 47,
-      "col": 8,
-      "color": null,
+      "id": "H47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H46",
+        "south": "H48",
+        "west": "G47",
+        "east": "I47"
       }
     },
     {
-      "row": 47,
-      "col": 9,
-      "color": null,
+      "id": "I47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I46",
+        "south": "I48",
+        "west": "H47",
+        "east": "J47"
       }
     },
     {
-      "row": 47,
-      "col": 10,
-      "color": null,
+      "id": "J47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J46",
+        "south": "J48",
+        "west": "I47",
+        "east": "K47"
       }
     },
     {
-      "row": 47,
-      "col": 11,
-      "color": null,
+      "id": "K47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K46",
+        "south": "K48",
+        "west": "J47",
+        "east": "L47"
       }
     },
     {
-      "row": 47,
-      "col": 12,
-      "color": null,
+      "id": "L47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L46",
+        "south": "L48",
+        "west": "K47",
+        "east": "M47"
       }
     },
     {
-      "row": 47,
-      "col": 13,
-      "color": null,
+      "id": "M47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M46",
+        "south": "M48",
+        "west": "L47",
+        "east": "N47"
       }
     },
     {
-      "row": 47,
-      "col": 14,
-      "color": null,
+      "id": "N47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N46",
+        "south": "N48",
+        "west": "M47",
+        "east": "O47"
       }
     },
     {
-      "row": 47,
-      "col": 15,
-      "color": null,
+      "id": "O47",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O46",
+        "south": "O48",
+        "west": "N47",
+        "east": "P47"
       }
     },
     {
-      "row": 47,
-      "col": 16,
-      "color": null,
+      "id": "P47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P46",
+        "south": "P48",
+        "west": "O47",
+        "east": "Q47"
       }
     },
     {
-      "row": 47,
-      "col": 17,
-      "color": null,
+      "id": "Q47",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q46",
+        "south": "Q48",
+        "west": "P47",
+        "east": "R47"
       }
     },
     {
-      "row": 47,
-      "col": 18,
-      "color": null,
+      "id": "R47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R46",
+        "south": "R48",
+        "west": "Q47",
+        "east": "S47"
       }
     },
     {
-      "row": 47,
-      "col": 19,
-      "color": null,
+      "id": "S47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S46",
+        "south": "S48",
+        "west": "R47",
+        "east": "T47"
       }
     },
     {
-      "row": 47,
-      "col": 20,
-      "color": null,
+      "id": "T47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T46",
+        "south": "T48",
+        "west": "S47",
+        "east": "U47"
       }
     },
     {
-      "row": 47,
-      "col": 21,
-      "color": null,
+      "id": "U47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U46",
+        "south": "U48",
+        "west": "T47",
+        "east": "V47"
       }
     },
     {
-      "row": 47,
-      "col": 22,
-      "color": null,
+      "id": "V47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V46",
+        "south": "V48",
+        "west": "U47",
+        "east": "W47"
       }
     },
     {
-      "row": 47,
-      "col": 23,
-      "color": null,
+      "id": "W47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W46",
+        "south": "W48",
+        "west": "V47",
+        "east": "X47"
       }
     },
     {
-      "row": 47,
-      "col": 24,
-      "color": null,
+      "id": "X47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X46",
+        "south": "X48",
+        "west": "W47",
+        "east": "Y47"
       }
     },
     {
-      "row": 47,
-      "col": 25,
-      "color": null,
+      "id": "Y47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y46",
+        "south": "Y48",
+        "west": "X47",
+        "east": "Z47"
       }
     },
     {
-      "row": 47,
-      "col": 26,
-      "color": null,
+      "id": "Z47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z46",
+        "south": "Z48",
+        "west": "Y47",
+        "east": "AA47"
       }
     },
     {
-      "row": 47,
-      "col": 27,
-      "color": null,
+      "id": "AA47",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA46",
+        "south": "AA48",
+        "west": "Z47",
+        "east": "AB47"
       }
     },
     {
-      "row": 47,
-      "col": 28,
-      "color": null,
+      "id": "AB47",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB46",
+        "south": "AB48",
+        "west": "AA47",
+        "east": "AC47"
       }
     },
     {
-      "row": 47,
-      "col": 29,
-      "color": null,
+      "id": "AC47",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC46",
+        "south": "AC48",
+        "west": "AB47",
+        "east": "AD47"
       }
     },
     {
-      "row": 47,
-      "col": 30,
-      "color": null,
+      "id": "AD47",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD46",
+        "south": "AD48",
+        "west": "AC47",
+        "east": "AE47"
       }
     },
     {
-      "row": 47,
-      "col": 31,
-      "color": null,
+      "id": "AE47",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE46",
+        "south": "AE48",
+        "west": "AD47",
+        "east": "AF47"
       }
     },
     {
-      "row": 47,
-      "col": 32,
-      "color": null,
+      "id": "AF47",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF46",
+        "south": "AF48",
+        "west": "AE47",
+        "east": "AG47"
       }
     },
     {
-      "row": 47,
-      "col": 33,
-      "color": null,
+      "id": "AG47",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG46",
+        "south": "AG48",
+        "west": "AF47",
+        "east": "AH47"
       }
     },
     {
-      "row": 47,
-      "col": 34,
-      "color": null,
+      "id": "AH47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH46",
+        "south": "AH48",
+        "west": "AG47",
+        "east": "AI47"
       }
     },
     {
-      "row": 47,
-      "col": 35,
-      "color": null,
+      "id": "AI47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI46",
+        "south": "AI48",
+        "west": "AH47",
+        "east": "AJ47"
       }
     },
     {
-      "row": 47,
-      "col": 36,
-      "color": null,
+      "id": "AJ47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ46",
+        "south": "AJ48",
+        "west": "AI47",
+        "east": "AK47"
       }
     },
     {
-      "row": 47,
-      "col": 37,
-      "color": null,
+      "id": "AK47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK46",
+        "south": "AK48",
+        "west": "AJ47",
+        "east": "AL47"
       }
     },
     {
-      "row": 47,
-      "col": 38,
-      "color": null,
+      "id": "AL47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL46",
+        "south": "AL48",
+        "west": "AK47",
+        "east": "AM47"
       }
     },
     {
-      "row": 47,
-      "col": 39,
-      "color": null,
+      "id": "AM47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM46",
+        "south": "AM48",
+        "west": "AL47",
+        "east": "AN47"
       }
     },
     {
-      "row": 47,
-      "col": 40,
-      "color": null,
+      "id": "AN47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN46",
+        "south": "AN48",
+        "west": "AM47",
+        "east": "AO47"
       }
     },
     {
-      "row": 47,
-      "col": 41,
-      "color": null,
+      "id": "AO47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO46",
+        "south": "AO48",
+        "west": "AN47",
+        "east": "AP47"
       }
     },
     {
-      "row": 47,
-      "col": 42,
-      "color": null,
+      "id": "AP47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP46",
+        "south": "AP48",
+        "west": "AO47",
+        "east": "AQ47"
       }
     },
     {
-      "row": 47,
-      "col": 43,
-      "color": null,
+      "id": "AQ47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ46",
+        "south": "AQ48",
+        "west": "AP47",
+        "east": "AR47"
       }
     },
     {
-      "row": 47,
-      "col": 44,
-      "color": null,
+      "id": "AR47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR46",
+        "south": "AR48",
+        "west": "AQ47",
+        "east": "AS47"
       }
     },
     {
-      "row": 47,
-      "col": 45,
-      "color": null,
+      "id": "AS47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS46",
+        "south": "AS48",
+        "west": "AR47",
+        "east": "AT47"
       }
     },
     {
-      "row": 47,
-      "col": 46,
-      "color": null,
+      "id": "AT47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT46",
+        "south": "AT48",
+        "west": "AS47",
+        "east": "AU47"
       }
     },
     {
-      "row": 47,
-      "col": 47,
-      "color": null,
+      "id": "AU47",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU46",
+        "south": "AU48",
+        "west": "AT47",
+        "east": "AV47"
       }
     },
     {
-      "row": 47,
-      "col": 48,
-      "color": null,
+      "id": "AV47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV46",
+        "south": "AV48",
+        "west": "AU47",
+        "east": "AW47"
       }
     },
     {
-      "row": 47,
-      "col": 49,
-      "color": null,
+      "id": "AW47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW46",
+        "south": "AW48",
+        "west": "AV47",
+        "east": "AX47"
       }
     },
     {
-      "row": 47,
-      "col": 50,
-      "color": null,
+      "id": "AX47",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX46",
+        "south": "AX48",
+        "west": "AW47"
       }
     },
     {
-      "row": 48,
-      "col": 1,
-      "color": null,
+      "id": "A48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A47",
+        "south": "A49",
+        "east": "B48"
       }
     },
     {
-      "row": 48,
-      "col": 2,
-      "color": null,
+      "id": "B48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B47",
+        "south": "B49",
+        "west": "A48",
+        "east": "C48"
       }
     },
     {
-      "row": 48,
-      "col": 3,
-      "color": null,
+      "id": "C48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C47",
+        "south": "C49",
+        "west": "B48",
+        "east": "D48"
       }
     },
     {
-      "row": 48,
-      "col": 4,
-      "color": null,
+      "id": "D48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D47",
+        "south": "D49",
+        "west": "C48",
+        "east": "E48"
       }
     },
     {
-      "row": 48,
-      "col": 5,
-      "color": null,
+      "id": "E48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E47",
+        "south": "E49",
+        "west": "D48",
+        "east": "F48"
       }
     },
     {
-      "row": 48,
-      "col": 6,
-      "color": null,
+      "id": "F48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F47",
+        "south": "F49",
+        "west": "E48",
+        "east": "G48"
       }
     },
     {
-      "row": 48,
-      "col": 7,
-      "color": null,
+      "id": "G48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G47",
+        "south": "G49",
+        "west": "F48",
+        "east": "H48"
       }
     },
     {
-      "row": 48,
-      "col": 8,
-      "color": null,
+      "id": "H48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H47",
+        "south": "H49",
+        "west": "G48",
+        "east": "I48"
       }
     },
     {
-      "row": 48,
-      "col": 9,
-      "color": null,
+      "id": "I48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I47",
+        "south": "I49",
+        "west": "H48",
+        "east": "J48"
       }
     },
     {
-      "row": 48,
-      "col": 10,
-      "color": null,
+      "id": "J48",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J47",
+        "south": "J49",
+        "west": "I48",
+        "east": "K48"
       }
     },
     {
-      "row": 48,
-      "col": 11,
-      "color": null,
+      "id": "K48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K47",
+        "south": "K49",
+        "west": "J48",
+        "east": "L48"
       }
     },
     {
-      "row": 48,
-      "col": 12,
-      "color": null,
+      "id": "L48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L47",
+        "south": "L49",
+        "west": "K48",
+        "east": "M48"
       }
     },
     {
-      "row": 48,
-      "col": 13,
-      "color": null,
+      "id": "M48",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M47",
+        "south": "M49",
+        "west": "L48",
+        "east": "N48"
       }
     },
     {
-      "row": 48,
-      "col": 14,
-      "color": null,
+      "id": "N48",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N47",
+        "south": "N49",
+        "west": "M48",
+        "east": "O48"
       }
     },
     {
-      "row": 48,
-      "col": 15,
-      "color": null,
+      "id": "O48",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O47",
+        "south": "O49",
+        "west": "N48",
+        "east": "P48"
       }
     },
     {
-      "row": 48,
-      "col": 16,
-      "color": null,
+      "id": "P48",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P47",
+        "south": "P49",
+        "west": "O48",
+        "east": "Q48"
       }
     },
     {
-      "row": 48,
-      "col": 17,
-      "color": null,
+      "id": "Q48",
+      "terrain": "j",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q47",
+        "south": "Q49",
+        "west": "P48",
+        "east": "R48"
       }
     },
     {
-      "row": 48,
-      "col": 18,
-      "color": null,
+      "id": "R48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R47",
+        "south": "R49",
+        "west": "Q48",
+        "east": "S48"
       }
     },
     {
-      "row": 48,
-      "col": 19,
-      "color": null,
+      "id": "S48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S47",
+        "south": "S49",
+        "west": "R48",
+        "east": "T48"
       }
     },
     {
-      "row": 48,
-      "col": 20,
-      "color": null,
+      "id": "T48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T47",
+        "south": "T49",
+        "west": "S48",
+        "east": "U48"
       }
     },
     {
-      "row": 48,
-      "col": 21,
-      "color": null,
+      "id": "U48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U47",
+        "south": "U49",
+        "west": "T48",
+        "east": "V48"
       }
     },
     {
-      "row": 48,
-      "col": 22,
-      "color": null,
+      "id": "V48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V47",
+        "south": "V49",
+        "west": "U48",
+        "east": "W48"
       }
     },
     {
-      "row": 48,
-      "col": 23,
-      "color": null,
+      "id": "W48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W47",
+        "south": "W49",
+        "west": "V48",
+        "east": "X48"
       }
     },
     {
-      "row": 48,
-      "col": 24,
-      "color": null,
+      "id": "X48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X47",
+        "south": "X49",
+        "west": "W48",
+        "east": "Y48"
       }
     },
     {
-      "row": 48,
-      "col": 25,
-      "color": null,
+      "id": "Y48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y47",
+        "south": "Y49",
+        "west": "X48",
+        "east": "Z48"
       }
     },
     {
-      "row": 48,
-      "col": 26,
-      "color": null,
+      "id": "Z48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z47",
+        "south": "Z49",
+        "west": "Y48",
+        "east": "AA48"
       }
     },
     {
-      "row": 48,
-      "col": 27,
-      "color": null,
+      "id": "AA48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA47",
+        "south": "AA49",
+        "west": "Z48",
+        "east": "AB48"
       }
     },
     {
-      "row": 48,
-      "col": 28,
-      "color": null,
+      "id": "AB48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB47",
+        "south": "AB49",
+        "west": "AA48",
+        "east": "AC48"
       }
     },
     {
-      "row": 48,
-      "col": 29,
-      "color": null,
+      "id": "AC48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC47",
+        "south": "AC49",
+        "west": "AB48",
+        "east": "AD48"
       }
     },
     {
-      "row": 48,
-      "col": 30,
-      "color": null,
+      "id": "AD48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD47",
+        "south": "AD49",
+        "west": "AC48",
+        "east": "AE48"
       }
     },
     {
-      "row": 48,
-      "col": 31,
-      "color": null,
+      "id": "AE48",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE47",
+        "south": "AE49",
+        "west": "AD48",
+        "east": "AF48"
       }
     },
     {
-      "row": 48,
-      "col": 32,
-      "color": null,
+      "id": "AF48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF47",
+        "south": "AF49",
+        "west": "AE48",
+        "east": "AG48"
       }
     },
     {
-      "row": 48,
-      "col": 33,
-      "color": null,
+      "id": "AG48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG47",
+        "south": "AG49",
+        "west": "AF48",
+        "east": "AH48"
       }
     },
     {
-      "row": 48,
-      "col": 34,
-      "color": null,
+      "id": "AH48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH47",
+        "south": "AH49",
+        "west": "AG48",
+        "east": "AI48"
       }
     },
     {
-      "row": 48,
-      "col": 35,
-      "color": null,
+      "id": "AI48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI47",
+        "south": "AI49",
+        "west": "AH48",
+        "east": "AJ48"
       }
     },
     {
-      "row": 48,
-      "col": 36,
-      "color": null,
+      "id": "AJ48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ47",
+        "south": "AJ49",
+        "west": "AI48",
+        "east": "AK48"
       }
     },
     {
-      "row": 48,
-      "col": 37,
-      "color": null,
+      "id": "AK48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK47",
+        "south": "AK49",
+        "west": "AJ48",
+        "east": "AL48"
       }
     },
     {
-      "row": 48,
-      "col": 38,
-      "color": null,
+      "id": "AL48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL47",
+        "south": "AL49",
+        "west": "AK48",
+        "east": "AM48"
       }
     },
     {
-      "row": 48,
-      "col": 39,
-      "color": null,
+      "id": "AM48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM47",
+        "south": "AM49",
+        "west": "AL48",
+        "east": "AN48"
       }
     },
     {
-      "row": 48,
-      "col": 40,
-      "color": null,
+      "id": "AN48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN47",
+        "south": "AN49",
+        "west": "AM48",
+        "east": "AO48"
       }
     },
     {
-      "row": 48,
-      "col": 41,
-      "color": null,
+      "id": "AO48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO47",
+        "south": "AO49",
+        "west": "AN48",
+        "east": "AP48"
       }
     },
     {
-      "row": 48,
-      "col": 42,
-      "color": null,
+      "id": "AP48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP47",
+        "south": "AP49",
+        "west": "AO48",
+        "east": "AQ48"
       }
     },
     {
-      "row": 48,
-      "col": 43,
-      "color": null,
+      "id": "AQ48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ47",
+        "south": "AQ49",
+        "west": "AP48",
+        "east": "AR48"
       }
     },
     {
-      "row": 48,
-      "col": 44,
-      "color": null,
+      "id": "AR48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR47",
+        "south": "AR49",
+        "west": "AQ48",
+        "east": "AS48"
       }
     },
     {
-      "row": 48,
-      "col": 45,
-      "color": null,
+      "id": "AS48",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS47",
+        "south": "AS49",
+        "west": "AR48",
+        "east": "AT48"
       }
     },
     {
-      "row": 48,
-      "col": 46,
-      "color": null,
+      "id": "AT48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT47",
+        "south": "AT49",
+        "west": "AS48",
+        "east": "AU48"
       }
     },
     {
-      "row": 48,
-      "col": 47,
-      "color": null,
+      "id": "AU48",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU47",
+        "south": "AU49",
+        "west": "AT48",
+        "east": "AV48"
       }
     },
     {
-      "row": 48,
-      "col": 48,
-      "color": null,
+      "id": "AV48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV47",
+        "south": "AV49",
+        "west": "AU48",
+        "east": "AW48"
       }
     },
     {
-      "row": 48,
-      "col": 49,
-      "color": null,
+      "id": "AW48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW47",
+        "south": "AW49",
+        "west": "AV48",
+        "east": "AX48"
       }
     },
     {
-      "row": 48,
-      "col": 50,
-      "color": null,
+      "id": "AX48",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX47",
+        "south": "AX49",
+        "west": "AW48"
       }
     },
     {
-      "row": 49,
-      "col": 1,
-      "color": null,
+      "id": "A49",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A48",
+        "south": "A50",
+        "east": "B49"
       }
     },
     {
-      "row": 49,
-      "col": 2,
-      "color": null,
+      "id": "B49",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B48",
+        "south": "B50",
+        "west": "A49",
+        "east": "C49"
       }
     },
     {
-      "row": 49,
-      "col": 3,
-      "color": null,
+      "id": "C49",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C48",
+        "south": "C50",
+        "west": "B49",
+        "east": "D49"
       }
     },
     {
-      "row": 49,
-      "col": 4,
-      "color": null,
+      "id": "D49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D48",
+        "south": "D50",
+        "west": "C49",
+        "east": "E49"
       }
     },
     {
-      "row": 49,
-      "col": 5,
-      "color": null,
+      "id": "E49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E48",
+        "south": "E50",
+        "west": "D49",
+        "east": "F49"
       }
     },
     {
-      "row": 49,
-      "col": 6,
-      "color": null,
+      "id": "F49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F48",
+        "south": "F50",
+        "west": "E49",
+        "east": "G49"
       }
     },
     {
-      "row": 49,
-      "col": 7,
-      "color": null,
+      "id": "G49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G48",
+        "south": "G50",
+        "west": "F49",
+        "east": "H49"
       }
     },
     {
-      "row": 49,
-      "col": 8,
-      "color": null,
+      "id": "H49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H48",
+        "south": "H50",
+        "west": "G49",
+        "east": "I49"
       }
     },
     {
-      "row": 49,
-      "col": 9,
-      "color": null,
+      "id": "I49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I48",
+        "south": "I50",
+        "west": "H49",
+        "east": "J49"
       }
     },
     {
-      "row": 49,
-      "col": 10,
-      "color": null,
+      "id": "J49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J48",
+        "south": "J50",
+        "west": "I49",
+        "east": "K49"
       }
     },
     {
-      "row": 49,
-      "col": 11,
-      "color": null,
+      "id": "K49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K48",
+        "south": "K50",
+        "west": "J49",
+        "east": "L49"
       }
     },
     {
-      "row": 49,
-      "col": 12,
-      "color": null,
+      "id": "L49",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L48",
+        "south": "L50",
+        "west": "K49",
+        "east": "M49"
       }
     },
     {
-      "row": 49,
-      "col": 13,
-      "color": null,
+      "id": "M49",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M48",
+        "south": "M50",
+        "west": "L49",
+        "east": "N49"
       }
     },
     {
-      "row": 49,
-      "col": 14,
-      "color": null,
+      "id": "N49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N48",
+        "south": "N50",
+        "west": "M49",
+        "east": "O49"
       }
     },
     {
-      "row": 49,
-      "col": 15,
-      "color": null,
+      "id": "O49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O48",
+        "south": "O50",
+        "west": "N49",
+        "east": "P49"
       }
     },
     {
-      "row": 49,
-      "col": 16,
-      "color": null,
+      "id": "P49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P48",
+        "south": "P50",
+        "west": "O49",
+        "east": "Q49"
       }
     },
     {
-      "row": 49,
-      "col": 17,
-      "color": null,
+      "id": "Q49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q48",
+        "south": "Q50",
+        "west": "P49",
+        "east": "R49"
       }
     },
     {
-      "row": 49,
-      "col": 18,
-      "color": null,
+      "id": "R49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R48",
+        "south": "R50",
+        "west": "Q49",
+        "east": "S49"
       }
     },
     {
-      "row": 49,
-      "col": 19,
-      "color": null,
+      "id": "S49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S48",
+        "south": "S50",
+        "west": "R49",
+        "east": "T49"
       }
     },
     {
-      "row": 49,
-      "col": 20,
-      "color": null,
+      "id": "T49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T48",
+        "south": "T50",
+        "west": "S49",
+        "east": "U49"
       }
     },
     {
-      "row": 49,
-      "col": 21,
-      "color": null,
+      "id": "U49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U48",
+        "south": "U50",
+        "west": "T49",
+        "east": "V49"
       }
     },
     {
-      "row": 49,
-      "col": 22,
-      "color": null,
+      "id": "V49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V48",
+        "south": "V50",
+        "west": "U49",
+        "east": "W49"
       }
     },
     {
-      "row": 49,
-      "col": 23,
-      "color": null,
+      "id": "W49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W48",
+        "south": "W50",
+        "west": "V49",
+        "east": "X49"
       }
     },
     {
-      "row": 49,
-      "col": 24,
-      "color": null,
+      "id": "X49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X48",
+        "south": "X50",
+        "west": "W49",
+        "east": "Y49"
       }
     },
     {
-      "row": 49,
-      "col": 25,
-      "color": null,
+      "id": "Y49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y48",
+        "south": "Y50",
+        "west": "X49",
+        "east": "Z49"
       }
     },
     {
-      "row": 49,
-      "col": 26,
-      "color": null,
+      "id": "Z49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z48",
+        "south": "Z50",
+        "west": "Y49",
+        "east": "AA49"
       }
     },
     {
-      "row": 49,
-      "col": 27,
-      "color": null,
+      "id": "AA49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA48",
+        "south": "AA50",
+        "west": "Z49",
+        "east": "AB49"
       }
     },
     {
-      "row": 49,
-      "col": 28,
-      "color": null,
+      "id": "AB49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB48",
+        "south": "AB50",
+        "west": "AA49",
+        "east": "AC49"
       }
     },
     {
-      "row": 49,
-      "col": 29,
-      "color": null,
+      "id": "AC49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC48",
+        "south": "AC50",
+        "west": "AB49",
+        "east": "AD49"
       }
     },
     {
-      "row": 49,
-      "col": 30,
-      "color": null,
+      "id": "AD49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD48",
+        "south": "AD50",
+        "west": "AC49",
+        "east": "AE49"
       }
     },
     {
-      "row": 49,
-      "col": 31,
-      "color": null,
+      "id": "AE49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE48",
+        "south": "AE50",
+        "west": "AD49",
+        "east": "AF49"
       }
     },
     {
-      "row": 49,
-      "col": 32,
-      "color": null,
+      "id": "AF49",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF48",
+        "south": "AF50",
+        "west": "AE49",
+        "east": "AG49"
       }
     },
     {
-      "row": 49,
-      "col": 33,
-      "color": null,
+      "id": "AG49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG48",
+        "south": "AG50",
+        "west": "AF49",
+        "east": "AH49"
       }
     },
     {
-      "row": 49,
-      "col": 34,
-      "color": null,
+      "id": "AH49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH48",
+        "south": "AH50",
+        "west": "AG49",
+        "east": "AI49"
       }
     },
     {
-      "row": 49,
-      "col": 35,
-      "color": null,
+      "id": "AI49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI48",
+        "south": "AI50",
+        "west": "AH49",
+        "east": "AJ49"
       }
     },
     {
-      "row": 49,
-      "col": 36,
-      "color": null,
+      "id": "AJ49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ48",
+        "south": "AJ50",
+        "west": "AI49",
+        "east": "AK49"
       }
     },
     {
-      "row": 49,
-      "col": 37,
-      "color": null,
+      "id": "AK49",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK48",
+        "south": "AK50",
+        "west": "AJ49",
+        "east": "AL49"
       }
     },
     {
-      "row": 49,
-      "col": 38,
-      "color": null,
+      "id": "AL49",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL48",
+        "south": "AL50",
+        "west": "AK49",
+        "east": "AM49"
       }
     },
     {
-      "row": 49,
-      "col": 39,
-      "color": null,
+      "id": "AM49",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM48",
+        "south": "AM50",
+        "west": "AL49",
+        "east": "AN49"
       }
     },
     {
-      "row": 49,
-      "col": 40,
-      "color": null,
+      "id": "AN49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN48",
+        "south": "AN50",
+        "west": "AM49",
+        "east": "AO49"
       }
     },
     {
-      "row": 49,
-      "col": 41,
-      "color": null,
+      "id": "AO49",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO48",
+        "south": "AO50",
+        "west": "AN49",
+        "east": "AP49"
       }
     },
     {
-      "row": 49,
-      "col": 42,
-      "color": null,
+      "id": "AP49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP48",
+        "south": "AP50",
+        "west": "AO49",
+        "east": "AQ49"
       }
     },
     {
-      "row": 49,
-      "col": 43,
-      "color": null,
+      "id": "AQ49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ48",
+        "south": "AQ50",
+        "west": "AP49",
+        "east": "AR49"
       }
     },
     {
-      "row": 49,
-      "col": 44,
-      "color": null,
+      "id": "AR49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR48",
+        "south": "AR50",
+        "west": "AQ49",
+        "east": "AS49"
       }
     },
     {
-      "row": 49,
-      "col": 45,
-      "color": null,
+      "id": "AS49",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS48",
+        "south": "AS50",
+        "west": "AR49",
+        "east": "AT49"
       }
     },
     {
-      "row": 49,
-      "col": 46,
-      "color": null,
+      "id": "AT49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT48",
+        "south": "AT50",
+        "west": "AS49",
+        "east": "AU49"
       }
     },
     {
-      "row": 49,
-      "col": 47,
-      "color": null,
+      "id": "AU49",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU48",
+        "south": "AU50",
+        "west": "AT49",
+        "east": "AV49"
       }
     },
     {
-      "row": 49,
-      "col": 48,
-      "color": null,
+      "id": "AV49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV48",
+        "south": "AV50",
+        "west": "AU49",
+        "east": "AW49"
       }
     },
     {
-      "row": 49,
-      "col": 49,
-      "color": null,
+      "id": "AW49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW48",
+        "south": "AW50",
+        "west": "AV49",
+        "east": "AX49"
       }
     },
     {
-      "row": 49,
-      "col": 50,
-      "color": null,
+      "id": "AX49",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX48",
+        "south": "AX50",
+        "west": "AW49"
       }
     },
     {
-      "row": 50,
-      "col": 1,
-      "color": null,
+      "id": "A50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A49",
+        "south": "A51",
+        "east": "B50"
       }
     },
     {
-      "row": 50,
-      "col": 2,
-      "color": null,
+      "id": "B50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B49",
+        "south": "B51",
+        "west": "A50",
+        "east": "C50"
       }
     },
     {
-      "row": 50,
-      "col": 3,
-      "color": null,
+      "id": "C50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C49",
+        "south": "C51",
+        "west": "B50",
+        "east": "D50"
       }
     },
     {
-      "row": 50,
-      "col": 4,
-      "color": null,
+      "id": "D50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D49",
+        "south": "D51",
+        "west": "C50",
+        "east": "E50"
       }
     },
     {
-      "row": 50,
-      "col": 5,
-      "color": null,
+      "id": "E50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E49",
+        "south": "E51",
+        "west": "D50",
+        "east": "F50"
       }
     },
     {
-      "row": 50,
-      "col": 6,
-      "color": null,
+      "id": "F50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F49",
+        "south": "F51",
+        "west": "E50",
+        "east": "G50"
       }
     },
     {
-      "row": 50,
-      "col": 7,
-      "color": null,
+      "id": "G50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G49",
+        "south": "G51",
+        "west": "F50",
+        "east": "H50"
       }
     },
     {
-      "row": 50,
-      "col": 8,
-      "color": null,
+      "id": "H50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H49",
+        "south": "H51",
+        "west": "G50",
+        "east": "I50"
       }
     },
     {
-      "row": 50,
-      "col": 9,
-      "color": null,
+      "id": "I50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I49",
+        "south": "I51",
+        "west": "H50",
+        "east": "J50"
       }
     },
     {
-      "row": 50,
-      "col": 10,
-      "color": null,
+      "id": "J50",
+      "terrain": "Corsair",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J49",
+        "south": "J51",
+        "west": "I50",
+        "east": "K50"
       }
     },
     {
-      "row": 50,
-      "col": 11,
-      "color": null,
+      "id": "K50",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K49",
+        "south": "K51",
+        "west": "J50",
+        "east": "L50"
       }
     },
     {
-      "row": 50,
-      "col": 12,
-      "color": null,
+      "id": "L50",
+      "terrain": "path",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L49",
+        "south": "L51",
+        "west": "K50",
+        "east": "M50"
       }
     },
     {
-      "row": 50,
-      "col": 13,
-      "color": null,
+      "id": "M50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M49",
+        "south": "M51",
+        "west": "L50",
+        "east": "N50"
       }
     },
     {
-      "row": 50,
-      "col": 14,
-      "color": null,
+      "id": "N50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N49",
+        "south": "N51",
+        "west": "M50",
+        "east": "O50"
       }
     },
     {
-      "row": 50,
-      "col": 15,
-      "color": null,
+      "id": "O50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O49",
+        "south": "O51",
+        "west": "N50",
+        "east": "P50"
       }
     },
     {
-      "row": 50,
-      "col": 16,
-      "color": null,
+      "id": "P50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P49",
+        "south": "P51",
+        "west": "O50",
+        "east": "Q50"
       }
     },
     {
-      "row": 50,
-      "col": 17,
-      "color": null,
+      "id": "Q50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q49",
+        "south": "Q51",
+        "west": "P50",
+        "east": "R50"
       }
     },
     {
-      "row": 50,
-      "col": 18,
-      "color": null,
+      "id": "R50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R49",
+        "south": "R51",
+        "west": "Q50",
+        "east": "S50"
       }
     },
     {
-      "row": 50,
-      "col": 19,
-      "color": null,
+      "id": "S50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S49",
+        "south": "S51",
+        "west": "R50",
+        "east": "T50"
       }
     },
     {
-      "row": 50,
-      "col": 20,
-      "color": null,
+      "id": "T50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T49",
+        "south": "T51",
+        "west": "S50",
+        "east": "U50"
       }
     },
     {
-      "row": 50,
-      "col": 21,
-      "color": null,
+      "id": "U50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U49",
+        "south": "U51",
+        "west": "T50",
+        "east": "V50"
       }
     },
     {
-      "row": 50,
-      "col": 22,
-      "color": null,
+      "id": "V50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V49",
+        "south": "V51",
+        "west": "U50",
+        "east": "W50"
       }
     },
     {
-      "row": 50,
-      "col": 23,
-      "color": null,
+      "id": "W50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W49",
+        "south": "W51",
+        "west": "V50",
+        "east": "X50"
       }
     },
     {
-      "row": 50,
-      "col": 24,
-      "color": null,
+      "id": "X50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X49",
+        "south": "X51",
+        "west": "W50",
+        "east": "Y50"
       }
     },
     {
-      "row": 50,
-      "col": 25,
-      "color": null,
+      "id": "Y50",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y49",
+        "south": "Y51",
+        "west": "X50",
+        "east": "Z50"
       }
     },
     {
-      "row": 50,
-      "col": 26,
-      "color": null,
+      "id": "Z50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z49",
+        "south": "Z51",
+        "west": "Y50",
+        "east": "AA50"
       }
     },
     {
-      "row": 50,
-      "col": 27,
-      "color": null,
+      "id": "AA50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA49",
+        "south": "AA51",
+        "west": "Z50",
+        "east": "AB50"
       }
     },
     {
-      "row": 50,
-      "col": 28,
-      "color": null,
+      "id": "AB50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB49",
+        "south": "AB51",
+        "west": "AA50",
+        "east": "AC50"
       }
     },
     {
-      "row": 50,
-      "col": 29,
-      "color": null,
+      "id": "AC50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC49",
+        "south": "AC51",
+        "west": "AB50",
+        "east": "AD50"
       }
     },
     {
-      "row": 50,
-      "col": 30,
-      "color": null,
+      "id": "AD50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD49",
+        "south": "AD51",
+        "west": "AC50",
+        "east": "AE50"
       }
     },
     {
-      "row": 50,
-      "col": 31,
-      "color": null,
+      "id": "AE50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE49",
+        "south": "AE51",
+        "west": "AD50",
+        "east": "AF50"
       }
     },
     {
-      "row": 50,
-      "col": 32,
-      "color": null,
+      "id": "AF50",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF49",
+        "south": "AF51",
+        "west": "AE50",
+        "east": "AG50"
       }
     },
     {
-      "row": 50,
-      "col": 33,
-      "color": null,
+      "id": "AG50",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG49",
+        "south": "AG51",
+        "west": "AF50",
+        "east": "AH50"
       }
     },
     {
-      "row": 50,
-      "col": 34,
-      "color": null,
+      "id": "AH50",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH49",
+        "south": "AH51",
+        "west": "AG50",
+        "east": "AI50"
       }
     },
     {
-      "row": 50,
-      "col": 35,
-      "color": null,
+      "id": "AI50",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI49",
+        "south": "AI51",
+        "west": "AH50",
+        "east": "AJ50"
       }
     },
     {
-      "row": 50,
-      "col": 36,
-      "color": null,
+      "id": "AJ50",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ49",
+        "south": "AJ51",
+        "west": "AI50",
+        "east": "AK50"
       }
     },
     {
-      "row": 50,
-      "col": 37,
-      "color": null,
+      "id": "AK50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK49",
+        "south": "AK51",
+        "west": "AJ50",
+        "east": "AL50"
       }
     },
     {
-      "row": 50,
-      "col": 38,
-      "color": null,
+      "id": "AL50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL49",
+        "south": "AL51",
+        "west": "AK50",
+        "east": "AM50"
       }
     },
     {
-      "row": 50,
-      "col": 39,
-      "color": null,
+      "id": "AM50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM49",
+        "south": "AM51",
+        "west": "AL50",
+        "east": "AN50"
       }
     },
     {
-      "row": 50,
-      "col": 40,
-      "color": null,
+      "id": "AN50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN49",
+        "south": "AN51",
+        "west": "AM50",
+        "east": "AO50"
       }
     },
     {
-      "row": 50,
-      "col": 41,
-      "color": null,
+      "id": "AO50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO49",
+        "south": "AO51",
+        "west": "AN50",
+        "east": "AP50"
       }
     },
     {
-      "row": 50,
-      "col": 42,
-      "color": null,
+      "id": "AP50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP49",
+        "south": "AP51",
+        "west": "AO50",
+        "east": "AQ50"
       }
     },
     {
-      "row": 50,
-      "col": 43,
-      "color": null,
+      "id": "AQ50",
+      "terrain": "lf",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ49",
+        "south": "AQ51",
+        "west": "AP50",
+        "east": "AR50"
       }
     },
     {
-      "row": 50,
-      "col": 44,
-      "color": null,
+      "id": "AR50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR49",
+        "south": "AR51",
+        "west": "AQ50",
+        "east": "AS50"
       }
     },
     {
-      "row": 50,
-      "col": 45,
-      "color": null,
+      "id": "AS50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS49",
+        "south": "AS51",
+        "west": "AR50",
+        "east": "AT50"
       }
     },
     {
-      "row": 50,
-      "col": 46,
-      "color": null,
+      "id": "AT50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT49",
+        "south": "AT51",
+        "west": "AS50",
+        "east": "AU50"
       }
     },
     {
-      "row": 50,
-      "col": 47,
-      "color": null,
+      "id": "AU50",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU49",
+        "south": "AU51",
+        "west": "AT50",
+        "east": "AV50"
       }
     },
     {
-      "row": 50,
-      "col": 48,
-      "color": null,
+      "id": "AV50",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV49",
+        "south": "AV51",
+        "west": "AU50",
+        "east": "AW50"
       }
     },
     {
-      "row": 50,
-      "col": 49,
-      "color": null,
+      "id": "AW50",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW49",
+        "south": "AW51",
+        "west": "AV50",
+        "east": "AX50"
       }
     },
     {
-      "row": 50,
-      "col": 50,
-      "color": null,
+      "id": "AX50",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX49",
+        "south": "AX51",
+        "west": "AW50"
       }
     },
     {
-      "row": 51,
-      "col": 1,
-      "color": null,
+      "id": "A51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": false,
-        "east": true
+        "north": "A50",
+        "south": "A52",
+        "east": "B51"
       }
     },
     {
-      "row": 51,
-      "col": 2,
-      "color": null,
+      "id": "B51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "B50",
+        "south": "B52",
+        "west": "A51",
+        "east": "C51"
       }
     },
     {
-      "row": 51,
-      "col": 3,
-      "color": null,
+      "id": "C51",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "C50",
+        "south": "C52",
+        "west": "B51",
+        "east": "D51"
       }
     },
     {
-      "row": 51,
-      "col": 4,
-      "color": null,
+      "id": "D51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "D50",
+        "south": "D52",
+        "west": "C51",
+        "east": "E51"
       }
     },
     {
-      "row": 51,
-      "col": 5,
-      "color": null,
+      "id": "E51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "E50",
+        "south": "E52",
+        "west": "D51",
+        "east": "F51"
       }
     },
     {
-      "row": 51,
-      "col": 6,
-      "color": null,
+      "id": "F51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "F50",
+        "south": "F52",
+        "west": "E51",
+        "east": "G51"
       }
     },
     {
-      "row": 51,
-      "col": 7,
-      "color": null,
+      "id": "G51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "G50",
+        "south": "G52",
+        "west": "F51",
+        "east": "H51"
       }
     },
     {
-      "row": 51,
-      "col": 8,
-      "color": null,
+      "id": "H51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "H50",
+        "south": "H52",
+        "west": "G51",
+        "east": "I51"
       }
     },
     {
-      "row": 51,
-      "col": 9,
-      "color": null,
+      "id": "I51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "I50",
+        "south": "I52",
+        "west": "H51",
+        "east": "J51"
       }
     },
     {
-      "row": 51,
-      "col": 10,
-      "color": null,
+      "id": "J51",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "J50",
+        "south": "J52",
+        "west": "I51",
+        "east": "K51"
       }
     },
     {
-      "row": 51,
-      "col": 11,
-      "color": null,
+      "id": "K51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "K50",
+        "south": "K52",
+        "west": "J51",
+        "east": "L51"
       }
     },
     {
-      "row": 51,
-      "col": 12,
-      "color": null,
+      "id": "L51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "L50",
+        "south": "L52",
+        "west": "K51",
+        "east": "M51"
       }
     },
     {
-      "row": 51,
-      "col": 13,
-      "color": null,
+      "id": "M51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "M50",
+        "south": "M52",
+        "west": "L51",
+        "east": "N51"
       }
     },
     {
-      "row": 51,
-      "col": 14,
-      "color": null,
+      "id": "N51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "N50",
+        "south": "N52",
+        "west": "M51",
+        "east": "O51"
       }
     },
     {
-      "row": 51,
-      "col": 15,
-      "color": null,
+      "id": "O51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "O50",
+        "south": "O52",
+        "west": "N51",
+        "east": "P51"
       }
     },
     {
-      "row": 51,
-      "col": 16,
-      "color": null,
+      "id": "P51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "P50",
+        "south": "P52",
+        "west": "O51",
+        "east": "Q51"
       }
     },
     {
-      "row": 51,
-      "col": 17,
-      "color": null,
+      "id": "Q51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Q50",
+        "south": "Q52",
+        "west": "P51",
+        "east": "R51"
       }
     },
     {
-      "row": 51,
-      "col": 18,
-      "color": null,
+      "id": "R51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "R50",
+        "south": "R52",
+        "west": "Q51",
+        "east": "S51"
       }
     },
     {
-      "row": 51,
-      "col": 19,
-      "color": null,
+      "id": "S51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "S50",
+        "south": "S52",
+        "west": "R51",
+        "east": "T51"
       }
     },
     {
-      "row": 51,
-      "col": 20,
-      "color": null,
+      "id": "T51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "T50",
+        "south": "T52",
+        "west": "S51",
+        "east": "U51"
       }
     },
     {
-      "row": 51,
-      "col": 21,
-      "color": null,
+      "id": "U51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "U50",
+        "south": "U52",
+        "west": "T51",
+        "east": "V51"
       }
     },
     {
-      "row": 51,
-      "col": 22,
-      "color": null,
+      "id": "V51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "V50",
+        "south": "V52",
+        "west": "U51",
+        "east": "W51"
       }
     },
     {
-      "row": 51,
-      "col": 23,
-      "color": null,
+      "id": "W51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "W50",
+        "south": "W52",
+        "west": "V51",
+        "east": "X51"
       }
     },
     {
-      "row": 51,
-      "col": 24,
-      "color": null,
+      "id": "X51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "X50",
+        "south": "X52",
+        "west": "W51",
+        "east": "Y51"
       }
     },
     {
-      "row": 51,
-      "col": 25,
-      "color": null,
+      "id": "Y51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Y50",
+        "south": "Y52",
+        "west": "X51",
+        "east": "Z51"
       }
     },
     {
-      "row": 51,
-      "col": 26,
-      "color": null,
+      "id": "Z51",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "Z50",
+        "south": "Z52",
+        "west": "Y51",
+        "east": "AA51"
       }
     },
     {
-      "row": 51,
-      "col": 27,
-      "color": null,
+      "id": "AA51",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AA50",
+        "south": "AA52",
+        "west": "Z51",
+        "east": "AB51"
       }
     },
     {
-      "row": 51,
-      "col": 28,
-      "color": null,
+      "id": "AB51",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AB50",
+        "south": "AB52",
+        "west": "AA51",
+        "east": "AC51"
       }
     },
     {
-      "row": 51,
-      "col": 29,
-      "color": null,
+      "id": "AC51",
+      "terrain": "s",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AC50",
+        "south": "AC52",
+        "west": "AB51",
+        "east": "AD51"
       }
     },
     {
-      "row": 51,
-      "col": 30,
-      "color": null,
+      "id": "AD51",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AD50",
+        "south": "AD52",
+        "west": "AC51",
+        "east": "AE51"
       }
     },
     {
-      "row": 51,
-      "col": 31,
-      "color": null,
+      "id": "AE51",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AE50",
+        "south": "AE52",
+        "west": "AD51",
+        "east": "AF51"
       }
     },
     {
-      "row": 51,
-      "col": 32,
-      "color": null,
+      "id": "AF51",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AF50",
+        "south": "AF52",
+        "west": "AE51",
+        "east": "AG51"
       }
     },
     {
-      "row": 51,
-      "col": 33,
-      "color": null,
+      "id": "AG51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AG50",
+        "south": "AG52",
+        "west": "AF51",
+        "east": "AH51"
       }
     },
     {
-      "row": 51,
-      "col": 34,
-      "color": null,
+      "id": "AH51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AH50",
+        "south": "AH52",
+        "west": "AG51",
+        "east": "AI51"
       }
     },
     {
-      "row": 51,
-      "col": 35,
-      "color": null,
+      "id": "AI51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AI50",
+        "south": "AI52",
+        "west": "AH51",
+        "east": "AJ51"
       }
     },
     {
-      "row": 51,
-      "col": 36,
-      "color": null,
+      "id": "AJ51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AJ50",
+        "south": "AJ52",
+        "west": "AI51",
+        "east": "AK51"
       }
     },
     {
-      "row": 51,
-      "col": 37,
-      "color": null,
+      "id": "AK51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AK50",
+        "south": "AK52",
+        "west": "AJ51",
+        "east": "AL51"
       }
     },
     {
-      "row": 51,
-      "col": 38,
-      "color": null,
+      "id": "AL51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AL50",
+        "south": "AL52",
+        "west": "AK51",
+        "east": "AM51"
       }
     },
     {
-      "row": 51,
-      "col": 39,
-      "color": null,
+      "id": "AM51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AM50",
+        "south": "AM52",
+        "west": "AL51",
+        "east": "AN51"
       }
     },
     {
-      "row": 51,
-      "col": 40,
-      "color": null,
+      "id": "AN51",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AN50",
+        "south": "AN52",
+        "west": "AM51",
+        "east": "AO51"
       }
     },
     {
-      "row": 51,
-      "col": 41,
-      "color": null,
+      "id": "AO51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AO50",
+        "south": "AO52",
+        "west": "AN51",
+        "east": "AP51"
       }
     },
     {
-      "row": 51,
-      "col": 42,
-      "color": null,
+      "id": "AP51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AP50",
+        "south": "AP52",
+        "west": "AO51",
+        "east": "AQ51"
       }
     },
     {
-      "row": 51,
-      "col": 43,
-      "color": null,
+      "id": "AQ51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AQ50",
+        "south": "AQ52",
+        "west": "AP51",
+        "east": "AR51"
       }
     },
     {
-      "row": 51,
-      "col": 44,
-      "color": null,
+      "id": "AR51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AR50",
+        "south": "AR52",
+        "west": "AQ51",
+        "east": "AS51"
       }
     },
     {
-      "row": 51,
-      "col": 45,
-      "color": null,
+      "id": "AS51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AS50",
+        "south": "AS52",
+        "west": "AR51",
+        "east": "AT51"
       }
     },
     {
-      "row": 51,
-      "col": 46,
-      "color": null,
+      "id": "AT51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AT50",
+        "south": "AT52",
+        "west": "AS51",
+        "east": "AU51"
       }
     },
     {
-      "row": 51,
-      "col": 47,
-      "color": null,
+      "id": "AU51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AU50",
+        "south": "AU52",
+        "west": "AT51",
+        "east": "AV51"
       }
     },
     {
-      "row": 51,
-      "col": 48,
-      "color": null,
+      "id": "AV51",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AV50",
+        "south": "AV52",
+        "west": "AU51",
+        "east": "AW51"
       }
     },
     {
-      "row": 51,
-      "col": 49,
-      "color": null,
+      "id": "AW51",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": true
+        "north": "AW50",
+        "south": "AW52",
+        "west": "AV51",
+        "east": "AX51"
       }
     },
     {
-      "row": 51,
-      "col": 50,
-      "color": null,
+      "id": "AX51",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": true,
-        "west": true,
-        "east": false
+        "north": "AX50",
+        "south": "AX52",
+        "west": "AW51"
       }
     },
     {
-      "row": 52,
-      "col": 1,
-      "color": null,
+      "id": "A52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": false,
-        "east": true
+        "north": "A51",
+        "east": "B52"
       }
     },
     {
-      "row": 52,
-      "col": 2,
-      "color": null,
+      "id": "B52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "B51",
+        "west": "A52",
+        "east": "C52"
       }
     },
     {
-      "row": 52,
-      "col": 3,
-      "color": null,
+      "id": "C52",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "C51",
+        "west": "B52",
+        "east": "D52"
       }
     },
     {
-      "row": 52,
-      "col": 4,
-      "color": null,
+      "id": "D52",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "D51",
+        "west": "C52",
+        "east": "E52"
       }
     },
     {
-      "row": 52,
-      "col": 5,
-      "color": null,
+      "id": "E52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "E51",
+        "west": "D52",
+        "east": "F52"
       }
     },
     {
-      "row": 52,
-      "col": 6,
-      "color": null,
+      "id": "F52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "F51",
+        "west": "E52",
+        "east": "G52"
       }
     },
     {
-      "row": 52,
-      "col": 7,
-      "color": null,
+      "id": "G52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "G51",
+        "west": "F52",
+        "east": "H52"
       }
     },
     {
-      "row": 52,
-      "col": 8,
-      "color": null,
+      "id": "H52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "H51",
+        "west": "G52",
+        "east": "I52"
       }
     },
     {
-      "row": 52,
-      "col": 9,
-      "color": null,
+      "id": "I52",
+      "terrain": "w",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "I51",
+        "west": "H52",
+        "east": "J52"
       }
     },
     {
-      "row": 52,
-      "col": 10,
-      "color": null,
+      "id": "J52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "J51",
+        "west": "I52",
+        "east": "K52"
       }
     },
     {
-      "row": 52,
-      "col": 11,
-      "color": null,
+      "id": "K52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "K51",
+        "west": "J52",
+        "east": "L52"
       }
     },
     {
-      "row": 52,
-      "col": 12,
-      "color": null,
+      "id": "L52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "L51",
+        "west": "K52",
+        "east": "M52"
       }
     },
     {
-      "row": 52,
-      "col": 13,
-      "color": null,
+      "id": "M52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "M51",
+        "west": "L52",
+        "east": "N52"
       }
     },
     {
-      "row": 52,
-      "col": 14,
-      "color": null,
+      "id": "N52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "N51",
+        "west": "M52",
+        "east": "O52"
       }
     },
     {
-      "row": 52,
-      "col": 15,
-      "color": null,
+      "id": "O52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "O51",
+        "west": "N52",
+        "east": "P52"
       }
     },
     {
-      "row": 52,
-      "col": 16,
-      "color": null,
+      "id": "P52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "P51",
+        "west": "O52",
+        "east": "Q52"
       }
     },
     {
-      "row": 52,
-      "col": 17,
-      "color": null,
+      "id": "Q52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "Q51",
+        "west": "P52",
+        "east": "R52"
       }
     },
     {
-      "row": 52,
-      "col": 18,
-      "color": null,
+      "id": "R52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "R51",
+        "west": "Q52",
+        "east": "S52"
       }
     },
     {
-      "row": 52,
-      "col": 19,
-      "color": null,
+      "id": "S52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "S51",
+        "west": "R52",
+        "east": "T52"
       }
     },
     {
-      "row": 52,
-      "col": 20,
-      "color": null,
+      "id": "T52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "T51",
+        "west": "S52",
+        "east": "U52"
       }
     },
     {
-      "row": 52,
-      "col": 21,
-      "color": null,
+      "id": "U52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "U51",
+        "west": "T52",
+        "east": "V52"
       }
     },
     {
-      "row": 52,
-      "col": 22,
-      "color": null,
+      "id": "V52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "V51",
+        "west": "U52",
+        "east": "W52"
       }
     },
     {
-      "row": 52,
-      "col": 23,
-      "color": null,
+      "id": "W52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "W51",
+        "west": "V52",
+        "east": "X52"
       }
     },
     {
-      "row": 52,
-      "col": 24,
-      "color": null,
+      "id": "X52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "X51",
+        "west": "W52",
+        "east": "Y52"
       }
     },
     {
-      "row": 52,
-      "col": 25,
-      "color": null,
+      "id": "Y52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "Y51",
+        "west": "X52",
+        "east": "Z52"
       }
     },
     {
-      "row": 52,
-      "col": 26,
-      "color": null,
+      "id": "Z52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "Z51",
+        "west": "Y52",
+        "east": "AA52"
       }
     },
     {
-      "row": 52,
-      "col": 27,
-      "color": null,
+      "id": "AA52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AA51",
+        "west": "Z52",
+        "east": "AB52"
       }
     },
     {
-      "row": 52,
-      "col": 28,
-      "color": null,
+      "id": "AB52",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AB51",
+        "west": "AA52",
+        "east": "AC52"
       }
     },
     {
-      "row": 52,
-      "col": 29,
-      "color": null,
+      "id": "AC52",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AC51",
+        "west": "AB52",
+        "east": "AD52"
       }
     },
     {
-      "row": 52,
-      "col": 30,
-      "color": null,
+      "id": "AD52",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AD51",
+        "west": "AC52",
+        "east": "AE52"
       }
     },
     {
-      "row": 52,
-      "col": 31,
-      "color": null,
+      "id": "AE52",
+      "terrain": "h",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AE51",
+        "west": "AD52",
+        "east": "AF52"
       }
     },
     {
-      "row": 52,
-      "col": 32,
-      "color": null,
+      "id": "AF52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AF51",
+        "west": "AE52",
+        "east": "AG52"
       }
     },
     {
-      "row": 52,
-      "col": 33,
-      "color": null,
+      "id": "AG52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AG51",
+        "west": "AF52",
+        "east": "AH52"
       }
     },
     {
-      "row": 52,
-      "col": 34,
-      "color": null,
+      "id": "AH52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AH51",
+        "west": "AG52",
+        "east": "AI52"
       }
     },
     {
-      "row": 52,
-      "col": 35,
-      "color": null,
+      "id": "AI52",
+      "terrain": "p",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AI51",
+        "west": "AH52",
+        "east": "AJ52"
       }
     },
     {
-      "row": 52,
-      "col": 36,
-      "color": null,
+      "id": "AJ52",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AJ51",
+        "west": "AI52",
+        "east": "AK52"
       }
     },
     {
-      "row": 52,
-      "col": 37,
-      "color": null,
+      "id": "AK52",
+      "terrain": "trail",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AK51",
+        "west": "AJ52",
+        "east": "AL52"
       }
     },
     {
-      "row": 52,
-      "col": 38,
-      "color": null,
+      "id": "AL52",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AL51",
+        "west": "AK52",
+        "east": "AM52"
       }
     },
     {
-      "row": 52,
-      "col": 39,
-      "color": null,
+      "id": "AM52",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AM51",
+        "west": "AL52",
+        "east": "AN52"
       }
     },
     {
-      "row": 52,
-      "col": 40,
-      "color": null,
+      "id": "AN52",
+      "terrain": "m",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AN51",
+        "west": "AM52",
+        "east": "AO52"
       }
     },
     {
-      "row": 52,
-      "col": 41,
-      "color": null,
+      "id": "AO52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AO51",
+        "west": "AN52",
+        "east": "AP52"
       }
     },
     {
-      "row": 52,
-      "col": 42,
-      "color": null,
+      "id": "AP52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AP51",
+        "west": "AO52",
+        "east": "AQ52"
       }
     },
     {
-      "row": 52,
-      "col": 43,
-      "color": null,
+      "id": "AQ52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AQ51",
+        "west": "AP52",
+        "east": "AR52"
       }
     },
     {
-      "row": 52,
-      "col": 44,
-      "color": null,
+      "id": "AR52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AR51",
+        "west": "AQ52",
+        "east": "AS52"
       }
     },
     {
-      "row": 52,
-      "col": 45,
-      "color": null,
+      "id": "AS52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AS51",
+        "west": "AR52",
+        "east": "AT52"
       }
     },
     {
-      "row": 52,
-      "col": 46,
-      "color": null,
+      "id": "AT52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AT51",
+        "west": "AS52",
+        "east": "AU52"
       }
     },
     {
-      "row": 52,
-      "col": 47,
-      "color": null,
+      "id": "AU52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AU51",
+        "west": "AT52",
+        "east": "AV52"
       }
     },
     {
-      "row": 52,
-      "col": 48,
-      "color": null,
+      "id": "AV52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AV51",
+        "west": "AU52",
+        "east": "AW52"
       }
     },
     {
-      "row": 52,
-      "col": 49,
-      "color": null,
+      "id": "AW52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": true
+        "north": "AW51",
+        "west": "AV52",
+        "east": "AX52"
       }
     },
     {
-      "row": 52,
-      "col": 50,
-      "color": null,
+      "id": "AX52",
+      "terrain": "b",
       "exits": {
-        "north": true,
-        "south": false,
-        "west": true,
-        "east": false
+        "north": "AX51",
+        "west": "AW52"
       }
     }
   ]


### PR DESCRIPTION
### Motivation
- Produce a machine-readable map file that captures the rooms represented in `maps/globe-edaw.xlsx` for rows 3–52 and columns A–AX as discrete rooms with ids, terrain labels, and adjacency exits.
- Ensure the map can be regenerated without introducing new runtime dependencies by parsing the XLSX file using the OpenXML package format.

### Description
- Replace the previous grid-style entries with a `rooms` array where each room is an object containing `id` (e.g. `A3`), `terrain` (cell value), and an `exits` mapping of adjacent cells to `north`/`south`/`west`/`east` ids.
- Add a Python data-generation script that reads `maps/globe-edaw.xlsx` via `zipfile` + `xml.etree.ElementTree`, decodes `xl/sharedStrings.xml` when present, and iterates the requested cell range (rows 3–52, cols A–AX) to build the JSON.
- The generator omits empty cells and only creates exits where neighboring cells contain terrain, translating spreadsheet up/down/left/right into `north`/`south`/`west`/`east` respectively.
- The script writes `maps/globe-edaw.json` with the new schema and produced 2500 room entries for the requested range.

### Testing
- Executed the data-generation script which parsed the XLSX and printed `Rooms: 2500` indicating the output was produced successfully.
- Inspected the generated file with `head` and `nl -ba` to confirm top entries and exit mappings were written as expected.
- No unit or CI tests were run against game code after this data-only generation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bfbaccef48327bb6c07cd06c2056a)