### PR TITLE
Reformat maps/globe-edaw.json layout: collapse `id`/`terrain` and exits onto single lines

### DIFF
--- a/maps/globe-edaw.json
+++ b/maps/globe-edaw.json
@@ -1,24803 +1,15003 @@
 {
   "rooms": [
     {
-      "id": "A3",
-      "terrain": "p",
+      "id": "A3", "terrain": "p",
       "exits": {
-        "south": "A4",
-        "east": "B3"
+        "south": "A4", "east": "B3"
       }
     },
     {
-      "id": "B3",
-      "terrain": "p",
+      "id": "B3", "terrain": "p",
       "exits": {
-        "south": "B4",
-        "west": "A3",
-        "east": "C3"
+        "south": "B4", "west": "A3", "east": "C3"
       }
     },
     {
-      "id": "C3",
-      "terrain": "p",
+      "id": "C3", "terrain": "p",
       "exits": {
-        "south": "C4",
-        "west": "B3",
-        "east": "D3"
+        "south": "C4", "west": "B3", "east": "D3"
       }
     },
     {
-      "id": "D3",
-      "terrain": "p",
+      "id": "D3", "terrain": "p",
       "exits": {
-        "south": "D4",
-        "west": "C3",
-        "east": "E3"
+        "south": "D4", "west": "C3", "east": "E3"
       }
     },
     {
-      "id": "E3",
-      "terrain": "p",
+      "id": "E3", "terrain": "p",
       "exits": {
-        "south": "E4",
-        "west": "D3",
-        "east": "F3"
+        "south": "E4", "west": "D3", "east": "F3"
       }
     },
     {
-      "id": "F3",
-      "terrain": "p",
+      "id": "F3", "terrain": "p",
       "exits": {
-        "south": "F4",
-        "west": "E3",
-        "east": "G3"
+        "south": "F4", "west": "E3", "east": "G3"
       }
     },
     {
-      "id": "G3",
-      "terrain": "p",
+      "id": "G3", "terrain": "p",
       "exits": {
-        "south": "G4",
-        "west": "F3",
-        "east": "H3"
+        "south": "G4", "west": "F3", "east": "H3"
       }
     },
     {
-      "id": "H3",
-      "terrain": "p",
+      "id": "H3", "terrain": "p",
       "exits": {
-        "south": "H4",
-        "west": "G3",
-        "east": "I3"
+        "south": "H4", "west": "G3", "east": "I3"
       }
     },
     {
-      "id": "I3",
-      "terrain": "p",
+      "id": "I3", "terrain": "p",
       "exits": {
-        "south": "I4",
-        "west": "H3",
-        "east": "J3"
+        "south": "I4", "west": "H3", "east": "J3"
       }
     },
     {
-      "id": "J3",
-      "terrain": "p",
+      "id": "J3", "terrain": "p",
       "exits": {
-        "south": "J4",
-        "west": "I3",
-        "east": "K3"
+        "south": "J4", "west": "I3", "east": "K3"
       }
     },
     {
-      "id": "K3",
-      "terrain": "p",
+      "id": "K3", "terrain": "p",
       "exits": {
-        "south": "K4",
-        "west": "J3",
-        "east": "L3"
+        "south": "K4", "west": "J3", "east": "L3"
       }
     },
     {
-      "id": "L3",
-      "terrain": "p",
+      "id": "L3", "terrain": "p",
       "exits": {
-        "south": "L4",
-        "west": "K3",
-        "east": "M3"
+        "south": "L4", "west": "K3", "east": "M3"
       }
     },
     {
-      "id": "M3",
-      "terrain": "p",
+      "id": "M3", "terrain": "p",
       "exits": {
-        "south": "M4",
-        "west": "L3",
-        "east": "N3"
+        "south": "M4", "west": "L3", "east": "N3"
       }
     },
     {
-      "id": "N3",
-      "terrain": "p",
+      "id": "N3", "terrain": "p",
       "exits": {
-        "south": "N4",
-        "west": "M3",
-        "east": "O3"
+        "south": "N4", "west": "M3", "east": "O3"
       }
     },
     {
-      "id": "O3",
-      "terrain": "p",
+      "id": "O3", "terrain": "p",
       "exits": {
-        "south": "O4",
-        "west": "N3",
-        "east": "P3"
+        "south": "O4", "west": "N3", "east": "P3"
       }
     },
     {
-      "id": "P3",
-      "terrain": "p",
+      "id": "P3", "terrain": "p",
       "exits": {
-        "south": "P4",
-        "west": "O3",
-        "east": "Q3"
+        "south": "P4", "west": "O3", "east": "Q3"
       }
     },
     {
-      "id": "Q3",
-      "terrain": "p",
+      "id": "Q3", "terrain": "p",
       "exits": {
-        "south": "Q4",
-        "west": "P3",
-        "east": "R3"
+        "south": "Q4", "west": "P3", "east": "R3"
       }
     },
     {
-      "id": "R3",
-      "terrain": "p",
+      "id": "R3", "terrain": "p",
       "exits": {
-        "south": "R4",
-        "west": "Q3",
-        "east": "S3"
+        "south": "R4", "west": "Q3", "east": "S3"
       }
     },
     {
-      "id": "S3",
-      "terrain": "p",
+      "id": "S3", "terrain": "p",
       "exits": {
-        "south": "S4",
-        "west": "R3",
-        "east": "T3"
+        "south": "S4", "west": "R3", "east": "T3"
       }
     },
     {
-      "id": "T3",
-      "terrain": "p",
+      "id": "T3", "terrain": "p",
       "exits": {
-        "south": "T4",
-        "west": "S3",
-        "east": "U3"
+        "south": "T4", "west": "S3", "east": "U3"
       }
     },
     {
-      "id": "U3",
-      "terrain": "p",
+      "id": "U3", "terrain": "p",
       "exits": {
-        "south": "U4",
-        "west": "T3",
-        "east": "V3"
+        "south": "U4", "west": "T3", "east": "V3"
       }
     },
     {
-      "id": "V3",
-      "terrain": "p",
+      "id": "V3", "terrain": "p",
       "exits": {
-        "south": "V4",
-        "west": "U3",
-        "east": "W3"
+        "south": "V4", "west": "U3", "east": "W3"
       }
     },
     {
-      "id": "W3",
-      "terrain": "p",
+      "id": "W3", "terrain": "p",
       "exits": {
-        "south": "W4",
-        "west": "V3",
-        "east": "X3"
+        "south": "W4", "west": "V3", "east": "X3"
       }
     },
     {
-      "id": "X3",
-      "terrain": "p",
+      "id": "X3", "terrain": "p",
       "exits": {
-        "south": "X4",
-        "west": "W3",
-        "east": "Y3"
+        "south": "X4", "west": "W3", "east": "Y3"
       }
     },
     {
-      "id": "Y3",
-      "terrain": "p",
+      "id": "Y3", "terrain": "p",
       "exits": {
-        "south": "Y4",
-        "west": "X3",
-        "east": "Z3"
+        "south": "Y4", "west": "X3", "east": "Z3"
       }
     },
     {
-      "id": "Z3",
-      "terrain": "p",
+      "id": "Z3", "terrain": "p",
       "exits": {
-        "south": "Z4",
-        "west": "Y3",
-        "east": "AA3"
+        "south": "Z4", "west": "Y3", "east": "AA3"
       }
     },
     {
-      "id": "AA3",
-      "terrain": "p",
+      "id": "AA3", "terrain": "p",
       "exits": {
-        "south": "AA4",
-        "west": "Z3",
-        "east": "AB3"
+        "south": "AA4", "west": "Z3", "east": "AB3"
       }
     },
     {
-      "id": "AB3",
-      "terrain": "p",
+      "id": "AB3", "terrain": "p",
       "exits": {
-        "south": "AB4",
-        "west": "AA3",
-        "east": "AC3"
+        "south": "AB4", "west": "AA3", "east": "AC3"
       }
     },
     {
-      "id": "AC3",
-      "terrain": "h",
+      "id": "AC3", "terrain": "h",
       "exits": {
-        "south": "AC4",
-        "west": "AB3",
-        "east": "AD3"
+        "south": "AC4", "west": "AB3", "east": "AD3"
       }
     },
     {
-      "id": "AD3",
-      "terrain": "h",
+      "id": "AD3", "terrain": "h",
       "exits": {
-        "south": "AD4",
-        "west": "AC3",
-        "east": "AE3"
+        "south": "AD4", "west": "AC3", "east": "AE3"
       }
     },
     {
-      "id": "AE3",
-      "terrain": "h",
+      "id": "AE3", "terrain": "h",
       "exits": {
-        "south": "AE4",
-        "west": "AD3",
-        "east": "AF3"
+        "south": "AE4", "west": "AD3", "east": "AF3"
       }
     },
     {
-      "id": "AF3",
-      "terrain": "h",
+      "id": "AF3", "terrain": "h",
       "exits": {
-        "south": "AF4",
-        "west": "AE3",
-        "east": "AG3"
+        "south": "AF4", "west": "AE3", "east": "AG3"
       }
     },
     {
-      "id": "AG3",
-      "terrain": "h",
+      "id": "AG3", "terrain": "h",
       "exits": {
-        "south": "AG4",
-        "west": "AF3",
-        "east": "AH3"
+        "south": "AG4", "west": "AF3", "east": "AH3"
       }
     },
     {
-      "id": "AH3",
-      "terrain": "p",
+      "id": "AH3", "terrain": "p",
       "exits": {
-        "south": "AH4",
-        "west": "AG3",
-        "east": "AI3"
+        "south": "AH4", "west": "AG3", "east": "AI3"
       }
     },
     {
-      "id": "AI3",
-      "terrain": "p",
+      "id": "AI3", "terrain": "p",
       "exits": {
-        "south": "AI4",
-        "west": "AH3",
-        "east": "AJ3"
+        "south": "AI4", "west": "AH3", "east": "AJ3"
       }
     },
     {
-      "id": "AJ3",
-      "terrain": "lf",
+      "id": "AJ3", "terrain": "lf",
       "exits": {
-        "south": "AJ4",
-        "west": "AI3",
-        "east": "AK3"
+        "south": "AJ4", "west": "AI3", "east": "AK3"
       }
     },
     {
-      "id": "AK3",
-      "terrain": "p",
+      "id": "AK3", "terrain": "p",
       "exits": {
-        "south": "AK4",
-        "west": "AJ3",
-        "east": "AL3"
+        "south": "AK4", "west": "AJ3", "east": "AL3"
       }
     },
     {
-      "id": "AL3",
-      "terrain": "p",
+      "id": "AL3", "terrain": "p",
       "exits": {
-        "south": "AL4",
-        "west": "AK3",
-        "east": "AM3"
+        "south": "AL4", "west": "AK3", "east": "AM3"
       }
     },
     {
-      "id": "AM3",
-      "terrain": "p",
+      "id": "AM3", "terrain": "p",
       "exits": {
-        "south": "AM4",
-        "west": "AL3",
-        "east": "AN3"
+        "south": "AM4", "west": "AL3", "east": "AN3"
       }
     },
     {
-      "id": "AN3",
-      "terrain": "p",
+      "id": "AN3", "terrain": "p",
       "exits": {
-        "south": "AN4",
-        "west": "AM3",
-        "east": "AO3"
+        "south": "AN4", "west": "AM3", "east": "AO3"
       }
     },
     {
-      "id": "AO3",
-      "terrain": "p",
+      "id": "AO3", "terrain": "p",
       "exits": {
-        "south": "AO4",
-        "west": "AN3",
-        "east": "AP3"
+        "south": "AO4", "west": "AN3", "east": "AP3"
       }
     },
     {
-      "id": "AP3",
-      "terrain": "p",
+      "id": "AP3", "terrain": "p",
       "exits": {
-        "south": "AP4",
-        "west": "AO3",
-        "east": "AQ3"
+        "south": "AP4", "west": "AO3", "east": "AQ3"
       }
     },
     {
-      "id": "AQ3",
-      "terrain": "p",
+      "id": "AQ3", "terrain": "p",
       "exits": {
-        "south": "AQ4",
-        "west": "AP3",
-        "east": "AR3"
+        "south": "AQ4", "west": "AP3", "east": "AR3"
       }
     },
     {
-      "id": "AR3",
-      "terrain": "b",
+      "id": "AR3", "terrain": "b",
       "exits": {
-        "south": "AR4",
-        "west": "AQ3",
-        "east": "AS3"
+        "south": "AR4", "west": "AQ3", "east": "AS3"
       }
     },
     {
-      "id": "AS3",
-      "terrain": "b",
+      "id": "AS3", "terrain": "b",
       "exits": {
-        "south": "AS4",
-        "west": "AR3",
-        "east": "AT3"
+        "south": "AS4", "west": "AR3", "east": "AT3"
       }
     },
     {
-      "id": "AT3",
-      "terrain": "h",
+      "id": "AT3", "terrain": "h",
       "exits": {
-        "south": "AT4",
-        "west": "AS3",
-        "east": "AU3"
+        "south": "AT4", "west": "AS3", "east": "AU3"
       }
     },
     {
-      "id": "AU3",
-      "terrain": "h",
+      "id": "AU3", "terrain": "h",
       "exits": {
-        "south": "AU4",
-        "west": "AT3",
-        "east": "AV3"
+        "south": "AU4", "west": "AT3", "east": "AV3"
       }
     },
     {
-      "id": "AV3",
-      "terrain": "h",
+      "id": "AV3", "terrain": "h",
       "exits": {
-        "south": "AV4",
-        "west": "AU3",
-        "east": "AW3"
+        "south": "AV4", "west": "AU3", "east": "AW3"
       }
     },
     {
-      "id": "AW3",
-      "terrain": "h",
+      "id": "AW3", "terrain": "h",
       "exits": {
-        "south": "AW4",
-        "west": "AV3",
-        "east": "AX3"
+        "south": "AW4", "west": "AV3", "east": "AX3"
       }
     },
     {
-      "id": "AX3",
-      "terrain": "h",
+      "id": "AX3", "terrain": "h",
       "exits": {
-        "south": "AX4",
-        "west": "AW3"
+        "south": "AX4", "west": "AW3"
       }
     },
     {
-      "id": "A4",
-      "terrain": "p",
+      "id": "A4", "terrain": "p",
       "exits": {
-        "north": "A3",
-        "south": "A5",
-        "east": "B4"
+        "north": "A3", "south": "A5", "east": "B4"
       }
     },
     {
-      "id": "B4",
-      "terrain": "p",
+      "id": "B4", "terrain": "p",
       "exits": {
-        "north": "B3",
-        "south": "B5",
-        "west": "A4",
-        "east": "C4"
+        "north": "B3", "south": "B5", "west": "A4", "east": "C4"
       }
     },
     {
-      "id": "C4",
-      "terrain": "p",
+      "id": "C4", "terrain": "p",
       "exits": {
-        "north": "C3",
-        "south": "C5",
-        "west": "B4",
-        "east": "D4"
+        "north": "C3", "south": "C5", "west": "B4", "east": "D4"
       }
     },
     {
-      "id": "D4",
-      "terrain": "p",
+      "id": "D4", "terrain": "p",
       "exits": {
-        "north": "D3",
-        "south": "D5",
-        "west": "C4",
-        "east": "E4"
+        "north": "D3", "south": "D5", "west": "C4", "east": "E4"
       }
     },
     {
-      "id": "E4",
-      "terrain": "p",
+      "id": "E4", "terrain": "p",
       "exits": {
-        "north": "E3",
-        "south": "E5",
-        "west": "D4",
-        "east": "F4"
+        "north": "E3", "south": "E5", "west": "D4", "east": "F4"
       }
     },
     {
-      "id": "F4",
-      "terrain": "p",
+      "id": "F4", "terrain": "p",
       "exits": {
-        "north": "F3",
-        "south": "F5",
-        "west": "E4",
-        "east": "G4"
+        "north": "F3", "south": "F5", "west": "E4", "east": "G4"
       }
     },
     {
-      "id": "G4",
-      "terrain": "p",
+      "id": "G4", "terrain": "p",
       "exits": {
-        "north": "G3",
-        "south": "G5",
-        "west": "F4",
-        "east": "H4"
+        "north": "G3", "south": "G5", "west": "F4", "east": "H4"
       }
     },
     {
-      "id": "H4",
-      "terrain": "p",
+      "id": "H4", "terrain": "p",
       "exits": {
-        "north": "H3",
-        "south": "H5",
-        "west": "G4",
-        "east": "I4"
+        "north": "H3", "south": "H5", "west": "G4", "east": "I4"
       }
     },
     {
-      "id": "I4",
-      "terrain": "p",
+      "id": "I4", "terrain": "p",
       "exits": {
-        "north": "I3",
-        "south": "I5",
-        "west": "H4",
-        "east": "J4"
+        "north": "I3", "south": "I5", "west": "H4", "east": "J4"
       }
     },
     {
-      "id": "J4",
-      "terrain": "p",
+      "id": "J4", "terrain": "p",
       "exits": {
-        "north": "J3",
-        "south": "J5",
-        "west": "I4",
-        "east": "K4"
+        "north": "J3", "south": "J5", "west": "I4", "east": "K4"
       }
     },
     {
-      "id": "K4",
-      "terrain": "p",
+      "id": "K4", "terrain": "p",
       "exits": {
-        "north": "K3",
-        "south": "K5",
-        "west": "J4",
-        "east": "L4"
+        "north": "K3", "south": "K5", "west": "J4", "east": "L4"
       }
     },
     {
-      "id": "L4",
-      "terrain": "p",
+      "id": "L4", "terrain": "p",
       "exits": {
-        "north": "L3",
-        "south": "L5",
-        "west": "K4",
-        "east": "M4"
+        "north": "L3", "south": "L5", "west": "K4", "east": "M4"
       }
     },
     {
-      "id": "M4",
-      "terrain": "p",
+      "id": "M4", "terrain": "p",
       "exits": {
-        "north": "M3",
-        "south": "M5",
-        "west": "L4",
-        "east": "N4"
+        "north": "M3", "south": "M5", "west": "L4", "east": "N4"
       }
     },
     {
-      "id": "N4",
-      "terrain": "p",
+      "id": "N4", "terrain": "p",
       "exits": {
-        "north": "N3",
-        "south": "N5",
-        "west": "M4",
-        "east": "O4"
+        "north": "N3", "south": "N5", "west": "M4", "east": "O4"
       }
     },
     {
-      "id": "O4",
-      "terrain": "p",
+      "id": "O4", "terrain": "p",
       "exits": {
-        "north": "O3",
-        "south": "O5",
-        "west": "N4",
-        "east": "P4"
+        "north": "O3", "south": "O5", "west": "N4", "east": "P4"
       }
     },
     {
-      "id": "P4",
-      "terrain": "p",
+      "id": "P4", "terrain": "p",
       "exits": {
-        "north": "P3",
-        "south": "P5",
-        "west": "O4",
-        "east": "Q4"
+        "north": "P3", "south": "P5", "west": "O4", "east": "Q4"
       }
     },
     {
-      "id": "Q4",
-      "terrain": "p",
+      "id": "Q4", "terrain": "p",
       "exits": {
-        "north": "Q3",
-        "south": "Q5",
-        "west": "P4",
-        "east": "R4"
+        "north": "Q3", "south": "Q5", "west": "P4", "east": "R4"
       }
     },
     {
-      "id": "R4",
-      "terrain": "p",
+      "id": "R4", "terrain": "p",
       "exits": {
-        "north": "R3",
-        "south": "R5",
-        "west": "Q4",
-        "east": "S4"
+        "north": "R3", "south": "R5", "west": "Q4", "east": "S4"
       }
     },
     {
-      "id": "S4",
-      "terrain": "p",
+      "id": "S4", "terrain": "p",
       "exits": {
-        "north": "S3",
-        "south": "S5",
-        "west": "R4",
-        "east": "T4"
+        "north": "S3", "south": "S5", "west": "R4", "east": "T4"
       }
     },
     {
-      "id": "T4",
-      "terrain": "p",
+      "id": "T4", "terrain": "p",
       "exits": {
-        "north": "T3",
-        "south": "T5",
-        "west": "S4",
-        "east": "U4"
+        "north": "T3", "south": "T5", "west": "S4", "east": "U4"
       }
     },
     {
-      "id": "U4",
-      "terrain": "p",
+      "id": "U4", "terrain": "p",
       "exits": {
-        "north": "U3",
-        "south": "U5",
-        "west": "T4",
-        "east": "V4"
+        "north": "U3", "south": "U5", "west": "T4", "east": "V4"
       }
     },
     {
-      "id": "V4",
-      "terrain": "p",
+      "id": "V4", "terrain": "p",
       "exits": {
-        "north": "V3",
-        "south": "V5",
-        "west": "U4",
-        "east": "W4"
+        "north": "V3", "south": "V5", "west": "U4", "east": "W4"
       }
     },
     {
-      "id": "W4",
-      "terrain": "p",
+      "id": "W4", "terrain": "p",
       "exits": {
-        "north": "W3",
-        "south": "W5",
-        "west": "V4",
-        "east": "X4"
+        "north": "W3", "south": "W5", "west": "V4", "east": "X4"
       }
     },
     {
-      "id": "X4",
-      "terrain": "p",
+      "id": "X4", "terrain": "p",
       "exits": {
-        "north": "X3",
-        "south": "X5",
-        "west": "W4",
-        "east": "Y4"
+        "north": "X3", "south": "X5", "west": "W4", "east": "Y4"
       }
     },
     {
-      "id": "Y4",
-      "terrain": "p",
+      "id": "Y4", "terrain": "p",
       "exits": {
-        "north": "Y3",
-        "south": "Y5",
-        "west": "X4",
-        "east": "Z4"
+        "north": "Y3", "south": "Y5", "west": "X4", "east": "Z4"
       }
     },
     {
-      "id": "Z4",
-      "terrain": "p",
+      "id": "Z4", "terrain": "p",
       "exits": {
-        "north": "Z3",
-        "south": "Z5",
-        "west": "Y4",
-        "east": "AA4"
+        "north": "Z3", "south": "Z5", "west": "Y4", "east": "AA4"
       }
     },
     {
-      "id": "AA4",
-      "terrain": "exit ogre",
+      "id": "AA4", "terrain": "exit ogre",
       "exits": {
-        "north": "AA3",
-        "south": "AA5",
-        "west": "Z4",
-        "east": "AB4"
+        "north": "AA3", "south": "AA5", "west": "Z4", "east": "AB4"
       }
     },
     {
-      "id": "AB4",
-      "terrain": "p",
+      "id": "AB4", "terrain": "p",
       "exits": {
-        "north": "AB3",
-        "south": "AB5",
-        "west": "AA4",
-        "east": "AC4"
+        "north": "AB3", "south": "AB5", "west": "AA4", "east": "AC4"
       }
     },
     {
-      "id": "AC4",
-      "terrain": "h",
+      "id": "AC4", "terrain": "h",
       "exits": {
-        "north": "AC3",
-        "south": "AC5",
-        "west": "AB4",
-        "east": "AD4"
+        "north": "AC3", "south": "AC5", "west": "AB4", "east": "AD4"
       }
     },
     {
-      "id": "AD4",
-      "terrain": "h",
+      "id": "AD4", "terrain": "h",
       "exits": {
-        "north": "AD3",
-        "south": "AD5",
-        "west": "AC4",
-        "east": "AE4"
+        "north": "AD3", "south": "AD5", "west": "AC4", "east": "AE4"
       }
     },
     {
-      "id": "AE4",
-      "terrain": "h",
+      "id": "AE4", "terrain": "h",
       "exits": {
-        "north": "AE3",
-        "south": "AE5",
-        "west": "AD4",
-        "east": "AF4"
+        "north": "AE3", "south": "AE5", "west": "AD4", "east": "AF4"
       }
     },
     {
-      "id": "AF4",
-      "terrain": "h",
+      "id": "AF4", "terrain": "h",
       "exits": {
-        "north": "AF3",
-        "south": "AF5",
-        "west": "AE4",
-        "east": "AG4"
+        "north": "AF3", "south": "AF5", "west": "AE4", "east": "AG4"
       }
     },
     {
-      "id": "AG4",
-      "terrain": "h",
+      "id": "AG4", "terrain": "h",
       "exits": {
-        "north": "AG3",
-        "south": "AG5",
-        "west": "AF4",
-        "east": "AH4"
+        "north": "AG3", "south": "AG5", "west": "AF4", "east": "AH4"
       }
     },
     {
-      "id": "AH4",
-      "terrain": "h",
+      "id": "AH4", "terrain": "h",
       "exits": {
-        "north": "AH3",
-        "south": "AH5",
-        "west": "AG4",
-        "east": "AI4"
+        "north": "AH3", "south": "AH5", "west": "AG4", "east": "AI4"
       }
     },
     {
-      "id": "AI4",
-      "terrain": "h",
+      "id": "AI4", "terrain": "h",
       "exits": {
-        "north": "AI3",
-        "south": "AI5",
-        "west": "AH4",
-        "east": "AJ4"
+        "north": "AI3", "south": "AI5", "west": "AH4", "east": "AJ4"
       }
     },
     {
-      "id": "AJ4",
-      "terrain": "h",
+      "id": "AJ4", "terrain": "h",
       "exits": {
-        "north": "AJ3",
-        "south": "AJ5",
-        "west": "AI4",
-        "east": "AK4"
+        "north": "AJ3", "south": "AJ5", "west": "AI4", "east": "AK4"
       }
     },
     {
-      "id": "AK4",
-      "terrain": "p",
+      "id": "AK4", "terrain": "p",
       "exits": {
-        "north": "AK3",
-        "south": "AK5",
-        "west": "AJ4",
-        "east": "AL4"
+        "north": "AK3", "south": "AK5", "west": "AJ4", "east": "AL4"
       }
     },
     {
-      "id": "AL4",
-      "terrain": "p",
+      "id": "AL4", "terrain": "p",
       "exits": {
-        "north": "AL3",
-        "south": "AL5",
-        "west": "AK4",
-        "east": "AM4"
+        "north": "AL3", "south": "AL5", "west": "AK4", "east": "AM4"
       }
     },
     {
-      "id": "AM4",
-      "terrain": "p",
+      "id": "AM4", "terrain": "p",
       "exits": {
-        "north": "AM3",
-        "south": "AM5",
-        "west": "AL4",
-        "east": "AN4"
+        "north": "AM3", "south": "AM5", "west": "AL4", "east": "AN4"
       }
     },
     {
-      "id": "AN4",
-      "terrain": "p",
+      "id": "AN4", "terrain": "p",
       "exits": {
-        "north": "AN3",
-        "south": "AN5",
-        "west": "AM4",
-        "east": "AO4"
+        "north": "AN3", "south": "AN5", "west": "AM4", "east": "AO4"
       }
     },
     {
-      "id": "AO4",
-      "terrain": "p",
+      "id": "AO4", "terrain": "p",
       "exits": {
-        "north": "AO3",
-        "south": "AO5",
-        "west": "AN4",
-        "east": "AP4"
+        "north": "AO3", "south": "AO5", "west": "AN4", "east": "AP4"
       }
     },
     {
-      "id": "AP4",
-      "terrain": "p",
+      "id": "AP4", "terrain": "p",
       "exits": {
-        "north": "AP3",
-        "south": "AP5",
-        "west": "AO4",
-        "east": "AQ4"
+        "north": "AP3", "south": "AP5", "west": "AO4", "east": "AQ4"
       }
     },
     {
-      "id": "AQ4",
-      "terrain": "p",
+      "id": "AQ4", "terrain": "p",
       "exits": {
-        "north": "AQ3",
-        "south": "AQ5",
-        "west": "AP4",
-        "east": "AR4"
+        "north": "AQ3", "south": "AQ5", "west": "AP4", "east": "AR4"
       }
     },
     {
-      "id": "AR4",
-      "terrain": "b",
+      "id": "AR4", "terrain": "b",
       "exits": {
-        "north": "AR3",
-        "south": "AR5",
-        "west": "AQ4",
-        "east": "AS4"
+        "north": "AR3", "south": "AR5", "west": "AQ4", "east": "AS4"
       }
     },
     {
-      "id": "AS4",
-      "terrain": "b",
+      "id": "AS4", "terrain": "b",
       "exits": {
-        "north": "AS3",
-        "south": "AS5",
-        "west": "AR4",
-        "east": "AT4"
+        "north": "AS3", "south": "AS5", "west": "AR4", "east": "AT4"
       }
     },
     {
-      "id": "AT4",
-      "terrain": "b",
+      "id": "AT4", "terrain": "b",
       "exits": {
-        "north": "AT3",
-        "south": "AT5",
-        "west": "AS4",
-        "east": "AU4"
+        "north": "AT3", "south": "AT5", "west": "AS4", "east": "AU4"
       }
     },
     {
-      "id": "AU4",
-      "terrain": "h",
+      "id": "AU4", "terrain": "h",
       "exits": {
-        "north": "AU3",
-        "south": "AU5",
-        "west": "AT4",
-        "east": "AV4"
+        "north": "AU3", "south": "AU5", "west": "AT4", "east": "AV4"
       }
     },
     {
-      "id": "AV4",
-      "terrain": "h",
+      "id": "AV4", "terrain": "h",
       "exits": {
-        "north": "AV3",
-        "south": "AV5",
-        "west": "AU4",
-        "east": "AW4"
+        "north": "AV3", "south": "AV5", "west": "AU4", "east": "AW4"
       }
     },
     {
-      "id": "AW4",
-      "terrain": "h",
+      "id": "AW4", "terrain": "h",
       "exits": {
-        "north": "AW3",
-        "south": "AW5",
-        "west": "AV4",
-        "east": "AX4"
+        "north": "AW3", "south": "AW5", "west": "AV4", "east": "AX4"
       }
     },
     {
-      "id": "AX4",
-      "terrain": "h",
+      "id": "AX4", "terrain": "h",
       "exits": {
-        "north": "AX3",
-        "south": "AX5",
-        "west": "AW4"
+        "north": "AX3", "south": "AX5", "west": "AW4"
       }
     },
     {
-      "id": "A5",
-      "terrain": "p",
+      "id": "A5", "terrain": "p",
       "exits": {
-        "north": "A4",
-        "south": "A6",
-        "east": "B5"
+        "north": "A4", "south": "A6", "east": "B5"
       }
     },
     {
-      "id": "B5",
-      "terrain": "p",
+      "id": "B5", "terrain": "p",
       "exits": {
-        "north": "B4",
-        "south": "B6",
-        "west": "A5",
-        "east": "C5"
+        "north": "B4", "south": "B6", "west": "A5", "east": "C5"
       }
     },
     {
-      "id": "C5",
-      "terrain": "p",
+      "id": "C5", "terrain": "p",
       "exits": {
-        "north": "C4",
-        "south": "C6",
-        "west": "B5",
-        "east": "D5"
+        "north": "C4", "south": "C6", "west": "B5", "east": "D5"
       }
     },
     {
-      "id": "D5",
-      "terrain": "p",
+      "id": "D5", "terrain": "p",
       "exits": {
-        "north": "D4",
-        "south": "D6",
-        "west": "C5",
-        "east": "E5"
+        "north": "D4", "south": "D6", "west": "C5", "east": "E5"
       }
     },
     {
-      "id": "E5",
-      "terrain": "p",
+      "id": "E5", "terrain": "p",
       "exits": {
-        "north": "E4",
-        "south": "E6",
-        "west": "D5",
-        "east": "F5"
+        "north": "E4", "south": "E6", "west": "D5", "east": "F5"
       }
     },
     {
-      "id": "F5",
-      "terrain": "p",
+      "id": "F5", "terrain": "p",
       "exits": {
-        "north": "F4",
-        "south": "F6",
-        "west": "E5",
-        "east": "G5"
+        "north": "F4", "south": "F6", "west": "E5", "east": "G5"
       }
     },
     {
-      "id": "G5",
-      "terrain": "p",
+      "id": "G5", "terrain": "p",
       "exits": {
-        "north": "G4",
-        "south": "G6",
-        "west": "F5",
-        "east": "H5"
+        "north": "G4", "south": "G6", "west": "F5", "east": "H5"
       }
     },
     {
-      "id": "H5",
-      "terrain": "p",
+      "id": "H5", "terrain": "p",
       "exits": {
-        "north": "H4",
-        "south": "H6",
-        "west": "G5",
-        "east": "I5"
+        "north": "H4", "south": "H6", "west": "G5", "east": "I5"
       }
     },
     {
-      "id": "I5",
-      "terrain": "p",
+      "id": "I5", "terrain": "p",
       "exits": {
-        "north": "I4",
-        "south": "I6",
-        "west": "H5",
-        "east": "J5"
+        "north": "I4", "south": "I6", "west": "H5", "east": "J5"
       }
     },
     {
-      "id": "J5",
-      "terrain": "p",
+      "id": "J5", "terrain": "p",
       "exits": {
-        "north": "J4",
-        "south": "J6",
-        "west": "I5",
-        "east": "K5"
+        "north": "J4", "south": "J6", "west": "I5", "east": "K5"
       }
     },
     {
-      "id": "K5",
-      "terrain": "p",
+      "id": "K5", "terrain": "p",
       "exits": {
-        "north": "K4",
-        "south": "K6",
-        "west": "J5",
-        "east": "L5"
+        "north": "K4", "south": "K6", "west": "J5", "east": "L5"
       }
     },
     {
-      "id": "L5",
-      "terrain": "p",
+      "id": "L5", "terrain": "p",
       "exits": {
-        "north": "L4",
-        "south": "L6",
-        "west": "K5",
-        "east": "M5"
+        "north": "L4", "south": "L6", "west": "K5", "east": "M5"
       }
     },
     {
-      "id": "M5",
-      "terrain": "p",
+      "id": "M5", "terrain": "p",
       "exits": {
-        "north": "M4",
-        "south": "M6",
-        "west": "L5",
-        "east": "N5"
+        "north": "M4", "south": "M6", "west": "L5", "east": "N5"
       }
     },
     {
-      "id": "N5",
-      "terrain": "p",
+      "id": "N5", "terrain": "p",
       "exits": {
-        "north": "N4",
-        "south": "N6",
-        "west": "M5",
-        "east": "O5"
+        "north": "N4", "south": "N6", "west": "M5", "east": "O5"
       }
     },
     {
-      "id": "O5",
-      "terrain": "p",
+      "id": "O5", "terrain": "p",
       "exits": {
-        "north": "O4",
-        "south": "O6",
-        "west": "N5",
-        "east": "P5"
+        "north": "O4", "south": "O6", "west": "N5", "east": "P5"
       }
     },
     {
-      "id": "P5",
-      "terrain": "p",
+      "id": "P5", "terrain": "p",
       "exits": {
-        "north": "P4",
-        "south": "P6",
-        "west": "O5",
-        "east": "Q5"
+        "north": "P4", "south": "P6", "west": "O5", "east": "Q5"
       }
     },
     {
-      "id": "Q5",
-      "terrain": "p",
+      "id": "Q5", "terrain": "p",
       "exits": {
-        "north": "Q4",
-        "south": "Q6",
-        "west": "P5",
-        "east": "R5"
+        "north": "Q4", "south": "Q6", "west": "P5", "east": "R5"
       }
     },
     {
-      "id": "R5",
-      "terrain": "p",
+      "id": "R5", "terrain": "p",
       "exits": {
-        "north": "R4",
-        "south": "R6",
-        "west": "Q5",
-        "east": "S5"
+        "north": "R4", "south": "R6", "west": "Q5", "east": "S5"
       }
     },
     {
-      "id": "S5",
-      "terrain": "p",
+      "id": "S5", "terrain": "p",
       "exits": {
-        "north": "S4",
-        "south": "S6",
-        "west": "R5",
-        "east": "T5"
+        "north": "S4", "south": "S6", "west": "R5", "east": "T5"
       }
     },
     {
-      "id": "T5",
-      "terrain": "p",
+      "id": "T5", "terrain": "p",
       "exits": {
-        "north": "T4",
-        "south": "T6",
-        "west": "S5",
-        "east": "U5"
+        "north": "T4", "south": "T6", "west": "S5", "east": "U5"
       }
     },
     {
-      "id": "U5",
-      "terrain": "p",
+      "id": "U5", "terrain": "p",
       "exits": {
-        "north": "U4",
-        "south": "U6",
-        "west": "T5",
-        "east": "V5"
+        "north": "U4", "south": "U6", "west": "T5", "east": "V5"
       }
     },
     {
-      "id": "V5",
-      "terrain": "p",
+      "id": "V5", "terrain": "p",
       "exits": {
-        "north": "V4",
-        "south": "V6",
-        "west": "U5",
-        "east": "W5"
+        "north": "V4", "south": "V6", "west": "U5", "east": "W5"
       }
     },
     {
-      "id": "W5",
-      "terrain": "m",
+      "id": "W5", "terrain": "m",
       "exits": {
-        "north": "W4",
-        "south": "W6",
-        "west": "V5",
-        "east": "X5"
+        "north": "W4", "south": "W6", "west": "V5", "east": "X5"
       }
     },
     {
-      "id": "X5",
-      "terrain": "na",
+      "id": "X5", "terrain": "na",
       "exits": {
-        "north": "X4",
-        "south": "X6",
-        "west": "W5",
-        "east": "Y5"
+        "north": "X4", "south": "X6", "west": "W5", "east": "Y5"
       }
     },
     {
-      "id": "Y5",
-      "terrain": "m",
+      "id": "Y5", "terrain": "m",
       "exits": {
-        "north": "Y4",
-        "south": "Y6",
-        "west": "X5",
-        "east": "Z5"
+        "north": "Y4", "south": "Y6", "west": "X5", "east": "Z5"
       }
     },
     {
-      "id": "Z5",
-      "terrain": "h",
+      "id": "Z5", "terrain": "h",
       "exits": {
-        "north": "Z4",
-        "south": "Z6",
-        "west": "Y5",
-        "east": "AA5"
+        "north": "Z4", "south": "Z6", "west": "Y5", "east": "AA5"
       }
     },
     {
-      "id": "AA5",
-      "terrain": "bridge",
+      "id": "AA5", "terrain": "bridge",
       "exits": {
-        "north": "AA4",
-        "south": "AA6",
-        "west": "Z5",
-        "east": "AB5"
+        "north": "AA4", "south": "AA6", "west": "Z5", "east": "AB5"
       }
     },
     {
-      "id": "AB5",
-      "terrain": "h",
+      "id": "AB5", "terrain": "h",
       "exits": {
-        "north": "AB4",
-        "south": "AB6",
-        "west": "AA5",
-        "east": "AC5"
+        "north": "AB4", "south": "AB6", "west": "AA5", "east": "AC5"
       }
     },
     {
-      "id": "AC5",
-      "terrain": "h",
+      "id": "AC5", "terrain": "h",
       "exits": {
-        "north": "AC4",
-        "south": "AC6",
-        "west": "AB5",
-        "east": "AD5"
+        "north": "AC4", "south": "AC6", "west": "AB5", "east": "AD5"
       }
     },
     {
-      "id": "AD5",
-      "terrain": "h",
+      "id": "AD5", "terrain": "h",
       "exits": {
-        "north": "AD4",
-        "south": "AD6",
-        "west": "AC5",
-        "east": "AE5"
+        "north": "AD4", "south": "AD6", "west": "AC5", "east": "AE5"
       }
     },
     {
-      "id": "AE5",
-      "terrain": "h",
+      "id": "AE5", "terrain": "h",
       "exits": {
-        "north": "AE4",
-        "south": "AE6",
-        "west": "AD5",
-        "east": "AF5"
+        "north": "AE4", "south": "AE6", "west": "AD5", "east": "AF5"
       }
     },
     {
-      "id": "AF5",
-      "terrain": "h",
+      "id": "AF5", "terrain": "h",
       "exits": {
-        "north": "AF4",
-        "south": "AF6",
-        "west": "AE5",
-        "east": "AG5"
+        "north": "AF4", "south": "AF6", "west": "AE5", "east": "AG5"
       }
     },
     {
-      "id": "AG5",
-      "terrain": "h",
+      "id": "AG5", "terrain": "h",
       "exits": {
-        "north": "AG4",
-        "south": "AG6",
-        "west": "AF5",
-        "east": "AH5"
+        "north": "AG4", "south": "AG6", "west": "AF5", "east": "AH5"
       }
     },
     {
-      "id": "AH5",
-      "terrain": "h",
+      "id": "AH5", "terrain": "h",
       "exits": {
-        "north": "AH4",
-        "south": "AH6",
-        "west": "AG5",
-        "east": "AI5"
+        "north": "AH4", "south": "AH6", "west": "AG5", "east": "AI5"
       }
     },
     {
-      "id": "AI5",
-      "terrain": "h",
+      "id": "AI5", "terrain": "h",
       "exits": {
-        "north": "AI4",
-        "south": "AI6",
-        "west": "AH5",
-        "east": "AJ5"
+        "north": "AI4", "south": "AI6", "west": "AH5", "east": "AJ5"
       }
     },
     {
-      "id": "AJ5",
-      "terrain": "h",
+      "id": "AJ5", "terrain": "h",
       "exits": {
-        "north": "AJ4",
-        "south": "AJ6",
-        "west": "AI5",
-        "east": "AK5"
+        "north": "AJ4", "south": "AJ6", "west": "AI5", "east": "AK5"
       }
     },
     {
-      "id": "AK5",
-      "terrain": "p",
+      "id": "AK5", "terrain": "p",
       "exits": {
-        "north": "AK4",
-        "south": "AK6",
-        "west": "AJ5",
-        "east": "AL5"
+        "north": "AK4", "south": "AK6", "west": "AJ5", "east": "AL5"
       }
     },
     {
-      "id": "AL5",
-      "terrain": "p",
+      "id": "AL5", "terrain": "p",
       "exits": {
-        "north": "AL4",
-        "south": "AL6",
-        "west": "AK5",
-        "east": "AM5"
+        "north": "AL4", "south": "AL6", "west": "AK5", "east": "AM5"
       }
     },
     {
-      "id": "AM5",
-      "terrain": "p",
+      "id": "AM5", "terrain": "p",
       "exits": {
-        "north": "AM4",
-        "south": "AM6",
-        "west": "AL5",
-        "east": "AN5"
+        "north": "AM4", "south": "AM6", "west": "AL5", "east": "AN5"
       }
     },
     {
-      "id": "AN5",
-      "terrain": "p",
+      "id": "AN5", "terrain": "p",
       "exits": {
-        "north": "AN4",
-        "south": "AN6",
-        "west": "AM5",
-        "east": "AO5"
+        "north": "AN4", "south": "AN6", "west": "AM5", "east": "AO5"
       }
     },
     {
-      "id": "AO5",
-      "terrain": "p",
+      "id": "AO5", "terrain": "p",
       "exits": {
-        "north": "AO4",
-        "south": "AO6",
-        "west": "AN5",
-        "east": "AP5"
+        "north": "AO4", "south": "AO6", "west": "AN5", "east": "AP5"
       }
     },
     {
-      "id": "AP5",
-      "terrain": "p",
+      "id": "AP5", "terrain": "p",
       "exits": {
-        "north": "AP4",
-        "south": "AP6",
-        "west": "AO5",
-        "east": "AQ5"
+        "north": "AP4", "south": "AP6", "west": "AO5", "east": "AQ5"
       }
     },
     {
-      "id": "AQ5",
-      "terrain": "p",
+      "id": "AQ5", "terrain": "p",
       "exits": {
-        "north": "AQ4",
-        "south": "AQ6",
-        "west": "AP5",
-        "east": "AR5"
+        "north": "AQ4", "south": "AQ6", "west": "AP5", "east": "AR5"
       }
     },
     {
-      "id": "AR5",
-      "terrain": "p",
+      "id": "AR5", "terrain": "p",
       "exits": {
-        "north": "AR4",
-        "south": "AR6",
-        "west": "AQ5",
-        "east": "AS5"
+        "north": "AR4", "south": "AR6", "west": "AQ5", "east": "AS5"
       }
     },
     {
-      "id": "AS5",
-      "terrain": "p",
+      "id": "AS5", "terrain": "p",
       "exits": {
-        "north": "AS4",
-        "south": "AS6",
-        "west": "AR5",
-        "east": "AT5"
+        "north": "AS4", "south": "AS6", "west": "AR5", "east": "AT5"
       }
     },
     {
-      "id": "AT5",
-      "terrain": "lf",
+      "id": "AT5", "terrain": "lf",
       "exits": {
-        "north": "AT4",
-        "south": "AT6",
-        "west": "AS5",
-        "east": "AU5"
+        "north": "AT4", "south": "AT6", "west": "AS5", "east": "AU5"
       }
     },
     {
-      "id": "AU5",
-      "terrain": "lf",
+      "id": "AU5", "terrain": "lf",
       "exits": {
-        "north": "AU4",
-        "south": "AU6",
-        "west": "AT5",
-        "east": "AV5"
+        "north": "AU4", "south": "AU6", "west": "AT5", "east": "AV5"
       }
     },
     {
-      "id": "AV5",
-      "terrain": "p",
+      "id": "AV5", "terrain": "p",
       "exits": {
-        "north": "AV4",
-        "south": "AV6",
-        "west": "AU5",
-        "east": "AW5"
+        "north": "AV4", "south": "AV6", "west": "AU5", "east": "AW5"
       }
     },
     {
-      "id": "AW5",
-      "terrain": "p",
+      "id": "AW5", "terrain": "p",
       "exits": {
-        "north": "AW4",
-        "south": "AW6",
-        "west": "AV5",
-        "east": "AX5"
+        "north": "AW4", "south": "AW6", "west": "AV5", "east": "AX5"
       }
     },
     {
-      "id": "AX5",
-      "terrain": "p",
+      "id": "AX5", "terrain": "p",
       "exits": {
-        "north": "AX4",
-        "south": "AX6",
-        "west": "AW5"
+        "north": "AX4", "south": "AX6", "west": "AW5"
       }
     },
     {
-      "id": "A6",
-      "terrain": "p",
+      "id": "A6", "terrain": "p",
       "exits": {
-        "north": "A5",
-        "south": "A7",
-        "east": "B6"
+        "north": "A5", "south": "A7", "east": "B6"
       }
     },
     {
-      "id": "B6",
-      "terrain": "p",
+      "id": "B6", "terrain": "p",
       "exits": {
-        "north": "B5",
-        "south": "B7",
-        "west": "A6",
-        "east": "C6"
+        "north": "B5", "south": "B7", "west": "A6", "east": "C6"
       }
     },
     {
-      "id": "C6",
-      "terrain": "p",
+      "id": "C6", "terrain": "p",
       "exits": {
-        "north": "C5",
-        "south": "C7",
-        "west": "B6",
-        "east": "D6"
+        "north": "C5", "south": "C7", "west": "B6", "east": "D6"
       }
     },
     {
-      "id": "D6",
-      "terrain": "p",
+      "id": "D6", "terrain": "p",
       "exits": {
-        "north": "D5",
-        "south": "D7",
-        "west": "C6",
-        "east": "E6"
+        "north": "D5", "south": "D7", "west": "C6", "east": "E6"
       }
     },
     {
-      "id": "E6",
-      "terrain": "p",
+      "id": "E6", "terrain": "p",
       "exits": {
-        "north": "E5",
-        "south": "E7",
-        "west": "D6",
-        "east": "F6"
+        "north": "E5", "south": "E7", "west": "D6", "east": "F6"
       }
     },
     {
-      "id": "F6",
-      "terrain": "p",
+      "id": "F6", "terrain": "p",
       "exits": {
-        "north": "F5",
-        "south": "F7",
-        "west": "E6",
-        "east": "G6"
+        "north": "F5", "south": "F7", "west": "E6", "east": "G6"
       }
     },
     {
-      "id": "G6",
-      "terrain": "p",
+      "id": "G6", "terrain": "p",
       "exits": {
-        "north": "G5",
-        "south": "G7",
-        "west": "F6",
-        "east": "H6"
+        "north": "G5", "south": "G7", "west": "F6", "east": "H6"
       }
     },
     {
-      "id": "H6",
-      "terrain": "p",
+      "id": "H6", "terrain": "p",
       "exits": {
-        "north": "H5",
-        "south": "H7",
-        "west": "G6",
-        "east": "I6"
+        "north": "H5", "south": "H7", "west": "G6", "east": "I6"
       }
     },
     {
-      "id": "I6",
-      "terrain": "p",
+      "id": "I6", "terrain": "p",
       "exits": {
-        "north": "I5",
-        "south": "I7",
-        "west": "H6",
-        "east": "J6"
+        "north": "I5", "south": "I7", "west": "H6", "east": "J6"
       }
     },
     {
-      "id": "J6",
-      "terrain": "p",
+      "id": "J6", "terrain": "p",
       "exits": {
-        "north": "J5",
-        "south": "J7",
-        "west": "I6",
-        "east": "K6"
+        "north": "J5", "south": "J7", "west": "I6", "east": "K6"
       }
     },
     {
-      "id": "K6",
-      "terrain": "p",
+      "id": "K6", "terrain": "p",
       "exits": {
-        "north": "K5",
-        "south": "K7",
-        "west": "J6",
-        "east": "L6"
+        "north": "K5", "south": "K7", "west": "J6", "east": "L6"
       }
     },
     {
-      "id": "L6",
-      "terrain": "p",
+      "id": "L6", "terrain": "p",
       "exits": {
-        "north": "L5",
-        "south": "L7",
-        "west": "K6",
-        "east": "M6"
+        "north": "L5", "south": "L7", "west": "K6", "east": "M6"
       }
     },
     {
-      "id": "M6",
-      "terrain": "p",
+      "id": "M6", "terrain": "p",
       "exits": {
-        "north": "M5",
-        "south": "M7",
-        "west": "L6",
-        "east": "N6"
+        "north": "M5", "south": "M7", "west": "L6", "east": "N6"
       }
     },
     {
-      "id": "N6",
-      "terrain": "p",
+      "id": "N6", "terrain": "p",
       "exits": {
-        "north": "N5",
-        "south": "N7",
-        "west": "M6",
-        "east": "O6"
+        "north": "N5", "south": "N7", "west": "M6", "east": "O6"
       }
     },
     {
-      "id": "O6",
-      "terrain": "p",
+      "id": "O6", "terrain": "p",
       "exits": {
-        "north": "O5",
-        "south": "O7",
-        "west": "N6",
-        "east": "P6"
+        "north": "O5", "south": "O7", "west": "N6", "east": "P6"
       }
     },
     {
-      "id": "P6",
-      "terrain": "p",
+      "id": "P6", "terrain": "p",
       "exits": {
-        "north": "P5",
-        "south": "P7",
-        "west": "O6",
-        "east": "Q6"
+        "north": "P5", "south": "P7", "west": "O6", "east": "Q6"
       }
     },
     {
-      "id": "Q6",
-      "terrain": "p",
+      "id": "Q6", "terrain": "p",
       "exits": {
-        "north": "Q5",
-        "south": "Q7",
-        "west": "P6",
-        "east": "R6"
+        "north": "Q5", "south": "Q7", "west": "P6", "east": "R6"
       }
     },
     {
-      "id": "R6",
-      "terrain": "p",
+      "id": "R6", "terrain": "p",
       "exits": {
-        "north": "R5",
-        "south": "R7",
-        "west": "Q6",
-        "east": "S6"
+        "north": "R5", "south": "R7", "west": "Q6", "east": "S6"
       }
     },
     {
-      "id": "S6",
-      "terrain": "p",
+      "id": "S6", "terrain": "p",
       "exits": {
-        "north": "S5",
-        "south": "S7",
-        "west": "R6",
-        "east": "T6"
+        "north": "S5", "south": "S7", "west": "R6", "east": "T6"
       }
     },
     {
-      "id": "T6",
-      "terrain": "p",
+      "id": "T6", "terrain": "p",
       "exits": {
-        "north": "T5",
-        "south": "T7",
-        "west": "S6",
-        "east": "U6"
+        "north": "T5", "south": "T7", "west": "S6", "east": "U6"
       }
     },
     {
-      "id": "U6",
-      "terrain": "p",
+      "id": "U6", "terrain": "p",
       "exits": {
-        "north": "U5",
-        "south": "U7",
-        "west": "T6",
-        "east": "V6"
+        "north": "U5", "south": "U7", "west": "T6", "east": "V6"
       }
     },
     {
-      "id": "V6",
-      "terrain": "w",
+      "id": "V6", "terrain": "w",
       "exits": {
-        "north": "V5",
-        "south": "V7",
-        "west": "U6",
-        "east": "W6"
+        "north": "V5", "south": "V7", "west": "U6", "east": "W6"
       }
     },
     {
-      "id": "W6",
-      "terrain": "m",
+      "id": "W6", "terrain": "m",
       "exits": {
-        "north": "W5",
-        "south": "W7",
-        "west": "V6",
-        "east": "X6"
+        "north": "W5", "south": "W7", "west": "V6", "east": "X6"
       }
     },
     {
-      "id": "X6",
-      "terrain": "m",
+      "id": "X6", "terrain": "m",
       "exits": {
-        "north": "X5",
-        "south": "X7",
-        "west": "W6",
-        "east": "Y6"
+        "north": "X5", "south": "X7", "west": "W6", "east": "Y6"
       }
     },
     {
-      "id": "Y6",
-      "terrain": "m",
+      "id": "Y6", "terrain": "m",
       "exits": {
-        "north": "Y5",
-        "south": "Y7",
-        "west": "X6",
-        "east": "Z6"
+        "north": "Y5", "south": "Y7", "west": "X6", "east": "Z6"
       }
     },
     {
-      "id": "Z6",
-      "terrain": "h",
+      "id": "Z6", "terrain": "h",
       "exits": {
-        "north": "Z5",
-        "south": "Z7",
-        "west": "Y6",
-        "east": "AA6"
+        "north": "Z5", "south": "Z7", "west": "Y6", "east": "AA6"
       }
     },
     {
-      "id": "AA6",
-      "terrain": "h",
+      "id": "AA6", "terrain": "h",
       "exits": {
-        "north": "AA5",
-        "south": "AA7",
-        "west": "Z6",
-        "east": "AB6"
+        "north": "AA5", "south": "AA7", "west": "Z6", "east": "AB6"
       }
     },
     {
-      "id": "AB6",
-      "terrain": "h",
+      "id": "AB6", "terrain": "h",
       "exits": {
-        "north": "AB5",
-        "south": "AB7",
-        "west": "AA6",
-        "east": "AC6"
+        "north": "AB5", "south": "AB7", "west": "AA6", "east": "AC6"
       }
     },
     {
-      "id": "AC6",
-      "terrain": "h",
+      "id": "AC6", "terrain": "h",
       "exits": {
-        "north": "AC5",
-        "south": "AC7",
-        "west": "AB6",
-        "east": "AD6"
+        "north": "AC5", "south": "AC7", "west": "AB6", "east": "AD6"
       }
     },
     {
-      "id": "AD6",
-      "terrain": "h",
+      "id": "AD6", "terrain": "h",
       "exits": {
-        "north": "AD5",
-        "south": "AD7",
-        "west": "AC6",
-        "east": "AE6"
+        "north": "AD5", "south": "AD7", "west": "AC6", "east": "AE6"
       }
     },
     {
-      "id": "AE6",
-      "terrain": "h",
+      "id": "AE6", "terrain": "h",
       "exits": {
-        "north": "AE5",
-        "south": "AE7",
-        "west": "AD6",
-        "east": "AF6"
+        "north": "AE5", "south": "AE7", "west": "AD6", "east": "AF6"
       }
     },
     {
-      "id": "AF6",
-      "terrain": "h",
+      "id": "AF6", "terrain": "h",
       "exits": {
-        "north": "AF5",
-        "south": "AF7",
-        "west": "AE6",
-        "east": "AG6"
+        "north": "AF5", "south": "AF7", "west": "AE6", "east": "AG6"
       }
     },
     {
-      "id": "AG6",
-      "terrain": "h",
+      "id": "AG6", "terrain": "h",
       "exits": {
-        "north": "AG5",
-        "south": "AG7",
-        "west": "AF6",
-        "east": "AH6"
+        "north": "AG5", "south": "AG7", "west": "AF6", "east": "AH6"
       }
     },
     {
-      "id": "AH6",
-      "terrain": "h",
+      "id": "AH6", "terrain": "h",
       "exits": {
-        "north": "AH5",
-        "south": "AH7",
-        "west": "AG6",
-        "east": "AI6"
+        "north": "AH5", "south": "AH7", "west": "AG6", "east": "AI6"
       }
     },
     {
-      "id": "AI6",
-      "terrain": "h",
+      "id": "AI6", "terrain": "h",
       "exits": {
-        "north": "AI5",
-        "south": "AI7",
-        "west": "AH6",
-        "east": "AJ6"
+        "north": "AI5", "south": "AI7", "west": "AH6", "east": "AJ6"
       }
     },
     {
-      "id": "AJ6",
-      "terrain": "m",
+      "id": "AJ6", "terrain": "m",
       "exits": {
-        "north": "AJ5",
-        "south": "AJ7",
-        "west": "AI6",
-        "east": "AK6"
+        "north": "AJ5", "south": "AJ7", "west": "AI6", "east": "AK6"
       }
     },
     {
-      "id": "AK6",
-      "terrain": "m",
+      "id": "AK6", "terrain": "m",
       "exits": {
-        "north": "AK5",
-        "south": "AK7",
-        "west": "AJ6",
-        "east": "AL6"
+        "north": "AK5", "south": "AK7", "west": "AJ6", "east": "AL6"
       }
     },
     {
-      "id": "AL6",
-      "terrain": "p",
+      "id": "AL6", "terrain": "p",
       "exits": {
-        "north": "AL5",
-        "south": "AL7",
-        "west": "AK6",
-        "east": "AM6"
+        "north": "AL5", "south": "AL7", "west": "AK6", "east": "AM6"
       }
     },
     {
-      "id": "AM6",
-      "terrain": "p",
+      "id": "AM6", "terrain": "p",
       "exits": {
-        "north": "AM5",
-        "south": "AM7",
-        "west": "AL6",
-        "east": "AN6"
+        "north": "AM5", "south": "AM7", "west": "AL6", "east": "AN6"
       }
     },
     {
-      "id": "AN6",
-      "terrain": "p",
+      "id": "AN6", "terrain": "p",
       "exits": {
-        "north": "AN5",
-        "south": "AN7",
-        "west": "AM6",
-        "east": "AO6"
+        "north": "AN5", "south": "AN7", "west": "AM6", "east": "AO6"
       }
     },
     {
-      "id": "AO6",
-      "terrain": "p",
+      "id": "AO6", "terrain": "p",
       "exits": {
-        "north": "AO5",
-        "south": "AO7",
-        "west": "AN6",
-        "east": "AP6"
+        "north": "AO5", "south": "AO7", "west": "AN6", "east": "AP6"
       }
     },
     {
-      "id": "AP6",
-      "terrain": "p",
+      "id": "AP6", "terrain": "p",
       "exits": {
-        "north": "AP5",
-        "south": "AP7",
-        "west": "AO6",
-        "east": "AQ6"
+        "north": "AP5", "south": "AP7", "west": "AO6", "east": "AQ6"
       }
     },
     {
-      "id": "AQ6",
-      "terrain": "p",
+      "id": "AQ6", "terrain": "p",
       "exits": {
-        "north": "AQ5",
-        "south": "AQ7",
-        "west": "AP6",
-        "east": "AR6"
+        "north": "AQ5", "south": "AQ7", "west": "AP6", "east": "AR6"
       }
     },
     {
-      "id": "AR6",
-      "terrain": "p",
+      "id": "AR6", "terrain": "p",
       "exits": {
-        "north": "AR5",
-        "south": "AR7",
-        "west": "AQ6",
-        "east": "AS6"
+        "north": "AR5", "south": "AR7", "west": "AQ6", "east": "AS6"
       }
     },
     {
-      "id": "AS6",
-      "terrain": "p",
+      "id": "AS6", "terrain": "p",
       "exits": {
-        "north": "AS5",
-        "south": "AS7",
-        "west": "AR6",
-        "east": "AT6"
+        "north": "AS5", "south": "AS7", "west": "AR6", "east": "AT6"
       }
     },
     {
-      "id": "AT6",
-      "terrain": "lf",
+      "id": "AT6", "terrain": "lf",
       "exits": {
-        "north": "AT5",
-        "south": "AT7",
-        "west": "AS6",
-        "east": "AU6"
+        "north": "AT5", "south": "AT7", "west": "AS6", "east": "AU6"
       }
     },
     {
-      "id": "AU6",
-      "terrain": "lf",
+      "id": "AU6", "terrain": "lf",
       "exits": {
-        "north": "AU5",
-        "south": "AU7",
-        "west": "AT6",
-        "east": "AV6"
+        "north": "AU5", "south": "AU7", "west": "AT6", "east": "AV6"
       }
     },
     {
-      "id": "AV6",
-      "terrain": "p",
+      "id": "AV6", "terrain": "p",
       "exits": {
-        "north": "AV5",
-        "south": "AV7",
-        "west": "AU6",
-        "east": "AW6"
+        "north": "AV5", "south": "AV7", "west": "AU6", "east": "AW6"
       }
     },
     {
-      "id": "AW6",
-      "terrain": "p",
+      "id": "AW6", "terrain": "p",
       "exits": {
-        "north": "AW5",
-        "south": "AW7",
-        "west": "AV6",
-        "east": "AX6"
+        "north": "AW5", "south": "AW7", "west": "AV6", "east": "AX6"
       }
     },
     {
-      "id": "AX6",
-      "terrain": "p",
+      "id": "AX6", "terrain": "p",
       "exits": {
-        "north": "AX5",
-        "south": "AX7",
-        "west": "AW6"
+        "north": "AX5", "south": "AX7", "west": "AW6"
       }
     },
     {
-      "id": "A7",
-      "terrain": "p",
+      "id": "A7", "terrain": "p",
       "exits": {
-        "north": "A6",
-        "south": "A8",
-        "east": "B7"
+        "north": "A6", "south": "A8", "east": "B7"
       }
     },
     {
-      "id": "B7",
-      "terrain": "p",
+      "id": "B7", "terrain": "p",
       "exits": {
-        "north": "B6",
-        "south": "B8",
-        "west": "A7",
-        "east": "C7"
+        "north": "B6", "south": "B8", "west": "A7", "east": "C7"
       }
     },
     {
-      "id": "C7",
-      "terrain": "p",
+      "id": "C7", "terrain": "p",
       "exits": {
-        "north": "C6",
-        "south": "C8",
-        "west": "B7",
-        "east": "D7"
+        "north": "C6", "south": "C8", "west": "B7", "east": "D7"
       }
     },
     {
-      "id": "D7",
-      "terrain": "p",
+      "id": "D7", "terrain": "p",
       "exits": {
-        "north": "D6",
-        "south": "D8",
-        "west": "C7",
-        "east": "E7"
+        "north": "D6", "south": "D8", "west": "C7", "east": "E7"
       }
     },
     {
-      "id": "E7",
-      "terrain": "p",
+      "id": "E7", "terrain": "p",
       "exits": {
-        "north": "E6",
-        "south": "E8",
-        "west": "D7",
-        "east": "F7"
+        "north": "E6", "south": "E8", "west": "D7", "east": "F7"
       }
     },
     {
-      "id": "F7",
-      "terrain": "p",
+      "id": "F7", "terrain": "p",
       "exits": {
-        "north": "F6",
-        "south": "F8",
-        "west": "E7",
-        "east": "G7"
+        "north": "F6", "south": "F8", "west": "E7", "east": "G7"
       }
     },
     {
-      "id": "G7",
-      "terrain": "p",
+      "id": "G7", "terrain": "p",
       "exits": {
-        "north": "G6",
-        "south": "G8",
-        "west": "F7",
-        "east": "H7"
+        "north": "G6", "south": "G8", "west": "F7", "east": "H7"
       }
     },
     {
-      "id": "H7",
-      "terrain": "p",
+      "id": "H7", "terrain": "p",
       "exits": {
-        "north": "H6",
-        "south": "H8",
-        "west": "G7",
-        "east": "I7"
+        "north": "H6", "south": "H8", "west": "G7", "east": "I7"
       }
     },
     {
-      "id": "I7",
-      "terrain": "p",
+      "id": "I7", "terrain": "p",
       "exits": {
-        "north": "I6",
-        "south": "I8",
-        "west": "H7",
-        "east": "J7"
+        "north": "I6", "south": "I8", "west": "H7", "east": "J7"
       }
     },
     {
-      "id": "J7",
-      "terrain": "p",
+      "id": "J7", "terrain": "p",
       "exits": {
-        "north": "J6",
-        "south": "J8",
-        "west": "I7",
-        "east": "K7"
+        "north": "J6", "south": "J8", "west": "I7", "east": "K7"
       }
     },
     {
-      "id": "K7",
-      "terrain": "p",
+      "id": "K7", "terrain": "p",
       "exits": {
-        "north": "K6",
-        "south": "K8",
-        "west": "J7",
-        "east": "L7"
+        "north": "K6", "south": "K8", "west": "J7", "east": "L7"
       }
     },
     {
-      "id": "L7",
-      "terrain": "p",
+      "id": "L7", "terrain": "p",
       "exits": {
-        "north": "L6",
-        "south": "L8",
-        "west": "K7",
-        "east": "M7"
+        "north": "L6", "south": "L8", "west": "K7", "east": "M7"
       }
     },
     {
-      "id": "M7",
-      "terrain": "p",
+      "id": "M7", "terrain": "p",
       "exits": {
-        "north": "M6",
-        "south": "M8",
-        "west": "L7",
-        "east": "N7"
+        "north": "M6", "south": "M8", "west": "L7", "east": "N7"
       }
     },
     {
-      "id": "N7",
-      "terrain": "p",
+      "id": "N7", "terrain": "p",
       "exits": {
-        "north": "N6",
-        "south": "N8",
-        "west": "M7",
-        "east": "O7"
+        "north": "N6", "south": "N8", "west": "M7", "east": "O7"
       }
     },
     {
-      "id": "O7",
-      "terrain": "p",
+      "id": "O7", "terrain": "p",
       "exits": {
-        "north": "O6",
-        "south": "O8",
-        "west": "N7",
-        "east": "P7"
+        "north": "O6", "south": "O8", "west": "N7", "east": "P7"
       }
     },
     {
-      "id": "P7",
-      "terrain": "p",
+      "id": "P7", "terrain": "p",
       "exits": {
-        "north": "P6",
-        "south": "P8",
-        "west": "O7",
-        "east": "Q7"
+        "north": "P6", "south": "P8", "west": "O7", "east": "Q7"
       }
     },
     {
-      "id": "Q7",
-      "terrain": "p",
+      "id": "Q7", "terrain": "p",
       "exits": {
-        "north": "Q6",
-        "south": "Q8",
-        "west": "P7",
-        "east": "R7"
+        "north": "Q6", "south": "Q8", "west": "P7", "east": "R7"
       }
     },
     {
-      "id": "R7",
-      "terrain": "p",
+      "id": "R7", "terrain": "p",
       "exits": {
-        "north": "R6",
-        "south": "R8",
-        "west": "Q7",
-        "east": "S7"
+        "north": "R6", "south": "R8", "west": "Q7", "east": "S7"
       }
     },
     {
-      "id": "S7",
-      "terrain": "p",
+      "id": "S7", "terrain": "p",
       "exits": {
-        "north": "S6",
-        "south": "S8",
-        "west": "R7",
-        "east": "T7"
+        "north": "S6", "south": "S8", "west": "R7", "east": "T7"
       }
     },
     {
-      "id": "T7",
-      "terrain": "p",
+      "id": "T7", "terrain": "p",
       "exits": {
-        "north": "T6",
-        "south": "T8",
-        "west": "S7",
-        "east": "U7"
+        "north": "T6", "south": "T8", "west": "S7", "east": "U7"
       }
     },
     {
-      "id": "U7",
-      "terrain": "p",
+      "id": "U7", "terrain": "p",
       "exits": {
-        "north": "U6",
-        "south": "U8",
-        "west": "T7",
-        "east": "V7"
+        "north": "U6", "south": "U8", "west": "T7", "east": "V7"
       }
     },
     {
-      "id": "V7",
-      "terrain": "w",
+      "id": "V7", "terrain": "w",
       "exits": {
-        "north": "V6",
-        "south": "V8",
-        "west": "U7",
-        "east": "W7"
+        "north": "V6", "south": "V8", "west": "U7", "east": "W7"
       }
     },
     {
-      "id": "W7",
-      "terrain": "m",
+      "id": "W7", "terrain": "m",
       "exits": {
-        "north": "W6",
-        "south": "W8",
-        "west": "V7",
-        "east": "X7"
+        "north": "W6", "south": "W8", "west": "V7", "east": "X7"
       }
     },
     {
-      "id": "X7",
-      "terrain": "m",
+      "id": "X7", "terrain": "m",
       "exits": {
-        "north": "X6",
-        "south": "X8",
-        "west": "W7",
-        "east": "Y7"
+        "north": "X6", "south": "X8", "west": "W7", "east": "Y7"
       }
     },
     {
-      "id": "Y7",
-      "terrain": "Anshelm",
+      "id": "Y7", "terrain": "Anshelm",
       "exits": {
-        "north": "Y6",
-        "south": "Y8",
-        "west": "X7",
-        "east": "Z7"
+        "north": "Y6", "south": "Y8", "west": "X7", "east": "Z7"
       }
     },
     {
-      "id": "Z7",
-      "terrain": "m",
+      "id": "Z7", "terrain": "m",
       "exits": {
-        "north": "Z6",
-        "south": "Z8",
-        "west": "Y7",
-        "east": "AA7"
+        "north": "Z6", "south": "Z8", "west": "Y7", "east": "AA7"
       }
     },
     {
-      "id": "AA7",
-      "terrain": "gorge",
+      "id": "AA7", "terrain": "gorge",
       "exits": {
-        "north": "AA6",
-        "south": "AA8",
-        "west": "Z7",
-        "east": "AB7"
+        "north": "AA6", "south": "AA8", "west": "Z7", "east": "AB7"
       }
     },
     {
-      "id": "AB7",
-      "terrain": "h",
+      "id": "AB7", "terrain": "h",
       "exits": {
-        "north": "AB6",
-        "south": "AB8",
-        "west": "AA7",
-        "east": "AC7"
+        "north": "AB6", "south": "AB8", "west": "AA7", "east": "AC7"
       }
     },
     {
-      "id": "AC7",
-      "terrain": "h",
+      "id": "AC7", "terrain": "h",
       "exits": {
-        "north": "AC6",
-        "south": "AC8",
-        "west": "AB7",
-        "east": "AD7"
+        "north": "AC6", "south": "AC8", "west": "AB7", "east": "AD7"
       }
     },
     {
-      "id": "AD7",
-      "terrain": "h",
+      "id": "AD7", "terrain": "h",
       "exits": {
-        "north": "AD6",
-        "south": "AD8",
-        "west": "AC7",
-        "east": "AE7"
+        "north": "AD6", "south": "AD8", "west": "AC7", "east": "AE7"
       }
     },
     {
-      "id": "AE7",
-      "terrain": "h",
+      "id": "AE7", "terrain": "h",
       "exits": {
-        "north": "AE6",
-        "south": "AE8",
-        "west": "AD7",
-        "east": "AF7"
+        "north": "AE6", "south": "AE8", "west": "AD7", "east": "AF7"
       }
     },
     {
-      "id": "AF7",
-      "terrain": "h",
+      "id": "AF7", "terrain": "h",
       "exits": {
-        "north": "AF6",
-        "south": "AF8",
-        "west": "AE7",
-        "east": "AG7"
+        "north": "AF6", "south": "AF8", "west": "AE7", "east": "AG7"
       }
     },
     {
-      "id": "AG7",
-      "terrain": "h",
+      "id": "AG7", "terrain": "h",
       "exits": {
-        "north": "AG6",
-        "south": "AG8",
-        "west": "AF7",
-        "east": "AH7"
+        "north": "AG6", "south": "AG8", "west": "AF7", "east": "AH7"
       }
     },
     {
-      "id": "AH7",
-      "terrain": "m",
+      "id": "AH7", "terrain": "m",
       "exits": {
-        "north": "AH6",
-        "south": "AH8",
-        "west": "AG7",
-        "east": "AI7"
+        "north": "AH6", "south": "AH8", "west": "AG7", "east": "AI7"
       }
     },
     {
-      "id": "AI7",
-      "terrain": "m",
+      "id": "AI7", "terrain": "m",
       "exits": {
-        "north": "AI6",
-        "south": "AI8",
-        "west": "AH7",
-        "east": "AJ7"
+        "north": "AI6", "south": "AI8", "west": "AH7", "east": "AJ7"
       }
     },
     {
-      "id": "AJ7",
-      "terrain": "m",
+      "id": "AJ7", "terrain": "m",
       "exits": {
-        "north": "AJ6",
-        "south": "AJ8",
-        "west": "AI7",
-        "east": "AK7"
+        "north": "AJ6", "south": "AJ8", "west": "AI7", "east": "AK7"
       }
     },
     {
-      "id": "AK7",
-      "terrain": "m",
+      "id": "AK7", "terrain": "m",
       "exits": {
-        "north": "AK6",
-        "south": "AK8",
-        "west": "AJ7",
-        "east": "AL7"
+        "north": "AK6", "south": "AK8", "west": "AJ7", "east": "AL7"
       }
     },
     {
-      "id": "AL7",
-      "terrain": "m",
+      "id": "AL7", "terrain": "m",
       "exits": {
-        "north": "AL6",
-        "south": "AL8",
-        "west": "AK7",
-        "east": "AM7"
+        "north": "AL6", "south": "AL8", "west": "AK7", "east": "AM7"
       }
     },
     {
-      "id": "AM7",
-      "terrain": "m",
+      "id": "AM7", "terrain": "m",
       "exits": {
-        "north": "AM6",
-        "south": "AM8",
-        "west": "AL7",
-        "east": "AN7"
+        "north": "AM6", "south": "AM8", "west": "AL7", "east": "AN7"
       }
     },
     {
-      "id": "AN7",
-      "terrain": "m",
+      "id": "AN7", "terrain": "m",
       "exits": {
-        "north": "AN6",
-        "south": "AN8",
-        "west": "AM7",
-        "east": "AO7"
+        "north": "AN6", "south": "AN8", "west": "AM7", "east": "AO7"
       }
     },
     {
-      "id": "AO7",
-      "terrain": "p",
+      "id": "AO7", "terrain": "p",
       "exits": {
-        "north": "AO6",
-        "south": "AO8",
-        "west": "AN7",
-        "east": "AP7"
+        "north": "AO6", "south": "AO8", "west": "AN7", "east": "AP7"
       }
     },
     {
-      "id": "AP7",
-      "terrain": "p",
+      "id": "AP7", "terrain": "p",
       "exits": {
-        "north": "AP6",
-        "south": "AP8",
-        "west": "AO7",
-        "east": "AQ7"
+        "north": "AP6", "south": "AP8", "west": "AO7", "east": "AQ7"
       }
     },
     {
-      "id": "AQ7",
-      "terrain": "p",
+      "id": "AQ7", "terrain": "p",
       "exits": {
-        "north": "AQ6",
-        "south": "AQ8",
-        "west": "AP7",
-        "east": "AR7"
+        "north": "AQ6", "south": "AQ8", "west": "AP7", "east": "AR7"
       }
     },
     {
-      "id": "AR7",
-      "terrain": "p",
+      "id": "AR7", "terrain": "p",
       "exits": {
-        "north": "AR6",
-        "south": "AR8",
-        "west": "AQ7",
-        "east": "AS7"
+        "north": "AR6", "south": "AR8", "west": "AQ7", "east": "AS7"
       }
     },
     {
-      "id": "AS7",
-      "terrain": "p",
+      "id": "AS7", "terrain": "p",
       "exits": {
-        "north": "AS6",
-        "south": "AS8",
-        "west": "AR7",
-        "east": "AT7"
+        "north": "AS6", "south": "AS8", "west": "AR7", "east": "AT7"
       }
     },
     {
-      "id": "AT7",
-      "terrain": "lf",
+      "id": "AT7", "terrain": "lf",
       "exits": {
-        "north": "AT6",
-        "south": "AT8",
-        "west": "AS7",
-        "east": "AU7"
+        "north": "AT6", "south": "AT8", "west": "AS7", "east": "AU7"
       }
     },
     {
-      "id": "AU7",
-      "terrain": "lf",
+      "id": "AU7", "terrain": "lf",
       "exits": {
-        "north": "AU6",
-        "south": "AU8",
-        "west": "AT7",
-        "east": "AV7"
+        "north": "AU6", "south": "AU8", "west": "AT7", "east": "AV7"
       }
     },
     {
-      "id": "AV7",
-      "terrain": "p",
+      "id": "AV7", "terrain": "p",
       "exits": {
-        "north": "AV6",
-        "south": "AV8",
-        "west": "AU7",
-        "east": "AW7"
+        "north": "AV6", "south": "AV8", "west": "AU7", "east": "AW7"
       }
     },
     {
-      "id": "AW7",
-      "terrain": "p",
+      "id": "AW7", "terrain": "p",
       "exits": {
-        "north": "AW6",
-        "south": "AW8",
-        "west": "AV7",
-        "east": "AX7"
+        "north": "AW6", "south": "AW8", "west": "AV7", "east": "AX7"
       }
     },
     {
-      "id": "AX7",
-      "terrain": "p",
+      "id": "AX7", "terrain": "p",
       "exits": {
-        "north": "AX6",
-        "south": "AX8",
-        "west": "AW7"
+        "north": "AX6", "south": "AX8", "west": "AW7"
       }
     },
     {
-      "id": "A8",
-      "terrain": "p",
+      "id": "A8", "terrain": "p",
       "exits": {
-        "north": "A7",
-        "south": "A9",
-        "east": "B8"
+        "north": "A7", "south": "A9", "east": "B8"
       }
     },
     {
-      "id": "B8",
-      "terrain": "p",
+      "id": "B8", "terrain": "p",
       "exits": {
-        "north": "B7",
-        "south": "B9",
-        "west": "A8",
-        "east": "C8"
+        "north": "B7", "south": "B9", "west": "A8", "east": "C8"
       }
     },
     {
-      "id": "C8",
-      "terrain": "p",
+      "id": "C8", "terrain": "p",
       "exits": {
-        "north": "C7",
-        "south": "C9",
-        "west": "B8",
-        "east": "D8"
+        "north": "C7", "south": "C9", "west": "B8", "east": "D8"
       }
     },
     {
-      "id": "D8",
-      "terrain": "p",
+      "id": "D8", "terrain": "p",
       "exits": {
-        "north": "D7",
-        "south": "D9",
-        "west": "C8",
-        "east": "E8"
+        "north": "D7", "south": "D9", "west": "C8", "east": "E8"
       }
     },
     {
-      "id": "E8",
-      "terrain": "p",
+      "id": "E8", "terrain": "p",
       "exits": {
-        "north": "E7",
-        "south": "E9",
-        "west": "D8",
-        "east": "F8"
+        "north": "E7", "south": "E9", "west": "D8", "east": "F8"
       }
     },
     {
-      "id": "F8",
-      "terrain": "p",
+      "id": "F8", "terrain": "p",
       "exits": {
-        "north": "F7",
-        "south": "F9",
-        "west": "E8",
-        "east": "G8"
+        "north": "F7", "south": "F9", "west": "E8", "east": "G8"
       }
     },
     {
-      "id": "G8",
-      "terrain": "h",
+      "id": "G8", "terrain": "h",
       "exits": {
-        "north": "G7",
-        "south": "G9",
-        "west": "F8",
-        "east": "H8"
+        "north": "G7", "south": "G9", "west": "F8", "east": "H8"
       }
     },
     {
-      "id": "H8",
-      "terrain": "h",
+      "id": "H8", "terrain": "h",
       "exits": {
-        "north": "H7",
-        "south": "H9",
-        "west": "G8",
-        "east": "I8"
+        "north": "H7", "south": "H9", "west": "G8", "east": "I8"
       }
     },
     {
-      "id": "I8",
-      "terrain": "d",
+      "id": "I8", "terrain": "d",
       "exits": {
-        "north": "I7",
-        "south": "I9",
-        "west": "H8",
-        "east": "J8"
+        "north": "I7", "south": "I9", "west": "H8", "east": "J8"
       }
     },
     {
-      "id": "J8",
-      "terrain": "d",
+      "id": "J8", "terrain": "d",
       "exits": {
-        "north": "J7",
-        "south": "J9",
-        "west": "I8",
-        "east": "K8"
+        "north": "J7", "south": "J9", "west": "I8", "east": "K8"
       }
     },
     {
-      "id": "K8",
-      "terrain": "d",
+      "id": "K8", "terrain": "d",
       "exits": {
-        "north": "K7",
-        "south": "K9",
-        "west": "J8",
-        "east": "L8"
+        "north": "K7", "south": "K9", "west": "J8", "east": "L8"
       }
     },
     {
-      "id": "L8",
-      "terrain": "p",
+      "id": "L8", "terrain": "p",
       "exits": {
-        "north": "L7",
-        "south": "L9",
-        "west": "K8",
-        "east": "M8"
+        "north": "L7", "south": "L9", "west": "K8", "east": "M8"
       }
     },
     {
-      "id": "M8",
-      "terrain": "p",
+      "id": "M8", "terrain": "p",
       "exits": {
-        "north": "M7",
-        "south": "M9",
-        "west": "L8",
-        "east": "N8"
+        "north": "M7", "south": "M9", "west": "L8", "east": "N8"
       }
     },
     {
-      "id": "N8",
-      "terrain": "p",
+      "id": "N8", "terrain": "p",
       "exits": {
-        "north": "N7",
-        "south": "N9",
-        "west": "M8",
-        "east": "O8"
+        "north": "N7", "south": "N9", "west": "M8", "east": "O8"
       }
     },
     {
-      "id": "O8",
-      "terrain": "p",
+      "id": "O8", "terrain": "p",
       "exits": {
-        "north": "O7",
-        "south": "O9",
-        "west": "N8",
-        "east": "P8"
+        "north": "O7", "south": "O9", "west": "N8", "east": "P8"
       }
     },
     {
-      "id": "P8",
-      "terrain": "p",
+      "id": "P8", "terrain": "p",
       "exits": {
-        "north": "P7",
-        "south": "P9",
-        "west": "O8",
-        "east": "Q8"
+        "north": "P7", "south": "P9", "west": "O8", "east": "Q8"
       }
     },
     {
-      "id": "Q8",
-      "terrain": "p",
+      "id": "Q8", "terrain": "p",
       "exits": {
-        "north": "Q7",
-        "south": "Q9",
-        "west": "P8",
-        "east": "R8"
+        "north": "Q7", "south": "Q9", "west": "P8", "east": "R8"
       }
     },
     {
-      "id": "R8",
-      "terrain": "p",
+      "id": "R8", "terrain": "p",
       "exits": {
-        "north": "R7",
-        "south": "R9",
-        "west": "Q8",
-        "east": "S8"
+        "north": "R7", "south": "R9", "west": "Q8", "east": "S8"
       }
     },
     {
-      "id": "S8",
-      "terrain": "p",
+      "id": "S8", "terrain": "p",
       "exits": {
-        "north": "S7",
-        "south": "S9",
-        "west": "R8",
-        "east": "T8"
+        "north": "S7", "south": "S9", "west": "R8", "east": "T8"
       }
     },
     {
-      "id": "T8",
-      "terrain": "p",
+      "id": "T8", "terrain": "p",
       "exits": {
-        "north": "T7",
-        "south": "T9",
-        "west": "S8",
-        "east": "U8"
+        "north": "T7", "south": "T9", "west": "S8", "east": "U8"
       }
     },
     {
-      "id": "U8",
-      "terrain": "castle",
+      "id": "U8", "terrain": "castle",
       "exits": {
-        "north": "U7",
-        "south": "U9",
-        "west": "T8",
-        "east": "V8"
+        "north": "U7", "south": "U9", "west": "T8", "east": "V8"
       }
     },
     {
-      "id": "V8",
-      "terrain": "w",
+      "id": "V8", "terrain": "w",
       "exits": {
-        "north": "V7",
-        "south": "V9",
-        "west": "U8",
-        "east": "W8"
+        "north": "V7", "south": "V9", "west": "U8", "east": "W8"
       }
     },
     {
-      "id": "W8",
-      "terrain": "tower",
+      "id": "W8", "terrain": "tower",
       "exits": {
-        "north": "W7",
-        "south": "W9",
-        "west": "V8",
-        "east": "X8"
+        "north": "W7", "south": "W9", "west": "V8", "east": "X8"
       }
     },
     {
-      "id": "X8",
-      "terrain": "m",
+      "id": "X8", "terrain": "m",
       "exits": {
-        "north": "X7",
-        "south": "X9",
-        "west": "W8",
-        "east": "Y8"
+        "north": "X7", "south": "X9", "west": "W8", "east": "Y8"
       }
     },
     {
-      "id": "Y8",
-      "terrain": "r",
+      "id": "Y8", "terrain": "r",
       "exits": {
-        "north": "Y7",
-        "south": "Y9",
-        "west": "X8",
-        "east": "Z8"
+        "north": "Y7", "south": "Y9", "west": "X8", "east": "Z8"
       }
     },
     {
-      "id": "Z8",
-      "terrain": "p",
+      "id": "Z8", "terrain": "p",
       "exits": {
-        "north": "Z7",
-        "south": "Z9",
-        "west": "Y8",
-        "east": "AA8"
+        "north": "Z7", "south": "Z9", "west": "Y8", "east": "AA8"
       }
     },
     {
-      "id": "AA8",
-      "terrain": "m",
+      "id": "AA8", "terrain": "m",
       "exits": {
-        "north": "AA7",
-        "south": "AA9",
-        "west": "Z8",
-        "east": "AB8"
+        "north": "AA7", "south": "AA9", "west": "Z8", "east": "AB8"
       }
     },
     {
-      "id": "AB8",
-      "terrain": "h",
+      "id": "AB8", "terrain": "h",
       "exits": {
-        "north": "AB7",
-        "south": "AB9",
-        "west": "AA8",
-        "east": "AC8"
+        "north": "AB7", "south": "AB9", "west": "AA8", "east": "AC8"
       }
     },
     {
-      "id": "AC8",
-      "terrain": "h",
+      "id": "AC8", "terrain": "h",
       "exits": {
-        "north": "AC7",
-        "south": "AC9",
-        "west": "AB8",
-        "east": "AD8"
+        "north": "AC7", "south": "AC9", "west": "AB8", "east": "AD8"
       }
     },
     {
-      "id": "AD8",
-      "terrain": "h",
+      "id": "AD8", "terrain": "h",
       "exits": {
-        "north": "AD7",
-        "south": "AD9",
-        "west": "AC8",
-        "east": "AE8"
+        "north": "AD7", "south": "AD9", "west": "AC8", "east": "AE8"
       }
     },
     {
-      "id": "AE8",
-      "terrain": "m",
+      "id": "AE8", "terrain": "m",
       "exits": {
-        "north": "AE7",
-        "south": "AE9",
-        "west": "AD8",
-        "east": "AF8"
+        "north": "AE7", "south": "AE9", "west": "AD8", "east": "AF8"
       }
     },
     {
-      "id": "AF8",
-      "terrain": "valley",
+      "id": "AF8", "terrain": "valley",
       "exits": {
-        "north": "AF7",
-        "south": "AF9",
-        "west": "AE8",
-        "east": "AG8"
+        "north": "AF7", "south": "AF9", "west": "AE8", "east": "AG8"
       }
     },
     {
-      "id": "AG8",
-      "terrain": "m",
+      "id": "AG8", "terrain": "m",
       "exits": {
-        "north": "AG7",
-        "south": "AG9",
-        "west": "AF8",
-        "east": "AH8"
+        "north": "AG7", "south": "AG9", "west": "AF8", "east": "AH8"
       }
     },
     {
-      "id": "AH8",
-      "terrain": "m",
+      "id": "AH8", "terrain": "m",
       "exits": {
-        "north": "AH7",
-        "south": "AH9",
-        "west": "AG8",
-        "east": "AI8"
+        "north": "AH7", "south": "AH9", "west": "AG8", "east": "AI8"
       }
     },
     {
-      "id": "AI8",
-      "terrain": "m",
+      "id": "AI8", "terrain": "m",
       "exits": {
-        "north": "AI7",
-        "south": "AI9",
-        "west": "AH8",
-        "east": "AJ8"
+        "north": "AI7", "south": "AI9", "west": "AH8", "east": "AJ8"
       }
     },
     {
-      "id": "AJ8",
-      "terrain": "m",
+      "id": "AJ8", "terrain": "m",
       "exits": {
-        "north": "AJ7",
-        "south": "AJ9",
-        "west": "AI8",
-        "east": "AK8"
+        "north": "AJ7", "south": "AJ9", "west": "AI8", "east": "AK8"
       }
     },
     {
-      "id": "AK8",
-      "terrain": "m",
+      "id": "AK8", "terrain": "m",
       "exits": {
-        "north": "AK7",
-        "south": "AK9",
-        "west": "AJ8",
-        "east": "AL8"
+        "north": "AK7", "south": "AK9", "west": "AJ8", "east": "AL8"
       }
     },
     {
-      "id": "AL8",
-      "terrain": "m",
+      "id": "AL8", "terrain": "m",
       "exits": {
-        "north": "AL7",
-        "south": "AL9",
-        "west": "AK8",
-        "east": "AM8"
+        "north": "AL7", "south": "AL9", "west": "AK8", "east": "AM8"
       }
     },
     {
-      "id": "AM8",
-      "terrain": "m",
+      "id": "AM8", "terrain": "m",
       "exits": {
-        "north": "AM7",
-        "south": "AM9",
-        "west": "AL8",
-        "east": "AN8"
+        "north": "AM7", "south": "AM9", "west": "AL8", "east": "AN8"
       }
     },
     {
-      "id": "AN8",
-      "terrain": "m",
+      "id": "AN8", "terrain": "m",
       "exits": {
-        "north": "AN7",
-        "south": "AN9",
-        "west": "AM8",
-        "east": "AO8"
+        "north": "AN7", "south": "AN9", "west": "AM8", "east": "AO8"
       }
     },
     {
-      "id": "AO8",
-      "terrain": "m",
+      "id": "AO8", "terrain": "m",
       "exits": {
-        "north": "AO7",
-        "south": "AO9",
-        "west": "AN8",
-        "east": "AP8"
+        "north": "AO7", "south": "AO9", "west": "AN8", "east": "AP8"
       }
     },
     {
-      "id": "AP8",
-      "terrain": "m",
+      "id": "AP8", "terrain": "m",
       "exits": {
-        "north": "AP7",
-        "south": "AP9",
-        "west": "AO8",
-        "east": "AQ8"
+        "north": "AP7", "south": "AP9", "west": "AO8", "east": "AQ8"
       }
     },
     {
-      "id": "AQ8",
-      "terrain": "m",
+      "id": "AQ8", "terrain": "m",
       "exits": {
-        "north": "AQ7",
-        "south": "AQ9",
-        "west": "AP8",
-        "east": "AR8"
+        "north": "AQ7", "south": "AQ9", "west": "AP8", "east": "AR8"
       }
     },
     {
-      "id": "AR8",
-      "terrain": "m",
+      "id": "AR8", "terrain": "m",
       "exits": {
-        "north": "AR7",
-        "south": "AR9",
-        "west": "AQ8",
-        "east": "AS8"
+        "north": "AR7", "south": "AR9", "west": "AQ8", "east": "AS8"
       }
     },
     {
-      "id": "AS8",
-      "terrain": "m",
+      "id": "AS8", "terrain": "m",
       "exits": {
-        "north": "AS7",
-        "south": "AS9",
-        "west": "AR8",
-        "east": "AT8"
+        "north": "AS7", "south": "AS9", "west": "AR8", "east": "AT8"
       }
     },
     {
-      "id": "AT8",
-      "terrain": "m",
+      "id": "AT8", "terrain": "m",
       "exits": {
-        "north": "AT7",
-        "south": "AT9",
-        "west": "AS8",
-        "east": "AU8"
+        "north": "AT7", "south": "AT9", "west": "AS8", "east": "AU8"
       }
     },
     {
-      "id": "AU8",
-      "terrain": "m",
+      "id": "AU8", "terrain": "m",
       "exits": {
-        "north": "AU7",
-        "south": "AU9",
-        "west": "AT8",
-        "east": "AV8"
+        "north": "AU7", "south": "AU9", "west": "AT8", "east": "AV8"
       }
     },
     {
-      "id": "AV8",
-      "terrain": "p",
+      "id": "AV8", "terrain": "p",
       "exits": {
-        "north": "AV7",
-        "south": "AV9",
-        "west": "AU8",
-        "east": "AW8"
+        "north": "AV7", "south": "AV9", "west": "AU8", "east": "AW8"
       }
     },
     {
-      "id": "AW8",
-      "terrain": "p",
+      "id": "AW8", "terrain": "p",
       "exits": {
-        "north": "AW7",
-        "south": "AW9",
-        "west": "AV8",
-        "east": "AX8"
+        "north": "AW7", "south": "AW9", "west": "AV8", "east": "AX8"
       }
     },
     {
-      "id": "AX8",
-      "terrain": "p",
+      "id": "AX8", "terrain": "p",
       "exits": {
-        "north": "AX7",
-        "south": "AX9",
-        "west": "AW8"
+        "north": "AX7", "south": "AX9", "west": "AW8"
       }
     },
     {
-      "id": "A9",
-      "terrain": "p",
+      "id": "A9", "terrain": "p",
       "exits": {
-        "north": "A8",
-        "south": "A10",
-        "east": "B9"
+        "north": "A8", "south": "A10", "east": "B9"
       }
     },
     {
-      "id": "B9",
-      "terrain": "p",
+      "id": "B9", "terrain": "p",
       "exits": {
-        "north": "B8",
-        "south": "B10",
-        "west": "A9",
-        "east": "C9"
+        "north": "B8", "south": "B10", "west": "A9", "east": "C9"
       }
     },
     {
-      "id": "C9",
-      "terrain": "p",
+      "id": "C9", "terrain": "p",
       "exits": {
-        "north": "C8",
-        "south": "C10",
-        "west": "B9",
-        "east": "D9"
+        "north": "C8", "south": "C10", "west": "B9", "east": "D9"
       }
     },
     {
-      "id": "D9",
-      "terrain": "p",
+      "id": "D9", "terrain": "p",
       "exits": {
-        "north": "D8",
-        "south": "D10",
-        "west": "C9",
-        "east": "E9"
+        "north": "D8", "south": "D10", "west": "C9", "east": "E9"
       }
     },
     {
-      "id": "E9",
-      "terrain": "p",
+      "id": "E9", "terrain": "p",
       "exits": {
-        "north": "E8",
-        "south": "E10",
-        "west": "D9",
-        "east": "F9"
+        "north": "E8", "south": "E10", "west": "D9", "east": "F9"
       }
     },
     {
-      "id": "F9",
-      "terrain": "h",
+      "id": "F9", "terrain": "h",
       "exits": {
-        "north": "F8",
-        "south": "F10",
-        "west": "E9",
-        "east": "G9"
+        "north": "F8", "south": "F10", "west": "E9", "east": "G9"
       }
     },
     {
-      "id": "G9",
-      "terrain": "h",
+      "id": "G9", "terrain": "h",
       "exits": {
-        "north": "G8",
-        "south": "G10",
-        "west": "F9",
-        "east": "H9"
+        "north": "G8", "south": "G10", "west": "F9", "east": "H9"
       }
     },
     {
-      "id": "H9",
-      "terrain": "p",
+      "id": "H9", "terrain": "p",
       "exits": {
-        "north": "H8",
-        "south": "H10",
-        "west": "G9",
-        "east": "I9"
+        "north": "H8", "south": "H10", "west": "G9", "east": "I9"
       }
     },
     {
-      "id": "I9",
-      "terrain": "d",
+      "id": "I9", "terrain": "d",
       "exits": {
-        "north": "I8",
-        "south": "I10",
-        "west": "H9",
-        "east": "J9"
+        "north": "I8", "south": "I10", "west": "H9", "east": "J9"
       }
     },
     {
-      "id": "J9",
-      "terrain": "d",
+      "id": "J9", "terrain": "d",
       "exits": {
-        "north": "J8",
-        "south": "J10",
-        "west": "I9",
-        "east": "K9"
+        "north": "J8", "south": "J10", "west": "I9", "east": "K9"
       }
     },
     {
-      "id": "K9",
-      "terrain": "d",
+      "id": "K9", "terrain": "d",
       "exits": {
-        "north": "K8",
-        "south": "K10",
-        "west": "J9",
-        "east": "L9"
+        "north": "K8", "south": "K10", "west": "J9", "east": "L9"
       }
     },
     {
-      "id": "L9",
-      "terrain": "d",
+      "id": "L9", "terrain": "d",
       "exits": {
-        "north": "L8",
-        "south": "L10",
-        "west": "K9",
-        "east": "M9"
+        "north": "L8", "south": "L10", "west": "K9", "east": "M9"
       }
     },
     {
-      "id": "M9",
-      "terrain": "p",
+      "id": "M9", "terrain": "p",
       "exits": {
-        "north": "M8",
-        "south": "M10",
-        "west": "L9",
-        "east": "N9"
+        "north": "M8", "south": "M10", "west": "L9", "east": "N9"
       }
     },
     {
-      "id": "N9",
-      "terrain": "p",
+      "id": "N9", "terrain": "p",
       "exits": {
-        "north": "N8",
-        "south": "N10",
-        "west": "M9",
-        "east": "O9"
+        "north": "N8", "south": "N10", "west": "M9", "east": "O9"
       }
     },
     {
-      "id": "O9",
-      "terrain": "p",
+      "id": "O9", "terrain": "p",
       "exits": {
-        "north": "O8",
-        "south": "O10",
-        "west": "N9",
-        "east": "P9"
+        "north": "O8", "south": "O10", "west": "N9", "east": "P9"
       }
     },
     {
-      "id": "P9",
-      "terrain": "p",
+      "id": "P9", "terrain": "p",
       "exits": {
-        "north": "P8",
-        "south": "P10",
-        "west": "O9",
-        "east": "Q9"
+        "north": "P8", "south": "P10", "west": "O9", "east": "Q9"
       }
     },
     {
-      "id": "Q9",
-      "terrain": "p",
+      "id": "Q9", "terrain": "p",
       "exits": {
-        "north": "Q8",
-        "south": "Q10",
-        "west": "P9",
-        "east": "R9"
+        "north": "Q8", "south": "Q10", "west": "P9", "east": "R9"
       }
     },
     {
-      "id": "R9",
-      "terrain": "p",
+      "id": "R9", "terrain": "p",
       "exits": {
-        "north": "R8",
-        "south": "R10",
-        "west": "Q9",
-        "east": "S9"
+        "north": "R8", "south": "R10", "west": "Q9", "east": "S9"
       }
     },
     {
-      "id": "S9",
-      "terrain": "p",
+      "id": "S9", "terrain": "p",
       "exits": {
-        "north": "S8",
-        "south": "S10",
-        "west": "R9",
-        "east": "T9"
+        "north": "S8", "south": "S10", "west": "R9", "east": "T9"
       }
     },
     {
-      "id": "T9",
-      "terrain": "p",
+      "id": "T9", "terrain": "p",
       "exits": {
-        "north": "T8",
-        "south": "T10",
-        "west": "S9",
-        "east": "U9"
+        "north": "T8", "south": "T10", "west": "S9", "east": "U9"
       }
     },
     {
-      "id": "U9",
-      "terrain": "p",
+      "id": "U9", "terrain": "p",
       "exits": {
-        "north": "U8",
-        "south": "U10",
-        "west": "T9",
-        "east": "V9"
+        "north": "U8", "south": "U10", "west": "T9", "east": "V9"
       }
     },
     {
-      "id": "V9",
-      "terrain": "w",
+      "id": "V9", "terrain": "w",
       "exits": {
-        "north": "V8",
-        "south": "V10",
-        "west": "U9",
-        "east": "W9"
+        "north": "V8", "south": "V10", "west": "U9", "east": "W9"
       }
     },
     {
-      "id": "W9",
-      "terrain": "m",
+      "id": "W9", "terrain": "m",
       "exits": {
-        "north": "W8",
-        "south": "W10",
-        "west": "V9",
-        "east": "X9"
+        "north": "W8", "south": "W10", "west": "V9", "east": "X9"
       }
     },
     {
-      "id": "X9",
-      "terrain": "m",
+      "id": "X9", "terrain": "m",
       "exits": {
-        "north": "X8",
-        "south": "X10",
-        "west": "W9",
-        "east": "Y9"
+        "north": "X8", "south": "X10", "west": "W9", "east": "Y9"
       }
     },
     {
-      "id": "Y9",
-      "terrain": "r",
+      "id": "Y9", "terrain": "r",
       "exits": {
-        "north": "Y8",
-        "south": "Y10",
-        "west": "X9",
-        "east": "Z9"
+        "north": "Y8", "south": "Y10", "west": "X9", "east": "Z9"
       }
     },
     {
-      "id": "Z9",
-      "terrain": "p",
+      "id": "Z9", "terrain": "p",
       "exits": {
-        "north": "Z8",
-        "south": "Z10",
-        "west": "Y9",
-        "east": "AA9"
+        "north": "Z8", "south": "Z10", "west": "Y9", "east": "AA9"
       }
     },
     {
-      "id": "AA9",
-      "terrain": "p",
+      "id": "AA9", "terrain": "p",
       "exits": {
-        "north": "AA8",
-        "south": "AA10",
-        "west": "Z9",
-        "east": "AB9"
+        "north": "AA8", "south": "AA10", "west": "Z9", "east": "AB9"
       }
     },
     {
-      "id": "AB9",
-      "terrain": "h",
+      "id": "AB9", "terrain": "h",
       "exits": {
-        "north": "AB8",
-        "south": "AB10",
-        "west": "AA9",
-        "east": "AC9"
+        "north": "AB8", "south": "AB10", "west": "AA9", "east": "AC9"
       }
     },
     {
-      "id": "AC9",
-      "terrain": "m",
+      "id": "AC9", "terrain": "m",
       "exits": {
-        "north": "AC8",
-        "south": "AC10",
-        "west": "AB9",
-        "east": "AD9"
+        "north": "AC8", "south": "AC10", "west": "AB9", "east": "AD9"
       }
     },
     {
-      "id": "AD9",
-      "terrain": "h",
+      "id": "AD9", "terrain": "h",
       "exits": {
-        "north": "AD8",
-        "south": "AD10",
-        "west": "AC9",
-        "east": "AE9"
+        "north": "AD8", "south": "AD10", "west": "AC9", "east": "AE9"
       }
     },
     {
-      "id": "AE9",
-      "terrain": "m",
+      "id": "AE9", "terrain": "m",
       "exits": {
-        "north": "AE8",
-        "south": "AE10",
-        "west": "AD9",
-        "east": "AF9"
+        "north": "AE8", "south": "AE10", "west": "AD9", "east": "AF9"
       }
     },
     {
-      "id": "AF9",
-      "terrain": "m",
+      "id": "AF9", "terrain": "m",
       "exits": {
-        "north": "AF8",
-        "south": "AF10",
-        "west": "AE9",
-        "east": "AG9"
+        "north": "AF8", "south": "AF10", "west": "AE9", "east": "AG9"
       }
     },
     {
-      "id": "AG9",
-      "terrain": "m",
+      "id": "AG9", "terrain": "m",
       "exits": {
-        "north": "AG8",
-        "south": "AG10",
-        "west": "AF9",
-        "east": "AH9"
+        "north": "AG8", "south": "AG10", "west": "AF9", "east": "AH9"
       }
     },
     {
-      "id": "AH9",
-      "terrain": "m",
+      "id": "AH9", "terrain": "m",
       "exits": {
-        "north": "AH8",
-        "south": "AH10",
-        "west": "AG9",
-        "east": "AI9"
+        "north": "AH8", "south": "AH10", "west": "AG9", "east": "AI9"
       }
     },
     {
-      "id": "AI9",
-      "terrain": "m",
+      "id": "AI9", "terrain": "m",
       "exits": {
-        "north": "AI8",
-        "south": "AI10",
-        "west": "AH9",
-        "east": "AJ9"
+        "north": "AI8", "south": "AI10", "west": "AH9", "east": "AJ9"
       }
     },
     {
-      "id": "AJ9",
-      "terrain": "lf",
+      "id": "AJ9", "terrain": "lf",
       "exits": {
-        "north": "AJ8",
-        "south": "AJ10",
-        "west": "AI9",
-        "east": "AK9"
+        "north": "AJ8", "south": "AJ10", "west": "AI9", "east": "AK9"
       }
     },
     {
-      "id": "AK9",
-      "terrain": "m",
+      "id": "AK9", "terrain": "m",
       "exits": {
-        "north": "AK8",
-        "south": "AK10",
-        "west": "AJ9",
-        "east": "AL9"
+        "north": "AK8", "south": "AK10", "west": "AJ9", "east": "AL9"
       }
     },
     {
-      "id": "AL9",
-      "terrain": "m",
+      "id": "AL9", "terrain": "m",
       "exits": {
-        "north": "AL8",
-        "south": "AL10",
-        "west": "AK9",
-        "east": "AM9"
+        "north": "AL8", "south": "AL10", "west": "AK9", "east": "AM9"
       }
     },
     {
-      "id": "AM9",
-      "terrain": "m",
+      "id": "AM9", "terrain": "m",
       "exits": {
-        "north": "AM8",
-        "south": "AM10",
-        "west": "AL9",
-        "east": "AN9"
+        "north": "AM8", "south": "AM10", "west": "AL9", "east": "AN9"
       }
     },
     {
-      "id": "AN9",
-      "terrain": "p",
+      "id": "AN9", "terrain": "p",
       "exits": {
-        "north": "AN8",
-        "south": "AN10",
-        "west": "AM9",
-        "east": "AO9"
+        "north": "AN8", "south": "AN10", "west": "AM9", "east": "AO9"
       }
     },
     {
-      "id": "AO9",
-      "terrain": "m",
+      "id": "AO9", "terrain": "m",
       "exits": {
-        "north": "AO8",
-        "south": "AO10",
-        "west": "AN9",
-        "east": "AP9"
+        "north": "AO8", "south": "AO10", "west": "AN9", "east": "AP9"
       }
     },
     {
-      "id": "AP9",
-      "terrain": "m",
+      "id": "AP9", "terrain": "m",
       "exits": {
-        "north": "AP8",
-        "south": "AP10",
-        "west": "AO9",
-        "east": "AQ9"
+        "north": "AP8", "south": "AP10", "west": "AO9", "east": "AQ9"
       }
     },
     {
-      "id": "AQ9",
-      "terrain": "m",
+      "id": "AQ9", "terrain": "m",
       "exits": {
-        "north": "AQ8",
-        "south": "AQ10",
-        "west": "AP9",
-        "east": "AR9"
+        "north": "AQ8", "south": "AQ10", "west": "AP9", "east": "AR9"
       }
     },
     {
-      "id": "AR9",
-      "terrain": "m",
+      "id": "AR9", "terrain": "m",
       "exits": {
-        "north": "AR8",
-        "south": "AR10",
-        "west": "AQ9",
-        "east": "AS9"
+        "north": "AR8", "south": "AR10", "west": "AQ9", "east": "AS9"
       }
     },
     {
-      "id": "AS9",
-      "terrain": "m",
+      "id": "AS9", "terrain": "m",
       "exits": {
-        "north": "AS8",
-        "south": "AS10",
-        "west": "AR9",
-        "east": "AT9"
+        "north": "AS8", "south": "AS10", "west": "AR9", "east": "AT9"
       }
     },
     {
-      "id": "AT9",
-      "terrain": "m",
+      "id": "AT9", "terrain": "m",
       "exits": {
-        "north": "AT8",
-        "south": "AT10",
-        "west": "AS9",
-        "east": "AU9"
+        "north": "AT8", "south": "AT10", "west": "AS9", "east": "AU9"
       }
     },
     {
-      "id": "AU9",
-      "terrain": "lf",
+      "id": "AU9", "terrain": "lf",
       "exits": {
-        "north": "AU8",
-        "south": "AU10",
-        "west": "AT9",
-        "east": "AV9"
+        "north": "AU8", "south": "AU10", "west": "AT9", "east": "AV9"
       }
     },
     {
-      "id": "AV9",
-      "terrain": "p",
+      "id": "AV9", "terrain": "p",
       "exits": {
-        "north": "AV8",
-        "south": "AV10",
-        "west": "AU9",
-        "east": "AW9"
+        "north": "AV8", "south": "AV10", "west": "AU9", "east": "AW9"
       }
     },
     {
-      "id": "AW9",
-      "terrain": "p",
+      "id": "AW9", "terrain": "p",
       "exits": {
-        "north": "AW8",
-        "south": "AW10",
-        "west": "AV9",
-        "east": "AX9"
+        "north": "AW8", "south": "AW10", "west": "AV9", "east": "AX9"
       }
     },
     {
-      "id": "AX9",
-      "terrain": "p",
+      "id": "AX9", "terrain": "p",
       "exits": {
-        "north": "AX8",
-        "south": "AX10",
-        "west": "AW9"
+        "north": "AX8", "south": "AX10", "west": "AW9"
       }
     },
     {
-      "id": "A10",
-      "terrain": "p",
+      "id": "A10", "terrain": "p",
       "exits": {
-        "north": "A9",
-        "south": "A11",
-        "east": "B10"
+        "north": "A9", "south": "A11", "east": "B10"
       }
     },
     {
-      "id": "B10",
-      "terrain": "p",
+      "id": "B10", "terrain": "p",
       "exits": {
-        "north": "B9",
-        "south": "B11",
-        "west": "A10",
-        "east": "C10"
+        "north": "B9", "south": "B11", "west": "A10", "east": "C10"
       }
     },
     {
-      "id": "C10",
-      "terrain": "b",
+      "id": "C10", "terrain": "b",
       "exits": {
-        "north": "C9",
-        "south": "C11",
-        "west": "B10",
-        "east": "D10"
+        "north": "C9", "south": "C11", "west": "B10", "east": "D10"
       }
     },
     {
-      "id": "D10",
-      "terrain": "b",
+      "id": "D10", "terrain": "b",
       "exits": {
-        "north": "D9",
-        "south": "D11",
-        "west": "C10",
-        "east": "E10"
+        "north": "D9", "south": "D11", "west": "C10", "east": "E10"
       }
     },
     {
-      "id": "E10",
-      "terrain": "p",
+      "id": "E10", "terrain": "p",
       "exits": {
-        "north": "E9",
-        "south": "E11",
-        "west": "D10",
-        "east": "F10"
+        "north": "E9", "south": "E11", "west": "D10", "east": "F10"
       }
     },
     {
-      "id": "F10",
-      "terrain": "p",
+      "id": "F10", "terrain": "p",
       "exits": {
-        "north": "F9",
-        "south": "F11",
-        "west": "E10",
-        "east": "G10"
+        "north": "F9", "south": "F11", "west": "E10", "east": "G10"
       }
     },
     {
-      "id": "G10",
-      "terrain": "p",
+      "id": "G10", "terrain": "p",
       "exits": {
-        "north": "G9",
-        "south": "G11",
-        "west": "F10",
-        "east": "H10"
+        "north": "G9", "south": "G11", "west": "F10", "east": "H10"
       }
     },
     {
-      "id": "H10",
-      "terrain": "d",
+      "id": "H10", "terrain": "d",
       "exits": {
-        "north": "H9",
-        "south": "H11",
-        "west": "G10",
-        "east": "I10"
+        "north": "H9", "south": "H11", "west": "G10", "east": "I10"
       }
     },
     {
-      "id": "I10",
-      "terrain": "d",
+      "id": "I10", "terrain": "d",
       "exits": {
-        "north": "I9",
-        "south": "I11",
-        "west": "H10",
-        "east": "J10"
+        "north": "I9", "south": "I11", "west": "H10", "east": "J10"
       }
     },
     {
-      "id": "J10",
-      "terrain": "d",
+      "id": "J10", "terrain": "d",
       "exits": {
-        "north": "J9",
-        "south": "J11",
-        "west": "I10",
-        "east": "K10"
+        "north": "J9", "south": "J11", "west": "I10", "east": "K10"
       }
     },
     {
-      "id": "K10",
-      "terrain": "d",
+      "id": "K10", "terrain": "d",
       "exits": {
-        "north": "K9",
-        "south": "K11",
-        "west": "J10",
-        "east": "L10"
+        "north": "K9", "south": "K11", "west": "J10", "east": "L10"
       }
     },
     {
-      "id": "L10",
-      "terrain": "d",
+      "id": "L10", "terrain": "d",
       "exits": {
-        "north": "L9",
-        "south": "L11",
-        "west": "K10",
-        "east": "M10"
+        "north": "L9", "south": "L11", "west": "K10", "east": "M10"
       }
     },
     {
-      "id": "M10",
-      "terrain": "d",
+      "id": "M10", "terrain": "d",
       "exits": {
-        "north": "M9",
-        "south": "M11",
-        "west": "L10",
-        "east": "N10"
+        "north": "M9", "south": "M11", "west": "L10", "east": "N10"
       }
     },
     {
-      "id": "N10",
-      "terrain": "d",
+      "id": "N10", "terrain": "d",
       "exits": {
-        "north": "N9",
-        "south": "N11",
-        "west": "M10",
-        "east": "O10"
+        "north": "N9", "south": "N11", "west": "M10", "east": "O10"
       }
     },
     {
-      "id": "O10",
-      "terrain": "p",
+      "id": "O10", "terrain": "p",
       "exits": {
-        "north": "O9",
-        "south": "O11",
-        "west": "N10",
-        "east": "P10"
+        "north": "O9", "south": "O11", "west": "N10", "east": "P10"
       }
     },
     {
-      "id": "P10",
-      "terrain": "p",
+      "id": "P10", "terrain": "p",
       "exits": {
-        "north": "P9",
-        "south": "P11",
-        "west": "O10",
-        "east": "Q10"
+        "north": "P9", "south": "P11", "west": "O10", "east": "Q10"
       }
     },
     {
-      "id": "Q10",
-      "terrain": "p",
+      "id": "Q10", "terrain": "p",
       "exits": {
-        "north": "Q9",
-        "south": "Q11",
-        "west": "P10",
-        "east": "R10"
+        "north": "Q9", "south": "Q11", "west": "P10", "east": "R10"
       }
     },
     {
-      "id": "R10",
-      "terrain": "p",
+      "id": "R10", "terrain": "p",
       "exits": {
-        "north": "R9",
-        "south": "R11",
-        "west": "Q10",
-        "east": "S10"
+        "north": "R9", "south": "R11", "west": "Q10", "east": "S10"
       }
     },
     {
-      "id": "S10",
-      "terrain": "p",
+      "id": "S10", "terrain": "p",
       "exits": {
-        "north": "S9",
-        "south": "S11",
-        "west": "R10",
-        "east": "T10"
+        "north": "S9", "south": "S11", "west": "R10", "east": "T10"
       }
     },
     {
-      "id": "T10",
-      "terrain": "p",
+      "id": "T10", "terrain": "p",
       "exits": {
-        "north": "T9",
-        "south": "T11",
-        "west": "S10",
-        "east": "U10"
+        "north": "T9", "south": "T11", "west": "S10", "east": "U10"
       }
     },
     {
-      "id": "U10",
-      "terrain": "p",
+      "id": "U10", "terrain": "p",
       "exits": {
-        "north": "U9",
-        "south": "U11",
-        "west": "T10",
-        "east": "V10"
+        "north": "U9", "south": "U11", "west": "T10", "east": "V10"
       }
     },
     {
-      "id": "V10",
-      "terrain": "w",
+      "id": "V10", "terrain": "w",
       "exits": {
-        "north": "V9",
-        "south": "V11",
-        "west": "U10",
-        "east": "W10"
+        "north": "V9", "south": "V11", "west": "U10", "east": "W10"
       }
     },
     {
-      "id": "W10",
-      "terrain": "m",
+      "id": "W10", "terrain": "m",
       "exits": {
-        "north": "W9",
-        "south": "W11",
-        "west": "V10",
-        "east": "X10"
+        "north": "W9", "south": "W11", "west": "V10", "east": "X10"
       }
     },
     {
-      "id": "X10",
-      "terrain": "p",
+      "id": "X10", "terrain": "p",
       "exits": {
-        "north": "X9",
-        "south": "X11",
-        "west": "W10",
-        "east": "Y10"
+        "north": "X9", "south": "X11", "west": "W10", "east": "Y10"
       }
     },
     {
-      "id": "Y10",
-      "terrain": "r",
+      "id": "Y10", "terrain": "r",
       "exits": {
-        "north": "Y9",
-        "south": "Y11",
-        "west": "X10",
-        "east": "Z10"
+        "north": "Y9", "south": "Y11", "west": "X10", "east": "Z10"
       }
     },
     {
-      "id": "Z10",
-      "terrain": "p",
+      "id": "Z10", "terrain": "p",
       "exits": {
-        "north": "Z9",
-        "south": "Z11",
-        "west": "Y10",
-        "east": "AA10"
+        "north": "Z9", "south": "Z11", "west": "Y10", "east": "AA10"
       }
     },
     {
-      "id": "AA10",
-      "terrain": "p",
+      "id": "AA10", "terrain": "p",
       "exits": {
-        "north": "AA9",
-        "south": "AA11",
-        "west": "Z10",
-        "east": "AB10"
+        "north": "AA9", "south": "AA11", "west": "Z10", "east": "AB10"
       }
     },
     {
-      "id": "AB10",
-      "terrain": "m",
+      "id": "AB10", "terrain": "m",
       "exits": {
-        "north": "AB9",
-        "south": "AB11",
-        "west": "AA10",
-        "east": "AC10"
+        "north": "AB9", "south": "AB11", "west": "AA10", "east": "AC10"
       }
     },
     {
-      "id": "AC10",
-      "terrain": "m",
+      "id": "AC10", "terrain": "m",
       "exits": {
-        "north": "AC9",
-        "south": "AC11",
-        "west": "AB10",
-        "east": "AD10"
+        "north": "AC9", "south": "AC11", "west": "AB10", "east": "AD10"
       }
     },
     {
-      "id": "AD10",
-      "terrain": "m",
+      "id": "AD10", "terrain": "m",
       "exits": {
-        "north": "AD9",
-        "south": "AD11",
-        "west": "AC10",
-        "east": "AE10"
+        "north": "AD9", "south": "AD11", "west": "AC10", "east": "AE10"
       }
     },
     {
-      "id": "AE10",
-      "terrain": "m",
+      "id": "AE10", "terrain": "m",
       "exits": {
-        "north": "AE9",
-        "south": "AE11",
-        "west": "AD10",
-        "east": "AF10"
+        "north": "AE9", "south": "AE11", "west": "AD10", "east": "AF10"
       }
     },
     {
-      "id": "AF10",
-      "terrain": "p",
+      "id": "AF10", "terrain": "p",
       "exits": {
-        "north": "AF9",
-        "south": "AF11",
-        "west": "AE10",
-        "east": "AG10"
+        "north": "AF9", "south": "AF11", "west": "AE10", "east": "AG10"
       }
     },
     {
-      "id": "AG10",
-      "terrain": "p",
+      "id": "AG10", "terrain": "p",
       "exits": {
-        "north": "AG9",
-        "south": "AG11",
-        "west": "AF10",
-        "east": "AH10"
+        "north": "AG9", "south": "AG11", "west": "AF10", "east": "AH10"
       }
     },
     {
-      "id": "AH10",
-      "terrain": "p",
+      "id": "AH10", "terrain": "p",
       "exits": {
-        "north": "AH9",
-        "south": "AH11",
-        "west": "AG10",
-        "east": "AI10"
+        "north": "AH9", "south": "AH11", "west": "AG10", "east": "AI10"
       }
     },
     {
-      "id": "AI10",
-      "terrain": "p",
+      "id": "AI10", "terrain": "p",
       "exits": {
-        "north": "AI9",
-        "south": "AI11",
-        "west": "AH10",
-        "east": "AJ10"
+        "north": "AI9", "south": "AI11", "west": "AH10", "east": "AJ10"
       }
     },
     {
-      "id": "AJ10",
-      "terrain": "m",
+      "id": "AJ10", "terrain": "m",
       "exits": {
-        "north": "AJ9",
-        "south": "AJ11",
-        "west": "AI10",
-        "east": "AK10"
+        "north": "AJ9", "south": "AJ11", "west": "AI10", "east": "AK10"
       }
     },
     {
-      "id": "AK10",
-      "terrain": "m",
+      "id": "AK10", "terrain": "m",
       "exits": {
-        "north": "AK9",
-        "south": "AK11",
-        "west": "AJ10",
-        "east": "AL10"
+        "north": "AK9", "south": "AK11", "west": "AJ10", "east": "AL10"
       }
     },
     {
-      "id": "AL10",
-      "terrain": "m",
+      "id": "AL10", "terrain": "m",
       "exits": {
-        "north": "AL9",
-        "south": "AL11",
-        "west": "AK10",
-        "east": "AM10"
+        "north": "AL9", "south": "AL11", "west": "AK10", "east": "AM10"
       }
     },
     {
-      "id": "AM10",
-      "terrain": "m",
+      "id": "AM10", "terrain": "m",
       "exits": {
-        "north": "AM9",
-        "south": "AM11",
-        "west": "AL10",
-        "east": "AN10"
+        "north": "AM9", "south": "AM11", "west": "AL10", "east": "AN10"
       }
     },
     {
-      "id": "AN10",
-      "terrain": "m",
+      "id": "AN10", "terrain": "m",
       "exits": {
-        "north": "AN9",
-        "south": "AN11",
-        "west": "AM10",
-        "east": "AO10"
+        "north": "AN9", "south": "AN11", "west": "AM10", "east": "AO10"
       }
     },
     {
-      "id": "AO10",
-      "terrain": "m",
+      "id": "AO10", "terrain": "m",
       "exits": {
-        "north": "AO9",
-        "south": "AO11",
-        "west": "AN10",
-        "east": "AP10"
+        "north": "AO9", "south": "AO11", "west": "AN10", "east": "AP10"
       }
     },
     {
-      "id": "AP10",
-      "terrain": "m",
+      "id": "AP10", "terrain": "m",
       "exits": {
-        "north": "AP9",
-        "south": "AP11",
-        "west": "AO10",
-        "east": "AQ10"
+        "north": "AP9", "south": "AP11", "west": "AO10", "east": "AQ10"
       }
     },
     {
-      "id": "AQ10",
-      "terrain": "m",
+      "id": "AQ10", "terrain": "m",
       "exits": {
-        "north": "AQ9",
-        "south": "AQ11",
-        "west": "AP10",
-        "east": "AR10"
+        "north": "AQ9", "south": "AQ11", "west": "AP10", "east": "AR10"
       }
     },
     {
-      "id": "AR10",
-      "terrain": "m",
+      "id": "AR10", "terrain": "m",
       "exits": {
-        "north": "AR9",
-        "south": "AR11",
-        "west": "AQ10",
-        "east": "AS10"
+        "north": "AR9", "south": "AR11", "west": "AQ10", "east": "AS10"
       }
     },
     {
-      "id": "AS10",
-      "terrain": "m",
+      "id": "AS10", "terrain": "m",
       "exits": {
-        "north": "AS9",
-        "south": "AS11",
-        "west": "AR10",
-        "east": "AT10"
+        "north": "AS9", "south": "AS11", "west": "AR10", "east": "AT10"
       }
     },
     {
-      "id": "AT10",
-      "terrain": "lf",
+      "id": "AT10", "terrain": "lf",
       "exits": {
-        "north": "AT9",
-        "south": "AT11",
-        "west": "AS10",
-        "east": "AU10"
+        "north": "AT9", "south": "AT11", "west": "AS10", "east": "AU10"
       }
     },
     {
-      "id": "AU10",
-      "terrain": "lf",
+      "id": "AU10", "terrain": "lf",
       "exits": {
-        "north": "AU9",
-        "south": "AU11",
-        "west": "AT10",
-        "east": "AV10"
+        "north": "AU9", "south": "AU11", "west": "AT10", "east": "AV10"
       }
     },
     {
-      "id": "AV10",
-      "terrain": "p",
+      "id": "AV10", "terrain": "p",
       "exits": {
-        "north": "AV9",
-        "south": "AV11",
-        "west": "AU10",
-        "east": "AW10"
+        "north": "AV9", "south": "AV11", "west": "AU10", "east": "AW10"
       }
     },
     {
-      "id": "AW10",
-      "terrain": "p",
+      "id": "AW10", "terrain": "p",
       "exits": {
-        "north": "AW9",
-        "south": "AW11",
-        "west": "AV10",
-        "east": "AX10"
+        "north": "AW9", "south": "AW11", "west": "AV10", "east": "AX10"
       }
     },
     {
-      "id": "AX10",
-      "terrain": "p",
+      "id": "AX10", "terrain": "p",
       "exits": {
-        "north": "AX9",
-        "south": "AX11",
-        "west": "AW10"
+        "north": "AX9", "south": "AX11", "west": "AW10"
       }
     },
     {
-      "id": "A11",
-      "terrain": "p",
+      "id": "A11", "terrain": "p",
       "exits": {
-        "north": "A10",
-        "south": "A12",
-        "east": "B11"
+        "north": "A10", "south": "A12", "east": "B11"
       }
     },
     {
-      "id": "B11",
-      "terrain": "p",
+      "id": "B11", "terrain": "p",
       "exits": {
-        "north": "B10",
-        "south": "B12",
-        "west": "A11",
-        "east": "C11"
+        "north": "B10", "south": "B12", "west": "A11", "east": "C11"
       }
     },
     {
-      "id": "C11",
-      "terrain": "b",
+      "id": "C11", "terrain": "b",
       "exits": {
-        "north": "C10",
-        "south": "C12",
-        "west": "B11",
-        "east": "D11"
+        "north": "C10", "south": "C12", "west": "B11", "east": "D11"
       }
     },
     {
-      "id": "D11",
-      "terrain": "p",
+      "id": "D11", "terrain": "p",
       "exits": {
-        "north": "D10",
-        "south": "D12",
-        "west": "C11",
-        "east": "E11"
+        "north": "D10", "south": "D12", "west": "C11", "east": "E11"
       }
     },
     {
-      "id": "E11",
-      "terrain": "p",
+      "id": "E11", "terrain": "p",
       "exits": {
-        "north": "E10",
-        "south": "E12",
-        "west": "D11",
-        "east": "F11"
+        "north": "E10", "south": "E12", "west": "D11", "east": "F11"
       }
     },
     {
-      "id": "F11",
-      "terrain": "p",
+      "id": "F11", "terrain": "p",
       "exits": {
-        "north": "F10",
-        "south": "F12",
-        "west": "E11",
-        "east": "G11"
+        "north": "F10", "south": "F12", "west": "E11", "east": "G11"
       }
     },
     {
-      "id": "G11",
-      "terrain": "d",
+      "id": "G11", "terrain": "d",
       "exits": {
-        "north": "G10",
-        "south": "G12",
-        "west": "F11",
-        "east": "H11"
+        "north": "G10", "south": "G12", "west": "F11", "east": "H11"
       }
     },
     {
-      "id": "H11",
-      "terrain": "d",
+      "id": "H11", "terrain": "d",
       "exits": {
-        "north": "H10",
-        "south": "H12",
-        "west": "G11",
-        "east": "I11"
+        "north": "H10", "south": "H12", "west": "G11", "east": "I11"
       }
     },
     {
-      "id": "I11",
-      "terrain": "d",
+      "id": "I11", "terrain": "d",
       "exits": {
-        "north": "I10",
-        "south": "I12",
-        "west": "H11",
-        "east": "J11"
+        "north": "I10", "south": "I12", "west": "H11", "east": "J11"
       }
     },
     {
-      "id": "J11",
-      "terrain": "d",
+      "id": "J11", "terrain": "d",
       "exits": {
-        "north": "J10",
-        "south": "J12",
-        "west": "I11",
-        "east": "K11"
+        "north": "J10", "south": "J12", "west": "I11", "east": "K11"
       }
     },
     {
-      "id": "K11",
-      "terrain": "d",
+      "id": "K11", "terrain": "d",
       "exits": {
-        "north": "K10",
-        "south": "K12",
-        "west": "J11",
-        "east": "L11"
+        "north": "K10", "south": "K12", "west": "J11", "east": "L11"
       }
     },
     {
-      "id": "L11",
-      "terrain": "d",
+      "id": "L11", "terrain": "d",
       "exits": {
-        "north": "L10",
-        "south": "L12",
-        "west": "K11",
-        "east": "M11"
+        "north": "L10", "south": "L12", "west": "K11", "east": "M11"
       }
     },
     {
-      "id": "M11",
-      "terrain": "d",
+      "id": "M11", "terrain": "d",
       "exits": {
-        "north": "M10",
-        "south": "M12",
-        "west": "L11",
-        "east": "N11"
+        "north": "M10", "south": "M12", "west": "L11", "east": "N11"
       }
     },
     {
-      "id": "N11",
-      "terrain": "d",
+      "id": "N11", "terrain": "d",
       "exits": {
-        "north": "N10",
-        "south": "N12",
-        "west": "M11",
-        "east": "O11"
+        "north": "N10", "south": "N12", "west": "M11", "east": "O11"
       }
     },
     {
-      "id": "O11",
-      "terrain": "d",
+      "id": "O11", "terrain": "d",
       "exits": {
-        "north": "O10",
-        "south": "O12",
-        "west": "N11",
-        "east": "P11"
+        "north": "O10", "south": "O12", "west": "N11", "east": "P11"
       }
     },
     {
-      "id": "P11",
-      "terrain": "d",
+      "id": "P11", "terrain": "d",
       "exits": {
-        "north": "P10",
-        "south": "P12",
-        "west": "O11",
-        "east": "Q11"
+        "north": "P10", "south": "P12", "west": "O11", "east": "Q11"
       }
     },
     {
-      "id": "Q11",
-      "terrain": "d",
+      "id": "Q11", "terrain": "d",
       "exits": {
-        "north": "Q10",
-        "south": "Q12",
-        "west": "P11",
-        "east": "R11"
+        "north": "Q10", "south": "Q12", "west": "P11", "east": "R11"
       }
     },
     {
-      "id": "R11",
-      "terrain": "d",
+      "id": "R11", "terrain": "d",
       "exits": {
-        "north": "R10",
-        "south": "R12",
-        "west": "Q11",
-        "east": "S11"
+        "north": "R10", "south": "R12", "west": "Q11", "east": "S11"
       }
     },
     {
-      "id": "S11",
-      "terrain": "p",
+      "id": "S11", "terrain": "p",
       "exits": {
-        "north": "S10",
-        "south": "S12",
-        "west": "R11",
-        "east": "T11"
+        "north": "S10", "south": "S12", "west": "R11", "east": "T11"
       }
     },
     {
-      "id": "T11",
-      "terrain": "p",
+      "id": "T11", "terrain": "p",
       "exits": {
-        "north": "T10",
-        "south": "T12",
-        "west": "S11",
-        "east": "U11"
+        "north": "T10", "south": "T12", "west": "S11", "east": "U11"
       }
     },
     {
-      "id": "U11",
-      "terrain": "p",
+      "id": "U11", "terrain": "p",
       "exits": {
-        "north": "U10",
-        "south": "U12",
-        "west": "T11",
-        "east": "V11"
+        "north": "U10", "south": "U12", "west": "T11", "east": "V11"
       }
     },
     {
-      "id": "V11",
-      "terrain": "w",
+      "id": "V11", "terrain": "w",
       "exits": {
-        "north": "V10",
-        "south": "V12",
-        "west": "U11",
-        "east": "W11"
+        "north": "V10", "south": "V12", "west": "U11", "east": "W11"
       }
     },
     {
-      "id": "W11",
-      "terrain": "m",
+      "id": "W11", "terrain": "m",
       "exits": {
-        "north": "W10",
-        "south": "W12",
-        "west": "V11",
-        "east": "X11"
+        "north": "W10", "south": "W12", "west": "V11", "east": "X11"
       }
     },
     {
-      "id": "X11",
-      "terrain": "p",
+      "id": "X11", "terrain": "p",
       "exits": {
-        "north": "X10",
-        "south": "X12",
-        "west": "W11",
-        "east": "Y11"
+        "north": "X10", "south": "X12", "west": "W11", "east": "Y11"
       }
     },
     {
-      "id": "Y11",
-      "terrain": "r",
+      "id": "Y11", "terrain": "r",
       "exits": {
-        "north": "Y10",
-        "south": "Y12",
-        "west": "X11",
-        "east": "Z11"
+        "north": "Y10", "south": "Y12", "west": "X11", "east": "Z11"
       }
     },
     {
-      "id": "Z11",
-      "terrain": "p",
+      "id": "Z11", "terrain": "p",
       "exits": {
-        "north": "Z10",
-        "south": "Z12",
-        "west": "Y11",
-        "east": "AA11"
+        "north": "Z10", "south": "Z12", "west": "Y11", "east": "AA11"
       }
     },
     {
-      "id": "AA11",
-      "terrain": "m",
+      "id": "AA11", "terrain": "m",
       "exits": {
-        "north": "AA10",
-        "south": "AA12",
-        "west": "Z11",
-        "east": "AB11"
+        "north": "AA10", "south": "AA12", "west": "Z11", "east": "AB11"
       }
     },
     {
-      "id": "AB11",
-      "terrain": "m",
+      "id": "AB11", "terrain": "m",
       "exits": {
-        "north": "AB10",
-        "south": "AB12",
-        "west": "AA11",
-        "east": "AC11"
+        "north": "AB10", "south": "AB12", "west": "AA11", "east": "AC11"
       }
     },
     {
-      "id": "AC11",
-      "terrain": "m",
+      "id": "AC11", "terrain": "m",
       "exits": {
-        "north": "AC10",
-        "south": "AC12",
-        "west": "AB11",
-        "east": "AD11"
+        "north": "AC10", "south": "AC12", "west": "AB11", "east": "AD11"
       }
     },
     {
-      "id": "AD11",
-      "terrain": "m",
+      "id": "AD11", "terrain": "m",
       "exits": {
-        "north": "AD10",
-        "south": "AD12",
-        "west": "AC11",
-        "east": "AE11"
+        "north": "AD10", "south": "AD12", "west": "AC11", "east": "AE11"
       }
     },
     {
-      "id": "AE11",
-      "terrain": "m",
+      "id": "AE11", "terrain": "m",
       "exits": {
-        "north": "AE10",
-        "south": "AE12",
-        "west": "AD11",
-        "east": "AF11"
+        "north": "AE10", "south": "AE12", "west": "AD11", "east": "AF11"
       }
     },
     {
-      "id": "AF11",
-      "terrain": "p",
+      "id": "AF11", "terrain": "p",
       "exits": {
-        "north": "AF10",
-        "south": "AF12",
-        "west": "AE11",
-        "east": "AG11"
+        "north": "AF10", "south": "AF12", "west": "AE11", "east": "AG11"
       }
     },
     {
-      "id": "AG11",
-      "terrain": "p",
+      "id": "AG11", "terrain": "p",
       "exits": {
-        "north": "AG10",
-        "south": "AG12",
-        "west": "AF11",
-        "east": "AH11"
+        "north": "AG10", "south": "AG12", "west": "AF11", "east": "AH11"
       }
     },
     {
-      "id": "AH11",
-      "terrain": "p",
+      "id": "AH11", "terrain": "p",
       "exits": {
-        "north": "AH10",
-        "south": "AH12",
-        "west": "AG11",
-        "east": "AI11"
+        "north": "AH10", "south": "AH12", "west": "AG11", "east": "AI11"
       }
     },
     {
-      "id": "AI11",
-      "terrain": "p",
+      "id": "AI11", "terrain": "p",
       "exits": {
-        "north": "AI10",
-        "south": "AI12",
-        "west": "AH11",
-        "east": "AJ11"
+        "north": "AI10", "south": "AI12", "west": "AH11", "east": "AJ11"
       }
     },
     {
-      "id": "AJ11",
-      "terrain": "m",
+      "id": "AJ11", "terrain": "m",
       "exits": {
-        "north": "AJ10",
-        "south": "AJ12",
-        "west": "AI11",
-        "east": "AK11"
+        "north": "AJ10", "south": "AJ12", "west": "AI11", "east": "AK11"
       }
     },
     {
-      "id": "AK11",
-      "terrain": "m",
+      "id": "AK11", "terrain": "m",
       "exits": {
-        "north": "AK10",
-        "south": "AK12",
-        "west": "AJ11",
-        "east": "AL11"
+        "north": "AK10", "south": "AK12", "west": "AJ11", "east": "AL11"
       }
     },
     {
-      "id": "AL11",
-      "terrain": "d",
+      "id": "AL11", "terrain": "d",
       "exits": {
-        "north": "AL10",
-        "south": "AL12",
-        "west": "AK11",
-        "east": "AM11"
+        "north": "AL10", "south": "AL12", "west": "AK11", "east": "AM11"
       }
     },
     {
-      "id": "AM11",
-      "terrain": "d",
+      "id": "AM11", "terrain": "d",
       "exits": {
-        "north": "AM10",
-        "south": "AM12",
-        "west": "AL11",
-        "east": "AN11"
+        "north": "AM10", "south": "AM12", "west": "AL11", "east": "AN11"
       }
     },
     {
-      "id": "AN11",
-      "terrain": "d",
+      "id": "AN11", "terrain": "d",
       "exits": {
-        "north": "AN10",
-        "south": "AN12",
-        "west": "AM11",
-        "east": "AO11"
+        "north": "AN10", "south": "AN12", "west": "AM11", "east": "AO11"
       }
     },
     {
-      "id": "AO11",
-      "terrain": "d",
+      "id": "AO11", "terrain": "d",
       "exits": {
-        "north": "AO10",
-        "south": "AO12",
-        "west": "AN11",
-        "east": "AP11"
+        "north": "AO10", "south": "AO12", "west": "AN11", "east": "AP11"
       }
     },
     {
-      "id": "AP11",
-      "terrain": "m",
+      "id": "AP11", "terrain": "m",
       "exits": {
-        "north": "AP10",
-        "south": "AP12",
-        "west": "AO11",
-        "east": "AQ11"
+        "north": "AP10", "south": "AP12", "west": "AO11", "east": "AQ11"
       }
     },
     {
-      "id": "AQ11",
-      "terrain": "f",
+      "id": "AQ11", "terrain": "f",
       "exits": {
-        "north": "AQ10",
-        "south": "AQ12",
-        "west": "AP11",
-        "east": "AR11"
+        "north": "AQ10", "south": "AQ12", "west": "AP11", "east": "AR11"
       }
     },
     {
-      "id": "AR11",
-      "terrain": "f",
+      "id": "AR11", "terrain": "f",
       "exits": {
-        "north": "AR10",
-        "south": "AR12",
-        "west": "AQ11",
-        "east": "AS11"
+        "north": "AR10", "south": "AR12", "west": "AQ11", "east": "AS11"
       }
     },
     {
-      "id": "AS11",
-      "terrain": "f",
+      "id": "AS11", "terrain": "f",
       "exits": {
-        "north": "AS10",
-        "south": "AS12",
-        "west": "AR11",
-        "east": "AT11"
+        "north": "AS10", "south": "AS12", "west": "AR11", "east": "AT11"
       }
     },
     {
-      "id": "AT11",
-      "terrain": "lf",
+      "id": "AT11", "terrain": "lf",
       "exits": {
-        "north": "AT10",
-        "south": "AT12",
-        "west": "AS11",
-        "east": "AU11"
+        "north": "AT10", "south": "AT12", "west": "AS11", "east": "AU11"
       }
     },
     {
-      "id": "AU11",
-      "terrain": "lf",
+      "id": "AU11", "terrain": "lf",
       "exits": {
-        "north": "AU10",
-        "south": "AU12",
-        "west": "AT11",
-        "east": "AV11"
+        "north": "AU10", "south": "AU12", "west": "AT11", "east": "AV11"
       }
     },
     {
-      "id": "AV11",
-      "terrain": "p",
+      "id": "AV11", "terrain": "p",
       "exits": {
-        "north": "AV10",
-        "south": "AV12",
-        "west": "AU11",
-        "east": "AW11"
+        "north": "AV10", "south": "AV12", "west": "AU11", "east": "AW11"
       }
     },
     {
-      "id": "AW11",
-      "terrain": "p",
+      "id": "AW11", "terrain": "p",
       "exits": {
-        "north": "AW10",
-        "south": "AW12",
-        "west": "AV11",
-        "east": "AX11"
+        "north": "AW10", "south": "AW12", "west": "AV11", "east": "AX11"
       }
     },
     {
-      "id": "AX11",
-      "terrain": "p",
+      "id": "AX11", "terrain": "p",
       "exits": {
-        "north": "AX10",
-        "south": "AX12",
-        "west": "AW11"
+        "north": "AX10", "south": "AX12", "west": "AW11"
       }
     },
     {
-      "id": "A12",
-      "terrain": "p",
+      "id": "A12", "terrain": "p",
       "exits": {
-        "north": "A11",
-        "south": "A13",
-        "east": "B12"
+        "north": "A11", "south": "A13", "east": "B12"
       }
     },
     {
-      "id": "B12",
-      "terrain": "b",
+      "id": "B12", "terrain": "b",
       "exits": {
-        "north": "B11",
-        "south": "B13",
-        "west": "A12",
-        "east": "C12"
+        "north": "B11", "south": "B13", "west": "A12", "east": "C12"
       }
     },
     {
-      "id": "C12",
-      "terrain": "b",
+      "id": "C12", "terrain": "b",
       "exits": {
-        "north": "C11",
-        "south": "C13",
-        "west": "B12",
-        "east": "D12"
+        "north": "C11", "south": "C13", "west": "B12", "east": "D12"
       }
     },
     {
-      "id": "D12",
-      "terrain": "b",
+      "id": "D12", "terrain": "b",
       "exits": {
-        "north": "D11",
-        "south": "D13",
-        "west": "C12",
-        "east": "E12"
+        "north": "D11", "south": "D13", "west": "C12", "east": "E12"
       }
     },
     {
-      "id": "E12",
-      "terrain": "p",
+      "id": "E12", "terrain": "p",
       "exits": {
-        "north": "E11",
-        "south": "E13",
-        "west": "D12",
-        "east": "F12"
+        "north": "E11", "south": "E13", "west": "D12", "east": "F12"
       }
     },
     {
-      "id": "F12",
-      "terrain": "p",
+      "id": "F12", "terrain": "p",
       "exits": {
-        "north": "F11",
-        "south": "F13",
-        "west": "E12",
-        "east": "G12"
+        "north": "F11", "south": "F13", "west": "E12", "east": "G12"
       }
     },
     {
-      "id": "G12",
-      "terrain": "d",
+      "id": "G12", "terrain": "d",
       "exits": {
-        "north": "G11",
-        "south": "G13",
-        "west": "F12",
-        "east": "H12"
+        "north": "G11", "south": "G13", "west": "F12", "east": "H12"
       }
     },
     {
-      "id": "H12",
-      "terrain": "d",
+      "id": "H12", "terrain": "d",
       "exits": {
-        "north": "H11",
-        "south": "H13",
-        "west": "G12",
-        "east": "I12"
+        "north": "H11", "south": "H13", "west": "G12", "east": "I12"
       }
     },
     {
-      "id": "I12",
-      "terrain": "d",
+      "id": "I12", "terrain": "d",
       "exits": {
-        "north": "I11",
-        "south": "I13",
-        "west": "H12",
-        "east": "J12"
+        "north": "I11", "south": "I13", "west": "H12", "east": "J12"
       }
     },
     {
-      "id": "J12",
-      "terrain": "d",
+      "id": "J12", "terrain": "d",
       "exits": {
-        "north": "J11",
-        "south": "J13",
-        "west": "I12",
-        "east": "K12"
+        "north": "J11", "south": "J13", "west": "I12", "east": "K12"
       }
     },
     {
-      "id": "K12",
-      "terrain": "d",
+      "id": "K12", "terrain": "d",
       "exits": {
-        "north": "K11",
-        "south": "K13",
-        "west": "J12",
-        "east": "L12"
+        "north": "K11", "south": "K13", "west": "J12", "east": "L12"
       }
     },
     {
-      "id": "L12",
-      "terrain": "d",
+      "id": "L12", "terrain": "d",
       "exits": {
-        "north": "L11",
-        "south": "L13",
-        "west": "K12",
-        "east": "M12"
+        "north": "L11", "south": "L13", "west": "K12", "east": "M12"
       }
     },
     {
-      "id": "M12",
-      "terrain": "d",
+      "id": "M12", "terrain": "d",
       "exits": {
-        "north": "M11",
-        "south": "M13",
-        "west": "L12",
-        "east": "N12"
+        "north": "M11", "south": "M13", "west": "L12", "east": "N12"
       }
     },
     {
-      "id": "N12",
-      "terrain": "p",
+      "id": "N12", "terrain": "p",
       "exits": {
-        "north": "N11",
-        "south": "N13",
-        "west": "M12",
-        "east": "O12"
+        "north": "N11", "south": "N13", "west": "M12", "east": "O12"
       }
     },
     {
-      "id": "O12",
-      "terrain": "p",
+      "id": "O12", "terrain": "p",
       "exits": {
-        "north": "O11",
-        "south": "O13",
-        "west": "N12",
-        "east": "P12"
+        "north": "O11", "south": "O13", "west": "N12", "east": "P12"
       }
     },
     {
-      "id": "P12",
-      "terrain": "p",
+      "id": "P12", "terrain": "p",
       "exits": {
-        "north": "P11",
-        "south": "P13",
-        "west": "O12",
-        "east": "Q12"
+        "north": "P11", "south": "P13", "west": "O12", "east": "Q12"
       }
     },
     {
-      "id": "Q12",
-      "terrain": "p",
+      "id": "Q12", "terrain": "p",
       "exits": {
-        "north": "Q11",
-        "south": "Q13",
-        "west": "P12",
-        "east": "R12"
+        "north": "Q11", "south": "Q13", "west": "P12", "east": "R12"
       }
     },
     {
-      "id": "R12",
-      "terrain": "p",
+      "id": "R12", "terrain": "p",
       "exits": {
-        "north": "R11",
-        "south": "R13",
-        "west": "Q12",
-        "east": "S12"
+        "north": "R11", "south": "R13", "west": "Q12", "east": "S12"
       }
     },
     {
-      "id": "S12",
-      "terrain": "p",
+      "id": "S12", "terrain": "p",
       "exits": {
-        "north": "S11",
-        "south": "S13",
-        "west": "R12",
-        "east": "T12"
+        "north": "S11", "south": "S13", "west": "R12", "east": "T12"
       }
     },
     {
-      "id": "T12",
-      "terrain": "p",
+      "id": "T12", "terrain": "p",
       "exits": {
-        "north": "T11",
-        "south": "T13",
-        "west": "S12",
-        "east": "U12"
+        "north": "T11", "south": "T13", "west": "S12", "east": "U12"
       }
     },
     {
-      "id": "U12",
-      "terrain": "w",
+      "id": "U12", "terrain": "w",
       "exits": {
-        "north": "U11",
-        "south": "U13",
-        "west": "T12",
-        "east": "V12"
+        "north": "U11", "south": "U13", "west": "T12", "east": "V12"
       }
     },
     {
-      "id": "V12",
-      "terrain": "m",
+      "id": "V12", "terrain": "m",
       "exits": {
-        "north": "V11",
-        "south": "V13",
-        "west": "U12",
-        "east": "W12"
+        "north": "V11", "south": "V13", "west": "U12", "east": "W12"
       }
     },
     {
-      "id": "W12",
-      "terrain": "m",
+      "id": "W12", "terrain": "m",
       "exits": {
-        "north": "W11",
-        "south": "W13",
-        "west": "V12",
-        "east": "X12"
+        "north": "W11", "south": "W13", "west": "V12", "east": "X12"
       }
     },
     {
-      "id": "X12",
-      "terrain": "m",
+      "id": "X12", "terrain": "m",
       "exits": {
-        "north": "X11",
-        "south": "X13",
-        "west": "W12",
-        "east": "Y12"
+        "north": "X11", "south": "X13", "west": "W12", "east": "Y12"
       }
     },
     {
-      "id": "Y12",
-      "terrain": "r",
+      "id": "Y12", "terrain": "r",
       "exits": {
-        "north": "Y11",
-        "south": "Y13",
-        "west": "X12",
-        "east": "Z12"
+        "north": "Y11", "south": "Y13", "west": "X12", "east": "Z12"
       }
     },
     {
-      "id": "Z12",
-      "terrain": "p",
+      "id": "Z12", "terrain": "p",
       "exits": {
-        "north": "Z11",
-        "south": "Z13",
-        "west": "Y12",
-        "east": "AA12"
+        "north": "Z11", "south": "Z13", "west": "Y12", "east": "AA12"
       }
     },
     {
-      "id": "AA12",
-      "terrain": "keep",
+      "id": "AA12", "terrain": "keep",
       "exits": {
-        "north": "AA11",
-        "south": "AA13",
-        "west": "Z12",
-        "east": "AB12"
+        "north": "AA11", "south": "AA13", "west": "Z12", "east": "AB12"
       }
     },
     {
-      "id": "AB12",
-      "terrain": "m",
+      "id": "AB12", "terrain": "m",
       "exits": {
-        "north": "AB11",
-        "south": "AB13",
-        "west": "AA12",
-        "east": "AC12"
+        "north": "AB11", "south": "AB13", "west": "AA12", "east": "AC12"
       }
     },
     {
-      "id": "AC12",
-      "terrain": "m",
+      "id": "AC12", "terrain": "m",
       "exits": {
-        "north": "AC11",
-        "south": "AC13",
-        "west": "AB12",
-        "east": "AD12"
+        "north": "AC11", "south": "AC13", "west": "AB12", "east": "AD12"
       }
     },
     {
-      "id": "AD12",
-      "terrain": "p",
+      "id": "AD12", "terrain": "p",
       "exits": {
-        "north": "AD11",
-        "south": "AD13",
-        "west": "AC12",
-        "east": "AE12"
+        "north": "AD11", "south": "AD13", "west": "AC12", "east": "AE12"
       }
     },
     {
-      "id": "AE12",
-      "terrain": "p",
+      "id": "AE12", "terrain": "p",
       "exits": {
-        "north": "AE11",
-        "south": "AE13",
-        "west": "AD12",
-        "east": "AF12"
+        "north": "AE11", "south": "AE13", "west": "AD12", "east": "AF12"
       }
     },
     {
-      "id": "AF12",
-      "terrain": "p",
+      "id": "AF12", "terrain": "p",
       "exits": {
-        "north": "AF11",
-        "south": "AF13",
-        "west": "AE12",
-        "east": "AG12"
+        "north": "AF11", "south": "AF13", "west": "AE12", "east": "AG12"
       }
     },
     {
-      "id": "AG12",
-      "terrain": "p",
+      "id": "AG12", "terrain": "p",
       "exits": {
-        "north": "AG11",
-        "south": "AG13",
-        "west": "AF12",
-        "east": "AH12"
+        "north": "AG11", "south": "AG13", "west": "AF12", "east": "AH12"
       }
     },
     {
-      "id": "AH12",
-      "terrain": "p",
+      "id": "AH12", "terrain": "p",
       "exits": {
-        "north": "AH11",
-        "south": "AH13",
-        "west": "AG12",
-        "east": "AI12"
+        "north": "AH11", "south": "AH13", "west": "AG12", "east": "AI12"
       }
     },
     {
-      "id": "AI12",
-      "terrain": "p",
+      "id": "AI12", "terrain": "p",
       "exits": {
-        "north": "AI11",
-        "south": "AI13",
-        "west": "AH12",
-        "east": "AJ12"
+        "north": "AI11", "south": "AI13", "west": "AH12", "east": "AJ12"
       }
     },
     {
-      "id": "AJ12",
-      "terrain": "lf",
+      "id": "AJ12", "terrain": "lf",
       "exits": {
-        "north": "AJ11",
-        "south": "AJ13",
-        "west": "AI12",
-        "east": "AK12"
+        "north": "AJ11", "south": "AJ13", "west": "AI12", "east": "AK12"
       }
     },
     {
-      "id": "AK12",
-      "terrain": "p",
+      "id": "AK12", "terrain": "p",
       "exits": {
-        "north": "AK11",
-        "south": "AK13",
-        "west": "AJ12",
-        "east": "AL12"
+        "north": "AK11", "south": "AK13", "west": "AJ12", "east": "AL12"
       }
     },
     {
-      "id": "AL12",
-      "terrain": "d",
+      "id": "AL12", "terrain": "d",
       "exits": {
-        "north": "AL11",
-        "south": "AL13",
-        "west": "AK12",
-        "east": "AM12"
+        "north": "AL11", "south": "AL13", "west": "AK12", "east": "AM12"
       }
     },
     {
-      "id": "AM12",
-      "terrain": "d",
+      "id": "AM12", "terrain": "d",
       "exits": {
-        "north": "AM11",
-        "south": "AM13",
-        "west": "AL12",
-        "east": "AN12"
+        "north": "AM11", "south": "AM13", "west": "AL12", "east": "AN12"
       }
     },
     {
-      "id": "AN12",
-      "terrain": "d",
+      "id": "AN12", "terrain": "d",
       "exits": {
-        "north": "AN11",
-        "south": "AN13",
-        "west": "AM12",
-        "east": "AO12"
+        "north": "AN11", "south": "AN13", "west": "AM12", "east": "AO12"
       }
     },
     {
-      "id": "AO12",
-      "terrain": "lf",
+      "id": "AO12", "terrain": "lf",
       "exits": {
-        "north": "AO11",
-        "south": "AO13",
-        "west": "AN12",
-        "east": "AP12"
+        "north": "AO11", "south": "AO13", "west": "AN12", "east": "AP12"
       }
     },
     {
-      "id": "AP12",
-      "terrain": "f",
+      "id": "AP12", "terrain": "f",
       "exits": {
-        "north": "AP11",
-        "south": "AP13",
-        "west": "AO12",
-        "east": "AQ12"
+        "north": "AP11", "south": "AP13", "west": "AO12", "east": "AQ12"
       }
     },
     {
-      "id": "AQ12",
-      "terrain": "df",
+      "id": "AQ12", "terrain": "df",
       "exits": {
-        "north": "AQ11",
-        "south": "AQ13",
-        "west": "AP12",
-        "east": "AR12"
+        "north": "AQ11", "south": "AQ13", "west": "AP12", "east": "AR12"
       }
     },
     {
-      "id": "AR12",
-      "terrain": "df",
+      "id": "AR12", "terrain": "df",
       "exits": {
-        "north": "AR11",
-        "south": "AR13",
-        "west": "AQ12",
-        "east": "AS12"
+        "north": "AR11", "south": "AR13", "west": "AQ12", "east": "AS12"
       }
     },
     {
-      "id": "AS12",
-      "terrain": "df",
+      "id": "AS12", "terrain": "df",
       "exits": {
-        "north": "AS11",
-        "south": "AS13",
-        "west": "AR12",
-        "east": "AT12"
+        "north": "AS11", "south": "AS13", "west": "AR12", "east": "AT12"
       }
     },
     {
-      "id": "AT12",
-      "terrain": "df",
+      "id": "AT12", "terrain": "df",
       "exits": {
-        "north": "AT11",
-        "south": "AT13",
-        "west": "AS12",
-        "east": "AU12"
+        "north": "AT11", "south": "AT13", "west": "AS12", "east": "AU12"
       }
     },
     {
-      "id": "AU12",
-      "terrain": "lf",
+      "id": "AU12", "terrain": "lf",
       "exits": {
-        "north": "AU11",
-        "south": "AU13",
-        "west": "AT12",
-        "east": "AV12"
+        "north": "AU11", "south": "AU13", "west": "AT12", "east": "AV12"
       }
     },
     {
-      "id": "AV12",
-      "terrain": "p",
+      "id": "AV12", "terrain": "p",
       "exits": {
-        "north": "AV11",
-        "south": "AV13",
-        "west": "AU12",
-        "east": "AW12"
+        "north": "AV11", "south": "AV13", "west": "AU12", "east": "AW12"
       }
     },
     {
-      "id": "AW12",
-      "terrain": "p",
+      "id": "AW12", "terrain": "p",
       "exits": {
-        "north": "AW11",
-        "south": "AW13",
-        "west": "AV12",
-        "east": "AX12"
+        "north": "AW11", "south": "AW13", "west": "AV12", "east": "AX12"
       }
     },
     {
-      "id": "AX12",
-      "terrain": "p",
+      "id": "AX12", "terrain": "p",
       "exits": {
-        "north": "AX11",
-        "south": "AX13",
-        "west": "AW12"
+        "north": "AX11", "south": "AX13", "west": "AW12"
       }
     },
     {
-      "id": "A13",
-      "terrain": "p",
+      "id": "A13", "terrain": "p",
       "exits": {
-        "north": "A12",
-        "south": "A14",
-        "east": "B13"
+        "north": "A12", "south": "A14", "east": "B13"
       }
     },
     {
-      "id": "B13",
-      "terrain": "b",
+      "id": "B13", "terrain": "b",
       "exits": {
-        "north": "B12",
-        "south": "B14",
-        "west": "A13",
-        "east": "C13"
+        "north": "B12", "south": "B14", "west": "A13", "east": "C13"
       }
     },
     {
-      "id": "C13",
-      "terrain": "b",
+      "id": "C13", "terrain": "b",
       "exits": {
-        "north": "C12",
-        "south": "C14",
-        "west": "B13",
-        "east": "D13"
+        "north": "C12", "south": "C14", "west": "B13", "east": "D13"
       }
     },
     {
-      "id": "D13",
-      "terrain": "b",
+      "id": "D13", "terrain": "b",
       "exits": {
-        "north": "D12",
-        "south": "D14",
-        "west": "C13",
-        "east": "E13"
+        "north": "D12", "south": "D14", "west": "C13", "east": "E13"
       }
     },
     {
-      "id": "E13",
-      "terrain": "p",
+      "id": "E13", "terrain": "p",
       "exits": {
-        "north": "E12",
-        "south": "E14",
-        "west": "D13",
-        "east": "F13"
+        "north": "E12", "south": "E14", "west": "D13", "east": "F13"
       }
     },
     {
-      "id": "F13",
-      "terrain": "p",
+      "id": "F13", "terrain": "p",
       "exits": {
-        "north": "F12",
-        "south": "F14",
-        "west": "E13",
-        "east": "G13"
+        "north": "F12", "south": "F14", "west": "E13", "east": "G13"
       }
     },
     {
-      "id": "G13",
-      "terrain": "d",
+      "id": "G13", "terrain": "d",
       "exits": {
-        "north": "G12",
-        "south": "G14",
-        "west": "F13",
-        "east": "H13"
+        "north": "G12", "south": "G14", "west": "F13", "east": "H13"
       }
     },
     {
-      "id": "H13",
-      "terrain": "d",
+      "id": "H13", "terrain": "d",
       "exits": {
-        "north": "H12",
-        "south": "H14",
-        "west": "G13",
-        "east": "I13"
+        "north": "H12", "south": "H14", "west": "G13", "east": "I13"
       }
     },
     {
-      "id": "I13",
-      "terrain": "d",
+      "id": "I13", "terrain": "d",
       "exits": {
-        "north": "I12",
-        "south": "I14",
-        "west": "H13",
-        "east": "J13"
+        "north": "I12", "south": "I14", "west": "H13", "east": "J13"
       }
     },
     {
-      "id": "J13",
-      "terrain": "d",
+      "id": "J13", "terrain": "d",
       "exits": {
-        "north": "J12",
-        "south": "J14",
-        "west": "I13",
-        "east": "K13"
+        "north": "J12", "south": "J14", "west": "I13", "east": "K13"
       }
     },
     {
-      "id": "K13",
-      "terrain": "d",
+      "id": "K13", "terrain": "d",
       "exits": {
-        "north": "K12",
-        "south": "K14",
-        "west": "J13",
-        "east": "L13"
+        "north": "K12", "south": "K14", "west": "J13", "east": "L13"
       }
     },
     {
-      "id": "L13",
-      "terrain": "d",
+      "id": "L13", "terrain": "d",
       "exits": {
-        "north": "L12",
-        "south": "L14",
-        "west": "K13",
-        "east": "M13"
+        "north": "L12", "south": "L14", "west": "K13", "east": "M13"
       }
     },
     {
-      "id": "M13",
-      "terrain": "d",
+      "id": "M13", "terrain": "d",
       "exits": {
-        "north": "M12",
-        "south": "M14",
-        "west": "L13",
-        "east": "N13"
+        "north": "M12", "south": "M14", "west": "L13", "east": "N13"
       }
     },
     {
-      "id": "N13",
-      "terrain": "d",
+      "id": "N13", "terrain": "d",
       "exits": {
-        "north": "N12",
-        "south": "N14",
-        "west": "M13",
-        "east": "O13"
+        "north": "N12", "south": "N14", "west": "M13", "east": "O13"
       }
     },
     {
-      "id": "O13",
-      "terrain": "d",
+      "id": "O13", "terrain": "d",
       "exits": {
-        "north": "O12",
-        "south": "O14",
-        "west": "N13",
-        "east": "P13"
+        "north": "O12", "south": "O14", "west": "N13", "east": "P13"
       }
     },
     {
-      "id": "P13",
-      "terrain": "d",
+      "id": "P13", "terrain": "d",
       "exits": {
-        "north": "P12",
-        "south": "P14",
-        "west": "O13",
-        "east": "Q13"
+        "north": "P12", "south": "P14", "west": "O13", "east": "Q13"
       }
     },
     {
-      "id": "Q13",
-      "terrain": "d",
+      "id": "Q13", "terrain": "d",
       "exits": {
-        "north": "Q12",
-        "south": "Q14",
-        "west": "P13",
-        "east": "R13"
+        "north": "Q12", "south": "Q14", "west": "P13", "east": "R13"
       }
     },
     {
-      "id": "R13",
-      "terrain": "d",
+      "id": "R13", "terrain": "d",
       "exits": {
-        "north": "R12",
-        "south": "R14",
-        "west": "Q13",
-        "east": "S13"
+        "north": "R12", "south": "R14", "west": "Q13", "east": "S13"
       }
     },
     {
-      "id": "S13",
-      "terrain": "p",
+      "id": "S13", "terrain": "p",
       "exits": {
-        "north": "S12",
-        "south": "S14",
-        "west": "R13",
-        "east": "T13"
+        "north": "S12", "south": "S14", "west": "R13", "east": "T13"
       }
     },
     {
-      "id": "T13",
-      "terrain": "w",
+      "id": "T13", "terrain": "w",
       "exits": {
-        "north": "T12",
-        "south": "T14",
-        "west": "S13",
-        "east": "U13"
+        "north": "T12", "south": "T14", "west": "S13", "east": "U13"
       }
     },
     {
-      "id": "U13",
-      "terrain": "m",
+      "id": "U13", "terrain": "m",
       "exits": {
-        "north": "U12",
-        "south": "U14",
-        "west": "T13",
-        "east": "V13"
+        "north": "U12", "south": "U14", "west": "T13", "east": "V13"
       }
     },
     {
-      "id": "V13",
-      "terrain": "m",
+      "id": "V13", "terrain": "m",
       "exits": {
-        "north": "V12",
-        "south": "V14",
-        "west": "U13",
-        "east": "W13"
+        "north": "V12", "south": "V14", "west": "U13", "east": "W13"
       }
     },
     {
-      "id": "W13",
-      "terrain": "m",
+      "id": "W13", "terrain": "m",
       "exits": {
-        "north": "W12",
-        "south": "W14",
-        "west": "V13",
-        "east": "X13"
+        "north": "W12", "south": "W14", "west": "V13", "east": "X13"
       }
     },
     {
-      "id": "X13",
-      "terrain": "m",
+      "id": "X13", "terrain": "m",
       "exits": {
-        "north": "X12",
-        "south": "X14",
-        "west": "W13",
-        "east": "Y13"
+        "north": "X12", "south": "X14", "west": "W13", "east": "Y13"
       }
     },
     {
-      "id": "Y13",
-      "terrain": "r",
+      "id": "Y13", "terrain": "r",
       "exits": {
-        "north": "Y12",
-        "south": "Y14",
-        "west": "X13",
-        "east": "Z13"
+        "north": "Y12", "south": "Y14", "west": "X13", "east": "Z13"
       }
     },
     {
-      "id": "Z13",
-      "terrain": "p",
+      "id": "Z13", "terrain": "p",
       "exits": {
-        "north": "Z12",
-        "south": "Z14",
-        "west": "Y13",
-        "east": "AA13"
+        "north": "Z12", "south": "Z14", "west": "Y13", "east": "AA13"
       }
     },
     {
-      "id": "AA13",
-      "terrain": "p",
+      "id": "AA13", "terrain": "p",
       "exits": {
-        "north": "AA12",
-        "south": "AA14",
-        "west": "Z13",
-        "east": "AB13"
+        "north": "AA12", "south": "AA14", "west": "Z13", "east": "AB13"
       }
     },
     {
-      "id": "AB13",
-      "terrain": "p",
+      "id": "AB13", "terrain": "p",
       "exits": {
-        "north": "AB12",
-        "south": "AB14",
-        "west": "AA13",
-        "east": "AC13"
+        "north": "AB12", "south": "AB14", "west": "AA13", "east": "AC13"
       }
     },
     {
-      "id": "AC13",
-      "terrain": "p",
+      "id": "AC13", "terrain": "p",
       "exits": {
-        "north": "AC12",
-        "south": "AC14",
-        "west": "AB13",
-        "east": "AD13"
+        "north": "AC12", "south": "AC14", "west": "AB13", "east": "AD13"
       }
     },
     {
-      "id": "AD13",
-      "terrain": "p",
+      "id": "AD13", "terrain": "p",
       "exits": {
-        "north": "AD12",
-        "south": "AD14",
-        "west": "AC13",
-        "east": "AE13"
+        "north": "AD12", "south": "AD14", "west": "AC13", "east": "AE13"
       }
     },
     {
-      "id": "AE13",
-      "terrain": "p",
+      "id": "AE13", "terrain": "p",
       "exits": {
-        "north": "AE12",
-        "south": "AE14",
-        "west": "AD13",
-        "east": "AF13"
+        "north": "AE12", "south": "AE14", "west": "AD13", "east": "AF13"
       }
     },
     {
-      "id": "AF13",
-      "terrain": "p",
+      "id": "AF13", "terrain": "p",
       "exits": {
-        "north": "AF12",
-        "south": "AF14",
-        "west": "AE13",
-        "east": "AG13"
+        "north": "AF12", "south": "AF14", "west": "AE13", "east": "AG13"
       }
     },
     {
-      "id": "AG13",
-      "terrain": "p",
+      "id": "AG13", "terrain": "p",
       "exits": {
-        "north": "AG12",
-        "south": "AG14",
-        "west": "AF13",
-        "east": "AH13"
+        "north": "AG12", "south": "AG14", "west": "AF13", "east": "AH13"
       }
     },
     {
-      "id": "AH13",
-      "terrain": "p",
+      "id": "AH13", "terrain": "p",
       "exits": {
-        "north": "AH12",
-        "south": "AH14",
-        "west": "AG13",
-        "east": "AI13"
+        "north": "AH12", "south": "AH14", "west": "AG13", "east": "AI13"
       }
     },
     {
-      "id": "AI13",
-      "terrain": "p",
+      "id": "AI13", "terrain": "p",
       "exits": {
-        "north": "AI12",
-        "south": "AI14",
-        "west": "AH13",
-        "east": "AJ13"
+        "north": "AI12", "south": "AI14", "west": "AH13", "east": "AJ13"
       }
     },
     {
-      "id": "AJ13",
-      "terrain": "lf",
+      "id": "AJ13", "terrain": "lf",
       "exits": {
-        "north": "AJ12",
-        "south": "AJ14",
-        "west": "AI13",
-        "east": "AK13"
+        "north": "AJ12", "south": "AJ14", "west": "AI13", "east": "AK13"
       }
     },
     {
-      "id": "AK13",
-      "terrain": "lf",
+      "id": "AK13", "terrain": "lf",
       "exits": {
-        "north": "AK12",
-        "south": "AK14",
-        "west": "AJ13",
-        "east": "AL13"
+        "north": "AK12", "south": "AK14", "west": "AJ13", "east": "AL13"
       }
     },
     {
-      "id": "AL13",
-      "terrain": "d",
+      "id": "AL13", "terrain": "d",
       "exits": {
-        "north": "AL12",
-        "south": "AL14",
-        "west": "AK13",
-        "east": "AM13"
+        "north": "AL12", "south": "AL14", "west": "AK13", "east": "AM13"
       }
     },
     {
-      "id": "AM13",
-      "terrain": "d",
+      "id": "AM13", "terrain": "d",
       "exits": {
-        "north": "AM12",
-        "south": "AM14",
-        "west": "AL13",
-        "east": "AN13"
+        "north": "AM12", "south": "AM14", "west": "AL13", "east": "AN13"
       }
     },
     {
-      "id": "AN13",
-      "terrain": "lf",
+      "id": "AN13", "terrain": "lf",
       "exits": {
-        "north": "AN12",
-        "south": "AN14",
-        "west": "AM13",
-        "east": "AO13"
+        "north": "AN12", "south": "AN14", "west": "AM13", "east": "AO13"
       }
     },
     {
-      "id": "AO13",
-      "terrain": "lf",
+      "id": "AO13", "terrain": "lf",
       "exits": {
-        "north": "AO12",
-        "south": "AO14",
-        "west": "AN13",
-        "east": "AP13"
+        "north": "AO12", "south": "AO14", "west": "AN13", "east": "AP13"
       }
     },
     {
-      "id": "AP13",
-      "terrain": "f",
+      "id": "AP13", "terrain": "f",
       "exits": {
-        "north": "AP12",
-        "south": "AP14",
-        "west": "AO13",
-        "east": "AQ13"
+        "north": "AP12", "south": "AP14", "west": "AO13", "east": "AQ13"
       }
     },
     {
-      "id": "AQ13",
-      "terrain": "df",
+      "id": "AQ13", "terrain": "df",
       "exits": {
-        "north": "AQ12",
-        "south": "AQ14",
-        "west": "AP13",
-        "east": "AR13"
+        "north": "AQ12", "south": "AQ14", "west": "AP13", "east": "AR13"
       }
     },
     {
-      "id": "AR13",
-      "terrain": "df",
+      "id": "AR13", "terrain": "df",
       "exits": {
-        "north": "AR12",
-        "south": "AR14",
-        "west": "AQ13",
-        "east": "AS13"
+        "north": "AR12", "south": "AR14", "west": "AQ13", "east": "AS13"
       }
     },
     {
-      "id": "AS13",
-      "terrain": "df",
+      "id": "AS13", "terrain": "df",
       "exits": {
-        "north": "AS12",
-        "south": "AS14",
-        "west": "AR13",
-        "east": "AT13"
+        "north": "AS12", "south": "AS14", "west": "AR13", "east": "AT13"
       }
     },
     {
-      "id": "AT13",
-      "terrain": "Dark F",
+      "id": "AT13", "terrain": "Dark F",
       "exits": {
-        "north": "AT12",
-        "south": "AT14",
-        "west": "AS13",
-        "east": "AU13"
+        "north": "AT12", "south": "AT14", "west": "AS13", "east": "AU13"
       }
     },
     {
-      "id": "AU13",
-      "terrain": "f",
+      "id": "AU13", "terrain": "f",
       "exits": {
-        "north": "AU12",
-        "south": "AU14",
-        "west": "AT13",
-        "east": "AV13"
+        "north": "AU12", "south": "AU14", "west": "AT13", "east": "AV13"
       }
     },
     {
-      "id": "AV13",
-      "terrain": "lf",
+      "id": "AV13", "terrain": "lf",
       "exits": {
-        "north": "AV12",
-        "south": "AV14",
-        "west": "AU13",
-        "east": "AW13"
+        "north": "AV12", "south": "AV14", "west": "AU13", "east": "AW13"
       }
     },
     {
-      "id": "AW13",
-      "terrain": "lf",
+      "id": "AW13", "terrain": "lf",
       "exits": {
-        "north": "AW12",
-        "south": "AW14",
-        "west": "AV13",
-        "east": "AX13"
+        "north": "AW12", "south": "AW14", "west": "AV13", "east": "AX13"
       }
     },
     {
-      "id": "AX13",
-      "terrain": "p",
+      "id": "AX13", "terrain": "p",
       "exits": {
-        "north": "AX12",
-        "south": "AX14",
-        "west": "AW13"
+        "north": "AX12", "south": "AX14", "west": "AW13"
       }
     },
     {
-      "id": "A14",
-      "terrain": "p",
+      "id": "A14", "terrain": "p",
       "exits": {
-        "north": "A13",
-        "south": "A15",
-        "east": "B14"
+        "north": "A13", "south": "A15", "east": "B14"
       }
     },
     {
-      "id": "B14",
-      "terrain": "b",
+      "id": "B14", "terrain": "b",
       "exits": {
-        "north": "B13",
-        "south": "B15",
-        "west": "A14",
-        "east": "C14"
+        "north": "B13", "south": "B15", "west": "A14", "east": "C14"
       }
     },
     {
-      "id": "C14",
-      "terrain": "b",
+      "id": "C14", "terrain": "b",
       "exits": {
-        "north": "C13",
-        "south": "C15",
-        "west": "B14",
-        "east": "D14"
+        "north": "C13", "south": "C15", "west": "B14", "east": "D14"
       }
     },
     {
-      "id": "D14",
-      "terrain": "p",
+      "id": "D14", "terrain": "p",
       "exits": {
-        "north": "D13",
-        "south": "D15",
-        "west": "C14",
-        "east": "E14"
+        "north": "D13", "south": "D15", "west": "C14", "east": "E14"
       }
     },
     {
-      "id": "E14",
-      "terrain": "p",
+      "id": "E14", "terrain": "p",
       "exits": {
-        "north": "E13",
-        "south": "E15",
-        "west": "D14",
-        "east": "F14"
+        "north": "E13", "south": "E15", "west": "D14", "east": "F14"
       }
     },
     {
-      "id": "F14",
-      "terrain": "p",
+      "id": "F14", "terrain": "p",
       "exits": {
-        "north": "F13",
-        "south": "F15",
-        "west": "E14",
-        "east": "G14"
+        "north": "F13", "south": "F15", "west": "E14", "east": "G14"
       }
     },
     {
-      "id": "G14",
-      "terrain": "p",
+      "id": "G14", "terrain": "p",
       "exits": {
-        "north": "G13",
-        "south": "G15",
-        "west": "F14",
-        "east": "H14"
+        "north": "G13", "south": "G15", "west": "F14", "east": "H14"
       }
     },
     {
-      "id": "H14",
-      "terrain": "d",
+      "id": "H14", "terrain": "d",
       "exits": {
-        "north": "H13",
-        "south": "H15",
-        "west": "G14",
-        "east": "I14"
+        "north": "H13", "south": "H15", "west": "G14", "east": "I14"
       }
     },
     {
-      "id": "I14",
-      "terrain": "d",
+      "id": "I14", "terrain": "d",
       "exits": {
-        "north": "I13",
-        "south": "I15",
-        "west": "H14",
-        "east": "J14"
+        "north": "I13", "south": "I15", "west": "H14", "east": "J14"
       }
     },
     {
-      "id": "J14",
-      "terrain": "d",
+      "id": "J14", "terrain": "d",
       "exits": {
-        "north": "J13",
-        "south": "J15",
-        "west": "I14",
-        "east": "K14"
+        "north": "J13", "south": "J15", "west": "I14", "east": "K14"
       }
     },
     {
-      "id": "K14",
-      "terrain": "d",
+      "id": "K14", "terrain": "d",
       "exits": {
-        "north": "K13",
-        "south": "K15",
-        "west": "J14",
-        "east": "L14"
+        "north": "K13", "south": "K15", "west": "J14", "east": "L14"
       }
     },
     {
-      "id": "L14",
-      "terrain": "d",
+      "id": "L14", "terrain": "d",
       "exits": {
-        "north": "L13",
-        "south": "L15",
-        "west": "K14",
-        "east": "M14"
+        "north": "L13", "south": "L15", "west": "K14", "east": "M14"
       }
     },
     {
-      "id": "M14",
-      "terrain": "d",
+      "id": "M14", "terrain": "d",
       "exits": {
-        "north": "M13",
-        "south": "M15",
-        "west": "L14",
-        "east": "N14"
+        "north": "M13", "south": "M15", "west": "L14", "east": "N14"
       }
     },
     {
-      "id": "N14",
-      "terrain": "p",
+      "id": "N14", "terrain": "p",
       "exits": {
-        "north": "N13",
-        "south": "N15",
-        "west": "M14",
-        "east": "O14"
+        "north": "N13", "south": "N15", "west": "M14", "east": "O14"
       }
     },
     {
-      "id": "O14",
-      "terrain": "p",
+      "id": "O14", "terrain": "p",
       "exits": {
-        "north": "O13",
-        "south": "O15",
-        "west": "N14",
-        "east": "P14"
+        "north": "O13", "south": "O15", "west": "N14", "east": "P14"
       }
     },
     {
-      "id": "P14",
-      "terrain": "p",
+      "id": "P14", "terrain": "p",
       "exits": {
-        "north": "P13",
-        "south": "P15",
-        "west": "O14",
-        "east": "Q14"
+        "north": "P13", "south": "P15", "west": "O14", "east": "Q14"
       }
     },
     {
-      "id": "Q14",
-      "terrain": "p",
+      "id": "Q14", "terrain": "p",
       "exits": {
-        "north": "Q13",
-        "south": "Q15",
-        "west": "P14",
-        "east": "R14"
+        "north": "Q13", "south": "Q15", "west": "P14", "east": "R14"
       }
     },
     {
-      "id": "R14",
-      "terrain": "p",
+      "id": "R14", "terrain": "p",
       "exits": {
-        "north": "R13",
-        "south": "R15",
-        "west": "Q14",
-        "east": "S14"
+        "north": "R13", "south": "R15", "west": "Q14", "east": "S14"
       }
     },
     {
-      "id": "S14",
-      "terrain": "p",
+      "id": "S14", "terrain": "p",
       "exits": {
-        "north": "S13",
-        "south": "S15",
-        "west": "R14",
-        "east": "T14"
+        "north": "S13", "south": "S15", "west": "R14", "east": "T14"
       }
     },
     {
-      "id": "T14",
-      "terrain": "w",
+      "id": "T14", "terrain": "w",
       "exits": {
-        "north": "T13",
-        "south": "T15",
-        "west": "S14",
-        "east": "U14"
+        "north": "T13", "south": "T15", "west": "S14", "east": "U14"
       }
     },
     {
-      "id": "U14",
-      "terrain": "m",
+      "id": "U14", "terrain": "m",
       "exits": {
-        "north": "U13",
-        "south": "U15",
-        "west": "T14",
-        "east": "V14"
+        "north": "U13", "south": "U15", "west": "T14", "east": "V14"
       }
     },
     {
-      "id": "V14",
-      "terrain": "m",
+      "id": "V14", "terrain": "m",
       "exits": {
-        "north": "V13",
-        "south": "V15",
-        "west": "U14",
-        "east": "W14"
+        "north": "V13", "south": "V15", "west": "U14", "east": "W14"
       }
     },
     {
-      "id": "W14",
-      "terrain": "m",
+      "id": "W14", "terrain": "m",
       "exits": {
-        "north": "W13",
-        "south": "W15",
-        "west": "V14",
-        "east": "X14"
+        "north": "W13", "south": "W15", "west": "V14", "east": "X14"
       }
     },
     {
-      "id": "X14",
-      "terrain": "m",
+      "id": "X14", "terrain": "m",
       "exits": {
-        "north": "X13",
-        "south": "X15",
-        "west": "W14",
-        "east": "Y14"
+        "north": "X13", "south": "X15", "west": "W14", "east": "Y14"
       }
     },
     {
-      "id": "Y14",
-      "terrain": "r",
+      "id": "Y14", "terrain": "r",
       "exits": {
-        "north": "Y13",
-        "south": "Y15",
-        "west": "X14",
-        "east": "Z14"
+        "north": "Y13", "south": "Y15", "west": "X14", "east": "Z14"
       }
     },
     {
-      "id": "Z14",
-      "terrain": "p",
+      "id": "Z14", "terrain": "p",
       "exits": {
-        "north": "Z13",
-        "south": "Z15",
-        "west": "Y14",
-        "east": "AA14"
+        "north": "Z13", "south": "Z15", "west": "Y14", "east": "AA14"
       }
     },
     {
-      "id": "AA14",
-      "terrain": "p",
+      "id": "AA14", "terrain": "p",
       "exits": {
-        "north": "AA13",
-        "south": "AA15",
-        "west": "Z14",
-        "east": "AB14"
+        "north": "AA13", "south": "AA15", "west": "Z14", "east": "AB14"
       }
     },
     {
-      "id": "AB14",
-      "terrain": "p",
+      "id": "AB14", "terrain": "p",
       "exits": {
-        "north": "AB13",
-        "south": "AB15",
-        "west": "AA14",
-        "east": "AC14"
+        "north": "AB13", "south": "AB15", "west": "AA14", "east": "AC14"
       }
     },
     {
-      "id": "AC14",
-      "terrain": "p",
+      "id": "AC14", "terrain": "p",
       "exits": {
-        "north": "AC13",
-        "south": "AC15",
-        "west": "AB14",
-        "east": "AD14"
+        "north": "AC13", "south": "AC15", "west": "AB14", "east": "AD14"
       }
     },
     {
-      "id": "AD14",
-      "terrain": "p",
+      "id": "AD14", "terrain": "p",
       "exits": {
-        "north": "AD13",
-        "south": "AD15",
-        "west": "AC14",
-        "east": "AE14"
+        "north": "AD13", "south": "AD15", "west": "AC14", "east": "AE14"
       }
     },
     {
-      "id": "AE14",
-      "terrain": "p",
+      "id": "AE14", "terrain": "p",
       "exits": {
-        "north": "AE13",
-        "south": "AE15",
-        "west": "AD14",
-        "east": "AF14"
+        "north": "AE13", "south": "AE15", "west": "AD14", "east": "AF14"
       }
     },
     {
-      "id": "AF14",
-      "terrain": "p",
+      "id": "AF14", "terrain": "p",
       "exits": {
-        "north": "AF13",
-        "south": "AF15",
-        "west": "AE14",
-        "east": "AG14"
+        "north": "AF13", "south": "AF15", "west": "AE14", "east": "AG14"
       }
     },
     {
-      "id": "AG14",
-      "terrain": "p",
+      "id": "AG14", "terrain": "p",
       "exits": {
-        "north": "AG13",
-        "south": "AG15",
-        "west": "AF14",
-        "east": "AH14"
+        "north": "AG13", "south": "AG15", "west": "AF14", "east": "AH14"
       }
     },
     {
-      "id": "AH14",
-      "terrain": "p",
+      "id": "AH14", "terrain": "p",
       "exits": {
-        "north": "AH13",
-        "south": "AH15",
-        "west": "AG14",
-        "east": "AI14"
+        "north": "AH13", "south": "AH15", "west": "AG14", "east": "AI14"
       }
     },
     {
-      "id": "AI14",
-      "terrain": "p",
+      "id": "AI14", "terrain": "p",
       "exits": {
-        "north": "AI13",
-        "south": "AI15",
-        "west": "AH14",
-        "east": "AJ14"
+        "north": "AI13", "south": "AI15", "west": "AH14", "east": "AJ14"
       }
     },
     {
-      "id": "AJ14",
-      "terrain": "lf",
+      "id": "AJ14", "terrain": "lf",
       "exits": {
-        "north": "AJ13",
-        "south": "AJ15",
-        "west": "AI14",
-        "east": "AK14"
+        "north": "AJ13", "south": "AJ15", "west": "AI14", "east": "AK14"
       }
     },
     {
-      "id": "AK14",
-      "terrain": "lf",
+      "id": "AK14", "terrain": "lf",
       "exits": {
-        "north": "AK13",
-        "south": "AK15",
-        "west": "AJ14",
-        "east": "AL14"
+        "north": "AK13", "south": "AK15", "west": "AJ14", "east": "AL14"
       }
     },
     {
-      "id": "AL14",
-      "terrain": "lf",
+      "id": "AL14", "terrain": "lf",
       "exits": {
-        "north": "AL13",
-        "south": "AL15",
-        "west": "AK14",
-        "east": "AM14"
+        "north": "AL13", "south": "AL15", "west": "AK14", "east": "AM14"
       }
     },
     {
-      "id": "AM14",
-      "terrain": "lf",
+      "id": "AM14", "terrain": "lf",
       "exits": {
-        "north": "AM13",
-        "south": "AM15",
-        "west": "AL14",
-        "east": "AN14"
+        "north": "AM13", "south": "AM15", "west": "AL14", "east": "AN14"
       }
     },
     {
-      "id": "AN14",
-      "terrain": "f",
+      "id": "AN14", "terrain": "f",
       "exits": {
-        "north": "AN13",
-        "south": "AN15",
-        "west": "AM14",
-        "east": "AO14"
+        "north": "AN13", "south": "AN15", "west": "AM14", "east": "AO14"
       }
     },
     {
-      "id": "AO14",
-      "terrain": "f",
+      "id": "AO14", "terrain": "f",
       "exits": {
-        "north": "AO13",
-        "south": "AO15",
-        "west": "AN14",
-        "east": "AP14"
+        "north": "AO13", "south": "AO15", "west": "AN14", "east": "AP14"
       }
     },
     {
-      "id": "AP14",
-      "terrain": "f",
+      "id": "AP14", "terrain": "f",
       "exits": {
-        "north": "AP13",
-        "south": "AP15",
-        "west": "AO14",
-        "east": "AQ14"
+        "north": "AP13", "south": "AP15", "west": "AO14", "east": "AQ14"
       }
     },
     {
-      "id": "AQ14",
-      "terrain": "df",
+      "id": "AQ14", "terrain": "df",
       "exits": {
-        "north": "AQ13",
-        "south": "AQ15",
-        "west": "AP14",
-        "east": "AR14"
+        "north": "AQ13", "south": "AQ15", "west": "AP14", "east": "AR14"
       }
     },
     {
-      "id": "AR14",
-      "terrain": "df",
+      "id": "AR14", "terrain": "df",
       "exits": {
-        "north": "AR13",
-        "south": "AR15",
-        "west": "AQ14",
-        "east": "AS14"
+        "north": "AR13", "south": "AR15", "west": "AQ14", "east": "AS14"
       }
     },
     {
-      "id": "AS14",
-      "terrain": "df",
+      "id": "AS14", "terrain": "df",
       "exits": {
-        "north": "AS13",
-        "south": "AS15",
-        "west": "AR14",
-        "east": "AT14"
+        "north": "AS13", "south": "AS15", "west": "AR14", "east": "AT14"
       }
     },
     {
-      "id": "AT14",
-      "terrain": "f",
+      "id": "AT14", "terrain": "f",
       "exits": {
-        "north": "AT13",
-        "south": "AT15",
-        "west": "AS14",
-        "east": "AU14"
+        "north": "AT13", "south": "AT15", "west": "AS14", "east": "AU14"
       }
     },
     {
-      "id": "AU14",
-      "terrain": "f",
+      "id": "AU14", "terrain": "f",
       "exits": {
-        "north": "AU13",
-        "south": "AU15",
-        "west": "AT14",
-        "east": "AV14"
+        "north": "AU13", "south": "AU15", "west": "AT14", "east": "AV14"
       }
     },
     {
-      "id": "AV14",
-      "terrain": "f",
+      "id": "AV14", "terrain": "f",
       "exits": {
-        "north": "AV13",
-        "south": "AV15",
-        "west": "AU14",
-        "east": "AW14"
+        "north": "AV13", "south": "AV15", "west": "AU14", "east": "AW14"
       }
     },
     {
-      "id": "AW14",
-      "terrain": "lf",
+      "id": "AW14", "terrain": "lf",
       "exits": {
-        "north": "AW13",
-        "south": "AW15",
-        "west": "AV14",
-        "east": "AX14"
+        "north": "AW13", "south": "AW15", "west": "AV14", "east": "AX14"
       }
     },
     {
-      "id": "AX14",
-      "terrain": "lf",
+      "id": "AX14", "terrain": "lf",
       "exits": {
-        "north": "AX13",
-        "south": "AX15",
-        "west": "AW14"
+        "north": "AX13", "south": "AX15", "west": "AW14"
       }
     },
     {
-      "id": "A15",
-      "terrain": "p",
+      "id": "A15", "terrain": "p",
       "exits": {
-        "north": "A14",
-        "south": "A16",
-        "east": "B15"
+        "north": "A14", "south": "A16", "east": "B15"
       }
     },
     {
-      "id": "B15",
-      "terrain": "p",
+      "id": "B15", "terrain": "p",
       "exits": {
-        "north": "B14",
-        "south": "B16",
-        "west": "A15",
-        "east": "C15"
+        "north": "B14", "south": "B16", "west": "A15", "east": "C15"
       }
     },
     {
-      "id": "C15",
-      "terrain": "p",
+      "id": "C15", "terrain": "p",
       "exits": {
-        "north": "C14",
-        "south": "C16",
-        "west": "B15",
-        "east": "D15"
+        "north": "C14", "south": "C16", "west": "B15", "east": "D15"
       }
     },
     {
-      "id": "D15",
-      "terrain": "p",
+      "id": "D15", "terrain": "p",
       "exits": {
-        "north": "D14",
-        "south": "D16",
-        "west": "C15",
-        "east": "E15"
+        "north": "D14", "south": "D16", "west": "C15", "east": "E15"
       }
     },
     {
-      "id": "E15",
-      "terrain": "p",
+      "id": "E15", "terrain": "p",
       "exits": {
-        "north": "E14",
-        "south": "E16",
-        "west": "D15",
-        "east": "F15"
+        "north": "E14", "south": "E16", "west": "D15", "east": "F15"
       }
     },
     {
-      "id": "F15",
-      "terrain": "p",
+      "id": "F15", "terrain": "p",
       "exits": {
-        "north": "F14",
-        "south": "F16",
-        "west": "E15",
-        "east": "G15"
+        "north": "F14", "south": "F16", "west": "E15", "east": "G15"
       }
     },
     {
-      "id": "G15",
-      "terrain": "p",
+      "id": "G15", "terrain": "p",
       "exits": {
-        "north": "G14",
-        "south": "G16",
-        "west": "F15",
-        "east": "H15"
+        "north": "G14", "south": "G16", "west": "F15", "east": "H15"
       }
     },
     {
-      "id": "H15",
-      "terrain": "p",
+      "id": "H15", "terrain": "p",
       "exits": {
-        "north": "H14",
-        "south": "H16",
-        "west": "G15",
-        "east": "I15"
+        "north": "H14", "south": "H16", "west": "G15", "east": "I15"
       }
     },
     {
-      "id": "I15",
-      "terrain": "d",
+      "id": "I15", "terrain": "d",
       "exits": {
-        "north": "I14",
-        "south": "I16",
-        "west": "H15",
-        "east": "J15"
+        "north": "I14", "south": "I16", "west": "H15", "east": "J15"
       }
     },
     {
-      "id": "J15",
-      "terrain": "d",
+      "id": "J15", "terrain": "d",
       "exits": {
-        "north": "J14",
-        "south": "J16",
-        "west": "I15",
-        "east": "K15"
+        "north": "J14", "south": "J16", "west": "I15", "east": "K15"
       }
     },
     {
-      "id": "K15",
-      "terrain": "d",
+      "id": "K15", "terrain": "d",
       "exits": {
-        "north": "K14",
-        "south": "K16",
-        "west": "J15",
-        "east": "L15"
+        "north": "K14", "south": "K16", "west": "J15", "east": "L15"
       }
     },
     {
-      "id": "L15",
-      "terrain": "p",
+      "id": "L15", "terrain": "p",
       "exits": {
-        "north": "L14",
-        "south": "L16",
-        "west": "K15",
-        "east": "M15"
+        "north": "L14", "south": "L16", "west": "K15", "east": "M15"
       }
     },
     {
-      "id": "M15",
-      "terrain": "p",
+      "id": "M15", "terrain": "p",
       "exits": {
-        "north": "M14",
-        "south": "M16",
-        "west": "L15",
-        "east": "N15"
+        "north": "M14", "south": "M16", "west": "L15", "east": "N15"
       }
     },
     {
-      "id": "N15",
-      "terrain": "p",
+      "id": "N15", "terrain": "p",
       "exits": {
-        "north": "N14",
-        "south": "N16",
-        "west": "M15",
-        "east": "O15"
+        "north": "N14", "south": "N16", "west": "M15", "east": "O15"
       }
     },
     {
-      "id": "O15",
-      "terrain": "p",
+      "id": "O15", "terrain": "p",
       "exits": {
-        "north": "O14",
-        "south": "O16",
-        "west": "N15",
-        "east": "P15"
+        "north": "O14", "south": "O16", "west": "N15", "east": "P15"
       }
     },
     {
-      "id": "P15",
-      "terrain": "p",
+      "id": "P15", "terrain": "p",
       "exits": {
-        "north": "P14",
-        "south": "P16",
-        "west": "O15",
-        "east": "Q15"
+        "north": "P14", "south": "P16", "west": "O15", "east": "Q15"
       }
     },
     {
-      "id": "Q15",
-      "terrain": "p",
+      "id": "Q15", "terrain": "p",
       "exits": {
-        "north": "Q14",
-        "south": "Q16",
-        "west": "P15",
-        "east": "R15"
+        "north": "Q14", "south": "Q16", "west": "P15", "east": "R15"
       }
     },
     {
-      "id": "R15",
-      "terrain": "p",
+      "id": "R15", "terrain": "p",
       "exits": {
-        "north": "R14",
-        "south": "R16",
-        "west": "Q15",
-        "east": "S15"
+        "north": "R14", "south": "R16", "west": "Q15", "east": "S15"
       }
     },
     {
-      "id": "S15",
-      "terrain": "p",
+      "id": "S15", "terrain": "p",
       "exits": {
-        "north": "S14",
-        "south": "S16",
-        "west": "R15",
-        "east": "T15"
+        "north": "S14", "south": "S16", "west": "R15", "east": "T15"
       }
     },
     {
-      "id": "T15",
-      "terrain": "w",
+      "id": "T15", "terrain": "w",
       "exits": {
-        "north": "T14",
-        "south": "T16",
-        "west": "S15",
-        "east": "U15"
+        "north": "T14", "south": "T16", "west": "S15", "east": "U15"
       }
     },
     {
-      "id": "U15",
-      "terrain": "m",
+      "id": "U15", "terrain": "m",
       "exits": {
-        "north": "U14",
-        "south": "U16",
-        "west": "T15",
-        "east": "V15"
+        "north": "U14", "south": "U16", "west": "T15", "east": "V15"
       }
     },
     {
-      "id": "V15",
-      "terrain": "m",
+      "id": "V15", "terrain": "m",
       "exits": {
-        "north": "V14",
-        "south": "V16",
-        "west": "U15",
-        "east": "W15"
+        "north": "V14", "south": "V16", "west": "U15", "east": "W15"
       }
     },
     {
-      "id": "W15",
-      "terrain": "m",
+      "id": "W15", "terrain": "m",
       "exits": {
-        "north": "W14",
-        "south": "W16",
-        "west": "V15",
-        "east": "X15"
+        "north": "W14", "south": "W16", "west": "V15", "east": "X15"
       }
     },
     {
-      "id": "X15",
-      "terrain": "m",
+      "id": "X15", "terrain": "m",
       "exits": {
-        "north": "X14",
-        "south": "X16",
-        "west": "W15",
-        "east": "Y15"
+        "north": "X14", "south": "X16", "west": "W15", "east": "Y15"
       }
     },
     {
-      "id": "Y15",
-      "terrain": "r",
+      "id": "Y15", "terrain": "r",
       "exits": {
-        "north": "Y14",
-        "south": "Y16",
-        "west": "X15",
-        "east": "Z15"
+        "north": "Y14", "south": "Y16", "west": "X15", "east": "Z15"
       }
     },
     {
-      "id": "Z15",
-      "terrain": "p",
+      "id": "Z15", "terrain": "p",
       "exits": {
-        "north": "Z14",
-        "south": "Z16",
-        "west": "Y15",
-        "east": "AA15"
+        "north": "Z14", "south": "Z16", "west": "Y15", "east": "AA15"
       }
     },
     {
-      "id": "AA15",
-      "terrain": "p",
+      "id": "AA15", "terrain": "p",
       "exits": {
-        "north": "AA14",
-        "south": "AA16",
-        "west": "Z15",
-        "east": "AB15"
+        "north": "AA14", "south": "AA16", "west": "Z15", "east": "AB15"
       }
     },
     {
-      "id": "AB15",
-      "terrain": "p",
+      "id": "AB15", "terrain": "p",
       "exits": {
-        "north": "AB14",
-        "south": "AB16",
-        "west": "AA15",
-        "east": "AC15"
+        "north": "AB14", "south": "AB16", "west": "AA15", "east": "AC15"
       }
     },
     {
-      "id": "AC15",
-      "terrain": "p",
+      "id": "AC15", "terrain": "p",
       "exits": {
-        "north": "AC14",
-        "south": "AC16",
-        "west": "AB15",
-        "east": "AD15"
+        "north": "AC14", "south": "AC16", "west": "AB15", "east": "AD15"
       }
     },
     {
-      "id": "AD15",
-      "terrain": "p",
+      "id": "AD15", "terrain": "p",
       "exits": {
-        "north": "AD14",
-        "south": "AD16",
-        "west": "AC15",
-        "east": "AE15"
+        "north": "AD14", "south": "AD16", "west": "AC15", "east": "AE15"
       }
     },
     {
-      "id": "AE15",
-      "terrain": "p",
+      "id": "AE15", "terrain": "p",
       "exits": {
-        "north": "AE14",
-        "south": "AE16",
-        "west": "AD15",
-        "east": "AF15"
+        "north": "AE14", "south": "AE16", "west": "AD15", "east": "AF15"
       }
     },
     {
-      "id": "AF15",
-      "terrain": "p",
+      "id": "AF15", "terrain": "p",
       "exits": {
-        "north": "AF14",
-        "south": "AF16",
-        "west": "AE15",
-        "east": "AG15"
+        "north": "AF14", "south": "AF16", "west": "AE15", "east": "AG15"
       }
     },
     {
-      "id": "AG15",
-      "terrain": "p",
+      "id": "AG15", "terrain": "p",
       "exits": {
-        "north": "AG14",
-        "south": "AG16",
-        "west": "AF15",
-        "east": "AH15"
+        "north": "AG14", "south": "AG16", "west": "AF15", "east": "AH15"
       }
     },
     {
-      "id": "AH15",
-      "terrain": "p",
+      "id": "AH15", "terrain": "p",
       "exits": {
-        "north": "AH14",
-        "south": "AH16",
-        "west": "AG15",
-        "east": "AI15"
+        "north": "AH14", "south": "AH16", "west": "AG15", "east": "AI15"
       }
     },
     {
-      "id": "AI15",
-      "terrain": "p",
+      "id": "AI15", "terrain": "p",
       "exits": {
-        "north": "AI14",
-        "south": "AI16",
-        "west": "AH15",
-        "east": "AJ15"
+        "north": "AI14", "south": "AI16", "west": "AH15", "east": "AJ15"
       }
     },
     {
-      "id": "AJ15",
-      "terrain": "lf",
+      "id": "AJ15", "terrain": "lf",
       "exits": {
-        "north": "AJ14",
-        "south": "AJ16",
-        "west": "AI15",
-        "east": "AK15"
+        "north": "AJ14", "south": "AJ16", "west": "AI15", "east": "AK15"
       }
     },
     {
-      "id": "AK15",
-      "terrain": "p",
+      "id": "AK15", "terrain": "p",
       "exits": {
-        "north": "AK14",
-        "south": "AK16",
-        "west": "AJ15",
-        "east": "AL15"
+        "north": "AK14", "south": "AK16", "west": "AJ15", "east": "AL15"
       }
     },
     {
-      "id": "AL15",
-      "terrain": "p",
+      "id": "AL15", "terrain": "p",
       "exits": {
-        "north": "AL14",
-        "south": "AL16",
-        "west": "AK15",
-        "east": "AM15"
+        "north": "AL14", "south": "AL16", "west": "AK15", "east": "AM15"
       }
     },
     {
-      "id": "AM15",
-      "terrain": "p",
+      "id": "AM15", "terrain": "p",
       "exits": {
-        "north": "AM14",
-        "south": "AM16",
-        "west": "AL15",
-        "east": "AN15"
+        "north": "AM14", "south": "AM16", "west": "AL15", "east": "AN15"
       }
     },
     {
-      "id": "AN15",
-      "terrain": "f",
+      "id": "AN15", "terrain": "f",
       "exits": {
-        "north": "AN14",
-        "south": "AN16",
-        "west": "AM15",
-        "east": "AO15"
+        "north": "AN14", "south": "AN16", "west": "AM15", "east": "AO15"
       }
     },
     {
-      "id": "AO15",
-      "terrain": "lf",
+      "id": "AO15", "terrain": "lf",
       "exits": {
-        "north": "AO14",
-        "south": "AO16",
-        "west": "AN15",
-        "east": "AP15"
+        "north": "AO14", "south": "AO16", "west": "AN15", "east": "AP15"
       }
     },
     {
-      "id": "AP15",
-      "terrain": "lf",
+      "id": "AP15", "terrain": "lf",
       "exits": {
-        "north": "AP14",
-        "south": "AP16",
-        "west": "AO15",
-        "east": "AQ15"
+        "north": "AP14", "south": "AP16", "west": "AO15", "east": "AQ15"
       }
     },
     {
-      "id": "AQ15",
-      "terrain": "f",
+      "id": "AQ15", "terrain": "f",
       "exits": {
-        "north": "AQ14",
-        "south": "AQ16",
-        "west": "AP15",
-        "east": "AR15"
+        "north": "AQ14", "south": "AQ16", "west": "AP15", "east": "AR15"
       }
     },
     {
-      "id": "AR15",
-      "terrain": "f",
+      "id": "AR15", "terrain": "f",
       "exits": {
-        "north": "AR14",
-        "south": "AR16",
-        "west": "AQ15",
-        "east": "AS15"
+        "north": "AR14", "south": "AR16", "west": "AQ15", "east": "AS15"
       }
     },
     {
-      "id": "AS15",
-      "terrain": "f",
+      "id": "AS15", "terrain": "f",
       "exits": {
-        "north": "AS14",
-        "south": "AS16",
-        "west": "AR15",
-        "east": "AT15"
+        "north": "AS14", "south": "AS16", "west": "AR15", "east": "AT15"
       }
     },
     {
-      "id": "AT15",
-      "terrain": "f",
+      "id": "AT15", "terrain": "f",
       "exits": {
-        "north": "AT14",
-        "south": "AT16",
-        "west": "AS15",
-        "east": "AU15"
+        "north": "AT14", "south": "AT16", "west": "AS15", "east": "AU15"
       }
     },
     {
-      "id": "AU15",
-      "terrain": "lf",
+      "id": "AU15", "terrain": "lf",
       "exits": {
-        "north": "AU14",
-        "south": "AU16",
-        "west": "AT15",
-        "east": "AV15"
+        "north": "AU14", "south": "AU16", "west": "AT15", "east": "AV15"
       }
     },
     {
-      "id": "AV15",
-      "terrain": "lf",
+      "id": "AV15", "terrain": "lf",
       "exits": {
-        "north": "AV14",
-        "south": "AV16",
-        "west": "AU15",
-        "east": "AW15"
+        "north": "AV14", "south": "AV16", "west": "AU15", "east": "AW15"
       }
     },
     {
-      "id": "AW15",
-      "terrain": "lf",
+      "id": "AW15", "terrain": "lf",
       "exits": {
-        "north": "AW14",
-        "south": "AW16",
-        "west": "AV15",
-        "east": "AX15"
+        "north": "AW14", "south": "AW16", "west": "AV15", "east": "AX15"
       }
     },
     {
-      "id": "AX15",
-      "terrain": "lf",
+      "id": "AX15", "terrain": "lf",
       "exits": {
-        "north": "AX14",
-        "south": "AX16",
-        "west": "AW15"
+        "north": "AX14", "south": "AX16", "west": "AW15"
       }
     },
     {
-      "id": "A16",
-      "terrain": "p",
+      "id": "A16", "terrain": "p",
       "exits": {
-        "north": "A15",
-        "south": "A17",
-        "east": "B16"
+        "north": "A15", "south": "A17", "east": "B16"
       }
     },
     {
-      "id": "B16",
-      "terrain": "p",
+      "id": "B16", "terrain": "p",
       "exits": {
-        "north": "B15",
-        "south": "B17",
-        "west": "A16",
-        "east": "C16"
+        "north": "B15", "south": "B17", "west": "A16", "east": "C16"
       }
     },
     {
-      "id": "C16",
-      "terrain": "p",
+      "id": "C16", "terrain": "p",
       "exits": {
-        "north": "C15",
-        "south": "C17",
-        "west": "B16",
-        "east": "D16"
+        "north": "C15", "south": "C17", "west": "B16", "east": "D16"
       }
     },
     {
-      "id": "D16",
-      "terrain": "p",
+      "id": "D16", "terrain": "p",
       "exits": {
-        "north": "D15",
-        "south": "D17",
-        "west": "C16",
-        "east": "E16"
+        "north": "D15", "south": "D17", "west": "C16", "east": "E16"
       }
     },
     {
-      "id": "E16",
-      "terrain": "p",
+      "id": "E16", "terrain": "p",
       "exits": {
-        "north": "E15",
-        "south": "E17",
-        "west": "D16",
-        "east": "F16"
+        "north": "E15", "south": "E17", "west": "D16", "east": "F16"
       }
     },
     {
-      "id": "F16",
-      "terrain": "p",
+      "id": "F16", "terrain": "p",
       "exits": {
-        "north": "F15",
-        "south": "F17",
-        "west": "E16",
-        "east": "G16"
+        "north": "F15", "south": "F17", "west": "E16", "east": "G16"
       }
     },
     {
-      "id": "G16",
-      "terrain": "p",
+      "id": "G16", "terrain": "p",
       "exits": {
-        "north": "G15",
-        "south": "G17",
-        "west": "F16",
-        "east": "H16"
+        "north": "G15", "south": "G17", "west": "F16", "east": "H16"
       }
     },
     {
-      "id": "H16",
-      "terrain": "p",
+      "id": "H16", "terrain": "p",
       "exits": {
-        "north": "H15",
-        "south": "H17",
-        "west": "G16",
-        "east": "I16"
+        "north": "H15", "south": "H17", "west": "G16", "east": "I16"
       }
     },
     {
-      "id": "I16",
-      "terrain": "p",
+      "id": "I16", "terrain": "p",
       "exits": {
-        "north": "I15",
-        "south": "I17",
-        "west": "H16",
-        "east": "J16"
+        "north": "I15", "south": "I17", "west": "H16", "east": "J16"
       }
     },
     {
-      "id": "J16",
-      "terrain": "p",
+      "id": "J16", "terrain": "p",
       "exits": {
-        "north": "J15",
-        "south": "J17",
-        "west": "I16",
-        "east": "K16"
+        "north": "J15", "south": "J17", "west": "I16", "east": "K16"
       }
     },
     {
-      "id": "K16",
-      "terrain": "p",
+      "id": "K16", "terrain": "p",
       "exits": {
-        "north": "K15",
-        "south": "K17",
-        "west": "J16",
-        "east": "L16"
+        "north": "K15", "south": "K17", "west": "J16", "east": "L16"
       }
     },
     {
-      "id": "L16",
-      "terrain": "p",
+      "id": "L16", "terrain": "p",
       "exits": {
-        "north": "L15",
-        "south": "L17",
-        "west": "K16",
-        "east": "M16"
+        "north": "L15", "south": "L17", "west": "K16", "east": "M16"
       }
     },
     {
-      "id": "M16",
-      "terrain": "p",
+      "id": "M16", "terrain": "p",
       "exits": {
-        "north": "M15",
-        "south": "M17",
-        "west": "L16",
-        "east": "N16"
+        "north": "M15", "south": "M17", "west": "L16", "east": "N16"
       }
     },
     {
-      "id": "N16",
-      "terrain": "p",
+      "id": "N16", "terrain": "p",
       "exits": {
-        "north": "N15",
-        "south": "N17",
-        "west": "M16",
-        "east": "O16"
+        "north": "N15", "south": "N17", "west": "M16", "east": "O16"
       }
     },
     {
-      "id": "O16",
-      "terrain": "p",
+      "id": "O16", "terrain": "p",
       "exits": {
-        "north": "O15",
-        "south": "O17",
-        "west": "N16",
-        "east": "P16"
+        "north": "O15", "south": "O17", "west": "N16", "east": "P16"
       }
     },
     {
-      "id": "P16",
-      "terrain": "p",
+      "id": "P16", "terrain": "p",
       "exits": {
-        "north": "P15",
-        "south": "P17",
-        "west": "O16",
-        "east": "Q16"
+        "north": "P15", "south": "P17", "west": "O16", "east": "Q16"
       }
     },
     {
-      "id": "Q16",
-      "terrain": "p",
+      "id": "Q16", "terrain": "p",
       "exits": {
-        "north": "Q15",
-        "south": "Q17",
-        "west": "P16",
-        "east": "R16"
+        "north": "Q15", "south": "Q17", "west": "P16", "east": "R16"
       }
     },
     {
-      "id": "R16",
-      "terrain": "p",
+      "id": "R16", "terrain": "p",
       "exits": {
-        "north": "R15",
-        "south": "R17",
-        "west": "Q16",
-        "east": "S16"
+        "north": "R15", "south": "R17", "west": "Q16", "east": "S16"
       }
     },
     {
-      "id": "S16",
-      "terrain": "p",
+      "id": "S16", "terrain": "p",
       "exits": {
-        "north": "S15",
-        "south": "S17",
-        "west": "R16",
-        "east": "T16"
+        "north": "S15", "south": "S17", "west": "R16", "east": "T16"
       }
     },
     {
-      "id": "T16",
-      "terrain": "w",
+      "id": "T16", "terrain": "w",
       "exits": {
-        "north": "T15",
-        "south": "T17",
-        "west": "S16",
-        "east": "U16"
+        "north": "T15", "south": "T17", "west": "S16", "east": "U16"
       }
     },
     {
-      "id": "U16",
-      "terrain": "m",
+      "id": "U16", "terrain": "m",
       "exits": {
-        "north": "U15",
-        "south": "U17",
-        "west": "T16",
-        "east": "V16"
+        "north": "U15", "south": "U17", "west": "T16", "east": "V16"
       }
     },
     {
-      "id": "V16",
-      "terrain": "m",
+      "id": "V16", "terrain": "m",
       "exits": {
-        "north": "V15",
-        "south": "V17",
-        "west": "U16",
-        "east": "W16"
+        "north": "V15", "south": "V17", "west": "U16", "east": "W16"
       }
     },
     {
-      "id": "W16",
-      "terrain": "m",
+      "id": "W16", "terrain": "m",
       "exits": {
-        "north": "W15",
-        "south": "W17",
-        "west": "V16",
-        "east": "X16"
+        "north": "W15", "south": "W17", "west": "V16", "east": "X16"
       }
     },
     {
-      "id": "X16",
-      "terrain": "p",
+      "id": "X16", "terrain": "p",
       "exits": {
-        "north": "X15",
-        "south": "X17",
-        "west": "W16",
-        "east": "Y16"
+        "north": "X15", "south": "X17", "west": "W16", "east": "Y16"
       }
     },
     {
-      "id": "Y16",
-      "terrain": "r",
+      "id": "Y16", "terrain": "r",
       "exits": {
-        "north": "Y15",
-        "south": "Y17",
-        "west": "X16",
-        "east": "Z16"
+        "north": "Y15", "south": "Y17", "west": "X16", "east": "Z16"
       }
     },
     {
-      "id": "Z16",
-      "terrain": "p",
+      "id": "Z16", "terrain": "p",
       "exits": {
-        "north": "Z15",
-        "south": "Z17",
-        "west": "Y16",
-        "east": "AA16"
+        "north": "Z15", "south": "Z17", "west": "Y16", "east": "AA16"
       }
     },
     {
-      "id": "AA16",
-      "terrain": "p",
+      "id": "AA16", "terrain": "p",
       "exits": {
-        "north": "AA15",
-        "south": "AA17",
-        "west": "Z16",
-        "east": "AB16"
+        "north": "AA15", "south": "AA17", "west": "Z16", "east": "AB16"
       }
     },
     {
-      "id": "AB16",
-      "terrain": "p",
+      "id": "AB16", "terrain": "p",
       "exits": {
-        "north": "AB15",
-        "south": "AB17",
-        "west": "AA16",
-        "east": "AC16"
+        "north": "AB15", "south": "AB17", "west": "AA16", "east": "AC16"
       }
     },
     {
-      "id": "AC16",
-      "terrain": "p",
+      "id": "AC16", "terrain": "p",
       "exits": {
-        "north": "AC15",
-        "south": "AC17",
-        "west": "AB16",
-        "east": "AD16"
+        "north": "AC15", "south": "AC17", "west": "AB16", "east": "AD16"
       }
     },
     {
-      "id": "AD16",
-      "terrain": "p",
+      "id": "AD16", "terrain": "p",
       "exits": {
-        "north": "AD15",
-        "south": "AD17",
-        "west": "AC16",
-        "east": "AE16"
+        "north": "AD15", "south": "AD17", "west": "AC16", "east": "AE16"
       }
     },
     {
-      "id": "AE16",
-      "terrain": "p",
+      "id": "AE16", "terrain": "p",
       "exits": {
-        "north": "AE15",
-        "south": "AE17",
-        "west": "AD16",
-        "east": "AF16"
+        "north": "AE15", "south": "AE17", "west": "AD16", "east": "AF16"
       }
     },
     {
-      "id": "AF16",
-      "terrain": "p",
+      "id": "AF16", "terrain": "p",
       "exits": {
-        "north": "AF15",
-        "south": "AF17",
-        "west": "AE16",
-        "east": "AG16"
+        "north": "AF15", "south": "AF17", "west": "AE16", "east": "AG16"
       }
     },
     {
-      "id": "AG16",
-      "terrain": "p",
+      "id": "AG16", "terrain": "p",
       "exits": {
-        "north": "AG15",
-        "south": "AG17",
-        "west": "AF16",
-        "east": "AH16"
+        "north": "AG15", "south": "AG17", "west": "AF16", "east": "AH16"
       }
     },
     {
-      "id": "AH16",
-      "terrain": "p",
+      "id": "AH16", "terrain": "p",
       "exits": {
-        "north": "AH15",
-        "south": "AH17",
-        "west": "AG16",
-        "east": "AI16"
+        "north": "AH15", "south": "AH17", "west": "AG16", "east": "AI16"
       }
     },
     {
-      "id": "AI16",
-      "terrain": "p",
+      "id": "AI16", "terrain": "p",
       "exits": {
-        "north": "AI15",
-        "south": "AI17",
-        "west": "AH16",
-        "east": "AJ16"
+        "north": "AI15", "south": "AI17", "west": "AH16", "east": "AJ16"
       }
     },
     {
-      "id": "AJ16",
-      "terrain": "M",
+      "id": "AJ16", "terrain": "M",
       "exits": {
-        "north": "AJ15",
-        "south": "AJ17",
-        "west": "AI16",
-        "east": "AK16"
+        "north": "AJ15", "south": "AJ17", "west": "AI16", "east": "AK16"
       }
     },
     {
-      "id": "AK16",
-      "terrain": "p",
+      "id": "AK16", "terrain": "p",
       "exits": {
-        "north": "AK15",
-        "south": "AK17",
-        "west": "AJ16",
-        "east": "AL16"
+        "north": "AK15", "south": "AK17", "west": "AJ16", "east": "AL16"
       }
     },
     {
-      "id": "AL16",
-      "terrain": "p",
+      "id": "AL16", "terrain": "p",
       "exits": {
-        "north": "AL15",
-        "south": "AL17",
-        "west": "AK16",
-        "east": "AM16"
+        "north": "AL15", "south": "AL17", "west": "AK16", "east": "AM16"
       }
     },
     {
-      "id": "AM16",
-      "terrain": "p",
+      "id": "AM16", "terrain": "p",
       "exits": {
-        "north": "AM15",
-        "south": "AM17",
-        "west": "AL16",
-        "east": "AN16"
+        "north": "AM15", "south": "AM17", "west": "AL16", "east": "AN16"
       }
     },
     {
-      "id": "AN16",
-      "terrain": "p",
+      "id": "AN16", "terrain": "p",
       "exits": {
-        "north": "AN15",
-        "south": "AN17",
-        "west": "AM16",
-        "east": "AO16"
+        "north": "AN15", "south": "AN17", "west": "AM16", "east": "AO16"
       }
     },
     {
-      "id": "AO16",
-      "terrain": "p",
+      "id": "AO16", "terrain": "p",
       "exits": {
-        "north": "AO15",
-        "south": "AO17",
-        "west": "AN16",
-        "east": "AP16"
+        "north": "AO15", "south": "AO17", "west": "AN16", "east": "AP16"
       }
     },
     {
-      "id": "AP16",
-      "terrain": "p",
+      "id": "AP16", "terrain": "p",
       "exits": {
-        "north": "AP15",
-        "south": "AP17",
-        "west": "AO16",
-        "east": "AQ16"
+        "north": "AP15", "south": "AP17", "west": "AO16", "east": "AQ16"
       }
     },
     {
-      "id": "AQ16",
-      "terrain": "p",
+      "id": "AQ16", "terrain": "p",
       "exits": {
-        "north": "AQ15",
-        "south": "AQ17",
-        "west": "AP16",
-        "east": "AR16"
+        "north": "AQ15", "south": "AQ17", "west": "AP16", "east": "AR16"
       }
     },
     {
-      "id": "AR16",
-      "terrain": "f",
+      "id": "AR16", "terrain": "f",
       "exits": {
-        "north": "AR15",
-        "south": "AR17",
-        "west": "AQ16",
-        "east": "AS16"
+        "north": "AR15", "south": "AR17", "west": "AQ16", "east": "AS16"
       }
     },
     {
-      "id": "AS16",
-      "terrain": "b",
+      "id": "AS16", "terrain": "b",
       "exits": {
-        "north": "AS15",
-        "south": "AS17",
-        "west": "AR16",
-        "east": "AT16"
+        "north": "AS15", "south": "AS17", "west": "AR16", "east": "AT16"
       }
     },
     {
-      "id": "AT16",
-      "terrain": "b",
+      "id": "AT16", "terrain": "b",
       "exits": {
-        "north": "AT15",
-        "south": "AT17",
-        "west": "AS16",
-        "east": "AU16"
+        "north": "AT15", "south": "AT17", "west": "AS16", "east": "AU16"
       }
     },
     {
-      "id": "AU16",
-      "terrain": "b",
+      "id": "AU16", "terrain": "b",
       "exits": {
-        "north": "AU15",
-        "south": "AU17",
-        "west": "AT16",
-        "east": "AV16"
+        "north": "AU15", "south": "AU17", "west": "AT16", "east": "AV16"
       }
     },
     {
-      "id": "AV16",
-      "terrain": "p",
+      "id": "AV16", "terrain": "p",
       "exits": {
-        "north": "AV15",
-        "south": "AV17",
-        "west": "AU16",
-        "east": "AW16"
+        "north": "AV15", "south": "AV17", "west": "AU16", "east": "AW16"
       }
     },
     {
-      "id": "AW16",
-      "terrain": "p",
+      "id": "AW16", "terrain": "p",
       "exits": {
-        "north": "AW15",
-        "south": "AW17",
-        "west": "AV16",
-        "east": "AX16"
+        "north": "AW15", "south": "AW17", "west": "AV16", "east": "AX16"
       }
     },
     {
-      "id": "AX16",
-      "terrain": "p",
+      "id": "AX16", "terrain": "p",
       "exits": {
-        "north": "AX15",
-        "south": "AX17",
-        "west": "AW16"
+        "north": "AX15", "south": "AX17", "west": "AW16"
       }
     },
     {
-      "id": "A17",
-      "terrain": "p",
+      "id": "A17", "terrain": "p",
       "exits": {
-        "north": "A16",
-        "south": "A18",
-        "east": "B17"
+        "north": "A16", "south": "A18", "east": "B17"
       }
     },
     {
-      "id": "B17",
-      "terrain": "p",
+      "id": "B17", "terrain": "p",
       "exits": {
-        "north": "B16",
-        "south": "B18",
-        "west": "A17",
-        "east": "C17"
+        "north": "B16", "south": "B18", "west": "A17", "east": "C17"
       }
     },
     {
-      "id": "C17",
-      "terrain": "p",
+      "id": "C17", "terrain": "p",
       "exits": {
-        "north": "C16",
-        "south": "C18",
-        "west": "B17",
-        "east": "D17"
+        "north": "C16", "south": "C18", "west": "B17", "east": "D17"
       }
     },
     {
-      "id": "D17",
-      "terrain": "p",
+      "id": "D17", "terrain": "p",
       "exits": {
-        "north": "D16",
-        "south": "D18",
-        "west": "C17",
-        "east": "E17"
+        "north": "D16", "south": "D18", "west": "C17", "east": "E17"
       }
     },
     {
-      "id": "E17",
-      "terrain": "p",
+      "id": "E17", "terrain": "p",
       "exits": {
-        "north": "E16",
-        "south": "E18",
-        "west": "D17",
-        "east": "F17"
+        "north": "E16", "south": "E18", "west": "D17", "east": "F17"
       }
     },
     {
-      "id": "F17",
-      "terrain": "p",
+      "id": "F17", "terrain": "p",
       "exits": {
-        "north": "F16",
-        "south": "F18",
-        "west": "E17",
-        "east": "G17"
+        "north": "F16", "south": "F18", "west": "E17", "east": "G17"
       }
     },
     {
-      "id": "G17",
-      "terrain": "p",
+      "id": "G17", "terrain": "p",
       "exits": {
-        "north": "G16",
-        "south": "G18",
-        "west": "F17",
-        "east": "H17"
+        "north": "G16", "south": "G18", "west": "F17", "east": "H17"
       }
     },
     {
-      "id": "H17",
-      "terrain": "p",
+      "id": "H17", "terrain": "p",
       "exits": {
-        "north": "H16",
-        "south": "H18",
-        "west": "G17",
-        "east": "I17"
+        "north": "H16", "south": "H18", "west": "G17", "east": "I17"
       }
     },
     {
-      "id": "I17",
-      "terrain": "p",
+      "id": "I17", "terrain": "p",
       "exits": {
-        "north": "I16",
-        "south": "I18",
-        "west": "H17",
-        "east": "J17"
+        "north": "I16", "south": "I18", "west": "H17", "east": "J17"
       }
     },
     {
-      "id": "J17",
-      "terrain": "p",
+      "id": "J17", "terrain": "p",
       "exits": {
-        "north": "J16",
-        "south": "J18",
-        "west": "I17",
-        "east": "K17"
+        "north": "J16", "south": "J18", "west": "I17", "east": "K17"
       }
     },
     {
-      "id": "K17",
-      "terrain": "p",
+      "id": "K17", "terrain": "p",
       "exits": {
-        "north": "K16",
-        "south": "K18",
-        "west": "J17",
-        "east": "L17"
+        "north": "K16", "south": "K18", "west": "J17", "east": "L17"
       }
     },
     {
-      "id": "L17",
-      "terrain": "p",
+      "id": "L17", "terrain": "p",
       "exits": {
-        "north": "L16",
-        "south": "L18",
-        "west": "K17",
-        "east": "M17"
+        "north": "L16", "south": "L18", "west": "K17", "east": "M17"
       }
     },
     {
-      "id": "M17",
-      "terrain": "p",
+      "id": "M17", "terrain": "p",
       "exits": {
-        "north": "M16",
-        "south": "M18",
-        "west": "L17",
-        "east": "N17"
+        "north": "M16", "south": "M18", "west": "L17", "east": "N17"
       }
     },
     {
-      "id": "N17",
-      "terrain": "p",
+      "id": "N17", "terrain": "p",
       "exits": {
-        "north": "N16",
-        "south": "N18",
-        "west": "M17",
-        "east": "O17"
+        "north": "N16", "south": "N18", "west": "M17", "east": "O17"
       }
     },
     {
-      "id": "O17",
-      "terrain": "p",
+      "id": "O17", "terrain": "p",
       "exits": {
-        "north": "O16",
-        "south": "O18",
-        "west": "N17",
-        "east": "P17"
+        "north": "O16", "south": "O18", "west": "N17", "east": "P17"
       }
     },
     {
-      "id": "P17",
-      "terrain": "p",
+      "id": "P17", "terrain": "p",
       "exits": {
-        "north": "P16",
-        "south": "P18",
-        "west": "O17",
-        "east": "Q17"
+        "north": "P16", "south": "P18", "west": "O17", "east": "Q17"
       }
     },
     {
-      "id": "Q17",
-      "terrain": "p",
+      "id": "Q17", "terrain": "p",
       "exits": {
-        "north": "Q16",
-        "south": "Q18",
-        "west": "P17",
-        "east": "R17"
+        "north": "Q16", "south": "Q18", "west": "P17", "east": "R17"
       }
     },
     {
-      "id": "R17",
-      "terrain": "w",
+      "id": "R17", "terrain": "w",
       "exits": {
-        "north": "R16",
-        "south": "R18",
-        "west": "Q17",
-        "east": "S17"
+        "north": "R16", "south": "R18", "west": "Q17", "east": "S17"
       }
     },
     {
-      "id": "S17",
-      "terrain": "w",
+      "id": "S17", "terrain": "w",
       "exits": {
-        "north": "S16",
-        "south": "S18",
-        "west": "R17",
-        "east": "T17"
+        "north": "S16", "south": "S18", "west": "R17", "east": "T17"
       }
     },
     {
-      "id": "T17",
-      "terrain": "m",
+      "id": "T17", "terrain": "m",
       "exits": {
-        "north": "T16",
-        "south": "T18",
-        "west": "S17",
-        "east": "U17"
+        "north": "T16", "south": "T18", "west": "S17", "east": "U17"
       }
     },
     {
-      "id": "U17",
-      "terrain": "m",
+      "id": "U17", "terrain": "m",
       "exits": {
-        "north": "U16",
-        "south": "U18",
-        "west": "T17",
-        "east": "V17"
+        "north": "U16", "south": "U18", "west": "T17", "east": "V17"
       }
     },
     {
-      "id": "V17",
-      "terrain": "m",
+      "id": "V17", "terrain": "m",
       "exits": {
-        "north": "V16",
-        "south": "V18",
-        "west": "U17",
-        "east": "W17"
+        "north": "V16", "south": "V18", "west": "U17", "east": "W17"
       }
     },
     {
-      "id": "W17",
-      "terrain": "m",
+      "id": "W17", "terrain": "m",
       "exits": {
-        "north": "W16",
-        "south": "W18",
-        "west": "V17",
-        "east": "X17"
+        "north": "W16", "south": "W18", "west": "V17", "east": "X17"
       }
     },
     {
-      "id": "X17",
-      "terrain": "m",
+      "id": "X17", "terrain": "m",
       "exits": {
-        "north": "X16",
-        "south": "X18",
-        "west": "W17",
-        "east": "Y17"
+        "north": "X16", "south": "X18", "west": "W17", "east": "Y17"
       }
     },
     {
-      "id": "Y17",
-      "terrain": "r",
+      "id": "Y17", "terrain": "r",
       "exits": {
-        "north": "Y16",
-        "south": "Y18",
-        "west": "X17",
-        "east": "Z17"
+        "north": "Y16", "south": "Y18", "west": "X17", "east": "Z17"
       }
     },
     {
-      "id": "Z17",
-      "terrain": "p",
+      "id": "Z17", "terrain": "p",
       "exits": {
-        "north": "Z16",
-        "south": "Z18",
-        "west": "Y17",
-        "east": "AA17"
+        "north": "Z16", "south": "Z18", "west": "Y17", "east": "AA17"
       }
     },
     {
-      "id": "AA17",
-      "terrain": "p",
+      "id": "AA17", "terrain": "p",
       "exits": {
-        "north": "AA16",
-        "south": "AA18",
-        "west": "Z17",
-        "east": "AB17"
+        "north": "AA16", "south": "AA18", "west": "Z17", "east": "AB17"
       }
     },
     {
-      "id": "AB17",
-      "terrain": "p",
+      "id": "AB17", "terrain": "p",
       "exits": {
-        "north": "AB16",
-        "south": "AB18",
-        "west": "AA17",
-        "east": "AC17"
+        "north": "AB16", "south": "AB18", "west": "AA17", "east": "AC17"
       }
     },
     {
-      "id": "AC17",
-      "terrain": "p",
+      "id": "AC17", "terrain": "p",
       "exits": {
-        "north": "AC16",
-        "south": "AC18",
-        "west": "AB17",
-        "east": "AD17"
+        "north": "AC16", "south": "AC18", "west": "AB17", "east": "AD17"
       }
     },
     {
-      "id": "AD17",
-      "terrain": "p",
+      "id": "AD17", "terrain": "p",
       "exits": {
-        "north": "AD16",
-        "south": "AD18",
-        "west": "AC17",
-        "east": "AE17"
+        "north": "AD16", "south": "AD18", "west": "AC17", "east": "AE17"
       }
     },
     {
-      "id": "AE17",
-      "terrain": "p",
+      "id": "AE17", "terrain": "p",
       "exits": {
-        "north": "AE16",
-        "south": "AE18",
-        "west": "AD17",
-        "east": "AF17"
+        "north": "AE16", "south": "AE18", "west": "AD17", "east": "AF17"
       }
     },
     {
-      "id": "AF17",
-      "terrain": "p",
+      "id": "AF17", "terrain": "p",
       "exits": {
-        "north": "AF16",
-        "south": "AF18",
-        "west": "AE17",
-        "east": "AG17"
+        "north": "AF16", "south": "AF18", "west": "AE17", "east": "AG17"
       }
     },
     {
-      "id": "AG17",
-      "terrain": "p",
+      "id": "AG17", "terrain": "p",
       "exits": {
-        "north": "AG16",
-        "south": "AG18",
-        "west": "AF17",
-        "east": "AH17"
+        "north": "AG16", "south": "AG18", "west": "AF17", "east": "AH17"
       }
     },
     {
-      "id": "AH17",
-      "terrain": "p",
+      "id": "AH17", "terrain": "p",
       "exits": {
-        "north": "AH16",
-        "south": "AH18",
-        "west": "AG17",
-        "east": "AI17"
+        "north": "AH16", "south": "AH18", "west": "AG17", "east": "AI17"
       }
     },
     {
-      "id": "AI17",
-      "terrain": "p",
+      "id": "AI17", "terrain": "p",
       "exits": {
-        "north": "AI16",
-        "south": "AI18",
-        "west": "AH17",
-        "east": "AJ17"
+        "north": "AI16", "south": "AI18", "west": "AH17", "east": "AJ17"
       }
     },
     {
-      "id": "AJ17",
-      "terrain": "M",
+      "id": "AJ17", "terrain": "M",
       "exits": {
-        "north": "AJ16",
-        "south": "AJ18",
-        "west": "AI17",
-        "east": "AK17"
+        "north": "AJ16", "south": "AJ18", "west": "AI17", "east": "AK17"
       }
     },
     {
-      "id": "AK17",
-      "terrain": "p",
+      "id": "AK17", "terrain": "p",
       "exits": {
-        "north": "AK16",
-        "south": "AK18",
-        "west": "AJ17",
-        "east": "AL17"
+        "north": "AK16", "south": "AK18", "west": "AJ17", "east": "AL17"
       }
     },
     {
-      "id": "AL17",
-      "terrain": "p",
+      "id": "AL17", "terrain": "p",
       "exits": {
-        "north": "AL16",
-        "south": "AL18",
-        "west": "AK17",
-        "east": "AM17"
+        "north": "AL16", "south": "AL18", "west": "AK17", "east": "AM17"
       }
     },
     {
-      "id": "AM17",
-      "terrain": "p",
+      "id": "AM17", "terrain": "p",
       "exits": {
-        "north": "AM16",
-        "south": "AM18",
-        "west": "AL17",
-        "east": "AN17"
+        "north": "AM16", "south": "AM18", "west": "AL17", "east": "AN17"
       }
     },
     {
-      "id": "AN17",
-      "terrain": "p",
+      "id": "AN17", "terrain": "p",
       "exits": {
-        "north": "AN16",
-        "south": "AN18",
-        "west": "AM17",
-        "east": "AO17"
+        "north": "AN16", "south": "AN18", "west": "AM17", "east": "AO17"
       }
     },
     {
-      "id": "AO17",
-      "terrain": "p",
+      "id": "AO17", "terrain": "p",
       "exits": {
-        "north": "AO16",
-        "south": "AO18",
-        "west": "AN17",
-        "east": "AP17"
+        "north": "AO16", "south": "AO18", "west": "AN17", "east": "AP17"
       }
     },
     {
-      "id": "AP17",
-      "terrain": "p",
+      "id": "AP17", "terrain": "p",
       "exits": {
-        "north": "AP16",
-        "south": "AP18",
-        "west": "AO17",
-        "east": "AQ17"
+        "north": "AP16", "south": "AP18", "west": "AO17", "east": "AQ17"
       }
     },
     {
-      "id": "AQ17",
-      "terrain": "p",
+      "id": "AQ17", "terrain": "p",
       "exits": {
-        "north": "AQ16",
-        "south": "AQ18",
-        "west": "AP17",
-        "east": "AR17"
+        "north": "AQ16", "south": "AQ18", "west": "AP17", "east": "AR17"
       }
     },
     {
-      "id": "AR17",
-      "terrain": "p",
+      "id": "AR17", "terrain": "p",
       "exits": {
-        "north": "AR16",
-        "south": "AR18",
-        "west": "AQ17",
-        "east": "AS17"
+        "north": "AR16", "south": "AR18", "west": "AQ17", "east": "AS17"
       }
     },
     {
-      "id": "AS17",
-      "terrain": "p",
+      "id": "AS17", "terrain": "p",
       "exits": {
-        "north": "AS16",
-        "south": "AS18",
-        "west": "AR17",
-        "east": "AT17"
+        "north": "AS16", "south": "AS18", "west": "AR17", "east": "AT17"
       }
     },
     {
-      "id": "AT17",
-      "terrain": "lf",
+      "id": "AT17", "terrain": "lf",
       "exits": {
-        "north": "AT16",
-        "south": "AT18",
-        "west": "AS17",
-        "east": "AU17"
+        "north": "AT16", "south": "AT18", "west": "AS17", "east": "AU17"
       }
     },
     {
-      "id": "AU17",
-      "terrain": "lf",
+      "id": "AU17", "terrain": "lf",
       "exits": {
-        "north": "AU16",
-        "south": "AU18",
-        "west": "AT17",
-        "east": "AV17"
+        "north": "AU16", "south": "AU18", "west": "AT17", "east": "AV17"
       }
     },
     {
-      "id": "AV17",
-      "terrain": "p",
+      "id": "AV17", "terrain": "p",
       "exits": {
-        "north": "AV16",
-        "south": "AV18",
-        "west": "AU17",
-        "east": "AW17"
+        "north": "AV16", "south": "AV18", "west": "AU17", "east": "AW17"
       }
     },
     {
-      "id": "AW17",
-      "terrain": "p",
+      "id": "AW17", "terrain": "p",
       "exits": {
-        "north": "AW16",
-        "south": "AW18",
-        "west": "AV17",
-        "east": "AX17"
+        "north": "AW16", "south": "AW18", "west": "AV17", "east": "AX17"
       }
     },
     {
-      "id": "AX17",
-      "terrain": "p",
+      "id": "AX17", "terrain": "p",
       "exits": {
-        "north": "AX16",
-        "south": "AX18",
-        "west": "AW17"
+        "north": "AX16", "south": "AX18", "west": "AW17"
       }
     },
     {
-      "id": "A18",
-      "terrain": "p",
+      "id": "A18", "terrain": "p",
       "exits": {
-        "north": "A17",
-        "south": "A19",
-        "east": "B18"
+        "north": "A17", "south": "A19", "east": "B18"
       }
     },
     {
-      "id": "B18",
-      "terrain": "p",
+      "id": "B18", "terrain": "p",
       "exits": {
-        "north": "B17",
-        "south": "B19",
-        "west": "A18",
-        "east": "C18"
+        "north": "B17", "south": "B19", "west": "A18", "east": "C18"
       }
     },
     {
-      "id": "C18",
-      "terrain": "p",
+      "id": "C18", "terrain": "p",
       "exits": {
-        "north": "C17",
-        "south": "C19",
-        "west": "B18",
-        "east": "D18"
+        "north": "C17", "south": "C19", "west": "B18", "east": "D18"
       }
     },
     {
-      "id": "D18",
-      "terrain": "p",
+      "id": "D18", "terrain": "p",
       "exits": {
-        "north": "D17",
-        "south": "D19",
-        "west": "C18",
-        "east": "E18"
+        "north": "D17", "south": "D19", "west": "C18", "east": "E18"
       }
     },
     {
-      "id": "E18",
-      "terrain": "p",
+      "id": "E18", "terrain": "p",
       "exits": {
-        "north": "E17",
-        "south": "E19",
-        "west": "D18",
-        "east": "F18"
+        "north": "E17", "south": "E19", "west": "D18", "east": "F18"
       }
     },
     {
-      "id": "F18",
-      "terrain": "p",
+      "id": "F18", "terrain": "p",
       "exits": {
-        "north": "F17",
-        "south": "F19",
-        "west": "E18",
-        "east": "G18"
+        "north": "F17", "south": "F19", "west": "E18", "east": "G18"
       }
     },
     {
-      "id": "G18",
-      "terrain": "lf",
+      "id": "G18", "terrain": "lf",
       "exits": {
-        "north": "G17",
-        "south": "G19",
-        "west": "F18",
-        "east": "H18"
+        "north": "G17", "south": "G19", "west": "F18", "east": "H18"
       }
     },
     {
-      "id": "H18",
-      "terrain": "p",
+      "id": "H18", "terrain": "p",
       "exits": {
-        "north": "H17",
-        "south": "H19",
-        "west": "G18",
-        "east": "I18"
+        "north": "H17", "south": "H19", "west": "G18", "east": "I18"
       }
     },
     {
-      "id": "I18",
-      "terrain": "p",
+      "id": "I18", "terrain": "p",
       "exits": {
-        "north": "I17",
-        "south": "I19",
-        "west": "H18",
-        "east": "J18"
+        "north": "I17", "south": "I19", "west": "H18", "east": "J18"
       }
     },
     {
-      "id": "J18",
-      "terrain": "p",
+      "id": "J18", "terrain": "p",
       "exits": {
-        "north": "J17",
-        "south": "J19",
-        "west": "I18",
-        "east": "K18"
+        "north": "J17", "south": "J19", "west": "I18", "east": "K18"
       }
     },
     {
-      "id": "K18",
-      "terrain": "p",
+      "id": "K18", "terrain": "p",
       "exits": {
-        "north": "K17",
-        "south": "K19",
-        "west": "J18",
-        "east": "L18"
+        "north": "K17", "south": "K19", "west": "J18", "east": "L18"
       }
     },
     {
-      "id": "L18",
-      "terrain": "p",
+      "id": "L18", "terrain": "p",
       "exits": {
-        "north": "L17",
-        "south": "L19",
-        "west": "K18",
-        "east": "M18"
+        "north": "L17", "south": "L19", "west": "K18", "east": "M18"
       }
     },
     {
-      "id": "M18",
-      "terrain": "p",
+      "id": "M18", "terrain": "p",
       "exits": {
-        "north": "M17",
-        "south": "M19",
-        "west": "L18",
-        "east": "N18"
+        "north": "M17", "south": "M19", "west": "L18", "east": "N18"
       }
     },
     {
-      "id": "N18",
-      "terrain": "p",
+      "id": "N18", "terrain": "p",
       "exits": {
-        "north": "N17",
-        "south": "N19",
-        "west": "M18",
-        "east": "O18"
+        "north": "N17", "south": "N19", "west": "M18", "east": "O18"
       }
     },
     {
-      "id": "O18",
-      "terrain": "p",
+      "id": "O18", "terrain": "p",
       "exits": {
-        "north": "O17",
-        "south": "O19",
-        "west": "N18",
-        "east": "P18"
+        "north": "O17", "south": "O19", "west": "N18", "east": "P18"
       }
     },
     {
-      "id": "P18",
-      "terrain": "w",
+      "id": "P18", "terrain": "w",
       "exits": {
-        "north": "P17",
-        "south": "P19",
-        "west": "O18",
-        "east": "Q18"
+        "north": "P17", "south": "P19", "west": "O18", "east": "Q18"
       }
     },
     {
-      "id": "Q18",
-      "terrain": "w",
+      "id": "Q18", "terrain": "w",
       "exits": {
-        "north": "Q17",
-        "south": "Q19",
-        "west": "P18",
-        "east": "R18"
+        "north": "Q17", "south": "Q19", "west": "P18", "east": "R18"
       }
     },
     {
-      "id": "R18",
-      "terrain": "m",
+      "id": "R18", "terrain": "m",
       "exits": {
-        "north": "R17",
-        "south": "R19",
-        "west": "Q18",
-        "east": "S18"
+        "north": "R17", "south": "R19", "west": "Q18", "east": "S18"
       }
     },
     {
-      "id": "S18",
-      "terrain": "m",
+      "id": "S18", "terrain": "m",
       "exits": {
-        "north": "S17",
-        "south": "S19",
-        "west": "R18",
-        "east": "T18"
+        "north": "S17", "south": "S19", "west": "R18", "east": "T18"
       }
     },
     {
-      "id": "T18",
-      "terrain": "m",
+      "id": "T18", "terrain": "m",
       "exits": {
-        "north": "T17",
-        "south": "T19",
-        "west": "S18",
-        "east": "U18"
+        "north": "T17", "south": "T19", "west": "S18", "east": "U18"
       }
     },
     {
-      "id": "U18",
-      "terrain": "m",
+      "id": "U18", "terrain": "m",
       "exits": {
-        "north": "U17",
-        "south": "U19",
-        "west": "T18",
-        "east": "V18"
+        "north": "U17", "south": "U19", "west": "T18", "east": "V18"
       }
     },
     {
-      "id": "V18",
-      "terrain": "m",
+      "id": "V18", "terrain": "m",
       "exits": {
-        "north": "V17",
-        "south": "V19",
-        "west": "U18",
-        "east": "W18"
+        "north": "V17", "south": "V19", "west": "U18", "east": "W18"
       }
     },
     {
-      "id": "W18",
-      "terrain": "p",
+      "id": "W18", "terrain": "p",
       "exits": {
-        "north": "W17",
-        "south": "W19",
-        "west": "V18",
-        "east": "X18"
+        "north": "W17", "south": "W19", "west": "V18", "east": "X18"
       }
     },
     {
-      "id": "X18",
-      "terrain": "p",
+      "id": "X18", "terrain": "p",
       "exits": {
-        "north": "X17",
-        "south": "X19",
-        "west": "W18",
-        "east": "Y18"
+        "north": "X17", "south": "X19", "west": "W18", "east": "Y18"
       }
     },
     {
-      "id": "Y18",
-      "terrain": "r",
+      "id": "Y18", "terrain": "r",
       "exits": {
-        "north": "Y17",
-        "south": "Y19",
-        "west": "X18",
-        "east": "Z18"
+        "north": "Y17", "south": "Y19", "west": "X18", "east": "Z18"
       }
     },
     {
-      "id": "Z18",
-      "terrain": "p",
+      "id": "Z18", "terrain": "p",
       "exits": {
-        "north": "Z17",
-        "south": "Z19",
-        "west": "Y18",
-        "east": "AA18"
+        "north": "Z17", "south": "Z19", "west": "Y18", "east": "AA18"
       }
     },
     {
-      "id": "AA18",
-      "terrain": "p",
+      "id": "AA18", "terrain": "p",
       "exits": {
-        "north": "AA17",
-        "south": "AA19",
-        "west": "Z18",
-        "east": "AB18"
+        "north": "AA17", "south": "AA19", "west": "Z18", "east": "AB18"
       }
     },
     {
-      "id": "AB18",
-      "terrain": "p",
+      "id": "AB18", "terrain": "p",
       "exits": {
-        "north": "AB17",
-        "south": "AB19",
-        "west": "AA18",
-        "east": "AC18"
+        "north": "AB17", "south": "AB19", "west": "AA18", "east": "AC18"
       }
     },
     {
-      "id": "AC18",
-      "terrain": "p",
+      "id": "AC18", "terrain": "p",
       "exits": {
-        "north": "AC17",
-        "south": "AC19",
-        "west": "AB18",
-        "east": "AD18"
+        "north": "AC17", "south": "AC19", "west": "AB18", "east": "AD18"
       }
     },
     {
-      "id": "AD18",
-      "terrain": "p",
+      "id": "AD18", "terrain": "p",
       "exits": {
-        "north": "AD17",
-        "south": "AD19",
-        "west": "AC18",
-        "east": "AE18"
+        "north": "AD17", "south": "AD19", "west": "AC18", "east": "AE18"
       }
     },
     {
-      "id": "AE18",
-      "terrain": "p",
+      "id": "AE18", "terrain": "p",
       "exits": {
-        "north": "AE17",
-        "south": "AE19",
-        "west": "AD18",
-        "east": "AF18"
+        "north": "AE17", "south": "AE19", "west": "AD18", "east": "AF18"
       }
     },
     {
-      "id": "AF18",
-      "terrain": "p",
+      "id": "AF18", "terrain": "p",
       "exits": {
-        "north": "AF17",
-        "south": "AF19",
-        "west": "AE18",
-        "east": "AG18"
+        "north": "AF17", "south": "AF19", "west": "AE18", "east": "AG18"
       }
     },
     {
-      "id": "AG18",
-      "terrain": "p",
+      "id": "AG18", "terrain": "p",
       "exits": {
-        "north": "AG17",
-        "south": "AG19",
-        "west": "AF18",
-        "east": "AH18"
+        "north": "AG17", "south": "AG19", "west": "AF18", "east": "AH18"
       }
     },
     {
-      "id": "AH18",
-      "terrain": "p",
+      "id": "AH18", "terrain": "p",
       "exits": {
-        "north": "AH17",
-        "south": "AH19",
-        "west": "AG18",
-        "east": "AI18"
+        "north": "AH17", "south": "AH19", "west": "AG18", "east": "AI18"
       }
     },
     {
-      "id": "AI18",
-      "terrain": "p",
+      "id": "AI18", "terrain": "p",
       "exits": {
-        "north": "AI17",
-        "south": "AI19",
-        "west": "AH18",
-        "east": "AJ18"
+        "north": "AI17", "south": "AI19", "west": "AH18", "east": "AJ18"
       }
     },
     {
-      "id": "AJ18",
-      "terrain": "lf",
+      "id": "AJ18", "terrain": "lf",
       "exits": {
-        "north": "AJ17",
-        "south": "AJ19",
-        "west": "AI18",
-        "east": "AK18"
+        "north": "AJ17", "south": "AJ19", "west": "AI18", "east": "AK18"
       }
     },
     {
-      "id": "AK18",
-      "terrain": "M",
+      "id": "AK18", "terrain": "M",
       "exits": {
-        "north": "AK17",
-        "south": "AK19",
-        "west": "AJ18",
-        "east": "AL18"
+        "north": "AK17", "south": "AK19", "west": "AJ18", "east": "AL18"
       }
     },
     {
-      "id": "AL18",
-      "terrain": "p",
+      "id": "AL18", "terrain": "p",
       "exits": {
-        "north": "AL17",
-        "south": "AL19",
-        "west": "AK18",
-        "east": "AM18"
+        "north": "AL17", "south": "AL19", "west": "AK18", "east": "AM18"
       }
     },
     {
-      "id": "AM18",
-      "terrain": "p",
+      "id": "AM18", "terrain": "p",
       "exits": {
-        "north": "AM17",
-        "south": "AM19",
-        "west": "AL18",
-        "east": "AN18"
+        "north": "AM17", "south": "AM19", "west": "AL18", "east": "AN18"
       }
     },
     {
-      "id": "AN18",
-      "terrain": "p",
+      "id": "AN18", "terrain": "p",
       "exits": {
-        "north": "AN17",
-        "south": "AN19",
-        "west": "AM18",
-        "east": "AO18"
+        "north": "AN17", "south": "AN19", "west": "AM18", "east": "AO18"
       }
     },
     {
-      "id": "AO18",
-      "terrain": "p",
+      "id": "AO18", "terrain": "p",
       "exits": {
-        "north": "AO17",
-        "south": "AO19",
-        "west": "AN18",
-        "east": "AP18"
+        "north": "AO17", "south": "AO19", "west": "AN18", "east": "AP18"
       }
     },
     {
-      "id": "AP18",
-      "terrain": "p",
+      "id": "AP18", "terrain": "p",
       "exits": {
-        "north": "AP17",
-        "south": "AP19",
-        "west": "AO18",
-        "east": "AQ18"
+        "north": "AP17", "south": "AP19", "west": "AO18", "east": "AQ18"
       }
     },
     {
-      "id": "AQ18",
-      "terrain": "p",
+      "id": "AQ18", "terrain": "p",
       "exits": {
-        "north": "AQ17",
-        "south": "AQ19",
-        "west": "AP18",
-        "east": "AR18"
+        "north": "AQ17", "south": "AQ19", "west": "AP18", "east": "AR18"
       }
     },
     {
-      "id": "AR18",
-      "terrain": "p",
+      "id": "AR18", "terrain": "p",
       "exits": {
-        "north": "AR17",
-        "south": "AR19",
-        "west": "AQ18",
-        "east": "AS18"
+        "north": "AR17", "south": "AR19", "west": "AQ18", "east": "AS18"
       }
     },
     {
-      "id": "AS18",
-      "terrain": "p",
+      "id": "AS18", "terrain": "p",
       "exits": {
-        "north": "AS17",
-        "south": "AS19",
-        "west": "AR18",
-        "east": "AT18"
+        "north": "AS17", "south": "AS19", "west": "AR18", "east": "AT18"
       }
     },
     {
-      "id": "AT18",
-      "terrain": "lf",
+      "id": "AT18", "terrain": "lf",
       "exits": {
-        "north": "AT17",
-        "south": "AT19",
-        "west": "AS18",
-        "east": "AU18"
+        "north": "AT17", "south": "AT19", "west": "AS18", "east": "AU18"
       }
     },
     {
-      "id": "AU18",
-      "terrain": "lf",
+      "id": "AU18", "terrain": "lf",
       "exits": {
-        "north": "AU17",
-        "south": "AU19",
-        "west": "AT18",
-        "east": "AV18"
+        "north": "AU17", "south": "AU19", "west": "AT18", "east": "AV18"
       }
     },
     {
-      "id": "AV18",
-      "terrain": "p",
+      "id": "AV18", "terrain": "p",
       "exits": {
-        "north": "AV17",
-        "south": "AV19",
-        "west": "AU18",
-        "east": "AW18"
+        "north": "AV17", "south": "AV19", "west": "AU18", "east": "AW18"
       }
     },
     {
-      "id": "AW18",
-      "terrain": "p",
+      "id": "AW18", "terrain": "p",
       "exits": {
-        "north": "AW17",
-        "south": "AW19",
-        "west": "AV18",
-        "east": "AX18"
+        "north": "AW17", "south": "AW19", "west": "AV18", "east": "AX18"
       }
     },
     {
-      "id": "AX18",
-      "terrain": "p",
+      "id": "AX18", "terrain": "p",
       "exits": {
-        "north": "AX17",
-        "south": "AX19",
-        "west": "AW18"
+        "north": "AX17", "south": "AX19", "west": "AW18"
       }
     },
     {
-      "id": "A19",
-      "terrain": "p",
+      "id": "A19", "terrain": "p",
       "exits": {
-        "north": "A18",
-        "south": "A20",
-        "east": "B19"
+        "north": "A18", "south": "A20", "east": "B19"
       }
     },
     {
-      "id": "B19",
-      "terrain": "p",
+      "id": "B19", "terrain": "p",
       "exits": {
-        "north": "B18",
-        "south": "B20",
-        "west": "A19",
-        "east": "C19"
+        "north": "B18", "south": "B20", "west": "A19", "east": "C19"
       }
     },
     {
-      "id": "C19",
-      "terrain": "lf",
+      "id": "C19", "terrain": "lf",
       "exits": {
-        "north": "C18",
-        "south": "C20",
-        "west": "B19",
-        "east": "D19"
+        "north": "C18", "south": "C20", "west": "B19", "east": "D19"
       }
     },
     {
-      "id": "D19",
-      "terrain": "lf",
+      "id": "D19", "terrain": "lf",
       "exits": {
-        "north": "D18",
-        "south": "D20",
-        "west": "C19",
-        "east": "E19"
+        "north": "D18", "south": "D20", "west": "C19", "east": "E19"
       }
     },
     {
-      "id": "E19",
-      "terrain": "f",
+      "id": "E19", "terrain": "f",
       "exits": {
-        "north": "E18",
-        "south": "E20",
-        "west": "D19",
-        "east": "F19"
+        "north": "E18", "south": "E20", "west": "D19", "east": "F19"
       }
     },
     {
-      "id": "F19",
-      "terrain": "f",
+      "id": "F19", "terrain": "f",
       "exits": {
-        "north": "F18",
-        "south": "F20",
-        "west": "E19",
-        "east": "G19"
+        "north": "F18", "south": "F20", "west": "E19", "east": "G19"
       }
     },
     {
-      "id": "G19",
-      "terrain": "f",
+      "id": "G19", "terrain": "f",
       "exits": {
-        "north": "G18",
-        "south": "G20",
-        "west": "F19",
-        "east": "H19"
+        "north": "G18", "south": "G20", "west": "F19", "east": "H19"
       }
     },
     {
-      "id": "H19",
-      "terrain": "lf",
+      "id": "H19", "terrain": "lf",
       "exits": {
-        "north": "H18",
-        "south": "H20",
-        "west": "G19",
-        "east": "I19"
+        "north": "H18", "south": "H20", "west": "G19", "east": "I19"
       }
     },
     {
-      "id": "I19",
-      "terrain": "p",
+      "id": "I19", "terrain": "p",
       "exits": {
-        "north": "I18",
-        "south": "I20",
-        "west": "H19",
-        "east": "J19"
+        "north": "I18", "south": "I20", "west": "H19", "east": "J19"
       }
     },
     {
-      "id": "J19",
-      "terrain": "p",
+      "id": "J19", "terrain": "p",
       "exits": {
-        "north": "J18",
-        "south": "J20",
-        "west": "I19",
-        "east": "K19"
+        "north": "J18", "south": "J20", "west": "I19", "east": "K19"
       }
     },
     {
-      "id": "K19",
-      "terrain": "p",
+      "id": "K19", "terrain": "p",
       "exits": {
-        "north": "K18",
-        "south": "K20",
-        "west": "J19",
-        "east": "L19"
+        "north": "K18", "south": "K20", "west": "J19", "east": "L19"
       }
     },
     {
-      "id": "L19",
-      "terrain": "p",
+      "id": "L19", "terrain": "p",
       "exits": {
-        "north": "L18",
-        "south": "L20",
-        "west": "K19",
-        "east": "M19"
+        "north": "L18", "south": "L20", "west": "K19", "east": "M19"
       }
     },
     {
-      "id": "M19",
-      "terrain": "p",
+      "id": "M19", "terrain": "p",
       "exits": {
-        "north": "M18",
-        "south": "M20",
-        "west": "L19",
-        "east": "N19"
+        "north": "M18", "south": "M20", "west": "L19", "east": "N19"
       }
     },
     {
-      "id": "N19",
-      "terrain": "p",
+      "id": "N19", "terrain": "p",
       "exits": {
-        "north": "N18",
-        "south": "N20",
-        "west": "M19",
-        "east": "O19"
+        "north": "N18", "south": "N20", "west": "M19", "east": "O19"
       }
     },
     {
-      "id": "O19",
-      "terrain": "w",
+      "id": "O19", "terrain": "w",
       "exits": {
-        "north": "O18",
-        "south": "O20",
-        "west": "N19",
-        "east": "P19"
+        "north": "O18", "south": "O20", "west": "N19", "east": "P19"
       }
     },
     {
-      "id": "P19",
-      "terrain": "m",
+      "id": "P19", "terrain": "m",
       "exits": {
-        "north": "P18",
-        "south": "P20",
-        "west": "O19",
-        "east": "Q19"
+        "north": "P18", "south": "P20", "west": "O19", "east": "Q19"
       }
     },
     {
-      "id": "Q19",
-      "terrain": "m",
+      "id": "Q19", "terrain": "m",
       "exits": {
-        "north": "Q18",
-        "south": "Q20",
-        "west": "P19",
-        "east": "R19"
+        "north": "Q18", "south": "Q20", "west": "P19", "east": "R19"
       }
     },
     {
-      "id": "R19",
-      "terrain": "m",
+      "id": "R19", "terrain": "m",
       "exits": {
-        "north": "R18",
-        "south": "R20",
-        "west": "Q19",
-        "east": "S19"
+        "north": "R18", "south": "R20", "west": "Q19", "east": "S19"
       }
     },
     {
-      "id": "S19",
-      "terrain": "m",
+      "id": "S19", "terrain": "m",
       "exits": {
-        "north": "S18",
-        "south": "S20",
-        "west": "R19",
-        "east": "T19"
+        "north": "S18", "south": "S20", "west": "R19", "east": "T19"
       }
     },
     {
-      "id": "T19",
-      "terrain": "m",
+      "id": "T19", "terrain": "m",
       "exits": {
-        "north": "T18",
-        "south": "T20",
-        "west": "S19",
-        "east": "U19"
+        "north": "T18", "south": "T20", "west": "S19", "east": "U19"
       }
     },
     {
-      "id": "U19",
-      "terrain": "m",
+      "id": "U19", "terrain": "m",
       "exits": {
-        "north": "U18",
-        "south": "U20",
-        "west": "T19",
-        "east": "V19"
+        "north": "U18", "south": "U20", "west": "T19", "east": "V19"
       }
     },
     {
-      "id": "V19",
-      "terrain": "m",
+      "id": "V19", "terrain": "m",
       "exits": {
-        "north": "V18",
-        "south": "V20",
-        "west": "U19",
-        "east": "W19"
+        "north": "V18", "south": "V20", "west": "U19", "east": "W19"
       }
     },
     {
-      "id": "W19",
-      "terrain": "p",
+      "id": "W19", "terrain": "p",
       "exits": {
-        "north": "W18",
-        "south": "W20",
-        "west": "V19",
-        "east": "X19"
+        "north": "W18", "south": "W20", "west": "V19", "east": "X19"
       }
     },
     {
-      "id": "X19",
-      "terrain": "p",
+      "id": "X19", "terrain": "p",
       "exits": {
-        "north": "X18",
-        "south": "X20",
-        "west": "W19",
-        "east": "Y19"
+        "north": "X18", "south": "X20", "west": "W19", "east": "Y19"
       }
     },
     {
-      "id": "Y19",
-      "terrain": "r",
+      "id": "Y19", "terrain": "r",
       "exits": {
-        "north": "Y18",
-        "south": "Y20",
-        "west": "X19",
-        "east": "Z19"
+        "north": "Y18", "south": "Y20", "west": "X19", "east": "Z19"
       }
     },
     {
-      "id": "Z19",
-      "terrain": "p",
+      "id": "Z19", "terrain": "p",
       "exits": {
-        "north": "Z18",
-        "south": "Z20",
-        "west": "Y19",
-        "east": "AA19"
+        "north": "Z18", "south": "Z20", "west": "Y19", "east": "AA19"
       }
     },
     {
-      "id": "AA19",
-      "terrain": "p",
+      "id": "AA19", "terrain": "p",
       "exits": {
-        "north": "AA18",
-        "south": "AA20",
-        "west": "Z19",
-        "east": "AB19"
+        "north": "AA18", "south": "AA20", "west": "Z19", "east": "AB19"
       }
     },
     {
-      "id": "AB19",
-      "terrain": "p",
+      "id": "AB19", "terrain": "p",
       "exits": {
-        "north": "AB18",
-        "south": "AB20",
-        "west": "AA19",
-        "east": "AC19"
+        "north": "AB18", "south": "AB20", "west": "AA19", "east": "AC19"
       }
     },
     {
-      "id": "AC19",
-      "terrain": "p",
+      "id": "AC19", "terrain": "p",
       "exits": {
-        "north": "AC18",
-        "south": "AC20",
-        "west": "AB19",
-        "east": "AD19"
+        "north": "AC18", "south": "AC20", "west": "AB19", "east": "AD19"
       }
     },
     {
-      "id": "AD19",
-      "terrain": "p",
+      "id": "AD19", "terrain": "p",
       "exits": {
-        "north": "AD18",
-        "south": "AD20",
-        "west": "AC19",
-        "east": "AE19"
+        "north": "AD18", "south": "AD20", "west": "AC19", "east": "AE19"
       }
     },
     {
-      "id": "AE19",
-      "terrain": "p",
+      "id": "AE19", "terrain": "p",
       "exits": {
-        "north": "AE18",
-        "south": "AE20",
-        "west": "AD19",
-        "east": "AF19"
+        "north": "AE18", "south": "AE20", "west": "AD19", "east": "AF19"
       }
     },
     {
-      "id": "AF19",
-      "terrain": "p",
+      "id": "AF19", "terrain": "p",
       "exits": {
-        "north": "AF18",
-        "south": "AF20",
-        "west": "AE19",
-        "east": "AG19"
+        "north": "AF18", "south": "AF20", "west": "AE19", "east": "AG19"
       }
     },
     {
-      "id": "AG19",
-      "terrain": "p",
+      "id": "AG19", "terrain": "p",
       "exits": {
-        "north": "AG18",
-        "south": "AG20",
-        "west": "AF19",
-        "east": "AH19"
+        "north": "AG18", "south": "AG20", "west": "AF19", "east": "AH19"
       }
     },
     {
-      "id": "AH19",
-      "terrain": "p",
+      "id": "AH19", "terrain": "p",
       "exits": {
-        "north": "AH18",
-        "south": "AH20",
-        "west": "AG19",
-        "east": "AI19"
+        "north": "AH18", "south": "AH20", "west": "AG19", "east": "AI19"
       }
     },
     {
-      "id": "AI19",
-      "terrain": "p",
+      "id": "AI19", "terrain": "p",
       "exits": {
-        "north": "AI18",
-        "south": "AI20",
-        "west": "AH19",
-        "east": "AJ19"
+        "north": "AI18", "south": "AI20", "west": "AH19", "east": "AJ19"
       }
     },
     {
-      "id": "AJ19",
-      "terrain": "lf",
+      "id": "AJ19", "terrain": "lf",
       "exits": {
-        "north": "AJ18",
-        "south": "AJ20",
-        "west": "AI19",
-        "east": "AK19"
+        "north": "AJ18", "south": "AJ20", "west": "AI19", "east": "AK19"
       }
     },
     {
-      "id": "AK19",
-      "terrain": "p",
+      "id": "AK19", "terrain": "p",
       "exits": {
-        "north": "AK18",
-        "south": "AK20",
-        "west": "AJ19",
-        "east": "AL19"
+        "north": "AK18", "south": "AK20", "west": "AJ19", "east": "AL19"
       }
     },
     {
-      "id": "AL19",
-      "terrain": "p",
+      "id": "AL19", "terrain": "p",
       "exits": {
-        "north": "AL18",
-        "south": "AL20",
-        "west": "AK19",
-        "east": "AM19"
+        "north": "AL18", "south": "AL20", "west": "AK19", "east": "AM19"
       }
     },
     {
-      "id": "AM19",
-      "terrain": "p",
+      "id": "AM19", "terrain": "p",
       "exits": {
-        "north": "AM18",
-        "south": "AM20",
-        "west": "AL19",
-        "east": "AN19"
+        "north": "AM18", "south": "AM20", "west": "AL19", "east": "AN19"
       }
     },
     {
-      "id": "AN19",
-      "terrain": "p",
+      "id": "AN19", "terrain": "p",
       "exits": {
-        "north": "AN18",
-        "south": "AN20",
-        "west": "AM19",
-        "east": "AO19"
+        "north": "AN18", "south": "AN20", "west": "AM19", "east": "AO19"
       }
     },
     {
-      "id": "AO19",
-      "terrain": "p",
+      "id": "AO19", "terrain": "p",
       "exits": {
-        "north": "AO18",
-        "south": "AO20",
-        "west": "AN19",
-        "east": "AP19"
+        "north": "AO18", "south": "AO20", "west": "AN19", "east": "AP19"
       }
     },
     {
-      "id": "AP19",
-      "terrain": "p",
+      "id": "AP19", "terrain": "p",
       "exits": {
-        "north": "AP18",
-        "south": "AP20",
-        "west": "AO19",
-        "east": "AQ19"
+        "north": "AP18", "south": "AP20", "west": "AO19", "east": "AQ19"
       }
     },
     {
-      "id": "AQ19",
-      "terrain": "p",
+      "id": "AQ19", "terrain": "p",
       "exits": {
-        "north": "AQ18",
-        "south": "AQ20",
-        "west": "AP19",
-        "east": "AR19"
+        "north": "AQ18", "south": "AQ20", "west": "AP19", "east": "AR19"
       }
     },
     {
-      "id": "AR19",
-      "terrain": "p",
+      "id": "AR19", "terrain": "p",
       "exits": {
-        "north": "AR18",
-        "south": "AR20",
-        "west": "AQ19",
-        "east": "AS19"
+        "north": "AR18", "south": "AR20", "west": "AQ19", "east": "AS19"
       }
     },
     {
-      "id": "AS19",
-      "terrain": "p",
+      "id": "AS19", "terrain": "p",
       "exits": {
-        "north": "AS18",
-        "south": "AS20",
-        "west": "AR19",
-        "east": "AT19"
+        "north": "AS18", "south": "AS20", "west": "AR19", "east": "AT19"
       }
     },
     {
-      "id": "AT19",
-      "terrain": "lf",
+      "id": "AT19", "terrain": "lf",
       "exits": {
-        "north": "AT18",
-        "south": "AT20",
-        "west": "AS19",
-        "east": "AU19"
+        "north": "AT18", "south": "AT20", "west": "AS19", "east": "AU19"
       }
     },
     {
-      "id": "AU19",
-      "terrain": "lf",
+      "id": "AU19", "terrain": "lf",
       "exits": {
-        "north": "AU18",
-        "south": "AU20",
-        "west": "AT19",
-        "east": "AV19"
+        "north": "AU18", "south": "AU20", "west": "AT19", "east": "AV19"
       }
     },
     {
-      "id": "AV19",
-      "terrain": "p",
+      "id": "AV19", "terrain": "p",
       "exits": {
-        "north": "AV18",
-        "south": "AV20",
-        "west": "AU19",
-        "east": "AW19"
+        "north": "AV18", "south": "AV20", "west": "AU19", "east": "AW19"
       }
     },
     {
-      "id": "AW19",
-      "terrain": "p",
+      "id": "AW19", "terrain": "p",
       "exits": {
-        "north": "AW18",
-        "south": "AW20",
-        "west": "AV19",
-        "east": "AX19"
+        "north": "AW18", "south": "AW20", "west": "AV19", "east": "AX19"
       }
     },
     {
-      "id": "AX19",
-      "terrain": "p",
+      "id": "AX19", "terrain": "p",
       "exits": {
-        "north": "AX18",
-        "south": "AX20",
-        "west": "AW19"
+        "north": "AX18", "south": "AX20", "west": "AW19"
       }
     },
     {
-      "id": "A20",
-      "terrain": "p",
+      "id": "A20", "terrain": "p",
       "exits": {
-        "north": "A19",
-        "south": "A21",
-        "east": "B20"
+        "north": "A19", "south": "A21", "east": "B20"
       }
     },
     {
-      "id": "B20",
-      "terrain": "p",
+      "id": "B20", "terrain": "p",
       "exits": {
-        "north": "B19",
-        "south": "B21",
-        "west": "A20",
-        "east": "C20"
+        "north": "B19", "south": "B21", "west": "A20", "east": "C20"
       }
     },
     {
-      "id": "C20",
-      "terrain": "p",
+      "id": "C20", "terrain": "p",
       "exits": {
-        "north": "C19",
-        "south": "C21",
-        "west": "B20",
-        "east": "D20"
+        "north": "C19", "south": "C21", "west": "B20", "east": "D20"
       }
     },
     {
-      "id": "D20",
-      "terrain": "p",
+      "id": "D20", "terrain": "p",
       "exits": {
-        "north": "D19",
-        "south": "D21",
-        "west": "C20",
-        "east": "E20"
+        "north": "D19", "south": "D21", "west": "C20", "east": "E20"
       }
     },
     {
-      "id": "E20",
-      "terrain": "f",
+      "id": "E20", "terrain": "f",
       "exits": {
-        "north": "E19",
-        "south": "E21",
-        "west": "D20",
-        "east": "F20"
+        "north": "E19", "south": "E21", "west": "D20", "east": "F20"
       }
     },
     {
-      "id": "F20",
-      "terrain": "df",
+      "id": "F20", "terrain": "df",
       "exits": {
-        "north": "F19",
-        "south": "F21",
-        "west": "E20",
-        "east": "G20"
+        "north": "F19", "south": "F21", "west": "E20", "east": "G20"
       }
     },
     {
-      "id": "G20",
-      "terrain": "f",
+      "id": "G20", "terrain": "f",
       "exits": {
-        "north": "G19",
-        "south": "G21",
-        "west": "F20",
-        "east": "H20"
+        "north": "G19", "south": "G21", "west": "F20", "east": "H20"
       }
     },
     {
-      "id": "H20",
-      "terrain": "lf",
+      "id": "H20", "terrain": "lf",
       "exits": {
-        "north": "H19",
-        "south": "H21",
-        "west": "G20",
-        "east": "I20"
+        "north": "H19", "south": "H21", "west": "G20", "east": "I20"
       }
     },
     {
-      "id": "I20",
-      "terrain": "p",
+      "id": "I20", "terrain": "p",
       "exits": {
-        "north": "I19",
-        "south": "I21",
-        "west": "H20",
-        "east": "J20"
+        "north": "I19", "south": "I21", "west": "H20", "east": "J20"
       }
     },
     {
-      "id": "J20",
-      "terrain": "p",
+      "id": "J20", "terrain": "p",
       "exits": {
-        "north": "J19",
-        "south": "J21",
-        "west": "I20",
-        "east": "K20"
+        "north": "J19", "south": "J21", "west": "I20", "east": "K20"
       }
     },
     {
-      "id": "K20",
-      "terrain": "p",
+      "id": "K20", "terrain": "p",
       "exits": {
-        "north": "K19",
-        "south": "K21",
-        "west": "J20",
-        "east": "L20"
+        "north": "K19", "south": "K21", "west": "J20", "east": "L20"
       }
     },
     {
-      "id": "L20",
-      "terrain": "p",
+      "id": "L20", "terrain": "p",
       "exits": {
-        "north": "L19",
-        "south": "L21",
-        "west": "K20",
-        "east": "M20"
+        "north": "L19", "south": "L21", "west": "K20", "east": "M20"
       }
     },
     {
-      "id": "M20",
-      "terrain": "p",
+      "id": "M20", "terrain": "p",
       "exits": {
-        "north": "M19",
-        "south": "M21",
-        "west": "L20",
-        "east": "N20"
+        "north": "M19", "south": "M21", "west": "L20", "east": "N20"
       }
     },
     {
-      "id": "N20",
-      "terrain": "p",
+      "id": "N20", "terrain": "p",
       "exits": {
-        "north": "N19",
-        "south": "N21",
-        "west": "M20",
-        "east": "O20"
+        "north": "N19", "south": "N21", "west": "M20", "east": "O20"
       }
     },
     {
-      "id": "O20",
-      "terrain": "m",
+      "id": "O20", "terrain": "m",
       "exits": {
-        "north": "O19",
-        "south": "O21",
-        "west": "N20",
-        "east": "P20"
+        "north": "O19", "south": "O21", "west": "N20", "east": "P20"
       }
     },
     {
-      "id": "P20",
-      "terrain": "m",
+      "id": "P20", "terrain": "m",
       "exits": {
-        "north": "P19",
-        "south": "P21",
-        "west": "O20",
-        "east": "Q20"
+        "north": "P19", "south": "P21", "west": "O20", "east": "Q20"
       }
     },
     {
-      "id": "Q20",
-      "terrain": "m",
+      "id": "Q20", "terrain": "m",
       "exits": {
-        "north": "Q19",
-        "south": "Q21",
-        "west": "P20",
-        "east": "R20"
+        "north": "Q19", "south": "Q21", "west": "P20", "east": "R20"
       }
     },
     {
-      "id": "R20",
-      "terrain": "m",
+      "id": "R20", "terrain": "m",
       "exits": {
-        "north": "R19",
-        "south": "R21",
-        "west": "Q20",
-        "east": "S20"
+        "north": "R19", "south": "R21", "west": "Q20", "east": "S20"
       }
     },
     {
-      "id": "S20",
-      "terrain": "p",
+      "id": "S20", "terrain": "p",
       "exits": {
-        "north": "S19",
-        "south": "S21",
-        "west": "R20",
-        "east": "T20"
+        "north": "S19", "south": "S21", "west": "R20", "east": "T20"
       }
     },
     {
-      "id": "T20",
-      "terrain": "p",
+      "id": "T20", "terrain": "p",
       "exits": {
-        "north": "T19",
-        "south": "T21",
-        "west": "S20",
-        "east": "U20"
+        "north": "T19", "south": "T21", "west": "S20", "east": "U20"
       }
     },
     {
-      "id": "U20",
-      "terrain": "p",
+      "id": "U20", "terrain": "p",
       "exits": {
-        "north": "U19",
-        "south": "U21",
-        "west": "T20",
-        "east": "V20"
+        "north": "U19", "south": "U21", "west": "T20", "east": "V20"
       }
     },
     {
-      "id": "V20",
-      "terrain": "p",
+      "id": "V20", "terrain": "p",
       "exits": {
-        "north": "V19",
-        "south": "V21",
-        "west": "U20",
-        "east": "W20"
+        "north": "V19", "south": "V21", "west": "U20", "east": "W20"
       }
     },
     {
-      "id": "W20",
-      "terrain": "p",
+      "id": "W20", "terrain": "p",
       "exits": {
-        "north": "W19",
-        "south": "W21",
-        "west": "V20",
-        "east": "X20"
+        "north": "W19", "south": "W21", "west": "V20", "east": "X20"
       }
     },
     {
-      "id": "X20",
-      "terrain": "p",
+      "id": "X20", "terrain": "p",
       "exits": {
-        "north": "X19",
-        "south": "X21",
-        "west": "W20",
-        "east": "Y20"
+        "north": "X19", "south": "X21", "west": "W20", "east": "Y20"
       }
     },
     {
-      "id": "Y20",
-      "terrain": "r",
+      "id": "Y20", "terrain": "r",
       "exits": {
-        "north": "Y19",
-        "south": "Y21",
-        "west": "X20",
-        "east": "Z20"
+        "north": "Y19", "south": "Y21", "west": "X20", "east": "Z20"
       }
     },
     {
-      "id": "Z20",
-      "terrain": "p",
+      "id": "Z20", "terrain": "p",
       "exits": {
-        "north": "Z19",
-        "south": "Z21",
-        "west": "Y20",
-        "east": "AA20"
+        "north": "Z19", "south": "Z21", "west": "Y20", "east": "AA20"
       }
     },
     {
-      "id": "AA20",
-      "terrain": "p",
+      "id": "AA20", "terrain": "p",
       "exits": {
-        "north": "AA19",
-        "south": "AA21",
-        "west": "Z20",
-        "east": "AB20"
+        "north": "AA19", "south": "AA21", "west": "Z20", "east": "AB20"
       }
     },
     {
-      "id": "AB20",
-      "terrain": "p",
+      "id": "AB20", "terrain": "p",
       "exits": {
-        "north": "AB19",
-        "south": "AB21",
-        "west": "AA20",
-        "east": "AC20"
+        "north": "AB19", "south": "AB21", "west": "AA20", "east": "AC20"
       }
     },
     {
-      "id": "AC20",
-      "terrain": "p",
+      "id": "AC20", "terrain": "p",
       "exits": {
-        "north": "AC19",
-        "south": "AC21",
-        "west": "AB20",
-        "east": "AD20"
+        "north": "AC19", "south": "AC21", "west": "AB20", "east": "AD20"
       }
     },
     {
-      "id": "AD20",
-      "terrain": "p",
+      "id": "AD20", "terrain": "p",
       "exits": {
-        "north": "AD19",
-        "south": "AD21",
-        "west": "AC20",
-        "east": "AE20"
+        "north": "AD19", "south": "AD21", "west": "AC20", "east": "AE20"
       }
     },
     {
-      "id": "AE20",
-      "terrain": "p",
+      "id": "AE20", "terrain": "p",
       "exits": {
-        "north": "AE19",
-        "south": "AE21",
-        "west": "AD20",
-        "east": "AF20"
+        "north": "AE19", "south": "AE21", "west": "AD20", "east": "AF20"
       }
     },
     {
-      "id": "AF20",
-      "terrain": "p",
+      "id": "AF20", "terrain": "p",
       "exits": {
-        "north": "AF19",
-        "south": "AF21",
-        "west": "AE20",
-        "east": "AG20"
+        "north": "AF19", "south": "AF21", "west": "AE20", "east": "AG20"
       }
     },
     {
-      "id": "AG20",
-      "terrain": "p",
+      "id": "AG20", "terrain": "p",
       "exits": {
-        "north": "AG19",
-        "south": "AG21",
-        "west": "AF20",
-        "east": "AH20"
+        "north": "AG19", "south": "AG21", "west": "AF20", "east": "AH20"
       }
     },
     {
-      "id": "AH20",
-      "terrain": "p",
+      "id": "AH20", "terrain": "p",
       "exits": {
-        "north": "AH19",
-        "south": "AH21",
-        "west": "AG20",
-        "east": "AI20"
+        "north": "AH19", "south": "AH21", "west": "AG20", "east": "AI20"
       }
     },
     {
-      "id": "AI20",
-      "terrain": "p",
+      "id": "AI20", "terrain": "p",
       "exits": {
-        "north": "AI19",
-        "south": "AI21",
-        "west": "AH20",
-        "east": "AJ20"
+        "north": "AI19", "south": "AI21", "west": "AH20", "east": "AJ20"
       }
     },
     {
-      "id": "AJ20",
-      "terrain": "b",
+      "id": "AJ20", "terrain": "b",
       "exits": {
-        "north": "AJ19",
-        "south": "AJ21",
-        "west": "AI20",
-        "east": "AK20"
+        "north": "AJ19", "south": "AJ21", "west": "AI20", "east": "AK20"
       }
     },
     {
-      "id": "AK20",
-      "terrain": "p",
+      "id": "AK20", "terrain": "p",
       "exits": {
-        "north": "AK19",
-        "south": "AK21",
-        "west": "AJ20",
-        "east": "AL20"
+        "north": "AK19", "south": "AK21", "west": "AJ20", "east": "AL20"
       }
     },
     {
-      "id": "AL20",
-      "terrain": "p",
+      "id": "AL20", "terrain": "p",
       "exits": {
-        "north": "AL19",
-        "south": "AL21",
-        "west": "AK20",
-        "east": "AM20"
+        "north": "AL19", "south": "AL21", "west": "AK20", "east": "AM20"
       }
     },
     {
-      "id": "AM20",
-      "terrain": "p",
+      "id": "AM20", "terrain": "p",
       "exits": {
-        "north": "AM19",
-        "south": "AM21",
-        "west": "AL20",
-        "east": "AN20"
+        "north": "AM19", "south": "AM21", "west": "AL20", "east": "AN20"
       }
     },
     {
-      "id": "AN20",
-      "terrain": "p",
+      "id": "AN20", "terrain": "p",
       "exits": {
-        "north": "AN19",
-        "south": "AN21",
-        "west": "AM20",
-        "east": "AO20"
+        "north": "AN19", "south": "AN21", "west": "AM20", "east": "AO20"
       }
     },
     {
-      "id": "AO20",
-      "terrain": "p",
+      "id": "AO20", "terrain": "p",
       "exits": {
-        "north": "AO19",
-        "south": "AO21",
-        "west": "AN20",
-        "east": "AP20"
+        "north": "AO19", "south": "AO21", "west": "AN20", "east": "AP20"
       }
     },
     {
-      "id": "AP20",
-      "terrain": "p",
+      "id": "AP20", "terrain": "p",
       "exits": {
-        "north": "AP19",
-        "south": "AP21",
-        "west": "AO20",
-        "east": "AQ20"
+        "north": "AP19", "south": "AP21", "west": "AO20", "east": "AQ20"
       }
     },
     {
-      "id": "AQ20",
-      "terrain": "p",
+      "id": "AQ20", "terrain": "p",
       "exits": {
-        "north": "AQ19",
-        "south": "AQ21",
-        "west": "AP20",
-        "east": "AR20"
+        "north": "AQ19", "south": "AQ21", "west": "AP20", "east": "AR20"
       }
     },
     {
-      "id": "AR20",
-      "terrain": "p",
+      "id": "AR20", "terrain": "p",
       "exits": {
-        "north": "AR19",
-        "south": "AR21",
-        "west": "AQ20",
-        "east": "AS20"
+        "north": "AR19", "south": "AR21", "west": "AQ20", "east": "AS20"
       }
     },
     {
-      "id": "AS20",
-      "terrain": "p",
+      "id": "AS20", "terrain": "p",
       "exits": {
-        "north": "AS19",
-        "south": "AS21",
-        "west": "AR20",
-        "east": "AT20"
+        "north": "AS19", "south": "AS21", "west": "AR20", "east": "AT20"
       }
     },
     {
-      "id": "AT20",
-      "terrain": "lf",
+      "id": "AT20", "terrain": "lf",
       "exits": {
-        "north": "AT19",
-        "south": "AT21",
-        "west": "AS20",
-        "east": "AU20"
+        "north": "AT19", "south": "AT21", "west": "AS20", "east": "AU20"
       }
     },
     {
-      "id": "AU20",
-      "terrain": "lf",
+      "id": "AU20", "terrain": "lf",
       "exits": {
-        "north": "AU19",
-        "south": "AU21",
-        "west": "AT20",
-        "east": "AV20"
+        "north": "AU19", "south": "AU21", "west": "AT20", "east": "AV20"
       }
     },
     {
-      "id": "AV20",
-      "terrain": "p",
+      "id": "AV20", "terrain": "p",
       "exits": {
-        "north": "AV19",
-        "south": "AV21",
-        "west": "AU20",
-        "east": "AW20"
+        "north": "AV19", "south": "AV21", "west": "AU20", "east": "AW20"
       }
     },
     {
-      "id": "AW20",
-      "terrain": "p",
+      "id": "AW20", "terrain": "p",
       "exits": {
-        "north": "AW19",
-        "south": "AW21",
-        "west": "AV20",
-        "east": "AX20"
+        "north": "AW19", "south": "AW21", "west": "AV20", "east": "AX20"
       }
     },
     {
-      "id": "AX20",
-      "terrain": "p",
+      "id": "AX20", "terrain": "p",
       "exits": {
-        "north": "AX19",
-        "south": "AX21",
-        "west": "AW20"
+        "north": "AX19", "south": "AX21", "west": "AW20"
       }
     },
     {
-      "id": "A21",
-      "terrain": "p",
+      "id": "A21", "terrain": "p",
       "exits": {
-        "north": "A20",
-        "south": "A22",
-        "east": "B21"
+        "north": "A20", "south": "A22", "east": "B21"
       }
     },
     {
-      "id": "B21",
-      "terrain": "p",
+      "id": "B21", "terrain": "p",
       "exits": {
-        "north": "B20",
-        "south": "B22",
-        "west": "A21",
-        "east": "C21"
+        "north": "B20", "south": "B22", "west": "A21", "east": "C21"
       }
     },
     {
-      "id": "C21",
-      "terrain": "p",
+      "id": "C21", "terrain": "p",
       "exits": {
-        "north": "C20",
-        "south": "C22",
-        "west": "B21",
-        "east": "D21"
+        "north": "C20", "south": "C22", "west": "B21", "east": "D21"
       }
     },
     {
-      "id": "D21",
-      "terrain": "b",
+      "id": "D21", "terrain": "b",
       "exits": {
-        "north": "D20",
-        "south": "D22",
-        "west": "C21",
-        "east": "E21"
+        "north": "D20", "south": "D22", "west": "C21", "east": "E21"
       }
     },
     {
-      "id": "E21",
-      "terrain": "f",
+      "id": "E21", "terrain": "f",
       "exits": {
-        "north": "E20",
-        "south": "E22",
-        "west": "D21",
-        "east": "F21"
+        "north": "E20", "south": "E22", "west": "D21", "east": "F21"
       }
     },
     {
-      "id": "F21",
-      "terrain": "f",
+      "id": "F21", "terrain": "f",
       "exits": {
-        "north": "F20",
-        "south": "F22",
-        "west": "E21",
-        "east": "G21"
+        "north": "F20", "south": "F22", "west": "E21", "east": "G21"
       }
     },
     {
-      "id": "G21",
-      "terrain": "f",
+      "id": "G21", "terrain": "f",
       "exits": {
-        "north": "G20",
-        "south": "G22",
-        "west": "F21",
-        "east": "H21"
+        "north": "G20", "south": "G22", "west": "F21", "east": "H21"
       }
     },
     {
-      "id": "H21",
-      "terrain": "gap",
+      "id": "H21", "terrain": "gap",
       "exits": {
-        "north": "H20",
-        "south": "H22",
-        "west": "G21",
-        "east": "I21"
+        "north": "H20", "south": "H22", "west": "G21", "east": "I21"
       }
     },
     {
-      "id": "I21",
-      "terrain": "p",
+      "id": "I21", "terrain": "p",
       "exits": {
-        "north": "I20",
-        "south": "I22",
-        "west": "H21",
-        "east": "J21"
+        "north": "I20", "south": "I22", "west": "H21", "east": "J21"
       }
     },
     {
-      "id": "J21",
-      "terrain": "p",
+      "id": "J21", "terrain": "p",
       "exits": {
-        "north": "J20",
-        "south": "J22",
-        "west": "I21",
-        "east": "K21"
+        "north": "J20", "south": "J22", "west": "I21", "east": "K21"
       }
     },
     {
-      "id": "K21",
-      "terrain": "p",
+      "id": "K21", "terrain": "p",
       "exits": {
-        "north": "K20",
-        "south": "K22",
-        "west": "J21",
-        "east": "L21"
+        "north": "K20", "south": "K22", "west": "J21", "east": "L21"
       }
     },
     {
-      "id": "L21",
-      "terrain": "p",
+      "id": "L21", "terrain": "p",
       "exits": {
-        "north": "L20",
-        "south": "L22",
-        "west": "K21",
-        "east": "M21"
+        "north": "L20", "south": "L22", "west": "K21", "east": "M21"
       }
     },
     {
-      "id": "M21",
-      "terrain": "p",
+      "id": "M21", "terrain": "p",
       "exits": {
-        "north": "M20",
-        "south": "M22",
-        "west": "L21",
-        "east": "N21"
+        "north": "M20", "south": "M22", "west": "L21", "east": "N21"
       }
     },
     {
-      "id": "N21",
-      "terrain": "p",
+      "id": "N21", "terrain": "p",
       "exits": {
-        "north": "N20",
-        "south": "N22",
-        "west": "M21",
-        "east": "O21"
+        "north": "N20", "south": "N22", "west": "M21", "east": "O21"
       }
     },
     {
-      "id": "O21",
-      "terrain": "p",
+      "id": "O21", "terrain": "p",
       "exits": {
-        "north": "O20",
-        "south": "O22",
-        "west": "N21",
-        "east": "P21"
+        "north": "O20", "south": "O22", "west": "N21", "east": "P21"
       }
     },
     {
-      "id": "P21",
-      "terrain": "p",
+      "id": "P21", "terrain": "p",
       "exits": {
-        "north": "P20",
-        "south": "P22",
-        "west": "O21",
-        "east": "Q21"
+        "north": "P20", "south": "P22", "west": "O21", "east": "Q21"
       }
     },
     {
-      "id": "Q21",
-      "terrain": "p",
+      "id": "Q21", "terrain": "p",
       "exits": {
-        "north": "Q20",
-        "south": "Q22",
-        "west": "P21",
-        "east": "R21"
+        "north": "Q20", "south": "Q22", "west": "P21", "east": "R21"
       }
     },
     {
-      "id": "R21",
-      "terrain": "p",
+      "id": "R21", "terrain": "p",
       "exits": {
-        "north": "R20",
-        "south": "R22",
-        "west": "Q21",
-        "east": "S21"
+        "north": "R20", "south": "R22", "west": "Q21", "east": "S21"
       }
     },
     {
-      "id": "S21",
-      "terrain": "p",
+      "id": "S21", "terrain": "p",
       "exits": {
-        "north": "S20",
-        "south": "S22",
-        "west": "R21",
-        "east": "T21"
+        "north": "S20", "south": "S22", "west": "R21", "east": "T21"
       }
     },
     {
-      "id": "T21",
-      "terrain": "p",
+      "id": "T21", "terrain": "p",
       "exits": {
-        "north": "T20",
-        "south": "T22",
-        "west": "S21",
-        "east": "U21"
+        "north": "T20", "south": "T22", "west": "S21", "east": "U21"
       }
     },
     {
-      "id": "U21",
-      "terrain": "p",
+      "id": "U21", "terrain": "p",
       "exits": {
-        "north": "U20",
-        "south": "U22",
-        "west": "T21",
-        "east": "V21"
+        "north": "U20", "south": "U22", "west": "T21", "east": "V21"
       }
     },
     {
-      "id": "V21",
-      "terrain": "p",
+      "id": "V21", "terrain": "p",
       "exits": {
-        "north": "V20",
-        "south": "V22",
-        "west": "U21",
-        "east": "W21"
+        "north": "V20", "south": "V22", "west": "U21", "east": "W21"
       }
     },
     {
-      "id": "W21",
-      "terrain": "p",
+      "id": "W21", "terrain": "p",
       "exits": {
-        "north": "W20",
-        "south": "W22",
-        "west": "V21",
-        "east": "X21"
+        "north": "W20", "south": "W22", "west": "V21", "east": "X21"
       }
     },
     {
-      "id": "X21",
-      "terrain": "p",
+      "id": "X21", "terrain": "p",
       "exits": {
-        "north": "X20",
-        "south": "X22",
-        "west": "W21",
-        "east": "Y21"
+        "north": "X20", "south": "X22", "west": "W21", "east": "Y21"
       }
     },
     {
-      "id": "Y21",
-      "terrain": "r",
+      "id": "Y21", "terrain": "r",
       "exits": {
-        "north": "Y20",
-        "south": "Y22",
-        "west": "X21",
-        "east": "Z21"
+        "north": "Y20", "south": "Y22", "west": "X21", "east": "Z21"
       }
     },
     {
-      "id": "Z21",
-      "terrain": "p",
+      "id": "Z21", "terrain": "p",
       "exits": {
-        "north": "Z20",
-        "south": "Z22",
-        "west": "Y21",
-        "east": "AA21"
+        "north": "Z20", "south": "Z22", "west": "Y21", "east": "AA21"
       }
     },
     {
-      "id": "AA21",
-      "terrain": "p",
+      "id": "AA21", "terrain": "p",
       "exits": {
-        "north": "AA20",
-        "south": "AA22",
-        "west": "Z21",
-        "east": "AB21"
+        "north": "AA20", "south": "AA22", "west": "Z21", "east": "AB21"
       }
     },
     {
-      "id": "AB21",
-      "terrain": "p",
+      "id": "AB21", "terrain": "p",
       "exits": {
-        "north": "AB20",
-        "south": "AB22",
-        "west": "AA21",
-        "east": "AC21"
+        "north": "AB20", "south": "AB22", "west": "AA21", "east": "AC21"
       }
     },
     {
-      "id": "AC21",
-      "terrain": "p",
+      "id": "AC21", "terrain": "p",
       "exits": {
-        "north": "AC20",
-        "south": "AC22",
-        "west": "AB21",
-        "east": "AD21"
+        "north": "AC20", "south": "AC22", "west": "AB21", "east": "AD21"
       }
     },
     {
-      "id": "AD21",
-      "terrain": "p",
+      "id": "AD21", "terrain": "p",
       "exits": {
-        "north": "AD20",
-        "south": "AD22",
-        "west": "AC21",
-        "east": "AE21"
+        "north": "AD20", "south": "AD22", "west": "AC21", "east": "AE21"
       }
     },
     {
-      "id": "AE21",
-      "terrain": "p",
+      "id": "AE21", "terrain": "p",
       "exits": {
-        "north": "AE20",
-        "south": "AE22",
-        "west": "AD21",
-        "east": "AF21"
+        "north": "AE20", "south": "AE22", "west": "AD21", "east": "AF21"
       }
     },
     {
-      "id": "AF21",
-      "terrain": "p",
+      "id": "AF21", "terrain": "p",
       "exits": {
-        "north": "AF20",
-        "south": "AF22",
-        "west": "AE21",
-        "east": "AG21"
+        "north": "AF20", "south": "AF22", "west": "AE21", "east": "AG21"
       }
     },
     {
-      "id": "AG21",
-      "terrain": "p",
+      "id": "AG21", "terrain": "p",
       "exits": {
-        "north": "AG20",
-        "south": "AG22",
-        "west": "AF21",
-        "east": "AH21"
+        "north": "AG20", "south": "AG22", "west": "AF21", "east": "AH21"
       }
     },
     {
-      "id": "AH21",
-      "terrain": "b",
+      "id": "AH21", "terrain": "b",
       "exits": {
-        "north": "AH20",
-        "south": "AH22",
-        "west": "AG21",
-        "east": "AI21"
+        "north": "AH20", "south": "AH22", "west": "AG21", "east": "AI21"
       }
     },
     {
-      "id": "AI21",
-      "terrain": "b",
+      "id": "AI21", "terrain": "b",
       "exits": {
-        "north": "AI20",
-        "south": "AI22",
-        "west": "AH21",
-        "east": "AJ21"
+        "north": "AI20", "south": "AI22", "west": "AH21", "east": "AJ21"
       }
     },
     {
-      "id": "AJ21",
-      "terrain": "b",
+      "id": "AJ21", "terrain": "b",
       "exits": {
-        "north": "AJ20",
-        "south": "AJ22",
-        "west": "AI21",
-        "east": "AK21"
+        "north": "AJ20", "south": "AJ22", "west": "AI21", "east": "AK21"
       }
     },
     {
-      "id": "AK21",
-      "terrain": "b",
+      "id": "AK21", "terrain": "b",
       "exits": {
-        "north": "AK20",
-        "south": "AK22",
-        "west": "AJ21",
-        "east": "AL21"
+        "north": "AK20", "south": "AK22", "west": "AJ21", "east": "AL21"
       }
     },
     {
-      "id": "AL21",
-      "terrain": "b",
+      "id": "AL21", "terrain": "b",
       "exits": {
-        "north": "AL20",
-        "south": "AL22",
-        "west": "AK21",
-        "east": "AM21"
+        "north": "AL20", "south": "AL22", "west": "AK21", "east": "AM21"
       }
     },
     {
-      "id": "AM21",
-      "terrain": "b",
+      "id": "AM21", "terrain": "b",
       "exits": {
-        "north": "AM20",
-        "south": "AM22",
-        "west": "AL21",
-        "east": "AN21"
+        "north": "AM20", "south": "AM22", "west": "AL21", "east": "AN21"
       }
     },
     {
-      "id": "AN21",
-      "terrain": "b",
+      "id": "AN21", "terrain": "b",
       "exits": {
-        "north": "AN20",
-        "south": "AN22",
-        "west": "AM21",
-        "east": "AO21"
+        "north": "AN20", "south": "AN22", "west": "AM21", "east": "AO21"
       }
     },
     {
-      "id": "AO21",
-      "terrain": "p",
+      "id": "AO21", "terrain": "p",
       "exits": {
-        "north": "AO20",
-        "south": "AO22",
-        "west": "AN21",
-        "east": "AP21"
+        "north": "AO20", "south": "AO22", "west": "AN21", "east": "AP21"
       }
     },
     {
-      "id": "AP21",
-      "terrain": "p",
+      "id": "AP21", "terrain": "p",
       "exits": {
-        "north": "AP20",
-        "south": "AP22",
-        "west": "AO21",
-        "east": "AQ21"
+        "north": "AP20", "south": "AP22", "west": "AO21", "east": "AQ21"
       }
     },
     {
-      "id": "AQ21",
-      "terrain": "p",
+      "id": "AQ21", "terrain": "p",
       "exits": {
-        "north": "AQ20",
-        "south": "AQ22",
-        "west": "AP21",
-        "east": "AR21"
+        "north": "AQ20", "south": "AQ22", "west": "AP21", "east": "AR21"
       }
     },
     {
-      "id": "AR21",
-      "terrain": "p",
+      "id": "AR21", "terrain": "p",
       "exits": {
-        "north": "AR20",
-        "south": "AR22",
-        "west": "AQ21",
-        "east": "AS21"
+        "north": "AR20", "south": "AR22", "west": "AQ21", "east": "AS21"
       }
     },
     {
-      "id": "AS21",
-      "terrain": "p",
+      "id": "AS21", "terrain": "p",
       "exits": {
-        "north": "AS20",
-        "south": "AS22",
-        "west": "AR21",
-        "east": "AT21"
+        "north": "AS20", "south": "AS22", "west": "AR21", "east": "AT21"
       }
     },
     {
-      "id": "AT21",
-      "terrain": "lf",
+      "id": "AT21", "terrain": "lf",
       "exits": {
-        "north": "AT20",
-        "south": "AT22",
-        "west": "AS21",
-        "east": "AU21"
+        "north": "AT20", "south": "AT22", "west": "AS21", "east": "AU21"
       }
     },
     {
-      "id": "AU21",
-      "terrain": "lf",
+      "id": "AU21", "terrain": "lf",
       "exits": {
-        "north": "AU20",
-        "south": "AU22",
-        "west": "AT21",
-        "east": "AV21"
+        "north": "AU20", "south": "AU22", "west": "AT21", "east": "AV21"
       }
     },
     {
-      "id": "AV21",
-      "terrain": "p",
+      "id": "AV21", "terrain": "p",
       "exits": {
-        "north": "AV20",
-        "south": "AV22",
-        "west": "AU21",
-        "east": "AW21"
+        "north": "AV20", "south": "AV22", "west": "AU21", "east": "AW21"
       }
     },
     {
-      "id": "AW21",
-      "terrain": "p",
+      "id": "AW21", "terrain": "p",
       "exits": {
-        "north": "AW20",
-        "south": "AW22",
-        "west": "AV21",
-        "east": "AX21"
+        "north": "AW20", "south": "AW22", "west": "AV21", "east": "AX21"
       }
     },
     {
-      "id": "AX21",
-      "terrain": "p",
+      "id": "AX21", "terrain": "p",
       "exits": {
-        "north": "AX20",
-        "south": "AX22",
-        "west": "AW21"
+        "north": "AX20", "south": "AX22", "west": "AW21"
       }
     },
     {
-      "id": "A22",
-      "terrain": "p",
+      "id": "A22", "terrain": "p",
       "exits": {
-        "north": "A21",
-        "south": "A23",
-        "east": "B22"
+        "north": "A21", "south": "A23", "east": "B22"
       }
     },
     {
-      "id": "B22",
-      "terrain": "p",
+      "id": "B22", "terrain": "p",
       "exits": {
-        "north": "B21",
-        "south": "B23",
-        "west": "A22",
-        "east": "C22"
+        "north": "B21", "south": "B23", "west": "A22", "east": "C22"
       }
     },
     {
-      "id": "C22",
-      "terrain": "p",
+      "id": "C22", "terrain": "p",
       "exits": {
-        "north": "C21",
-        "south": "C23",
-        "west": "B22",
-        "east": "D22"
+        "north": "C21", "south": "C23", "west": "B22", "east": "D22"
       }
     },
     {
-      "id": "D22",
-      "terrain": "p",
+      "id": "D22", "terrain": "p",
       "exits": {
-        "north": "D21",
-        "south": "D23",
-        "west": "C22",
-        "east": "E22"
+        "north": "D21", "south": "D23", "west": "C22", "east": "E22"
       }
     },
     {
-      "id": "E22",
-      "terrain": "p",
+      "id": "E22", "terrain": "p",
       "exits": {
-        "north": "E21",
-        "south": "E23",
-        "west": "D22",
-        "east": "F22"
+        "north": "E21", "south": "E23", "west": "D22", "east": "F22"
       }
     },
     {
-      "id": "F22",
-      "terrain": "b",
+      "id": "F22", "terrain": "b",
       "exits": {
-        "north": "F21",
-        "south": "F23",
-        "west": "E22",
-        "east": "G22"
+        "north": "F21", "south": "F23", "west": "E22", "east": "G22"
       }
     },
     {
-      "id": "G22",
-      "terrain": "lf",
+      "id": "G22", "terrain": "lf",
       "exits": {
-        "north": "G21",
-        "south": "G23",
-        "west": "F22",
-        "east": "H22"
+        "north": "G21", "south": "G23", "west": "F22", "east": "H22"
       }
     },
     {
-      "id": "H22",
-      "terrain": "lf",
+      "id": "H22", "terrain": "lf",
       "exits": {
-        "north": "H21",
-        "south": "H23",
-        "west": "G22",
-        "east": "I22"
+        "north": "H21", "south": "H23", "west": "G22", "east": "I22"
       }
     },
     {
-      "id": "I22",
-      "terrain": "p",
+      "id": "I22", "terrain": "p",
       "exits": {
-        "north": "I21",
-        "south": "I23",
-        "west": "H22",
-        "east": "J22"
+        "north": "I21", "south": "I23", "west": "H22", "east": "J22"
       }
     },
     {
-      "id": "J22",
-      "terrain": "m",
+      "id": "J22", "terrain": "m",
       "exits": {
-        "north": "J21",
-        "south": "J23",
-        "west": "I22",
-        "east": "K22"
+        "north": "J21", "south": "J23", "west": "I22", "east": "K22"
       }
     },
     {
-      "id": "K22",
-      "terrain": "m",
+      "id": "K22", "terrain": "m",
       "exits": {
-        "north": "K21",
-        "south": "K23",
-        "west": "J22",
-        "east": "L22"
+        "north": "K21", "south": "K23", "west": "J22", "east": "L22"
       }
     },
     {
-      "id": "L22",
-      "terrain": "m",
+      "id": "L22", "terrain": "m",
       "exits": {
-        "north": "L21",
-        "south": "L23",
-        "west": "K22",
-        "east": "M22"
+        "north": "L21", "south": "L23", "west": "K22", "east": "M22"
       }
     },
     {
-      "id": "M22",
-      "terrain": "m",
+      "id": "M22", "terrain": "m",
       "exits": {
-        "north": "M21",
-        "south": "M23",
-        "west": "L22",
-        "east": "N22"
+        "north": "M21", "south": "M23", "west": "L22", "east": "N22"
       }
     },
     {
-      "id": "N22",
-      "terrain": "m",
+      "id": "N22", "terrain": "m",
       "exits": {
-        "north": "N21",
-        "south": "N23",
-        "west": "M22",
-        "east": "O22"
+        "north": "N21", "south": "N23", "west": "M22", "east": "O22"
       }
     },
     {
-      "id": "O22",
-      "terrain": "p",
+      "id": "O22", "terrain": "p",
       "exits": {
-        "north": "O21",
-        "south": "O23",
-        "west": "N22",
-        "east": "P22"
+        "north": "O21", "south": "O23", "west": "N22", "east": "P22"
       }
     },
     {
-      "id": "P22",
-      "terrain": "p",
+      "id": "P22", "terrain": "p",
       "exits": {
-        "north": "P21",
-        "south": "P23",
-        "west": "O22",
-        "east": "Q22"
+        "north": "P21", "south": "P23", "west": "O22", "east": "Q22"
       }
     },
     {
-      "id": "Q22",
-      "terrain": "p",
+      "id": "Q22", "terrain": "p",
       "exits": {
-        "north": "Q21",
-        "south": "Q23",
-        "west": "P22",
-        "east": "R22"
+        "north": "Q21", "south": "Q23", "west": "P22", "east": "R22"
       }
     },
     {
-      "id": "R22",
-      "terrain": "p",
+      "id": "R22", "terrain": "p",
       "exits": {
-        "north": "R21",
-        "south": "R23",
-        "west": "Q22",
-        "east": "S22"
+        "north": "R21", "south": "R23", "west": "Q22", "east": "S22"
       }
     },
     {
-      "id": "S22",
-      "terrain": "p",
+      "id": "S22", "terrain": "p",
       "exits": {
-        "north": "S21",
-        "south": "S23",
-        "west": "R22",
-        "east": "T22"
+        "north": "S21", "south": "S23", "west": "R22", "east": "T22"
       }
     },
     {
-      "id": "T22",
-      "terrain": "p",
+      "id": "T22", "terrain": "p",
       "exits": {
-        "north": "T21",
-        "south": "T23",
-        "west": "S22",
-        "east": "U22"
+        "north": "T21", "south": "T23", "west": "S22", "east": "U22"
       }
     },
     {
-      "id": "U22",
-      "terrain": "p",
+      "id": "U22", "terrain": "p",
       "exits": {
-        "north": "U21",
-        "south": "U23",
-        "west": "T22",
-        "east": "V22"
+        "north": "U21", "south": "U23", "west": "T22", "east": "V22"
       }
     },
     {
-      "id": "V22",
-      "terrain": "p",
+      "id": "V22", "terrain": "p",
       "exits": {
-        "north": "V21",
-        "south": "V23",
-        "west": "U22",
-        "east": "W22"
+        "north": "V21", "south": "V23", "west": "U22", "east": "W22"
       }
     },
     {
-      "id": "W22",
-      "terrain": "p",
+      "id": "W22", "terrain": "p",
       "exits": {
-        "north": "W21",
-        "south": "W23",
-        "west": "V22",
-        "east": "X22"
+        "north": "W21", "south": "W23", "west": "V22", "east": "X22"
       }
     },
     {
-      "id": "X22",
-      "terrain": "p",
+      "id": "X22", "terrain": "p",
       "exits": {
-        "north": "X21",
-        "south": "X23",
-        "west": "W22",
-        "east": "Y22"
+        "north": "X21", "south": "X23", "west": "W22", "east": "Y22"
       }
     },
     {
-      "id": "Y22",
-      "terrain": "r",
+      "id": "Y22", "terrain": "r",
       "exits": {
-        "north": "Y21",
-        "south": "Y23",
-        "west": "X22",
-        "east": "Z22"
+        "north": "Y21", "south": "Y23", "west": "X22", "east": "Z22"
       }
     },
     {
-      "id": "Z22",
-      "terrain": "p",
+      "id": "Z22", "terrain": "p",
       "exits": {
-        "north": "Z21",
-        "south": "Z23",
-        "west": "Y22",
-        "east": "AA22"
+        "north": "Z21", "south": "Z23", "west": "Y22", "east": "AA22"
       }
     },
     {
-      "id": "AA22",
-      "terrain": "p",
+      "id": "AA22", "terrain": "p",
       "exits": {
-        "north": "AA21",
-        "south": "AA23",
-        "west": "Z22",
-        "east": "AB22"
+        "north": "AA21", "south": "AA23", "west": "Z22", "east": "AB22"
       }
     },
     {
-      "id": "AB22",
-      "terrain": "p",
+      "id": "AB22", "terrain": "p",
       "exits": {
-        "north": "AB21",
-        "south": "AB23",
-        "west": "AA22",
-        "east": "AC22"
+        "north": "AB21", "south": "AB23", "west": "AA22", "east": "AC22"
       }
     },
     {
-      "id": "AC22",
-      "terrain": "p",
+      "id": "AC22", "terrain": "p",
       "exits": {
-        "north": "AC21",
-        "south": "AC23",
-        "west": "AB22",
-        "east": "AD22"
+        "north": "AC21", "south": "AC23", "west": "AB22", "east": "AD22"
       }
     },
     {
-      "id": "AD22",
-      "terrain": "p",
+      "id": "AD22", "terrain": "p",
       "exits": {
-        "north": "AD21",
-        "south": "AD23",
-        "west": "AC22",
-        "east": "AE22"
+        "north": "AD21", "south": "AD23", "west": "AC22", "east": "AE22"
       }
     },
     {
-      "id": "AE22",
-      "terrain": "p",
+      "id": "AE22", "terrain": "p",
       "exits": {
-        "north": "AE21",
-        "south": "AE23",
-        "west": "AD22",
-        "east": "AF22"
+        "north": "AE21", "south": "AE23", "west": "AD22", "east": "AF22"
       }
     },
     {
-      "id": "AF22",
-      "terrain": "p",
+      "id": "AF22", "terrain": "p",
       "exits": {
-        "north": "AF21",
-        "south": "AF23",
-        "west": "AE22",
-        "east": "AG22"
+        "north": "AF21", "south": "AF23", "west": "AE22", "east": "AG22"
       }
     },
     {
-      "id": "AG22",
-      "terrain": "b",
+      "id": "AG22", "terrain": "b",
       "exits": {
-        "north": "AG21",
-        "south": "AG23",
-        "west": "AF22",
-        "east": "AH22"
+        "north": "AG21", "south": "AG23", "west": "AF22", "east": "AH22"
       }
     },
     {
-      "id": "AH22",
-      "terrain": "b",
+      "id": "AH22", "terrain": "b",
       "exits": {
-        "north": "AH21",
-        "south": "AH23",
-        "west": "AG22",
-        "east": "AI22"
+        "north": "AH21", "south": "AH23", "west": "AG22", "east": "AI22"
       }
     },
     {
-      "id": "AI22",
-      "terrain": "b",
+      "id": "AI22", "terrain": "b",
       "exits": {
-        "north": "AI21",
-        "south": "AI23",
-        "west": "AH22",
-        "east": "AJ22"
+        "north": "AI21", "south": "AI23", "west": "AH22", "east": "AJ22"
       }
     },
     {
-      "id": "AJ22",
-      "terrain": "b",
+      "id": "AJ22", "terrain": "b",
       "exits": {
-        "north": "AJ21",
-        "south": "AJ23",
-        "west": "AI22",
-        "east": "AK22"
+        "north": "AJ21", "south": "AJ23", "west": "AI22", "east": "AK22"
       }
     },
     {
-      "id": "AK22",
-      "terrain": "b",
+      "id": "AK22", "terrain": "b",
       "exits": {
-        "north": "AK21",
-        "south": "AK23",
-        "west": "AJ22",
-        "east": "AL22"
+        "north": "AK21", "south": "AK23", "west": "AJ22", "east": "AL22"
       }
     },
     {
-      "id": "AL22",
-      "terrain": "b",
+      "id": "AL22", "terrain": "b",
       "exits": {
-        "north": "AL21",
-        "south": "AL23",
-        "west": "AK22",
-        "east": "AM22"
+        "north": "AL21", "south": "AL23", "west": "AK22", "east": "AM22"
       }
     },
     {
-      "id": "AM22",
-      "terrain": "b",
+      "id": "AM22", "terrain": "b",
       "exits": {
-        "north": "AM21",
-        "south": "AM23",
-        "west": "AL22",
-        "east": "AN22"
+        "north": "AM21", "south": "AM23", "west": "AL22", "east": "AN22"
       }
     },
     {
-      "id": "AN22",
-      "terrain": "p",
+      "id": "AN22", "terrain": "p",
       "exits": {
-        "north": "AN21",
-        "south": "AN23",
-        "west": "AM22",
-        "east": "AO22"
+        "north": "AN21", "south": "AN23", "west": "AM22", "east": "AO22"
       }
     },
     {
-      "id": "AO22",
-      "terrain": "p",
+      "id": "AO22", "terrain": "p",
       "exits": {
-        "north": "AO21",
-        "south": "AO23",
-        "west": "AN22",
-        "east": "AP22"
+        "north": "AO21", "south": "AO23", "west": "AN22", "east": "AP22"
       }
     },
     {
-      "id": "AP22",
-      "terrain": "p",
+      "id": "AP22", "terrain": "p",
       "exits": {
-        "north": "AP21",
-        "south": "AP23",
-        "west": "AO22",
-        "east": "AQ22"
+        "north": "AP21", "south": "AP23", "west": "AO22", "east": "AQ22"
       }
     },
     {
-      "id": "AQ22",
-      "terrain": "p",
+      "id": "AQ22", "terrain": "p",
       "exits": {
-        "north": "AQ21",
-        "south": "AQ23",
-        "west": "AP22",
-        "east": "AR22"
+        "north": "AQ21", "south": "AQ23", "west": "AP22", "east": "AR22"
       }
     },
     {
-      "id": "AR22",
-      "terrain": "p",
+      "id": "AR22", "terrain": "p",
       "exits": {
-        "north": "AR21",
-        "south": "AR23",
-        "west": "AQ22",
-        "east": "AS22"
+        "north": "AR21", "south": "AR23", "west": "AQ22", "east": "AS22"
       }
     },
     {
-      "id": "AS22",
-      "terrain": "p",
+      "id": "AS22", "terrain": "p",
       "exits": {
-        "north": "AS21",
-        "south": "AS23",
-        "west": "AR22",
-        "east": "AT22"
+        "north": "AS21", "south": "AS23", "west": "AR22", "east": "AT22"
       }
     },
     {
-      "id": "AT22",
-      "terrain": "lf",
+      "id": "AT22", "terrain": "lf",
       "exits": {
-        "north": "AT21",
-        "south": "AT23",
-        "west": "AS22",
-        "east": "AU22"
+        "north": "AT21", "south": "AT23", "west": "AS22", "east": "AU22"
       }
     },
     {
-      "id": "AU22",
-      "terrain": "lf",
+      "id": "AU22", "terrain": "lf",
       "exits": {
-        "north": "AU21",
-        "south": "AU23",
-        "west": "AT22",
-        "east": "AV22"
+        "north": "AU21", "south": "AU23", "west": "AT22", "east": "AV22"
       }
     },
     {
-      "id": "AV22",
-      "terrain": "p",
+      "id": "AV22", "terrain": "p",
       "exits": {
-        "north": "AV21",
-        "south": "AV23",
-        "west": "AU22",
-        "east": "AW22"
+        "north": "AV21", "south": "AV23", "west": "AU22", "east": "AW22"
       }
     },
     {
-      "id": "AW22",
-      "terrain": "p",
+      "id": "AW22", "terrain": "p",
       "exits": {
-        "north": "AW21",
-        "south": "AW23",
-        "west": "AV22",
-        "east": "AX22"
+        "north": "AW21", "south": "AW23", "west": "AV22", "east": "AX22"
       }
     },
     {
-      "id": "AX22",
-      "terrain": "p",
+      "id": "AX22", "terrain": "p",
       "exits": {
-        "north": "AX21",
-        "south": "AX23",
-        "west": "AW22"
+        "north": "AX21", "south": "AX23", "west": "AW22"
       }
     },
     {
-      "id": "A23",
-      "terrain": "p",
+      "id": "A23", "terrain": "p",
       "exits": {
-        "north": "A22",
-        "south": "A24",
-        "east": "B23"
+        "north": "A22", "south": "A24", "east": "B23"
       }
     },
     {
-      "id": "B23",
-      "terrain": "p",
+      "id": "B23", "terrain": "p",
       "exits": {
-        "north": "B22",
-        "south": "B24",
-        "west": "A23",
-        "east": "C23"
+        "north": "B22", "south": "B24", "west": "A23", "east": "C23"
       }
     },
     {
-      "id": "C23",
-      "terrain": "p",
+      "id": "C23", "terrain": "p",
       "exits": {
-        "north": "C22",
-        "south": "C24",
-        "west": "B23",
-        "east": "D23"
+        "north": "C22", "south": "C24", "west": "B23", "east": "D23"
       }
     },
     {
-      "id": "D23",
-      "terrain": "p",
+      "id": "D23", "terrain": "p",
       "exits": {
-        "north": "D22",
-        "south": "D24",
-        "west": "C23",
-        "east": "E23"
+        "north": "D22", "south": "D24", "west": "C23", "east": "E23"
       }
     },
     {
-      "id": "E23",
-      "terrain": "burrows",
+      "id": "E23", "terrain": "burrows",
       "exits": {
-        "north": "E22",
-        "south": "E24",
-        "west": "D23",
-        "east": "F23"
+        "north": "E22", "south": "E24", "west": "D23", "east": "F23"
       }
     },
     {
-      "id": "F23",
-      "terrain": "b",
+      "id": "F23", "terrain": "b",
       "exits": {
-        "north": "F22",
-        "south": "F24",
-        "west": "E23",
-        "east": "G23"
+        "north": "F22", "south": "F24", "west": "E23", "east": "G23"
       }
     },
     {
-      "id": "G23",
-      "terrain": "b",
+      "id": "G23", "terrain": "b",
       "exits": {
-        "north": "G22",
-        "south": "G24",
-        "west": "F23",
-        "east": "H23"
+        "north": "G22", "south": "G24", "west": "F23", "east": "H23"
       }
     },
     {
-      "id": "H23",
-      "terrain": "m",
+      "id": "H23", "terrain": "m",
       "exits": {
-        "north": "H22",
-        "south": "H24",
-        "west": "G23",
-        "east": "I23"
+        "north": "H22", "south": "H24", "west": "G23", "east": "I23"
       }
     },
     {
-      "id": "I23",
-      "terrain": "m",
+      "id": "I23", "terrain": "m",
       "exits": {
-        "north": "I22",
-        "south": "I24",
-        "west": "H23",
-        "east": "J23"
+        "north": "I22", "south": "I24", "west": "H23", "east": "J23"
       }
     },
     {
-      "id": "J23",
-      "terrain": "cave",
+      "id": "J23", "terrain": "cave",
       "exits": {
-        "north": "J22",
-        "south": "J24",
-        "west": "I23",
-        "east": "K23"
+        "north": "J22", "south": "J24", "west": "I23", "east": "K23"
       }
     },
     {
-      "id": "K23",
-      "terrain": "m",
+      "id": "K23", "terrain": "m",
       "exits": {
-        "north": "K22",
-        "south": "K24",
-        "west": "J23",
-        "east": "L23"
+        "north": "K22", "south": "K24", "west": "J23", "east": "L23"
       }
     },
     {
-      "id": "L23",
-      "terrain": "m",
+      "id": "L23", "terrain": "m",
       "exits": {
-        "north": "L22",
-        "south": "L24",
-        "west": "K23",
-        "east": "M23"
+        "north": "L22", "south": "L24", "west": "K23", "east": "M23"
       }
     },
     {
-      "id": "M23",
-      "terrain": "m",
+      "id": "M23", "terrain": "m",
       "exits": {
-        "north": "M22",
-        "south": "M24",
-        "west": "L23",
-        "east": "N23"
+        "north": "M22", "south": "M24", "west": "L23", "east": "N23"
       }
     },
     {
-      "id": "N23",
-      "terrain": "m",
+      "id": "N23", "terrain": "m",
       "exits": {
-        "north": "N22",
-        "south": "N24",
-        "west": "M23",
-        "east": "O23"
+        "north": "N22", "south": "N24", "west": "M23", "east": "O23"
       }
     },
     {
-      "id": "O23",
-      "terrain": "m",
+      "id": "O23", "terrain": "m",
       "exits": {
-        "north": "O22",
-        "south": "O24",
-        "west": "N23",
-        "east": "P23"
+        "north": "O22", "south": "O24", "west": "N23", "east": "P23"
       }
     },
     {
-      "id": "P23",
-      "terrain": "m",
+      "id": "P23", "terrain": "m",
       "exits": {
-        "north": "P22",
-        "south": "P24",
-        "west": "O23",
-        "east": "Q23"
+        "north": "P22", "south": "P24", "west": "O23", "east": "Q23"
       }
     },
     {
-      "id": "Q23",
-      "terrain": "p",
+      "id": "Q23", "terrain": "p",
       "exits": {
-        "north": "Q22",
-        "south": "Q24",
-        "west": "P23",
-        "east": "R23"
+        "north": "Q22", "south": "Q24", "west": "P23", "east": "R23"
       }
     },
     {
-      "id": "R23",
-      "terrain": "p",
+      "id": "R23", "terrain": "p",
       "exits": {
-        "north": "R22",
-        "south": "R24",
-        "west": "Q23",
-        "east": "S23"
+        "north": "R22", "south": "R24", "west": "Q23", "east": "S23"
       }
     },
     {
-      "id": "S23",
-      "terrain": "p",
+      "id": "S23", "terrain": "p",
       "exits": {
-        "north": "S22",
-        "south": "S24",
-        "west": "R23",
-        "east": "T23"
+        "north": "S22", "south": "S24", "west": "R23", "east": "T23"
       }
     },
     {
-      "id": "T23",
-      "terrain": "p",
+      "id": "T23", "terrain": "p",
       "exits": {
-        "north": "T22",
-        "south": "T24",
-        "west": "S23",
-        "east": "U23"
+        "north": "T22", "south": "T24", "west": "S23", "east": "U23"
       }
     },
     {
-      "id": "U23",
-      "terrain": "p",
+      "id": "U23", "terrain": "p",
       "exits": {
-        "north": "U22",
-        "south": "U24",
-        "west": "T23",
-        "east": "V23"
+        "north": "U22", "south": "U24", "west": "T23", "east": "V23"
       }
     },
     {
-      "id": "V23",
-      "terrain": "p",
+      "id": "V23", "terrain": "p",
       "exits": {
-        "north": "V22",
-        "south": "V24",
-        "west": "U23",
-        "east": "W23"
+        "north": "V22", "south": "V24", "west": "U23", "east": "W23"
       }
     },
     {
-      "id": "W23",
-      "terrain": "p",
+      "id": "W23", "terrain": "p",
       "exits": {
-        "north": "W22",
-        "south": "W24",
-        "west": "V23",
-        "east": "X23"
+        "north": "W22", "south": "W24", "west": "V23", "east": "X23"
       }
     },
     {
-      "id": "X23",
-      "terrain": "p",
+      "id": "X23", "terrain": "p",
       "exits": {
-        "north": "X22",
-        "south": "X24",
-        "west": "W23",
-        "east": "Y23"
+        "north": "X22", "south": "X24", "west": "W23", "east": "Y23"
       }
     },
     {
-      "id": "Y23",
-      "terrain": "r",
+      "id": "Y23", "terrain": "r",
       "exits": {
-        "north": "Y22",
-        "south": "Y24",
-        "west": "X23",
-        "east": "Z23"
+        "north": "Y22", "south": "Y24", "west": "X23", "east": "Z23"
       }
     },
     {
-      "id": "Z23",
-      "terrain": "p",
+      "id": "Z23", "terrain": "p",
       "exits": {
-        "north": "Z22",
-        "south": "Z24",
-        "west": "Y23",
-        "east": "AA23"
+        "north": "Z22", "south": "Z24", "west": "Y23", "east": "AA23"
       }
     },
     {
-      "id": "AA23",
-      "terrain": "p",
+      "id": "AA23", "terrain": "p",
       "exits": {
-        "north": "AA22",
-        "south": "AA24",
-        "west": "Z23",
-        "east": "AB23"
+        "north": "AA22", "south": "AA24", "west": "Z23", "east": "AB23"
       }
     },
     {
-      "id": "AB23",
-      "terrain": "p",
+      "id": "AB23", "terrain": "p",
       "exits": {
-        "north": "AB22",
-        "south": "AB24",
-        "west": "AA23",
-        "east": "AC23"
+        "north": "AB22", "south": "AB24", "west": "AA23", "east": "AC23"
       }
     },
     {
-      "id": "AC23",
-      "terrain": "p",
+      "id": "AC23", "terrain": "p",
       "exits": {
-        "north": "AC22",
-        "south": "AC24",
-        "west": "AB23",
-        "east": "AD23"
+        "north": "AC22", "south": "AC24", "west": "AB23", "east": "AD23"
       }
     },
     {
-      "id": "AD23",
-      "terrain": "p",
+      "id": "AD23", "terrain": "p",
       "exits": {
-        "north": "AD22",
-        "south": "AD24",
-        "west": "AC23",
-        "east": "AE23"
+        "north": "AD22", "south": "AD24", "west": "AC23", "east": "AE23"
       }
     },
     {
-      "id": "AE23",
-      "terrain": "p",
+      "id": "AE23", "terrain": "p",
       "exits": {
-        "north": "AE22",
-        "south": "AE24",
-        "west": "AD23",
-        "east": "AF23"
+        "north": "AE22", "south": "AE24", "west": "AD23", "east": "AF23"
       }
     },
     {
-      "id": "AF23",
-      "terrain": "p",
+      "id": "AF23", "terrain": "p",
       "exits": {
-        "north": "AF22",
-        "south": "AF24",
-        "west": "AE23",
-        "east": "AG23"
+        "north": "AF22", "south": "AF24", "west": "AE23", "east": "AG23"
       }
     },
     {
-      "id": "AG23",
-      "terrain": "b",
+      "id": "AG23", "terrain": "b",
       "exits": {
-        "north": "AG22",
-        "south": "AG24",
-        "west": "AF23",
-        "east": "AH23"
+        "north": "AG22", "south": "AG24", "west": "AF23", "east": "AH23"
       }
     },
     {
-      "id": "AH23",
-      "terrain": "b",
+      "id": "AH23", "terrain": "b",
       "exits": {
-        "north": "AH22",
-        "south": "AH24",
-        "west": "AG23",
-        "east": "AI23"
+        "north": "AH22", "south": "AH24", "west": "AG23", "east": "AI23"
       }
     },
     {
-      "id": "AI23",
-      "terrain": "b",
+      "id": "AI23", "terrain": "b",
       "exits": {
-        "north": "AI22",
-        "south": "AI24",
-        "west": "AH23",
-        "east": "AJ23"
+        "north": "AI22", "south": "AI24", "west": "AH23", "east": "AJ23"
       }
     },
     {
-      "id": "AJ23",
-      "terrain": "lf",
+      "id": "AJ23", "terrain": "lf",
       "exits": {
-        "north": "AJ22",
-        "south": "AJ24",
-        "west": "AI23",
-        "east": "AK23"
+        "north": "AJ22", "south": "AJ24", "west": "AI23", "east": "AK23"
       }
     },
     {
-      "id": "AK23",
-      "terrain": "f",
+      "id": "AK23", "terrain": "f",
       "exits": {
-        "north": "AK22",
-        "south": "AK24",
-        "west": "AJ23",
-        "east": "AL23"
+        "north": "AK22", "south": "AK24", "west": "AJ23", "east": "AL23"
       }
     },
     {
-      "id": "AL23",
-      "terrain": "lf",
+      "id": "AL23", "terrain": "lf",
       "exits": {
-        "north": "AL22",
-        "south": "AL24",
-        "west": "AK23",
-        "east": "AM23"
+        "north": "AL22", "south": "AL24", "west": "AK23", "east": "AM23"
       }
     },
     {
-      "id": "AM23",
-      "terrain": "b",
+      "id": "AM23", "terrain": "b",
       "exits": {
-        "north": "AM22",
-        "south": "AM24",
-        "west": "AL23",
-        "east": "AN23"
+        "north": "AM22", "south": "AM24", "west": "AL23", "east": "AN23"
       }
     },
     {
-      "id": "AN23",
-      "terrain": "p",
+      "id": "AN23", "terrain": "p",
       "exits": {
-        "north": "AN22",
-        "south": "AN24",
-        "west": "AM23",
-        "east": "AO23"
+        "north": "AN22", "south": "AN24", "west": "AM23", "east": "AO23"
       }
     },
     {
-      "id": "AO23",
-      "terrain": "p",
+      "id": "AO23", "terrain": "p",
       "exits": {
-        "north": "AO22",
-        "south": "AO24",
-        "west": "AN23",
-        "east": "AP23"
+        "north": "AO22", "south": "AO24", "west": "AN23", "east": "AP23"
       }
     },
     {
-      "id": "AP23",
-      "terrain": "p",
+      "id": "AP23", "terrain": "p",
       "exits": {
-        "north": "AP22",
-        "south": "AP24",
-        "west": "AO23",
-        "east": "AQ23"
+        "north": "AP22", "south": "AP24", "west": "AO23", "east": "AQ23"
       }
     },
     {
-      "id": "AQ23",
-      "terrain": "p",
+      "id": "AQ23", "terrain": "p",
       "exits": {
-        "north": "AQ22",
-        "south": "AQ24",
-        "west": "AP23",
-        "east": "AR23"
+        "north": "AQ22", "south": "AQ24", "west": "AP23", "east": "AR23"
       }
     },
     {
-      "id": "AR23",
-      "terrain": "p",
+      "id": "AR23", "terrain": "p",
       "exits": {
-        "north": "AR22",
-        "south": "AR24",
-        "west": "AQ23",
-        "east": "AS23"
+        "north": "AR22", "south": "AR24", "west": "AQ23", "east": "AS23"
       }
     },
     {
-      "id": "AS23",
-      "terrain": "p",
+      "id": "AS23", "terrain": "p",
       "exits": {
-        "north": "AS22",
-        "south": "AS24",
-        "west": "AR23",
-        "east": "AT23"
+        "north": "AS22", "south": "AS24", "west": "AR23", "east": "AT23"
       }
     },
     {
-      "id": "AT23",
-      "terrain": "lf",
+      "id": "AT23", "terrain": "lf",
       "exits": {
-        "north": "AT22",
-        "south": "AT24",
-        "west": "AS23",
-        "east": "AU23"
+        "north": "AT22", "south": "AT24", "west": "AS23", "east": "AU23"
       }
     },
     {
-      "id": "AU23",
-      "terrain": "lf",
+      "id": "AU23", "terrain": "lf",
       "exits": {
-        "north": "AU22",
-        "south": "AU24",
-        "west": "AT23",
-        "east": "AV23"
+        "north": "AU22", "south": "AU24", "west": "AT23", "east": "AV23"
       }
     },
     {
-      "id": "AV23",
-      "terrain": "p",
+      "id": "AV23", "terrain": "p",
       "exits": {
-        "north": "AV22",
-        "south": "AV24",
-        "west": "AU23",
-        "east": "AW23"
+        "north": "AV22", "south": "AV24", "west": "AU23", "east": "AW23"
       }
     },
     {
-      "id": "AW23",
-      "terrain": "p",
+      "id": "AW23", "terrain": "p",
       "exits": {
-        "north": "AW22",
-        "south": "AW24",
-        "west": "AV23",
-        "east": "AX23"
+        "north": "AW22", "south": "AW24", "west": "AV23", "east": "AX23"
       }
     },
     {
-      "id": "AX23",
-      "terrain": "p",
+      "id": "AX23", "terrain": "p",
       "exits": {
-        "north": "AX22",
-        "south": "AX24",
-        "west": "AW23"
+        "north": "AX22", "south": "AX24", "west": "AW23"
       }
     },
     {
-      "id": "A24",
-      "terrain": "b",
+      "id": "A24", "terrain": "b",
       "exits": {
-        "north": "A23",
-        "south": "A25",
-        "east": "B24"
+        "north": "A23", "south": "A25", "east": "B24"
       }
     },
     {
-      "id": "B24",
-      "terrain": "b",
+      "id": "B24", "terrain": "b",
       "exits": {
-        "north": "B23",
-        "south": "B25",
-        "west": "A24",
-        "east": "C24"
+        "north": "B23", "south": "B25", "west": "A24", "east": "C24"
       }
     },
     {
-      "id": "C24",
-      "terrain": "p",
+      "id": "C24", "terrain": "p",
       "exits": {
-        "north": "C23",
-        "south": "C25",
-        "west": "B24",
-        "east": "D24"
+        "north": "C23", "south": "C25", "west": "B24", "east": "D24"
       }
     },
     {
-      "id": "D24",
-      "terrain": "p",
+      "id": "D24", "terrain": "p",
       "exits": {
-        "north": "D23",
-        "south": "D25",
-        "west": "C24",
-        "east": "E24"
+        "north": "D23", "south": "D25", "west": "C24", "east": "E24"
       }
     },
     {
-      "id": "E24",
-      "terrain": "p",
+      "id": "E24", "terrain": "p",
       "exits": {
-        "north": "E23",
-        "south": "E25",
-        "west": "D24",
-        "east": "F24"
+        "north": "E23", "south": "E25", "west": "D24", "east": "F24"
       }
     },
     {
-      "id": "F24",
-      "terrain": "b",
+      "id": "F24", "terrain": "b",
       "exits": {
-        "north": "F23",
-        "south": "F25",
-        "west": "E24",
-        "east": "G24"
+        "north": "F23", "south": "F25", "west": "E24", "east": "G24"
       }
     },
     {
-      "id": "G24",
-      "terrain": "m",
+      "id": "G24", "terrain": "m",
       "exits": {
-        "north": "G23",
-        "south": "G25",
-        "west": "F24",
-        "east": "H24"
+        "north": "G23", "south": "G25", "west": "F24", "east": "H24"
       }
     },
     {
-      "id": "H24",
-      "terrain": "m",
+      "id": "H24", "terrain": "m",
       "exits": {
-        "north": "H23",
-        "south": "H25",
-        "west": "G24",
-        "east": "I24"
+        "north": "H23", "south": "H25", "west": "G24", "east": "I24"
       }
     },
     {
-      "id": "I24",
-      "terrain": "m",
+      "id": "I24", "terrain": "m",
       "exits": {
-        "north": "I23",
-        "south": "I25",
-        "west": "H24",
-        "east": "J24"
+        "north": "I23", "south": "I25", "west": "H24", "east": "J24"
       }
     },
     {
-      "id": "J24",
-      "terrain": "m",
+      "id": "J24", "terrain": "m",
       "exits": {
-        "north": "J23",
-        "south": "J25",
-        "west": "I24",
-        "east": "K24"
+        "north": "J23", "south": "J25", "west": "I24", "east": "K24"
       }
     },
     {
-      "id": "K24",
-      "terrain": "d",
+      "id": "K24", "terrain": "d",
       "exits": {
-        "north": "K23",
-        "south": "K25",
-        "west": "J24",
-        "east": "L24"
+        "north": "K23", "south": "K25", "west": "J24", "east": "L24"
       }
     },
     {
-      "id": "L24",
-      "terrain": "d",
+      "id": "L24", "terrain": "d",
       "exits": {
-        "north": "L23",
-        "south": "L25",
-        "west": "K24",
-        "east": "M24"
+        "north": "L23", "south": "L25", "west": "K24", "east": "M24"
       }
     },
     {
-      "id": "M24",
-      "terrain": "d",
+      "id": "M24", "terrain": "d",
       "exits": {
-        "north": "M23",
-        "south": "M25",
-        "west": "L24",
-        "east": "N24"
+        "north": "M23", "south": "M25", "west": "L24", "east": "N24"
       }
     },
     {
-      "id": "N24",
-      "terrain": "m",
+      "id": "N24", "terrain": "m",
       "exits": {
-        "north": "N23",
-        "south": "N25",
-        "west": "M24",
-        "east": "O24"
+        "north": "N23", "south": "N25", "west": "M24", "east": "O24"
       }
     },
     {
-      "id": "O24",
-      "terrain": "m",
+      "id": "O24", "terrain": "m",
       "exits": {
-        "north": "O23",
-        "south": "O25",
-        "west": "N24",
-        "east": "P24"
+        "north": "O23", "south": "O25", "west": "N24", "east": "P24"
       }
     },
     {
-      "id": "P24",
-      "terrain": "m",
+      "id": "P24", "terrain": "m",
       "exits": {
-        "north": "P23",
-        "south": "P25",
-        "west": "O24",
-        "east": "Q24"
+        "north": "P23", "south": "P25", "west": "O24", "east": "Q24"
       }
     },
     {
-      "id": "Q24",
-      "terrain": "m",
+      "id": "Q24", "terrain": "m",
       "exits": {
-        "north": "Q23",
-        "south": "Q25",
-        "west": "P24",
-        "east": "R24"
+        "north": "Q23", "south": "Q25", "west": "P24", "east": "R24"
       }
     },
     {
-      "id": "R24",
-      "terrain": "p",
+      "id": "R24", "terrain": "p",
       "exits": {
-        "north": "R23",
-        "south": "R25",
-        "west": "Q24",
-        "east": "S24"
+        "north": "R23", "south": "R25", "west": "Q24", "east": "S24"
       }
     },
     {
-      "id": "S24",
-      "terrain": "p",
+      "id": "S24", "terrain": "p",
       "exits": {
-        "north": "S23",
-        "south": "S25",
-        "west": "R24",
-        "east": "T24"
+        "north": "S23", "south": "S25", "west": "R24", "east": "T24"
       }
     },
     {
-      "id": "T24",
-      "terrain": "p",
+      "id": "T24", "terrain": "p",
       "exits": {
-        "north": "T23",
-        "south": "T25",
-        "west": "S24",
-        "east": "U24"
+        "north": "T23", "south": "T25", "west": "S24", "east": "U24"
       }
     },
     {
-      "id": "U24",
-      "terrain": "p",
+      "id": "U24", "terrain": "p",
       "exits": {
-        "north": "U23",
-        "south": "U25",
-        "west": "T24",
-        "east": "V24"
+        "north": "U23", "south": "U25", "west": "T24", "east": "V24"
       }
     },
     {
-      "id": "V24",
-      "terrain": "p",
+      "id": "V24", "terrain": "p",
       "exits": {
-        "north": "V23",
-        "south": "V25",
-        "west": "U24",
-        "east": "W24"
+        "north": "V23", "south": "V25", "west": "U24", "east": "W24"
       }
     },
     {
-      "id": "W24",
-      "terrain": "p",
+      "id": "W24", "terrain": "p",
       "exits": {
-        "north": "W23",
-        "south": "W25",
-        "west": "V24",
-        "east": "X24"
+        "north": "W23", "south": "W25", "west": "V24", "east": "X24"
       }
     },
     {
-      "id": "X24",
-      "terrain": "p",
+      "id": "X24", "terrain": "p",
       "exits": {
-        "north": "X23",
-        "south": "X25",
-        "west": "W24",
-        "east": "Y24"
+        "north": "X23", "south": "X25", "west": "W24", "east": "Y24"
       }
     },
     {
-      "id": "Y24",
-      "terrain": "r",
+      "id": "Y24", "terrain": "r",
       "exits": {
-        "north": "Y23",
-        "south": "Y25",
-        "west": "X24",
-        "east": "Z24"
+        "north": "Y23", "south": "Y25", "west": "X24", "east": "Z24"
       }
     },
     {
-      "id": "Z24",
-      "terrain": "p",
+      "id": "Z24", "terrain": "p",
       "exits": {
-        "north": "Z23",
-        "south": "Z25",
-        "west": "Y24",
-        "east": "AA24"
+        "north": "Z23", "south": "Z25", "west": "Y24", "east": "AA24"
       }
     },
     {
-      "id": "AA24",
-      "terrain": "p",
+      "id": "AA24", "terrain": "p",
       "exits": {
-        "north": "AA23",
-        "south": "AA25",
-        "west": "Z24",
-        "east": "AB24"
+        "north": "AA23", "south": "AA25", "west": "Z24", "east": "AB24"
       }
     },
     {
-      "id": "AB24",
-      "terrain": "p",
+      "id": "AB24", "terrain": "p",
       "exits": {
-        "north": "AB23",
-        "south": "AB25",
-        "west": "AA24",
-        "east": "AC24"
+        "north": "AB23", "south": "AB25", "west": "AA24", "east": "AC24"
       }
     },
     {
-      "id": "AC24",
-      "terrain": "b",
+      "id": "AC24", "terrain": "b",
       "exits": {
-        "north": "AC23",
-        "south": "AC25",
-        "west": "AB24",
-        "east": "AD24"
+        "north": "AC23", "south": "AC25", "west": "AB24", "east": "AD24"
       }
     },
     {
-      "id": "AD24",
-      "terrain": "b",
+      "id": "AD24", "terrain": "b",
       "exits": {
-        "north": "AD23",
-        "south": "AD25",
-        "west": "AC24",
-        "east": "AE24"
+        "north": "AD23", "south": "AD25", "west": "AC24", "east": "AE24"
       }
     },
     {
-      "id": "AE24",
-      "terrain": "b",
+      "id": "AE24", "terrain": "b",
       "exits": {
-        "north": "AE23",
-        "south": "AE25",
-        "west": "AD24",
-        "east": "AF24"
+        "north": "AE23", "south": "AE25", "west": "AD24", "east": "AF24"
       }
     },
     {
-      "id": "AF24",
-      "terrain": "b",
+      "id": "AF24", "terrain": "b",
       "exits": {
-        "north": "AF23",
-        "south": "AF25",
-        "west": "AE24",
-        "east": "AG24"
+        "north": "AF23", "south": "AF25", "west": "AE24", "east": "AG24"
       }
     },
     {
-      "id": "AG24",
-      "terrain": "b",
+      "id": "AG24", "terrain": "b",
       "exits": {
-        "north": "AG23",
-        "south": "AG25",
-        "west": "AF24",
-        "east": "AH24"
+        "north": "AG23", "south": "AG25", "west": "AF24", "east": "AH24"
       }
     },
     {
-      "id": "AH24",
-      "terrain": "b",
+      "id": "AH24", "terrain": "b",
       "exits": {
-        "north": "AH23",
-        "south": "AH25",
-        "west": "AG24",
-        "east": "AI24"
+        "north": "AH23", "south": "AH25", "west": "AG24", "east": "AI24"
       }
     },
     {
-      "id": "AI24",
-      "terrain": "b",
+      "id": "AI24", "terrain": "b",
       "exits": {
-        "north": "AI23",
-        "south": "AI25",
-        "west": "AH24",
-        "east": "AJ24"
+        "north": "AI23", "south": "AI25", "west": "AH24", "east": "AJ24"
       }
     },
     {
-      "id": "AJ24",
-      "terrain": "lf",
+      "id": "AJ24", "terrain": "lf",
       "exits": {
-        "north": "AJ23",
-        "south": "AJ25",
-        "west": "AI24",
-        "east": "AK24"
+        "north": "AJ23", "south": "AJ25", "west": "AI24", "east": "AK24"
       }
     },
     {
-      "id": "AK24",
-      "terrain": "f",
+      "id": "AK24", "terrain": "f",
       "exits": {
-        "north": "AK23",
-        "south": "AK25",
-        "west": "AJ24",
-        "east": "AL24"
+        "north": "AK23", "south": "AK25", "west": "AJ24", "east": "AL24"
       }
     },
     {
-      "id": "AL24",
-      "terrain": "lf",
+      "id": "AL24", "terrain": "lf",
       "exits": {
-        "north": "AL23",
-        "south": "AL25",
-        "west": "AK24",
-        "east": "AM24"
+        "north": "AL23", "south": "AL25", "west": "AK24", "east": "AM24"
       }
     },
     {
-      "id": "AM24",
-      "terrain": "b",
+      "id": "AM24", "terrain": "b",
       "exits": {
-        "north": "AM23",
-        "south": "AM25",
-        "west": "AL24",
-        "east": "AN24"
+        "north": "AM23", "south": "AM25", "west": "AL24", "east": "AN24"
       }
     },
     {
-      "id": "AN24",
-      "terrain": "b",
+      "id": "AN24", "terrain": "b",
       "exits": {
-        "north": "AN23",
-        "south": "AN25",
-        "west": "AM24",
-        "east": "AO24"
+        "north": "AN23", "south": "AN25", "west": "AM24", "east": "AO24"
       }
     },
     {
-      "id": "AO24",
-      "terrain": "b",
+      "id": "AO24", "terrain": "b",
       "exits": {
-        "north": "AO23",
-        "south": "AO25",
-        "west": "AN24",
-        "east": "AP24"
+        "north": "AO23", "south": "AO25", "west": "AN24", "east": "AP24"
       }
     },
     {
-      "id": "AP24",
-      "terrain": "p",
+      "id": "AP24", "terrain": "p",
       "exits": {
-        "north": "AP23",
-        "south": "AP25",
-        "west": "AO24",
-        "east": "AQ24"
+        "north": "AP23", "south": "AP25", "west": "AO24", "east": "AQ24"
       }
     },
     {
-      "id": "AQ24",
-      "terrain": "p",
+      "id": "AQ24", "terrain": "p",
       "exits": {
-        "north": "AQ23",
-        "south": "AQ25",
-        "west": "AP24",
-        "east": "AR24"
+        "north": "AQ23", "south": "AQ25", "west": "AP24", "east": "AR24"
       }
     },
     {
-      "id": "AR24",
-      "terrain": "p",
+      "id": "AR24", "terrain": "p",
       "exits": {
-        "north": "AR23",
-        "south": "AR25",
-        "west": "AQ24",
-        "east": "AS24"
+        "north": "AR23", "south": "AR25", "west": "AQ24", "east": "AS24"
       }
     },
     {
-      "id": "AS24",
-      "terrain": "p",
+      "id": "AS24", "terrain": "p",
       "exits": {
-        "north": "AS23",
-        "south": "AS25",
-        "west": "AR24",
-        "east": "AT24"
+        "north": "AS23", "south": "AS25", "west": "AR24", "east": "AT24"
       }
     },
     {
-      "id": "AT24",
-      "terrain": "lf",
+      "id": "AT24", "terrain": "lf",
       "exits": {
-        "north": "AT23",
-        "south": "AT25",
-        "west": "AS24",
-        "east": "AU24"
+        "north": "AT23", "south": "AT25", "west": "AS24", "east": "AU24"
       }
     },
     {
-      "id": "AU24",
-      "terrain": "lf",
+      "id": "AU24", "terrain": "lf",
       "exits": {
-        "north": "AU23",
-        "south": "AU25",
-        "west": "AT24",
-        "east": "AV24"
+        "north": "AU23", "south": "AU25", "west": "AT24", "east": "AV24"
       }
     },
     {
-      "id": "AV24",
-      "terrain": "p",
+      "id": "AV24", "terrain": "p",
       "exits": {
-        "north": "AV23",
-        "south": "AV25",
-        "west": "AU24",
-        "east": "AW24"
+        "north": "AV23", "south": "AV25", "west": "AU24", "east": "AW24"
       }
     },
     {
-      "id": "AW24",
-      "terrain": "s",
+      "id": "AW24", "terrain": "s",
       "exits": {
-        "north": "AW23",
-        "south": "AW25",
-        "west": "AV24",
-        "east": "AX24"
+        "north": "AW23", "south": "AW25", "west": "AV24", "east": "AX24"
       }
     },
     {
-      "id": "AX24",
-      "terrain": "s",
+      "id": "AX24", "terrain": "s",
       "exits": {
-        "north": "AX23",
-        "south": "AX25",
-        "west": "AW24"
+        "north": "AX23", "south": "AX25", "west": "AW24"
       }
     },
     {
-      "id": "A25",
-      "terrain": "b",
+      "id": "A25", "terrain": "b",
       "exits": {
-        "north": "A24",
-        "south": "A26",
-        "east": "B25"
+        "north": "A24", "south": "A26", "east": "B25"
       }
     },
     {
-      "id": "B25",
-      "terrain": "p",
+      "id": "B25", "terrain": "p",
       "exits": {
-        "north": "B24",
-        "south": "B26",
-        "west": "A25",
-        "east": "C25"
+        "north": "B24", "south": "B26", "west": "A25", "east": "C25"
       }
     },
     {
-      "id": "C25",
-      "terrain": "p",
+      "id": "C25", "terrain": "p",
       "exits": {
-        "north": "C24",
-        "south": "C26",
-        "west": "B25",
-        "east": "D25"
+        "north": "C24", "south": "C26", "west": "B25", "east": "D25"
       }
     },
     {
-      "id": "D25",
-      "terrain": "p",
+      "id": "D25", "terrain": "p",
       "exits": {
-        "north": "D24",
-        "south": "D26",
-        "west": "C25",
-        "east": "E25"
+        "north": "D24", "south": "D26", "west": "C25", "east": "E25"
       }
     },
     {
-      "id": "E25",
-      "terrain": "d",
+      "id": "E25", "terrain": "d",
       "exits": {
-        "north": "E24",
-        "south": "E26",
-        "west": "D25",
-        "east": "F25"
+        "north": "E24", "south": "E26", "west": "D25", "east": "F25"
       }
     },
     {
-      "id": "F25",
-      "terrain": "d",
+      "id": "F25", "terrain": "d",
       "exits": {
-        "north": "F24",
-        "south": "F26",
-        "west": "E25",
-        "east": "G25"
+        "north": "F24", "south": "F26", "west": "E25", "east": "G25"
       }
     },
     {
-      "id": "G25",
-      "terrain": "d",
+      "id": "G25", "terrain": "d",
       "exits": {
-        "north": "G24",
-        "south": "G26",
-        "west": "F25",
-        "east": "H25"
+        "north": "G24", "south": "G26", "west": "F25", "east": "H25"
       }
     },
     {
-      "id": "H25",
-      "terrain": "m",
+      "id": "H25", "terrain": "m",
       "exits": {
-        "north": "H24",
-        "south": "H26",
-        "west": "G25",
-        "east": "I25"
+        "north": "H24", "south": "H26", "west": "G25", "east": "I25"
       }
     },
     {
-      "id": "I25",
-      "terrain": "m",
+      "id": "I25", "terrain": "m",
       "exits": {
-        "north": "I24",
-        "south": "I26",
-        "west": "H25",
-        "east": "J25"
+        "north": "I24", "south": "I26", "west": "H25", "east": "J25"
       }
     },
     {
-      "id": "J25",
-      "terrain": "m",
+      "id": "J25", "terrain": "m",
       "exits": {
-        "north": "J24",
-        "south": "J26",
-        "west": "I25",
-        "east": "K25"
+        "north": "J24", "south": "J26", "west": "I25", "east": "K25"
       }
     },
     {
-      "id": "K25",
-      "terrain": "d",
+      "id": "K25", "terrain": "d",
       "exits": {
-        "north": "K24",
-        "south": "K26",
-        "west": "J25",
-        "east": "L25"
+        "north": "K24", "south": "K26", "west": "J25", "east": "L25"
       }
     },
     {
-      "id": "L25",
-      "terrain": "d",
+      "id": "L25", "terrain": "d",
       "exits": {
-        "north": "L24",
-        "south": "L26",
-        "west": "K25",
-        "east": "M25"
+        "north": "L24", "south": "L26", "west": "K25", "east": "M25"
       }
     },
     {
-      "id": "M25",
-      "terrain": "d",
+      "id": "M25", "terrain": "d",
       "exits": {
-        "north": "M24",
-        "south": "M26",
-        "west": "L25",
-        "east": "N25"
+        "north": "M24", "south": "M26", "west": "L25", "east": "N25"
       }
     },
     {
-      "id": "N25",
-      "terrain": "m",
+      "id": "N25", "terrain": "m",
       "exits": {
-        "north": "N24",
-        "south": "N26",
-        "west": "M25",
-        "east": "O25"
+        "north": "N24", "south": "N26", "west": "M25", "east": "O25"
       }
     },
     {
-      "id": "O25",
-      "terrain": "m",
+      "id": "O25", "terrain": "m",
       "exits": {
-        "north": "O24",
-        "south": "O26",
-        "west": "N25",
-        "east": "P25"
+        "north": "O24", "south": "O26", "west": "N25", "east": "P25"
       }
     },
     {
-      "id": "P25",
-      "terrain": "m",
+      "id": "P25", "terrain": "m",
       "exits": {
-        "north": "P24",
-        "south": "P26",
-        "west": "O25",
-        "east": "Q25"
+        "north": "P24", "south": "P26", "west": "O25", "east": "Q25"
       }
     },
     {
-      "id": "Q25",
-      "terrain": "crevice",
+      "id": "Q25", "terrain": "crevice",
       "exits": {
-        "north": "Q24",
-        "south": "Q26",
-        "west": "P25",
-        "east": "R25"
+        "north": "Q24", "south": "Q26", "west": "P25", "east": "R25"
       }
     },
     {
-      "id": "R25",
-      "terrain": "p",
+      "id": "R25", "terrain": "p",
       "exits": {
-        "north": "R24",
-        "south": "R26",
-        "west": "Q25",
-        "east": "S25"
+        "north": "R24", "south": "R26", "west": "Q25", "east": "S25"
       }
     },
     {
-      "id": "S25",
-      "terrain": "p",
+      "id": "S25", "terrain": "p",
       "exits": {
-        "north": "S24",
-        "south": "S26",
-        "west": "R25",
-        "east": "T25"
+        "north": "S24", "south": "S26", "west": "R25", "east": "T25"
       }
     },
     {
-      "id": "T25",
-      "terrain": "p",
+      "id": "T25", "terrain": "p",
       "exits": {
-        "north": "T24",
-        "south": "T26",
-        "west": "S25",
-        "east": "U25"
+        "north": "T24", "south": "T26", "west": "S25", "east": "U25"
       }
     },
     {
-      "id": "U25",
-      "terrain": "p",
+      "id": "U25", "terrain": "p",
       "exits": {
-        "north": "U24",
-        "south": "U26",
-        "west": "T25",
-        "east": "V25"
+        "north": "U24", "south": "U26", "west": "T25", "east": "V25"
       }
     },
     {
-      "id": "V25",
-      "terrain": "p",
+      "id": "V25", "terrain": "p",
       "exits": {
-        "north": "V24",
-        "south": "V26",
-        "west": "U25",
-        "east": "W25"
+        "north": "V24", "south": "V26", "west": "U25", "east": "W25"
       }
     },
     {
-      "id": "W25",
-      "terrain": "p",
+      "id": "W25", "terrain": "p",
       "exits": {
-        "north": "W24",
-        "south": "W26",
-        "west": "V25",
-        "east": "X25"
+        "north": "W24", "south": "W26", "west": "V25", "east": "X25"
       }
     },
     {
-      "id": "X25",
-      "terrain": "p",
+      "id": "X25", "terrain": "p",
       "exits": {
-        "north": "X24",
-        "south": "X26",
-        "west": "W25",
-        "east": "Y25"
+        "north": "X24", "south": "X26", "west": "W25", "east": "Y25"
       }
     },
     {
-      "id": "Y25",
-      "terrain": "r",
+      "id": "Y25", "terrain": "r",
       "exits": {
-        "north": "Y24",
-        "south": "Y26",
-        "west": "X25",
-        "east": "Z25"
+        "north": "Y24", "south": "Y26", "west": "X25", "east": "Z25"
       }
     },
     {
-      "id": "Z25",
-      "terrain": "p",
+      "id": "Z25", "terrain": "p",
       "exits": {
-        "north": "Z24",
-        "south": "Z26",
-        "west": "Y25",
-        "east": "AA25"
+        "north": "Z24", "south": "Z26", "west": "Y25", "east": "AA25"
       }
     },
     {
-      "id": "AA25",
-      "terrain": "p",
+      "id": "AA25", "terrain": "p",
       "exits": {
-        "north": "AA24",
-        "south": "AA26",
-        "west": "Z25",
-        "east": "AB25"
+        "north": "AA24", "south": "AA26", "west": "Z25", "east": "AB25"
       }
     },
     {
-      "id": "AB25",
-      "terrain": "p",
+      "id": "AB25", "terrain": "p",
       "exits": {
-        "north": "AB24",
-        "south": "AB26",
-        "west": "AA25",
-        "east": "AC25"
+        "north": "AB24", "south": "AB26", "west": "AA25", "east": "AC25"
       }
     },
     {
-      "id": "AC25",
-      "terrain": "h",
+      "id": "AC25", "terrain": "h",
       "exits": {
-        "north": "AC24",
-        "south": "AC26",
-        "west": "AB25",
-        "east": "AD25"
+        "north": "AC24", "south": "AC26", "west": "AB25", "east": "AD25"
       }
     },
     {
-      "id": "AD25",
-      "terrain": "p",
+      "id": "AD25", "terrain": "p",
       "exits": {
-        "north": "AD24",
-        "south": "AD26",
-        "west": "AC25",
-        "east": "AE25"
+        "north": "AD24", "south": "AD26", "west": "AC25", "east": "AE25"
       }
     },
     {
-      "id": "AE25",
-      "terrain": "p",
+      "id": "AE25", "terrain": "p",
       "exits": {
-        "north": "AE24",
-        "south": "AE26",
-        "west": "AD25",
-        "east": "AF25"
+        "north": "AE24", "south": "AE26", "west": "AD25", "east": "AF25"
       }
     },
     {
-      "id": "AF25",
-      "terrain": "p",
+      "id": "AF25", "terrain": "p",
       "exits": {
-        "north": "AF24",
-        "south": "AF26",
-        "west": "AE25",
-        "east": "AG25"
+        "north": "AF24", "south": "AF26", "west": "AE25", "east": "AG25"
       }
     },
     {
-      "id": "AG25",
-      "terrain": "p",
+      "id": "AG25", "terrain": "p",
       "exits": {
-        "north": "AG24",
-        "south": "AG26",
-        "west": "AF25",
-        "east": "AH25"
+        "north": "AG24", "south": "AG26", "west": "AF25", "east": "AH25"
       }
     },
     {
-      "id": "AH25",
-      "terrain": "p",
+      "id": "AH25", "terrain": "p",
       "exits": {
-        "north": "AH24",
-        "south": "AH26",
-        "west": "AG25",
-        "east": "AI25"
+        "north": "AH24", "south": "AH26", "west": "AG25", "east": "AI25"
       }
     },
     {
-      "id": "AI25",
-      "terrain": "b",
+      "id": "AI25", "terrain": "b",
       "exits": {
-        "north": "AI24",
-        "south": "AI26",
-        "west": "AH25",
-        "east": "AJ25"
+        "north": "AI24", "south": "AI26", "west": "AH25", "east": "AJ25"
       }
     },
     {
-      "id": "AJ25",
-      "terrain": "lf",
+      "id": "AJ25", "terrain": "lf",
       "exits": {
-        "north": "AJ24",
-        "south": "AJ26",
-        "west": "AI25",
-        "east": "AK25"
+        "north": "AJ24", "south": "AJ26", "west": "AI25", "east": "AK25"
       }
     },
     {
-      "id": "AK25",
-      "terrain": "b",
+      "id": "AK25", "terrain": "b",
       "exits": {
-        "north": "AK24",
-        "south": "AK26",
-        "west": "AJ25",
-        "east": "AL25"
+        "north": "AK24", "south": "AK26", "west": "AJ25", "east": "AL25"
       }
     },
     {
-      "id": "AL25",
-      "terrain": "b",
+      "id": "AL25", "terrain": "b",
       "exits": {
-        "north": "AL24",
-        "south": "AL26",
-        "west": "AK25",
-        "east": "AM25"
+        "north": "AL24", "south": "AL26", "west": "AK25", "east": "AM25"
       }
     },
     {
-      "id": "AM25",
-      "terrain": "b",
+      "id": "AM25", "terrain": "b",
       "exits": {
-        "north": "AM24",
-        "south": "AM26",
-        "west": "AL25",
-        "east": "AN25"
+        "north": "AM24", "south": "AM26", "west": "AL25", "east": "AN25"
       }
     },
     {
-      "id": "AN25",
-      "terrain": "p",
+      "id": "AN25", "terrain": "p",
       "exits": {
-        "north": "AN24",
-        "south": "AN26",
-        "west": "AM25",
-        "east": "AO25"
+        "north": "AN24", "south": "AN26", "west": "AM25", "east": "AO25"
       }
     },
     {
-      "id": "AO25",
-      "terrain": "b",
+      "id": "AO25", "terrain": "b",
       "exits": {
-        "north": "AO24",
-        "south": "AO26",
-        "west": "AN25",
-        "east": "AP25"
+        "north": "AO24", "south": "AO26", "west": "AN25", "east": "AP25"
       }
     },
     {
-      "id": "AP25",
-      "terrain": "p",
+      "id": "AP25", "terrain": "p",
       "exits": {
-        "north": "AP24",
-        "south": "AP26",
-        "west": "AO25",
-        "east": "AQ25"
+        "north": "AP24", "south": "AP26", "west": "AO25", "east": "AQ25"
       }
     },
     {
-      "id": "AQ25",
-      "terrain": "p",
+      "id": "AQ25", "terrain": "p",
       "exits": {
-        "north": "AQ24",
-        "south": "AQ26",
-        "west": "AP25",
-        "east": "AR25"
+        "north": "AQ24", "south": "AQ26", "west": "AP25", "east": "AR25"
       }
     },
     {
-      "id": "AR25",
-      "terrain": "p",
+      "id": "AR25", "terrain": "p",
       "exits": {
-        "north": "AR24",
-        "south": "AR26",
-        "west": "AQ25",
-        "east": "AS25"
+        "north": "AR24", "south": "AR26", "west": "AQ25", "east": "AS25"
       }
     },
     {
-      "id": "AS25",
-      "terrain": "p",
+      "id": "AS25", "terrain": "p",
       "exits": {
-        "north": "AS24",
-        "south": "AS26",
-        "west": "AR25",
-        "east": "AT25"
+        "north": "AS24", "south": "AS26", "west": "AR25", "east": "AT25"
       }
     },
     {
-      "id": "AT25",
-      "terrain": "lf",
+      "id": "AT25", "terrain": "lf",
       "exits": {
-        "north": "AT24",
-        "south": "AT26",
-        "west": "AS25",
-        "east": "AU25"
+        "north": "AT24", "south": "AT26", "west": "AS25", "east": "AU25"
       }
     },
     {
-      "id": "AU25",
-      "terrain": "lf",
+      "id": "AU25", "terrain": "lf",
       "exits": {
-        "north": "AU24",
-        "south": "AU26",
-        "west": "AT25",
-        "east": "AV25"
+        "north": "AU24", "south": "AU26", "west": "AT25", "east": "AV25"
       }
     },
     {
-      "id": "AV25",
-      "terrain": "p",
+      "id": "AV25", "terrain": "p",
       "exits": {
-        "north": "AV24",
-        "south": "AV26",
-        "west": "AU25",
-        "east": "AW25"
+        "north": "AV24", "south": "AV26", "west": "AU25", "east": "AW25"
       }
     },
     {
-      "id": "AW25",
-      "terrain": "s",
+      "id": "AW25", "terrain": "s",
       "exits": {
-        "north": "AW24",
-        "south": "AW26",
-        "west": "AV25",
-        "east": "AX25"
+        "north": "AW24", "south": "AW26", "west": "AV25", "east": "AX25"
       }
     },
     {
-      "id": "AX25",
-      "terrain": "s",
+      "id": "AX25", "terrain": "s",
       "exits": {
-        "north": "AX24",
-        "south": "AX26",
-        "west": "AW25"
+        "north": "AX24", "south": "AX26", "west": "AW25"
       }
     },
     {
-      "id": "A26",
-      "terrain": "j",
+      "id": "A26", "terrain": "j",
       "exits": {
-        "north": "A25",
-        "south": "A27",
-        "east": "B26"
+        "north": "A25", "south": "A27", "east": "B26"
       }
     },
     {
-      "id": "B26",
-      "terrain": "s",
+      "id": "B26", "terrain": "s",
       "exits": {
-        "north": "B25",
-        "south": "B27",
-        "west": "A26",
-        "east": "C26"
+        "north": "B25", "south": "B27", "west": "A26", "east": "C26"
       }
     },
     {
-      "id": "C26",
-      "terrain": "p",
+      "id": "C26", "terrain": "p",
       "exits": {
-        "north": "C25",
-        "south": "C27",
-        "west": "B26",
-        "east": "D26"
+        "north": "C25", "south": "C27", "west": "B26", "east": "D26"
       }
     },
     {
-      "id": "D26",
-      "terrain": "p",
+      "id": "D26", "terrain": "p",
       "exits": {
-        "north": "D25",
-        "south": "D27",
-        "west": "C26",
-        "east": "E26"
+        "north": "D25", "south": "D27", "west": "C26", "east": "E26"
       }
     },
     {
-      "id": "E26",
-      "terrain": "d",
+      "id": "E26", "terrain": "d",
       "exits": {
-        "north": "E25",
-        "south": "E27",
-        "west": "D26",
-        "east": "F26"
+        "north": "E25", "south": "E27", "west": "D26", "east": "F26"
       }
     },
     {
-      "id": "F26",
-      "terrain": "d",
+      "id": "F26", "terrain": "d",
       "exits": {
-        "north": "F25",
-        "south": "F27",
-        "west": "E26",
-        "east": "G26"
+        "north": "F25", "south": "F27", "west": "E26", "east": "G26"
       }
     },
     {
-      "id": "G26",
-      "terrain": "m",
+      "id": "G26", "terrain": "m",
       "exits": {
-        "north": "G25",
-        "south": "G27",
-        "west": "F26",
-        "east": "H26"
+        "north": "G25", "south": "G27", "west": "F26", "east": "H26"
       }
     },
     {
-      "id": "H26",
-      "terrain": "m",
+      "id": "H26", "terrain": "m",
       "exits": {
-        "north": "H25",
-        "south": "H27",
-        "west": "G26",
-        "east": "I26"
+        "north": "H25", "south": "H27", "west": "G26", "east": "I26"
       }
     },
     {
-      "id": "I26",
-      "terrain": "m",
+      "id": "I26", "terrain": "m",
       "exits": {
-        "north": "I25",
-        "south": "I27",
-        "west": "H26",
-        "east": "J26"
+        "north": "I25", "south": "I27", "west": "H26", "east": "J26"
       }
     },
     {
-      "id": "J26",
-      "terrain": "d",
+      "id": "J26", "terrain": "d",
       "exits": {
-        "north": "J25",
-        "south": "J27",
-        "west": "I26",
-        "east": "K26"
+        "north": "J25", "south": "J27", "west": "I26", "east": "K26"
       }
     },
     {
-      "id": "K26",
-      "terrain": "d",
+      "id": "K26", "terrain": "d",
       "exits": {
-        "north": "K25",
-        "south": "K27",
-        "west": "J26",
-        "east": "L26"
+        "north": "K25", "south": "K27", "west": "J26", "east": "L26"
       }
     },
     {
-      "id": "L26",
-      "terrain": "d",
+      "id": "L26", "terrain": "d",
       "exits": {
-        "north": "L25",
-        "south": "L27",
-        "west": "K26",
-        "east": "M26"
+        "north": "L25", "south": "L27", "west": "K26", "east": "M26"
       }
     },
     {
-      "id": "M26",
-      "terrain": "d",
+      "id": "M26", "terrain": "d",
       "exits": {
-        "north": "M25",
-        "south": "M27",
-        "west": "L26",
-        "east": "N26"
+        "north": "M25", "south": "M27", "west": "L26", "east": "N26"
       }
     },
     {
-      "id": "N26",
-      "terrain": "m",
+      "id": "N26", "terrain": "m",
       "exits": {
-        "north": "N25",
-        "south": "N27",
-        "west": "M26",
-        "east": "O26"
+        "north": "N25", "south": "N27", "west": "M26", "east": "O26"
       }
     },
     {
-      "id": "O26",
-      "terrain": "m",
+      "id": "O26", "terrain": "m",
       "exits": {
-        "north": "O25",
-        "south": "O27",
-        "west": "N26",
-        "east": "P26"
+        "north": "O25", "south": "O27", "west": "N26", "east": "P26"
       }
     },
     {
-      "id": "P26",
-      "terrain": "m",
+      "id": "P26", "terrain": "m",
       "exits": {
-        "north": "P25",
-        "south": "P27",
-        "west": "O26",
-        "east": "Q26"
+        "north": "P25", "south": "P27", "west": "O26", "east": "Q26"
       }
     },
     {
-      "id": "Q26",
-      "terrain": "m",
+      "id": "Q26", "terrain": "m",
       "exits": {
-        "north": "Q25",
-        "south": "Q27",
-        "west": "P26",
-        "east": "R26"
+        "north": "Q25", "south": "Q27", "west": "P26", "east": "R26"
       }
     },
     {
-      "id": "R26",
-      "terrain": "m",
+      "id": "R26", "terrain": "m",
       "exits": {
-        "north": "R25",
-        "south": "R27",
-        "west": "Q26",
-        "east": "S26"
+        "north": "R25", "south": "R27", "west": "Q26", "east": "S26"
       }
     },
     {
-      "id": "S26",
-      "terrain": "p",
+      "id": "S26", "terrain": "p",
       "exits": {
-        "north": "S25",
-        "south": "S27",
-        "west": "R26",
-        "east": "T26"
+        "north": "S25", "south": "S27", "west": "R26", "east": "T26"
       }
     },
     {
-      "id": "T26",
-      "terrain": "p",
+      "id": "T26", "terrain": "p",
       "exits": {
-        "north": "T25",
-        "south": "T27",
-        "west": "S26",
-        "east": "U26"
+        "north": "T25", "south": "T27", "west": "S26", "east": "U26"
       }
     },
     {
-      "id": "U26",
-      "terrain": "p",
+      "id": "U26", "terrain": "p",
       "exits": {
-        "north": "U25",
-        "south": "U27",
-        "west": "T26",
-        "east": "V26"
+        "north": "U25", "south": "U27", "west": "T26", "east": "V26"
       }
     },
     {
-      "id": "V26",
-      "terrain": "p",
+      "id": "V26", "terrain": "p",
       "exits": {
-        "north": "V25",
-        "south": "V27",
-        "west": "U26",
-        "east": "W26"
+        "north": "V25", "south": "V27", "west": "U26", "east": "W26"
       }
     },
     {
-      "id": "W26",
-      "terrain": "p",
+      "id": "W26", "terrain": "p",
       "exits": {
-        "north": "W25",
-        "south": "W27",
-        "west": "V26",
-        "east": "X26"
+        "north": "W25", "south": "W27", "west": "V26", "east": "X26"
       }
     },
     {
-      "id": "X26",
-      "terrain": "nv",
+      "id": "X26", "terrain": "nv",
       "exits": {
-        "north": "X25",
-        "south": "X27",
-        "west": "W26",
-        "east": "Y26"
+        "north": "X25", "south": "X27", "west": "W26", "east": "Y26"
       }
     },
     {
-      "id": "Y26",
-      "terrain": "r",
+      "id": "Y26", "terrain": "r",
       "exits": {
-        "north": "Y25",
-        "south": "Y27",
-        "west": "X26",
-        "east": "Z26"
+        "north": "Y25", "south": "Y27", "west": "X26", "east": "Z26"
       }
     },
     {
-      "id": "Z26",
-      "terrain": "p",
+      "id": "Z26", "terrain": "p",
       "exits": {
-        "north": "Z25",
-        "south": "Z27",
-        "west": "Y26",
-        "east": "AA26"
+        "north": "Z25", "south": "Z27", "west": "Y26", "east": "AA26"
       }
     },
     {
-      "id": "AA26",
-      "terrain": "p",
+      "id": "AA26", "terrain": "p",
       "exits": {
-        "north": "AA25",
-        "south": "AA27",
-        "west": "Z26",
-        "east": "AB26"
+        "north": "AA25", "south": "AA27", "west": "Z26", "east": "AB26"
       }
     },
     {
-      "id": "AB26",
-      "terrain": "h",
+      "id": "AB26", "terrain": "h",
       "exits": {
-        "north": "AB25",
-        "south": "AB27",
-        "west": "AA26",
-        "east": "AC26"
+        "north": "AB25", "south": "AB27", "west": "AA26", "east": "AC26"
       }
     },
     {
-      "id": "AC26",
-      "terrain": "h",
+      "id": "AC26", "terrain": "h",
       "exits": {
-        "north": "AC25",
-        "south": "AC27",
-        "west": "AB26",
-        "east": "AD26"
+        "north": "AC25", "south": "AC27", "west": "AB26", "east": "AD26"
       }
     },
     {
-      "id": "AD26",
-      "terrain": "h",
+      "id": "AD26", "terrain": "h",
       "exits": {
-        "north": "AD25",
-        "south": "AD27",
-        "west": "AC26",
-        "east": "AE26"
+        "north": "AD25", "south": "AD27", "west": "AC26", "east": "AE26"
       }
     },
     {
-      "id": "AE26",
-      "terrain": "p",
+      "id": "AE26", "terrain": "p",
       "exits": {
-        "north": "AE25",
-        "south": "AE27",
-        "west": "AD26",
-        "east": "AF26"
+        "north": "AE25", "south": "AE27", "west": "AD26", "east": "AF26"
       }
     },
     {
-      "id": "AF26",
-      "terrain": "p",
+      "id": "AF26", "terrain": "p",
       "exits": {
-        "north": "AF25",
-        "south": "AF27",
-        "west": "AE26",
-        "east": "AG26"
+        "north": "AF25", "south": "AF27", "west": "AE26", "east": "AG26"
       }
     },
     {
-      "id": "AG26",
-      "terrain": "p",
+      "id": "AG26", "terrain": "p",
       "exits": {
-        "north": "AG25",
-        "south": "AG27",
-        "west": "AF26",
-        "east": "AH26"
+        "north": "AG25", "south": "AG27", "west": "AF26", "east": "AH26"
       }
     },
     {
-      "id": "AH26",
-      "terrain": "b",
+      "id": "AH26", "terrain": "b",
       "exits": {
-        "north": "AH25",
-        "south": "AH27",
-        "west": "AG26",
-        "east": "AI26"
+        "north": "AH25", "south": "AH27", "west": "AG26", "east": "AI26"
       }
     },
     {
-      "id": "AI26",
-      "terrain": "b",
+      "id": "AI26", "terrain": "b",
       "exits": {
-        "north": "AI25",
-        "south": "AI27",
-        "west": "AH26",
-        "east": "AJ26"
+        "north": "AI25", "south": "AI27", "west": "AH26", "east": "AJ26"
       }
     },
     {
-      "id": "AJ26",
-      "terrain": "lf",
+      "id": "AJ26", "terrain": "lf",
       "exits": {
-        "north": "AJ25",
-        "south": "AJ27",
-        "west": "AI26",
-        "east": "AK26"
+        "north": "AJ25", "south": "AJ27", "west": "AI26", "east": "AK26"
       }
     },
     {
-      "id": "AK26",
-      "terrain": "b",
+      "id": "AK26", "terrain": "b",
       "exits": {
-        "north": "AK25",
-        "south": "AK27",
-        "west": "AJ26",
-        "east": "AL26"
+        "north": "AK25", "south": "AK27", "west": "AJ26", "east": "AL26"
       }
     },
     {
-      "id": "AL26",
-      "terrain": "b",
+      "id": "AL26", "terrain": "b",
       "exits": {
-        "north": "AL25",
-        "south": "AL27",
-        "west": "AK26",
-        "east": "AM26"
+        "north": "AL25", "south": "AL27", "west": "AK26", "east": "AM26"
       }
     },
     {
-      "id": "AM26",
-      "terrain": "b",
+      "id": "AM26", "terrain": "b",
       "exits": {
-        "north": "AM25",
-        "south": "AM27",
-        "west": "AL26",
-        "east": "AN26"
+        "north": "AM25", "south": "AM27", "west": "AL26", "east": "AN26"
       }
     },
     {
-      "id": "AN26",
-      "terrain": "p",
+      "id": "AN26", "terrain": "p",
       "exits": {
-        "north": "AN25",
-        "south": "AN27",
-        "west": "AM26",
-        "east": "AO26"
+        "north": "AN25", "south": "AN27", "west": "AM26", "east": "AO26"
       }
     },
     {
-      "id": "AO26",
-      "terrain": "p",
+      "id": "AO26", "terrain": "p",
       "exits": {
-        "north": "AO25",
-        "south": "AO27",
-        "west": "AN26",
-        "east": "AP26"
+        "north": "AO25", "south": "AO27", "west": "AN26", "east": "AP26"
       }
     },
     {
-      "id": "AP26",
-      "terrain": "p",
+      "id": "AP26", "terrain": "p",
       "exits": {
-        "north": "AP25",
-        "south": "AP27",
-        "west": "AO26",
-        "east": "AQ26"
+        "north": "AP25", "south": "AP27", "west": "AO26", "east": "AQ26"
       }
     },
     {
-      "id": "AQ26",
-      "terrain": "p",
+      "id": "AQ26", "terrain": "p",
       "exits": {
-        "north": "AQ25",
-        "south": "AQ27",
-        "west": "AP26",
-        "east": "AR26"
+        "north": "AQ25", "south": "AQ27", "west": "AP26", "east": "AR26"
       }
     },
     {
-      "id": "AR26",
-      "terrain": "cave",
+      "id": "AR26", "terrain": "cave",
       "exits": {
-        "north": "AR25",
-        "south": "AR27",
-        "west": "AQ26",
-        "east": "AS26"
+        "north": "AR25", "south": "AR27", "west": "AQ26", "east": "AS26"
       }
     },
     {
-      "id": "AS26",
-      "terrain": "p",
+      "id": "AS26", "terrain": "p",
       "exits": {
-        "north": "AS25",
-        "south": "AS27",
-        "west": "AR26",
-        "east": "AT26"
+        "north": "AS25", "south": "AS27", "west": "AR26", "east": "AT26"
       }
     },
     {
-      "id": "AT26",
-      "terrain": "lf",
+      "id": "AT26", "terrain": "lf",
       "exits": {
-        "north": "AT25",
-        "south": "AT27",
-        "west": "AS26",
-        "east": "AU26"
+        "north": "AT25", "south": "AT27", "west": "AS26", "east": "AU26"
       }
     },
     {
-      "id": "AU26",
-      "terrain": "lf",
+      "id": "AU26", "terrain": "lf",
       "exits": {
-        "north": "AU25",
-        "south": "AU27",
-        "west": "AT26",
-        "east": "AV26"
+        "north": "AU25", "south": "AU27", "west": "AT26", "east": "AV26"
       }
     },
     {
-      "id": "AV26",
-      "terrain": "s",
+      "id": "AV26", "terrain": "s",
       "exits": {
-        "north": "AV25",
-        "south": "AV27",
-        "west": "AU26",
-        "east": "AW26"
+        "north": "AV25", "south": "AV27", "west": "AU26", "east": "AW26"
       }
     },
     {
-      "id": "AW26",
-      "terrain": "j",
+      "id": "AW26", "terrain": "j",
       "exits": {
-        "north": "AW25",
-        "south": "AW27",
-        "west": "AV26",
-        "east": "AX26"
+        "north": "AW25", "south": "AW27", "west": "AV26", "east": "AX26"
       }
     },
     {
-      "id": "AX26",
-      "terrain": "s",
+      "id": "AX26", "terrain": "s",
       "exits": {
-        "north": "AX25",
-        "south": "AX27",
-        "west": "AW26"
+        "north": "AX25", "south": "AX27", "west": "AW26"
       }
     },
     {
-      "id": "A27",
-      "terrain": "j",
+      "id": "A27", "terrain": "j",
       "exits": {
-        "north": "A26",
-        "south": "A28",
-        "east": "B27"
+        "north": "A26", "south": "A28", "east": "B27"
       }
     },
     {
-      "id": "B27",
-      "terrain": "j",
+      "id": "B27", "terrain": "j",
       "exits": {
-        "north": "B26",
-        "south": "B28",
-        "west": "A27",
-        "east": "C27"
+        "north": "B26", "south": "B28", "west": "A27", "east": "C27"
       }
     },
     {
-      "id": "C27",
-      "terrain": "swamp",
+      "id": "C27", "terrain": "swamp",
       "exits": {
-        "north": "C26",
-        "south": "C28",
-        "west": "B27",
-        "east": "D27"
+        "north": "C26", "south": "C28", "west": "B27", "east": "D27"
       }
     },
     {
-      "id": "D27",
-      "terrain": "d",
+      "id": "D27", "terrain": "d",
       "exits": {
-        "north": "D26",
-        "south": "D28",
-        "west": "C27",
-        "east": "E27"
+        "north": "D26", "south": "D28", "west": "C27", "east": "E27"
       }
     },
     {
-      "id": "E27",
-      "terrain": "d",
+      "id": "E27", "terrain": "d",
       "exits": {
-        "north": "E26",
-        "south": "E28",
-        "west": "D27",
-        "east": "F27"
+        "north": "E26", "south": "E28", "west": "D27", "east": "F27"
       }
     },
     {
-      "id": "F27",
-      "terrain": "d",
+      "id": "F27", "terrain": "d",
       "exits": {
-        "north": "F26",
-        "south": "F28",
-        "west": "E27",
-        "east": "G27"
+        "north": "F26", "south": "F28", "west": "E27", "east": "G27"
       }
     },
     {
-      "id": "G27",
-      "terrain": "d",
+      "id": "G27", "terrain": "d",
       "exits": {
-        "north": "G26",
-        "south": "G28",
-        "west": "F27",
-        "east": "H27"
+        "north": "G26", "south": "G28", "west": "F27", "east": "H27"
       }
     },
     {
-      "id": "H27",
-      "terrain": "m",
+      "id": "H27", "terrain": "m",
       "exits": {
-        "north": "H26",
-        "south": "H28",
-        "west": "G27",
-        "east": "I27"
+        "north": "H26", "south": "H28", "west": "G27", "east": "I27"
       }
     },
     {
-      "id": "I27",
-      "terrain": "m",
+      "id": "I27", "terrain": "m",
       "exits": {
-        "north": "I26",
-        "south": "I28",
-        "west": "H27",
-        "east": "J27"
+        "north": "I26", "south": "I28", "west": "H27", "east": "J27"
       }
     },
     {
-      "id": "J27",
-      "terrain": "d",
+      "id": "J27", "terrain": "d",
       "exits": {
-        "north": "J26",
-        "south": "J28",
-        "west": "I27",
-        "east": "K27"
+        "north": "J26", "south": "J28", "west": "I27", "east": "K27"
       }
     },
     {
-      "id": "K27",
-      "terrain": "d",
+      "id": "K27", "terrain": "d",
       "exits": {
-        "north": "K26",
-        "south": "K28",
-        "west": "J27",
-        "east": "L27"
+        "north": "K26", "south": "K28", "west": "J27", "east": "L27"
       }
     },
     {
-      "id": "L27",
-      "terrain": "d",
+      "id": "L27", "terrain": "d",
       "exits": {
-        "north": "L26",
-        "south": "L28",
-        "west": "K27",
-        "east": "M27"
+        "north": "L26", "south": "L28", "west": "K27", "east": "M27"
       }
     },
     {
-      "id": "M27",
-      "terrain": "d",
+      "id": "M27", "terrain": "d",
       "exits": {
-        "north": "M26",
-        "south": "M28",
-        "west": "L27",
-        "east": "N27"
+        "north": "M26", "south": "M28", "west": "L27", "east": "N27"
       }
     },
     {
-      "id": "N27",
-      "terrain": "d",
+      "id": "N27", "terrain": "d",
       "exits": {
-        "north": "N26",
-        "south": "N28",
-        "west": "M27",
-        "east": "O27"
+        "north": "N26", "south": "N28", "west": "M27", "east": "O27"
       }
     },
     {
-      "id": "O27",
-      "terrain": "m",
+      "id": "O27", "terrain": "m",
       "exits": {
-        "north": "O26",
-        "south": "O28",
-        "west": "N27",
-        "east": "P27"
+        "north": "O26", "south": "O28", "west": "N27", "east": "P27"
       }
     },
     {
-      "id": "P27",
-      "terrain": "m",
+      "id": "P27", "terrain": "m",
       "exits": {
-        "north": "P26",
-        "south": "P28",
-        "west": "O27",
-        "east": "Q27"
+        "north": "P26", "south": "P28", "west": "O27", "east": "Q27"
       }
     },
     {
-      "id": "Q27",
-      "terrain": "m",
+      "id": "Q27", "terrain": "m",
       "exits": {
-        "north": "Q26",
-        "south": "Q28",
-        "west": "P27",
-        "east": "R27"
+        "north": "Q26", "south": "Q28", "west": "P27", "east": "R27"
       }
     },
     {
-      "id": "R27",
-      "terrain": "p",
+      "id": "R27", "terrain": "p",
       "exits": {
-        "north": "R26",
-        "south": "R28",
-        "west": "Q27",
-        "east": "S27"
+        "north": "R26", "south": "R28", "west": "Q27", "east": "S27"
       }
     },
     {
-      "id": "S27",
-      "terrain": "p",
+      "id": "S27", "terrain": "p",
       "exits": {
-        "north": "S26",
-        "south": "S28",
-        "west": "R27",
-        "east": "T27"
+        "north": "S26", "south": "S28", "west": "R27", "east": "T27"
       }
     },
     {
-      "id": "T27",
-      "terrain": "p",
+      "id": "T27", "terrain": "p",
       "exits": {
-        "north": "T26",
-        "south": "T28",
-        "west": "S27",
-        "east": "U27"
+        "north": "T26", "south": "T28", "west": "S27", "east": "U27"
       }
     },
     {
-      "id": "U27",
-      "terrain": "p",
+      "id": "U27", "terrain": "p",
       "exits": {
-        "north": "U26",
-        "south": "U28",
-        "west": "T27",
-        "east": "V27"
+        "north": "U26", "south": "U28", "west": "T27", "east": "V27"
       }
     },
     {
-      "id": "V27",
-      "terrain": "p",
+      "id": "V27", "terrain": "p",
       "exits": {
-        "north": "V26",
-        "south": "V28",
-        "west": "U27",
-        "east": "W27"
+        "north": "V26", "south": "V28", "west": "U27", "east": "W27"
       }
     },
     {
-      "id": "W27",
-      "terrain": "wv",
+      "id": "W27", "terrain": "wv",
       "exits": {
-        "north": "W26",
-        "south": "W28",
-        "west": "V27",
-        "east": "X27"
+        "north": "W26", "south": "W28", "west": "V27", "east": "X27"
       }
     },
     {
-      "id": "X27",
-      "terrain": "p",
+      "id": "X27", "terrain": "p",
       "exits": {
-        "north": "X26",
-        "south": "X28",
-        "west": "W27",
-        "east": "Y27"
+        "north": "X26", "south": "X28", "west": "W27", "east": "Y27"
       }
     },
     {
-      "id": "Y27",
-      "terrain": "r",
+      "id": "Y27", "terrain": "r",
       "exits": {
-        "north": "Y26",
-        "south": "Y28",
-        "west": "X27",
-        "east": "Z27"
+        "north": "Y26", "south": "Y28", "west": "X27", "east": "Z27"
       }
     },
     {
-      "id": "Z27",
-      "terrain": "p",
+      "id": "Z27", "terrain": "p",
       "exits": {
-        "north": "Z26",
-        "south": "Z28",
-        "west": "Y27",
-        "east": "AA27"
+        "north": "Z26", "south": "Z28", "west": "Y27", "east": "AA27"
       }
     },
     {
-      "id": "AA27",
-      "terrain": "p",
+      "id": "AA27", "terrain": "p",
       "exits": {
-        "north": "AA26",
-        "south": "AA28",
-        "west": "Z27",
-        "east": "AB27"
+        "north": "AA26", "south": "AA28", "west": "Z27", "east": "AB27"
       }
     },
     {
-      "id": "AB27",
-      "terrain": "village",
+      "id": "AB27", "terrain": "village",
       "exits": {
-        "north": "AB26",
-        "south": "AB28",
-        "west": "AA27",
-        "east": "AC27"
+        "north": "AB26", "south": "AB28", "west": "AA27", "east": "AC27"
       }
     },
     {
-      "id": "AC27",
-      "terrain": "h",
+      "id": "AC27", "terrain": "h",
       "exits": {
-        "north": "AC26",
-        "south": "AC28",
-        "west": "AB27",
-        "east": "AD27"
+        "north": "AC26", "south": "AC28", "west": "AB27", "east": "AD27"
       }
     },
     {
-      "id": "AD27",
-      "terrain": "h",
+      "id": "AD27", "terrain": "h",
       "exits": {
-        "north": "AD26",
-        "south": "AD28",
-        "west": "AC27",
-        "east": "AE27"
+        "north": "AD26", "south": "AD28", "west": "AC27", "east": "AE27"
       }
     },
     {
-      "id": "AE27",
-      "terrain": "p",
+      "id": "AE27", "terrain": "p",
       "exits": {
-        "north": "AE26",
-        "south": "AE28",
-        "west": "AD27",
-        "east": "AF27"
+        "north": "AE26", "south": "AE28", "west": "AD27", "east": "AF27"
       }
     },
     {
-      "id": "AF27",
-      "terrain": "p",
+      "id": "AF27", "terrain": "p",
       "exits": {
-        "north": "AF26",
-        "south": "AF28",
-        "west": "AE27",
-        "east": "AG27"
+        "north": "AF26", "south": "AF28", "west": "AE27", "east": "AG27"
       }
     },
     {
-      "id": "AG27",
-      "terrain": "b",
+      "id": "AG27", "terrain": "b",
       "exits": {
-        "north": "AG26",
-        "south": "AG28",
-        "west": "AF27",
-        "east": "AH27"
+        "north": "AG26", "south": "AG28", "west": "AF27", "east": "AH27"
       }
     },
     {
-      "id": "AH27",
-      "terrain": "b",
+      "id": "AH27", "terrain": "b",
       "exits": {
-        "north": "AH26",
-        "south": "AH28",
-        "west": "AG27",
-        "east": "AI27"
+        "north": "AH26", "south": "AH28", "west": "AG27", "east": "AI27"
       }
     },
     {
-      "id": "AI27",
-      "terrain": "b",
+      "id": "AI27", "terrain": "b",
       "exits": {
-        "north": "AI26",
-        "south": "AI28",
-        "west": "AH27",
-        "east": "AJ27"
+        "north": "AI26", "south": "AI28", "west": "AH27", "east": "AJ27"
       }
     },
     {
-      "id": "AJ27",
-      "terrain": "b",
+      "id": "AJ27", "terrain": "b",
       "exits": {
-        "north": "AJ26",
-        "south": "AJ28",
-        "west": "AI27",
-        "east": "AK27"
+        "north": "AJ26", "south": "AJ28", "west": "AI27", "east": "AK27"
       }
     },
     {
-      "id": "AK27",
-      "terrain": "b",
+      "id": "AK27", "terrain": "b",
       "exits": {
-        "north": "AK26",
-        "south": "AK28",
-        "west": "AJ27",
-        "east": "AL27"
+        "north": "AK26", "south": "AK28", "west": "AJ27", "east": "AL27"
       }
     },
     {
-      "id": "AL27",
-      "terrain": "p",
+      "id": "AL27", "terrain": "p",
       "exits": {
-        "north": "AL26",
-        "south": "AL28",
-        "west": "AK27",
-        "east": "AM27"
+        "north": "AL26", "south": "AL28", "west": "AK27", "east": "AM27"
       }
     },
     {
-      "id": "AM27",
-      "terrain": "p",
+      "id": "AM27", "terrain": "p",
       "exits": {
-        "north": "AM26",
-        "south": "AM28",
-        "west": "AL27",
-        "east": "AN27"
+        "north": "AM26", "south": "AM28", "west": "AL27", "east": "AN27"
       }
     },
     {
-      "id": "AN27",
-      "terrain": "p",
+      "id": "AN27", "terrain": "p",
       "exits": {
-        "north": "AN26",
-        "south": "AN28",
-        "west": "AM27",
-        "east": "AO27"
+        "north": "AN26", "south": "AN28", "west": "AM27", "east": "AO27"
       }
     },
     {
-      "id": "AO27",
-      "terrain": "p",
+      "id": "AO27", "terrain": "p",
       "exits": {
-        "north": "AO26",
-        "south": "AO28",
-        "west": "AN27",
-        "east": "AP27"
+        "north": "AO26", "south": "AO28", "west": "AN27", "east": "AP27"
       }
     },
     {
-      "id": "AP27",
-      "terrain": "p",
+      "id": "AP27", "terrain": "p",
       "exits": {
-        "north": "AP26",
-        "south": "AP28",
-        "west": "AO27",
-        "east": "AQ27"
+        "north": "AP26", "south": "AP28", "west": "AO27", "east": "AQ27"
       }
     },
     {
-      "id": "AQ27",
-      "terrain": "p",
+      "id": "AQ27", "terrain": "p",
       "exits": {
-        "north": "AQ26",
-        "south": "AQ28",
-        "west": "AP27",
-        "east": "AR27"
+        "north": "AQ26", "south": "AQ28", "west": "AP27", "east": "AR27"
       }
     },
     {
-      "id": "AR27",
-      "terrain": "p",
+      "id": "AR27", "terrain": "p",
       "exits": {
-        "north": "AR26",
-        "south": "AR28",
-        "west": "AQ27",
-        "east": "AS27"
+        "north": "AR26", "south": "AR28", "west": "AQ27", "east": "AS27"
       }
     },
     {
-      "id": "AS27",
-      "terrain": "p",
+      "id": "AS27", "terrain": "p",
       "exits": {
-        "north": "AS26",
-        "south": "AS28",
-        "west": "AR27",
-        "east": "AT27"
+        "north": "AS26", "south": "AS28", "west": "AR27", "east": "AT27"
       }
     },
     {
-      "id": "AT27",
-      "terrain": "lf",
+      "id": "AT27", "terrain": "lf",
       "exits": {
-        "north": "AT26",
-        "south": "AT28",
-        "west": "AS27",
-        "east": "AU27"
+        "north": "AT26", "south": "AT28", "west": "AS27", "east": "AU27"
       }
     },
     {
-      "id": "AU27",
-      "terrain": "s",
+      "id": "AU27", "terrain": "s",
       "exits": {
-        "north": "AU26",
-        "south": "AU28",
-        "west": "AT27",
-        "east": "AV27"
+        "north": "AU26", "south": "AU28", "west": "AT27", "east": "AV27"
       }
     },
     {
-      "id": "AV27",
-      "terrain": "j",
+      "id": "AV27", "terrain": "j",
       "exits": {
-        "north": "AV26",
-        "south": "AV28",
-        "west": "AU27",
-        "east": "AW27"
+        "north": "AV26", "south": "AV28", "west": "AU27", "east": "AW27"
       }
     },
     {
-      "id": "AW27",
-      "terrain": "s",
+      "id": "AW27", "terrain": "s",
       "exits": {
-        "north": "AW26",
-        "south": "AW28",
-        "west": "AV27",
-        "east": "AX27"
+        "north": "AW26", "south": "AW28", "west": "AV27", "east": "AX27"
       }
     },
     {
-      "id": "AX27",
-      "terrain": "s",
+      "id": "AX27", "terrain": "s",
       "exits": {
-        "north": "AX26",
-        "south": "AX28",
-        "west": "AW27"
+        "north": "AX26", "south": "AX28", "west": "AW27"
       }
     },
     {
-      "id": "A28",
-      "terrain": "j",
+      "id": "A28", "terrain": "j",
       "exits": {
-        "north": "A27",
-        "south": "A29",
-        "east": "B28"
+        "north": "A27", "south": "A29", "east": "B28"
       }
     },
     {
-      "id": "B28",
-      "terrain": "j",
+      "id": "B28", "terrain": "j",
       "exits": {
-        "north": "B27",
-        "south": "B29",
-        "west": "A28",
-        "east": "C28"
+        "north": "B27", "south": "B29", "west": "A28", "east": "C28"
       }
     },
     {
-      "id": "C28",
-      "terrain": "s",
+      "id": "C28", "terrain": "s",
       "exits": {
-        "north": "C27",
-        "south": "C29",
-        "west": "B28",
-        "east": "D28"
+        "north": "C27", "south": "C29", "west": "B28", "east": "D28"
       }
     },
     {
-      "id": "D28",
-      "terrain": "d",
+      "id": "D28", "terrain": "d",
       "exits": {
-        "north": "D27",
-        "south": "D29",
-        "west": "C28",
-        "east": "E28"
+        "north": "D27", "south": "D29", "west": "C28", "east": "E28"
       }
     },
     {
-      "id": "E28",
-      "terrain": "d",
+      "id": "E28", "terrain": "d",
       "exits": {
-        "north": "E27",
-        "south": "E29",
-        "west": "D28",
-        "east": "F28"
+        "north": "E27", "south": "E29", "west": "D28", "east": "F28"
       }
     },
     {
-      "id": "F28",
-      "terrain": "d",
+      "id": "F28", "terrain": "d",
       "exits": {
-        "north": "F27",
-        "south": "F29",
-        "west": "E28",
-        "east": "G28"
+        "north": "F27", "south": "F29", "west": "E28", "east": "G28"
       }
     },
     {
-      "id": "G28",
-      "terrain": "m",
+      "id": "G28", "terrain": "m",
       "exits": {
-        "north": "G27",
-        "south": "G29",
-        "west": "F28",
-        "east": "H28"
+        "north": "G27", "south": "G29", "west": "F28", "east": "H28"
       }
     },
     {
-      "id": "H28",
-      "terrain": "m",
+      "id": "H28", "terrain": "m",
       "exits": {
-        "north": "H27",
-        "south": "H29",
-        "west": "G28",
-        "east": "I28"
+        "north": "H27", "south": "H29", "west": "G28", "east": "I28"
       }
     },
     {
-      "id": "I28",
-      "terrain": "m",
+      "id": "I28", "terrain": "m",
       "exits": {
-        "north": "I27",
-        "south": "I29",
-        "west": "H28",
-        "east": "J28"
+        "north": "I27", "south": "I29", "west": "H28", "east": "J28"
       }
     },
     {
-      "id": "J28",
-      "terrain": "d",
+      "id": "J28", "terrain": "d",
       "exits": {
-        "north": "J27",
-        "south": "J29",
-        "west": "I28",
-        "east": "K28"
+        "north": "J27", "south": "J29", "west": "I28", "east": "K28"
       }
     },
     {
-      "id": "K28",
-      "terrain": "Candera",
+      "id": "K28", "terrain": "Candera",
       "exits": {
-        "north": "K27",
-        "south": "K29",
-        "west": "J28",
-        "east": "L28"
+        "north": "K27", "south": "K29", "west": "J28", "east": "L28"
       }
     },
     {
-      "id": "L28",
-      "terrain": "r",
+      "id": "L28", "terrain": "r",
       "exits": {
-        "north": "L27",
-        "south": "L29",
-        "west": "K28",
-        "east": "M28"
+        "north": "L27", "south": "L29", "west": "K28", "east": "M28"
       }
     },
     {
-      "id": "M28",
-      "terrain": "r",
+      "id": "M28", "terrain": "r",
       "exits": {
-        "north": "M27",
-        "south": "M29",
-        "west": "L28",
-        "east": "N28"
+        "north": "M27", "south": "M29", "west": "L28", "east": "N28"
       }
     },
     {
-      "id": "N28",
-      "terrain": "r",
+      "id": "N28", "terrain": "r",
       "exits": {
-        "north": "N27",
-        "south": "N29",
-        "west": "M28",
-        "east": "O28"
+        "north": "N27", "south": "N29", "west": "M28", "east": "O28"
       }
     },
     {
-      "id": "O28",
-      "terrain": "r",
+      "id": "O28", "terrain": "r",
       "exits": {
-        "north": "O27",
-        "south": "O29",
-        "west": "N28",
-        "east": "P28"
+        "north": "O27", "south": "O29", "west": "N28", "east": "P28"
       }
     },
     {
-      "id": "P28",
-      "terrain": "r",
+      "id": "P28", "terrain": "r",
       "exits": {
-        "north": "P27",
-        "south": "P29",
-        "west": "O28",
-        "east": "Q28"
+        "north": "P27", "south": "P29", "west": "O28", "east": "Q28"
       }
     },
     {
-      "id": "Q28",
-      "terrain": "r",
+      "id": "Q28", "terrain": "r",
       "exits": {
-        "north": "Q27",
-        "south": "Q29",
-        "west": "P28",
-        "east": "R28"
+        "north": "Q27", "south": "Q29", "west": "P28", "east": "R28"
       }
     },
     {
-      "id": "R28",
-      "terrain": "r",
+      "id": "R28", "terrain": "r",
       "exits": {
-        "north": "R27",
-        "south": "R29",
-        "west": "Q28",
-        "east": "S28"
+        "north": "R27", "south": "R29", "west": "Q28", "east": "S28"
       }
     },
     {
-      "id": "S28",
-      "terrain": "r",
+      "id": "S28", "terrain": "r",
       "exits": {
-        "north": "S27",
-        "south": "S29",
-        "west": "R28",
-        "east": "T28"
+        "north": "S27", "south": "S29", "west": "R28", "east": "T28"
       }
     },
     {
-      "id": "T28",
-      "terrain": "r",
+      "id": "T28", "terrain": "r",
       "exits": {
-        "north": "T27",
-        "south": "T29",
-        "west": "S28",
-        "east": "U28"
+        "north": "T27", "south": "T29", "west": "S28", "east": "U28"
       }
     },
     {
-      "id": "U28",
-      "terrain": "r",
+      "id": "U28", "terrain": "r",
       "exits": {
-        "north": "U27",
-        "south": "U29",
-        "west": "T28",
-        "east": "V28"
+        "north": "U27", "south": "U29", "west": "T28", "east": "V28"
       }
     },
     {
-      "id": "V28",
-      "terrain": "r",
+      "id": "V28", "terrain": "r",
       "exits": {
-        "north": "V27",
-        "south": "V29",
-        "west": "U28",
-        "east": "W28"
+        "north": "V27", "south": "V29", "west": "U28", "east": "W28"
       }
     },
     {
-      "id": "W28",
-      "terrain": "r",
+      "id": "W28", "terrain": "r",
       "exits": {
-        "north": "W27",
-        "south": "W29",
-        "west": "V28",
-        "east": "X28"
+        "north": "W27", "south": "W29", "west": "V28", "east": "X28"
       }
     },
     {
-      "id": "X28",
-      "terrain": "r",
+      "id": "X28", "terrain": "r",
       "exits": {
-        "north": "X27",
-        "south": "X29",
-        "west": "W28",
-        "east": "Y28"
+        "north": "X27", "south": "X29", "west": "W28", "east": "Y28"
       }
     },
     {
-      "id": "Y28",
-      "terrain": "Vesla",
+      "id": "Y28", "terrain": "Vesla",
       "exits": {
-        "north": "Y27",
-        "south": "Y29",
-        "west": "X28",
-        "east": "Z28"
+        "north": "Y27", "south": "Y29", "west": "X28", "east": "Z28"
       }
     },
     {
-      "id": "Z28",
-      "terrain": "r",
+      "id": "Z28", "terrain": "r",
       "exits": {
-        "north": "Z27",
-        "south": "Z29",
-        "west": "Y28",
-        "east": "AA28"
+        "north": "Z27", "south": "Z29", "west": "Y28", "east": "AA28"
       }
     },
     {
-      "id": "AA28",
-      "terrain": "r",
+      "id": "AA28", "terrain": "r",
       "exits": {
-        "north": "AA27",
-        "south": "AA29",
-        "west": "Z28",
-        "east": "AB28"
+        "north": "AA27", "south": "AA29", "west": "Z28", "east": "AB28"
       }
     },
     {
-      "id": "AB28",
-      "terrain": "r",
+      "id": "AB28", "terrain": "r",
       "exits": {
-        "north": "AB27",
-        "south": "AB29",
-        "west": "AA28",
-        "east": "AC28"
+        "north": "AB27", "south": "AB29", "west": "AA28", "east": "AC28"
       }
     },
     {
-      "id": "AC28",
-      "terrain": "r",
+      "id": "AC28", "terrain": "r",
       "exits": {
-        "north": "AC27",
-        "south": "AC29",
-        "west": "AB28",
-        "east": "AD28"
+        "north": "AC27", "south": "AC29", "west": "AB28", "east": "AD28"
       }
     },
     {
-      "id": "AD28",
-      "terrain": "r",
+      "id": "AD28", "terrain": "r",
       "exits": {
-        "north": "AD27",
-        "south": "AD29",
-        "west": "AC28",
-        "east": "AE28"
+        "north": "AD27", "south": "AD29", "west": "AC28", "east": "AE28"
       }
     },
     {
-      "id": "AE28",
-      "terrain": "r",
+      "id": "AE28", "terrain": "r",
       "exits": {
-        "north": "AE27",
-        "south": "AE29",
-        "west": "AD28",
-        "east": "AF28"
+        "north": "AE27", "south": "AE29", "west": "AD28", "east": "AF28"
       }
     },
     {
-      "id": "AF28",
-      "terrain": "r",
+      "id": "AF28", "terrain": "r",
       "exits": {
-        "north": "AF27",
-        "south": "AF29",
-        "west": "AE28",
-        "east": "AG28"
+        "north": "AF27", "south": "AF29", "west": "AE28", "east": "AG28"
       }
     },
     {
-      "id": "AG28",
-      "terrain": "r",
+      "id": "AG28", "terrain": "r",
       "exits": {
-        "north": "AG27",
-        "south": "AG29",
-        "west": "AF28",
-        "east": "AH28"
+        "north": "AG27", "south": "AG29", "west": "AF28", "east": "AH28"
       }
     },
     {
-      "id": "AH28",
-      "terrain": "r",
+      "id": "AH28", "terrain": "r",
       "exits": {
-        "north": "AH27",
-        "south": "AH29",
-        "west": "AG28",
-        "east": "AI28"
+        "north": "AH27", "south": "AH29", "west": "AG28", "east": "AI28"
       }
     },
     {
-      "id": "AI28",
-      "terrain": "r",
+      "id": "AI28", "terrain": "r",
       "exits": {
-        "north": "AI27",
-        "south": "AI29",
-        "west": "AH28",
-        "east": "AJ28"
+        "north": "AI27", "south": "AI29", "west": "AH28", "east": "AJ28"
       }
     },
     {
-      "id": "AJ28",
-      "terrain": "r",
+      "id": "AJ28", "terrain": "r",
       "exits": {
-        "north": "AJ27",
-        "south": "AJ29",
-        "west": "AI28",
-        "east": "AK28"
+        "north": "AJ27", "south": "AJ29", "west": "AI28", "east": "AK28"
       }
     },
     {
-      "id": "AK28",
-      "terrain": "r",
+      "id": "AK28", "terrain": "r",
       "exits": {
-        "north": "AK27",
-        "south": "AK29",
-        "west": "AJ28",
-        "east": "AL28"
+        "north": "AK27", "south": "AK29", "west": "AJ28", "east": "AL28"
       }
     },
     {
-      "id": "AL28",
-      "terrain": "r",
+      "id": "AL28", "terrain": "r",
       "exits": {
-        "north": "AL27",
-        "south": "AL29",
-        "west": "AK28",
-        "east": "AM28"
+        "north": "AL27", "south": "AL29", "west": "AK28", "east": "AM28"
       }
     },
     {
-      "id": "AM28",
-      "terrain": "r",
+      "id": "AM28", "terrain": "r",
       "exits": {
-        "north": "AM27",
-        "south": "AM29",
-        "west": "AL28",
-        "east": "AN28"
+        "north": "AM27", "south": "AM29", "west": "AL28", "east": "AN28"
       }
     },
     {
-      "id": "AN28",
-      "terrain": "r",
+      "id": "AN28", "terrain": "r",
       "exits": {
-        "north": "AN27",
-        "south": "AN29",
-        "west": "AM28",
-        "east": "AO28"
+        "north": "AN27", "south": "AN29", "west": "AM28", "east": "AO28"
       }
     },
     {
-      "id": "AO28",
-      "terrain": "r",
+      "id": "AO28", "terrain": "r",
       "exits": {
-        "north": "AO27",
-        "south": "AO29",
-        "west": "AN28",
-        "east": "AP28"
+        "north": "AO27", "south": "AO29", "west": "AN28", "east": "AP28"
       }
     },
     {
-      "id": "AP28",
-      "terrain": "r",
+      "id": "AP28", "terrain": "r",
       "exits": {
-        "north": "AP27",
-        "south": "AP29",
-        "west": "AO28",
-        "east": "AQ28"
+        "north": "AP27", "south": "AP29", "west": "AO28", "east": "AQ28"
       }
     },
     {
-      "id": "AQ28",
-      "terrain": "r",
+      "id": "AQ28", "terrain": "r",
       "exits": {
-        "north": "AQ27",
-        "south": "AQ29",
-        "west": "AP28",
-        "east": "AR28"
+        "north": "AQ27", "south": "AQ29", "west": "AP28", "east": "AR28"
       }
     },
     {
-      "id": "AR28",
-      "terrain": "r",
+      "id": "AR28", "terrain": "r",
       "exits": {
-        "north": "AR27",
-        "south": "AR29",
-        "west": "AQ28",
-        "east": "AS28"
+        "north": "AR27", "south": "AR29", "west": "AQ28", "east": "AS28"
       }
     },
     {
-      "id": "AS28",
-      "terrain": "Exedoria",
+      "id": "AS28", "terrain": "Exedoria",
       "exits": {
-        "north": "AS27",
-        "south": "AS29",
-        "west": "AR28",
-        "east": "AT28"
+        "north": "AS27", "south": "AS29", "west": "AR28", "east": "AT28"
       }
     },
     {
-      "id": "AT28",
-      "terrain": "lf",
+      "id": "AT28", "terrain": "lf",
       "exits": {
-        "north": "AT27",
-        "south": "AT29",
-        "west": "AS28",
-        "east": "AU28"
+        "north": "AT27", "south": "AT29", "west": "AS28", "east": "AU28"
       }
     },
     {
-      "id": "AU28",
-      "terrain": "lf",
+      "id": "AU28", "terrain": "lf",
       "exits": {
-        "north": "AU27",
-        "south": "AU29",
-        "west": "AT28",
-        "east": "AV28"
+        "north": "AU27", "south": "AU29", "west": "AT28", "east": "AV28"
       }
     },
     {
-      "id": "AV28",
-      "terrain": "j",
+      "id": "AV28", "terrain": "j",
       "exits": {
-        "north": "AV27",
-        "south": "AV29",
-        "west": "AU28",
-        "east": "AW28"
+        "north": "AV27", "south": "AV29", "west": "AU28", "east": "AW28"
       }
     },
     {
-      "id": "AW28",
-      "terrain": "j",
+      "id": "AW28", "terrain": "j",
       "exits": {
-        "north": "AW27",
-        "south": "AW29",
-        "west": "AV28",
-        "east": "AX28"
+        "north": "AW27", "south": "AW29", "west": "AV28", "east": "AX28"
       }
     },
     {
-      "id": "AX28",
-      "terrain": "j",
+      "id": "AX28", "terrain": "j",
       "exits": {
-        "north": "AX27",
-        "south": "AX29",
-        "west": "AW28"
+        "north": "AX27", "south": "AX29", "west": "AW28"
       }
     },
     {
-      "id": "A29",
-      "terrain": "s",
+      "id": "A29", "terrain": "s",
       "exits": {
-        "north": "A28",
-        "south": "A30",
-        "east": "B29"
+        "north": "A28", "south": "A30", "east": "B29"
       }
     },
     {
-      "id": "B29",
-      "terrain": "s",
+      "id": "B29", "terrain": "s",
       "exits": {
-        "north": "B28",
-        "south": "B30",
-        "west": "A29",
-        "east": "C29"
+        "north": "B28", "south": "B30", "west": "A29", "east": "C29"
       }
     },
     {
-      "id": "C29",
-      "terrain": "d",
+      "id": "C29", "terrain": "d",
       "exits": {
-        "north": "C28",
-        "south": "C30",
-        "west": "B29",
-        "east": "D29"
+        "north": "C28", "south": "C30", "west": "B29", "east": "D29"
       }
     },
     {
-      "id": "D29",
-      "terrain": "d",
+      "id": "D29", "terrain": "d",
       "exits": {
-        "north": "D28",
-        "south": "D30",
-        "west": "C29",
-        "east": "E29"
+        "north": "D28", "south": "D30", "west": "C29", "east": "E29"
       }
     },
     {
-      "id": "E29",
-      "terrain": "d",
+      "id": "E29", "terrain": "d",
       "exits": {
-        "north": "E28",
-        "south": "E30",
-        "west": "D29",
-        "east": "F29"
+        "north": "E28", "south": "E30", "west": "D29", "east": "F29"
       }
     },
     {
-      "id": "F29",
-      "terrain": "m",
+      "id": "F29", "terrain": "m",
       "exits": {
-        "north": "F28",
-        "south": "F30",
-        "west": "E29",
-        "east": "G29"
+        "north": "F28", "south": "F30", "west": "E29", "east": "G29"
       }
     },
     {
-      "id": "G29",
-      "terrain": "m",
+      "id": "G29", "terrain": "m",
       "exits": {
-        "north": "G28",
-        "south": "G30",
-        "west": "F29",
-        "east": "H29"
+        "north": "G28", "south": "G30", "west": "F29", "east": "H29"
       }
     },
     {
-      "id": "H29",
-      "terrain": "d",
+      "id": "H29", "terrain": "d",
       "exits": {
-        "north": "H28",
-        "south": "H30",
-        "west": "G29",
-        "east": "I29"
+        "north": "H28", "south": "H30", "west": "G29", "east": "I29"
       }
     },
     {
-      "id": "I29",
-      "terrain": "d",
+      "id": "I29", "terrain": "d",
       "exits": {
-        "north": "I28",
-        "south": "I30",
-        "west": "H29",
-        "east": "J29"
+        "north": "I28", "south": "I30", "west": "H29", "east": "J29"
       }
     },
     {
-      "id": "J29",
-      "terrain": "d",
+      "id": "J29", "terrain": "d",
       "exits": {
-        "north": "J28",
-        "south": "J30",
-        "west": "I29",
-        "east": "K29"
+        "north": "J28", "south": "J30", "west": "I29", "east": "K29"
       }
     },
     {
-      "id": "K29",
-      "terrain": "d",
+      "id": "K29", "terrain": "d",
       "exits": {
-        "north": "K28",
-        "south": "K30",
-        "west": "J29",
-        "east": "L29"
+        "north": "K28", "south": "K30", "west": "J29", "east": "L29"
       }
     },
     {
-      "id": "L29",
-      "terrain": "d",
+      "id": "L29", "terrain": "d",
       "exits": {
-        "north": "L28",
-        "south": "L30",
-        "west": "K29",
-        "east": "M29"
+        "north": "L28", "south": "L30", "west": "K29", "east": "M29"
       }
     },
     {
-      "id": "M29",
-      "terrain": "d",
+      "id": "M29", "terrain": "d",
       "exits": {
-        "north": "M28",
-        "south": "M30",
-        "west": "L29",
-        "east": "N29"
+        "north": "M28", "south": "M30", "west": "L29", "east": "N29"
       }
     },
     {
-      "id": "N29",
-      "terrain": "d",
+      "id": "N29", "terrain": "d",
       "exits": {
-        "north": "N28",
-        "south": "N30",
-        "west": "M29",
-        "east": "O29"
+        "north": "N28", "south": "N30", "west": "M29", "east": "O29"
       }
     },
     {
-      "id": "O29",
-      "terrain": "m",
+      "id": "O29", "terrain": "m",
       "exits": {
-        "north": "O28",
-        "south": "O30",
-        "west": "N29",
-        "east": "P29"
+        "north": "O28", "south": "O30", "west": "N29", "east": "P29"
       }
     },
     {
-      "id": "P29",
-      "terrain": "p",
+      "id": "P29", "terrain": "p",
       "exits": {
-        "north": "P28",
-        "south": "P30",
-        "west": "O29",
-        "east": "Q29"
+        "north": "P28", "south": "P30", "west": "O29", "east": "Q29"
       }
     },
     {
-      "id": "Q29",
-      "terrain": "m",
+      "id": "Q29", "terrain": "m",
       "exits": {
-        "north": "Q28",
-        "south": "Q30",
-        "west": "P29",
-        "east": "R29"
+        "north": "Q28", "south": "Q30", "west": "P29", "east": "R29"
       }
     },
     {
-      "id": "R29",
-      "terrain": "p",
+      "id": "R29", "terrain": "p",
       "exits": {
-        "north": "R28",
-        "south": "R30",
-        "west": "Q29",
-        "east": "S29"
+        "north": "R28", "south": "R30", "west": "Q29", "east": "S29"
       }
     },
     {
-      "id": "S29",
-      "terrain": "p",
+      "id": "S29", "terrain": "p",
       "exits": {
-        "north": "S28",
-        "south": "S30",
-        "west": "R29",
-        "east": "T29"
+        "north": "S28", "south": "S30", "west": "R29", "east": "T29"
       }
     },
     {
-      "id": "T29",
-      "terrain": "p",
+      "id": "T29", "terrain": "p",
       "exits": {
-        "north": "T28",
-        "south": "T30",
-        "west": "S29",
-        "east": "U29"
+        "north": "T28", "south": "T30", "west": "S29", "east": "U29"
       }
     },
     {
-      "id": "U29",
-      "terrain": "p",
+      "id": "U29", "terrain": "p",
       "exits": {
-        "north": "U28",
-        "south": "U30",
-        "west": "T29",
-        "east": "V29"
+        "north": "U28", "south": "U30", "west": "T29", "east": "V29"
       }
     },
     {
-      "id": "V29",
-      "terrain": "p",
+      "id": "V29", "terrain": "p",
       "exits": {
-        "north": "V28",
-        "south": "V30",
-        "west": "U29",
-        "east": "W29"
+        "north": "V28", "south": "V30", "west": "U29", "east": "W29"
       }
     },
     {
-      "id": "W29",
-      "terrain": "p",
+      "id": "W29", "terrain": "p",
       "exits": {
-        "north": "W28",
-        "south": "W30",
-        "west": "V29",
-        "east": "X29"
+        "north": "W28", "south": "W30", "west": "V29", "east": "X29"
       }
     },
     {
-      "id": "X29",
-      "terrain": "p",
+      "id": "X29", "terrain": "p",
       "exits": {
-        "north": "X28",
-        "south": "X30",
-        "west": "W29",
-        "east": "Y29"
+        "north": "X28", "south": "X30", "west": "W29", "east": "Y29"
       }
     },
     {
-      "id": "Y29",
-      "terrain": "Nature P",
+      "id": "Y29", "terrain": "Nature P",
       "exits": {
-        "north": "Y28",
-        "south": "Y30",
-        "west": "X29",
-        "east": "Z29"
+        "north": "Y28", "south": "Y30", "west": "X29", "east": "Z29"
       }
     },
     {
-      "id": "Z29",
-      "terrain": "p",
+      "id": "Z29", "terrain": "p",
       "exits": {
-        "north": "Z28",
-        "south": "Z30",
-        "west": "Y29",
-        "east": "AA29"
+        "north": "Z28", "south": "Z30", "west": "Y29", "east": "AA29"
       }
     },
     {
-      "id": "AA29",
-      "terrain": "p",
+      "id": "AA29", "terrain": "p",
       "exits": {
-        "north": "AA28",
-        "south": "AA30",
-        "west": "Z29",
-        "east": "AB29"
+        "north": "AA28", "south": "AA30", "west": "Z29", "east": "AB29"
       }
     },
     {
-      "id": "AB29",
-      "terrain": "h",
+      "id": "AB29", "terrain": "h",
       "exits": {
-        "north": "AB28",
-        "south": "AB30",
-        "west": "AA29",
-        "east": "AC29"
+        "north": "AB28", "south": "AB30", "west": "AA29", "east": "AC29"
       }
     },
     {
-      "id": "AC29",
-      "terrain": "h",
+      "id": "AC29", "terrain": "h",
       "exits": {
-        "north": "AC28",
-        "south": "AC30",
-        "west": "AB29",
-        "east": "AD29"
+        "north": "AC28", "south": "AC30", "west": "AB29", "east": "AD29"
       }
     },
     {
-      "id": "AD29",
-      "terrain": "h",
+      "id": "AD29", "terrain": "h",
       "exits": {
-        "north": "AD28",
-        "south": "AD30",
-        "west": "AC29",
-        "east": "AE29"
+        "north": "AD28", "south": "AD30", "west": "AC29", "east": "AE29"
       }
     },
     {
-      "id": "AE29",
-      "terrain": "p",
+      "id": "AE29", "terrain": "p",
       "exits": {
-        "north": "AE28",
-        "south": "AE30",
-        "west": "AD29",
-        "east": "AF29"
+        "north": "AE28", "south": "AE30", "west": "AD29", "east": "AF29"
       }
     },
     {
-      "id": "AF29",
-      "terrain": "p",
+      "id": "AF29", "terrain": "p",
       "exits": {
-        "north": "AF28",
-        "south": "AF30",
-        "west": "AE29",
-        "east": "AG29"
+        "north": "AF28", "south": "AF30", "west": "AE29", "east": "AG29"
       }
     },
     {
-      "id": "AG29",
-      "terrain": "p",
+      "id": "AG29", "terrain": "p",
       "exits": {
-        "north": "AG28",
-        "south": "AG30",
-        "west": "AF29",
-        "east": "AH29"
+        "north": "AG28", "south": "AG30", "west": "AF29", "east": "AH29"
       }
     },
     {
-      "id": "AH29",
-      "terrain": "b",
+      "id": "AH29", "terrain": "b",
       "exits": {
-        "north": "AH28",
-        "south": "AH30",
-        "west": "AG29",
-        "east": "AI29"
+        "north": "AH28", "south": "AH30", "west": "AG29", "east": "AI29"
       }
     },
     {
-      "id": "AI29",
-      "terrain": "b",
+      "id": "AI29", "terrain": "b",
       "exits": {
-        "north": "AI28",
-        "south": "AI30",
-        "west": "AH29",
-        "east": "AJ29"
+        "north": "AI28", "south": "AI30", "west": "AH29", "east": "AJ29"
       }
     },
     {
-      "id": "AJ29",
-      "terrain": "b",
+      "id": "AJ29", "terrain": "b",
       "exits": {
-        "north": "AJ28",
-        "south": "AJ30",
-        "west": "AI29",
-        "east": "AK29"
+        "north": "AJ28", "south": "AJ30", "west": "AI29", "east": "AK29"
       }
     },
     {
-      "id": "AK29",
-      "terrain": "b",
+      "id": "AK29", "terrain": "b",
       "exits": {
-        "north": "AK28",
-        "south": "AK30",
-        "west": "AJ29",
-        "east": "AL29"
+        "north": "AK28", "south": "AK30", "west": "AJ29", "east": "AL29"
       }
     },
     {
-      "id": "AL29",
-      "terrain": "p",
+      "id": "AL29", "terrain": "p",
       "exits": {
-        "north": "AL28",
-        "south": "AL30",
-        "west": "AK29",
-        "east": "AM29"
+        "north": "AL28", "south": "AL30", "west": "AK29", "east": "AM29"
       }
     },
     {
-      "id": "AM29",
-      "terrain": "p",
+      "id": "AM29", "terrain": "p",
       "exits": {
-        "north": "AM28",
-        "south": "AM30",
-        "west": "AL29",
-        "east": "AN29"
+        "north": "AM28", "south": "AM30", "west": "AL29", "east": "AN29"
       }
     },
     {
-      "id": "AN29",
-      "terrain": "p",
+      "id": "AN29", "terrain": "p",
       "exits": {
-        "north": "AN28",
-        "south": "AN30",
-        "west": "AM29",
-        "east": "AO29"
+        "north": "AN28", "south": "AN30", "west": "AM29", "east": "AO29"
       }
     },
     {
-      "id": "AO29",
-      "terrain": "p",
+      "id": "AO29", "terrain": "p",
       "exits": {
-        "north": "AO28",
-        "south": "AO30",
-        "west": "AN29",
-        "east": "AP29"
+        "north": "AO28", "south": "AO30", "west": "AN29", "east": "AP29"
       }
     },
     {
-      "id": "AP29",
-      "terrain": "p",
+      "id": "AP29", "terrain": "p",
       "exits": {
-        "north": "AP28",
-        "south": "AP30",
-        "west": "AO29",
-        "east": "AQ29"
+        "north": "AP28", "south": "AP30", "west": "AO29", "east": "AQ29"
       }
     },
     {
-      "id": "AQ29",
-      "terrain": "p",
+      "id": "AQ29", "terrain": "p",
       "exits": {
-        "north": "AQ28",
-        "south": "AQ30",
-        "west": "AP29",
-        "east": "AR29"
+        "north": "AQ28", "south": "AQ30", "west": "AP29", "east": "AR29"
       }
     },
     {
-      "id": "AR29",
-      "terrain": "p",
+      "id": "AR29", "terrain": "p",
       "exits": {
-        "north": "AR28",
-        "south": "AR30",
-        "west": "AQ29",
-        "east": "AS29"
+        "north": "AR28", "south": "AR30", "west": "AQ29", "east": "AS29"
       }
     },
     {
-      "id": "AS29",
-      "terrain": "p",
+      "id": "AS29", "terrain": "p",
       "exits": {
-        "north": "AS28",
-        "south": "AS30",
-        "west": "AR29",
-        "east": "AT29"
+        "north": "AS28", "south": "AS30", "west": "AR29", "east": "AT29"
       }
     },
     {
-      "id": "AT29",
-      "terrain": "lf",
+      "id": "AT29", "terrain": "lf",
       "exits": {
-        "north": "AT28",
-        "south": "AT30",
-        "west": "AS29",
-        "east": "AU29"
+        "north": "AT28", "south": "AT30", "west": "AS29", "east": "AU29"
       }
     },
     {
-      "id": "AU29",
-      "terrain": "lf",
+      "id": "AU29", "terrain": "lf",
       "exits": {
-        "north": "AU28",
-        "south": "AU30",
-        "west": "AT29",
-        "east": "AV29"
+        "north": "AU28", "south": "AU30", "west": "AT29", "east": "AV29"
       }
     },
     {
-      "id": "AV29",
-      "terrain": "j",
+      "id": "AV29", "terrain": "j",
       "exits": {
-        "north": "AV28",
-        "south": "AV30",
-        "west": "AU29",
-        "east": "AW29"
+        "north": "AV28", "south": "AV30", "west": "AU29", "east": "AW29"
       }
     },
     {
-      "id": "AW29",
-      "terrain": "j",
+      "id": "AW29", "terrain": "j",
       "exits": {
-        "north": "AW28",
-        "south": "AW30",
-        "west": "AV29",
-        "east": "AX29"
+        "north": "AW28", "south": "AW30", "west": "AV29", "east": "AX29"
       }
     },
     {
-      "id": "AX29",
-      "terrain": "j",
+      "id": "AX29", "terrain": "j",
       "exits": {
-        "north": "AX28",
-        "south": "AX30",
-        "west": "AW29"
+        "north": "AX28", "south": "AX30", "west": "AW29"
       }
     },
     {
-      "id": "A30",
-      "terrain": "j",
+      "id": "A30", "terrain": "j",
       "exits": {
-        "north": "A29",
-        "south": "A31",
-        "east": "B30"
+        "north": "A29", "south": "A31", "east": "B30"
       }
     },
     {
-      "id": "B30",
-      "terrain": "s",
+      "id": "B30", "terrain": "s",
       "exits": {
-        "north": "B29",
-        "south": "B31",
-        "west": "A30",
-        "east": "C30"
+        "north": "B29", "south": "B31", "west": "A30", "east": "C30"
       }
     },
     {
-      "id": "C30",
-      "terrain": "p",
+      "id": "C30", "terrain": "p",
       "exits": {
-        "north": "C29",
-        "south": "C31",
-        "west": "B30",
-        "east": "D30"
+        "north": "C29", "south": "C31", "west": "B30", "east": "D30"
       }
     },
     {
-      "id": "D30",
-      "terrain": "p",
+      "id": "D30", "terrain": "p",
       "exits": {
-        "north": "D29",
-        "south": "D31",
-        "west": "C30",
-        "east": "E30"
+        "north": "D29", "south": "D31", "west": "C30", "east": "E30"
       }
     },
     {
-      "id": "E30",
-      "terrain": "p",
+      "id": "E30", "terrain": "p",
       "exits": {
-        "north": "E29",
-        "south": "E31",
-        "west": "D30",
-        "east": "F30"
+        "north": "E29", "south": "E31", "west": "D30", "east": "F30"
       }
     },
     {
-      "id": "F30",
-      "terrain": "m",
+      "id": "F30", "terrain": "m",
       "exits": {
-        "north": "F29",
-        "south": "F31",
-        "west": "E30",
-        "east": "G30"
+        "north": "F29", "south": "F31", "west": "E30", "east": "G30"
       }
     },
     {
-      "id": "G30",
-      "terrain": "m",
+      "id": "G30", "terrain": "m",
       "exits": {
-        "north": "G29",
-        "south": "G31",
-        "west": "F30",
-        "east": "H30"
+        "north": "G29", "south": "G31", "west": "F30", "east": "H30"
       }
     },
     {
-      "id": "H30",
-      "terrain": "m",
+      "id": "H30", "terrain": "m",
       "exits": {
-        "north": "H29",
-        "south": "H31",
-        "west": "G30",
-        "east": "I30"
+        "north": "H29", "south": "H31", "west": "G30", "east": "I30"
       }
     },
     {
-      "id": "I30",
-      "terrain": "d",
+      "id": "I30", "terrain": "d",
       "exits": {
-        "north": "I29",
-        "south": "I31",
-        "west": "H30",
-        "east": "J30"
+        "north": "I29", "south": "I31", "west": "H30", "east": "J30"
       }
     },
     {
-      "id": "J30",
-      "terrain": "d",
+      "id": "J30", "terrain": "d",
       "exits": {
-        "north": "J29",
-        "south": "J31",
-        "west": "I30",
-        "east": "K30"
+        "north": "J29", "south": "J31", "west": "I30", "east": "K30"
       }
     },
     {
-      "id": "K30",
-      "terrain": "d",
+      "id": "K30", "terrain": "d",
       "exits": {
-        "north": "K29",
-        "south": "K31",
-        "west": "J30",
-        "east": "L30"
+        "north": "K29", "south": "K31", "west": "J30", "east": "L30"
       }
     },
     {
-      "id": "L30",
-      "terrain": "d",
+      "id": "L30", "terrain": "d",
       "exits": {
-        "north": "L29",
-        "south": "L31",
-        "west": "K30",
-        "east": "M30"
+        "north": "L29", "south": "L31", "west": "K30", "east": "M30"
       }
     },
     {
-      "id": "M30",
-      "terrain": "d",
+      "id": "M30", "terrain": "d",
       "exits": {
-        "north": "M29",
-        "south": "M31",
-        "west": "L30",
-        "east": "N30"
+        "north": "M29", "south": "M31", "west": "L30", "east": "N30"
       }
     },
     {
-      "id": "N30",
-      "terrain": "d",
+      "id": "N30", "terrain": "d",
       "exits": {
-        "north": "N29",
-        "south": "N31",
-        "west": "M30",
-        "east": "O30"
+        "north": "N29", "south": "N31", "west": "M30", "east": "O30"
       }
     },
     {
-      "id": "O30",
-      "terrain": "d",
+      "id": "O30", "terrain": "d",
       "exits": {
-        "north": "O29",
-        "south": "O31",
-        "west": "N30",
-        "east": "P30"
+        "north": "O29", "south": "O31", "west": "N30", "east": "P30"
       }
     },
     {
-      "id": "P30",
-      "terrain": "p",
+      "id": "P30", "terrain": "p",
       "exits": {
-        "north": "P29",
-        "south": "P31",
-        "west": "O30",
-        "east": "Q30"
+        "north": "P29", "south": "P31", "west": "O30", "east": "Q30"
       }
     },
     {
-      "id": "Q30",
-      "terrain": "p",
+      "id": "Q30", "terrain": "p",
       "exits": {
-        "north": "Q29",
-        "south": "Q31",
-        "west": "P30",
-        "east": "R30"
+        "north": "Q29", "south": "Q31", "west": "P30", "east": "R30"
       }
     },
     {
-      "id": "R30",
-      "terrain": "p",
+      "id": "R30", "terrain": "p",
       "exits": {
-        "north": "R29",
-        "south": "R31",
-        "west": "Q30",
-        "east": "S30"
+        "north": "R29", "south": "R31", "west": "Q30", "east": "S30"
       }
     },
     {
-      "id": "S30",
-      "terrain": "p",
+      "id": "S30", "terrain": "p",
       "exits": {
-        "north": "S29",
-        "south": "S31",
-        "west": "R30",
-        "east": "T30"
+        "north": "S29", "south": "S31", "west": "R30", "east": "T30"
       }
     },
     {
-      "id": "T30",
-      "terrain": "p",
+      "id": "T30", "terrain": "p",
       "exits": {
-        "north": "T29",
-        "south": "T31",
-        "west": "S30",
-        "east": "U30"
+        "north": "T29", "south": "T31", "west": "S30", "east": "U30"
       }
     },
     {
-      "id": "U30",
-      "terrain": "p",
+      "id": "U30", "terrain": "p",
       "exits": {
-        "north": "U29",
-        "south": "U31",
-        "west": "T30",
-        "east": "V30"
+        "north": "U29", "south": "U31", "west": "T30", "east": "V30"
       }
     },
     {
-      "id": "V30",
-      "terrain": "p",
+      "id": "V30", "terrain": "p",
       "exits": {
-        "north": "V29",
-        "south": "V31",
-        "west": "U30",
-        "east": "W30"
+        "north": "V29", "south": "V31", "west": "U30", "east": "W30"
       }
     },
     {
-      "id": "W30",
-      "terrain": "p",
+      "id": "W30", "terrain": "p",
       "exits": {
-        "north": "W29",
-        "south": "W31",
-        "west": "V30",
-        "east": "X30"
+        "north": "W29", "south": "W31", "west": "V30", "east": "X30"
       }
     },
     {
-      "id": "X30",
-      "terrain": "p",
+      "id": "X30", "terrain": "p",
       "exits": {
-        "north": "X29",
-        "south": "X31",
-        "west": "W30",
-        "east": "Y30"
+        "north": "X29", "south": "X31", "west": "W30", "east": "Y30"
       }
     },
     {
-      "id": "Y30",
-      "terrain": "r",
+      "id": "Y30", "terrain": "r",
       "exits": {
-        "north": "Y29",
-        "south": "Y31",
-        "west": "X30",
-        "east": "Z30"
+        "north": "Y29", "south": "Y31", "west": "X30", "east": "Z30"
       }
     },
     {
-      "id": "Z30",
-      "terrain": "p",
+      "id": "Z30", "terrain": "p",
       "exits": {
-        "north": "Z29",
-        "south": "Z31",
-        "west": "Y30",
-        "east": "AA30"
+        "north": "Z29", "south": "Z31", "west": "Y30", "east": "AA30"
       }
     },
     {
-      "id": "AA30",
-      "terrain": "p",
+      "id": "AA30", "terrain": "p",
       "exits": {
-        "north": "AA29",
-        "south": "AA31",
-        "west": "Z30",
-        "east": "AB30"
+        "north": "AA29", "south": "AA31", "west": "Z30", "east": "AB30"
       }
     },
     {
-      "id": "AB30",
-      "terrain": "p",
+      "id": "AB30", "terrain": "p",
       "exits": {
-        "north": "AB29",
-        "south": "AB31",
-        "west": "AA30",
-        "east": "AC30"
+        "north": "AB29", "south": "AB31", "west": "AA30", "east": "AC30"
       }
     },
     {
-      "id": "AC30",
-      "terrain": "h",
+      "id": "AC30", "terrain": "h",
       "exits": {
-        "north": "AC29",
-        "south": "AC31",
-        "west": "AB30",
-        "east": "AD30"
+        "north": "AC29", "south": "AC31", "west": "AB30", "east": "AD30"
       }
     },
     {
-      "id": "AD30",
-      "terrain": "h",
+      "id": "AD30", "terrain": "h",
       "exits": {
-        "north": "AD29",
-        "south": "AD31",
-        "west": "AC30",
-        "east": "AE30"
+        "north": "AD29", "south": "AD31", "west": "AC30", "east": "AE30"
       }
     },
     {
-      "id": "AE30",
-      "terrain": "p",
+      "id": "AE30", "terrain": "p",
       "exits": {
-        "north": "AE29",
-        "south": "AE31",
-        "west": "AD30",
-        "east": "AF30"
+        "north": "AE29", "south": "AE31", "west": "AD30", "east": "AF30"
       }
     },
     {
-      "id": "AF30",
-      "terrain": "p",
+      "id": "AF30", "terrain": "p",
       "exits": {
-        "north": "AF29",
-        "south": "AF31",
-        "west": "AE30",
-        "east": "AG30"
+        "north": "AF29", "south": "AF31", "west": "AE30", "east": "AG30"
       }
     },
     {
-      "id": "AG30",
-      "terrain": "p",
+      "id": "AG30", "terrain": "p",
       "exits": {
-        "north": "AG29",
-        "south": "AG31",
-        "west": "AF30",
-        "east": "AH30"
+        "north": "AG29", "south": "AG31", "west": "AF30", "east": "AH30"
       }
     },
     {
-      "id": "AH30",
-      "terrain": "p",
+      "id": "AH30", "terrain": "p",
       "exits": {
-        "north": "AH29",
-        "south": "AH31",
-        "west": "AG30",
-        "east": "AI30"
+        "north": "AH29", "south": "AH31", "west": "AG30", "east": "AI30"
       }
     },
     {
-      "id": "AI30",
-      "terrain": "b",
+      "id": "AI30", "terrain": "b",
       "exits": {
-        "north": "AI29",
-        "south": "AI31",
-        "west": "AH30",
-        "east": "AJ30"
+        "north": "AI29", "south": "AI31", "west": "AH30", "east": "AJ30"
       }
     },
     {
-      "id": "AJ30",
-      "terrain": "b",
+      "id": "AJ30", "terrain": "b",
       "exits": {
-        "north": "AJ29",
-        "south": "AJ31",
-        "west": "AI30",
-        "east": "AK30"
+        "north": "AJ29", "south": "AJ31", "west": "AI30", "east": "AK30"
       }
     },
     {
-      "id": "AK30",
-      "terrain": "b",
+      "id": "AK30", "terrain": "b",
       "exits": {
-        "north": "AK29",
-        "south": "AK31",
-        "west": "AJ30",
-        "east": "AL30"
+        "north": "AK29", "south": "AK31", "west": "AJ30", "east": "AL30"
       }
     },
     {
-      "id": "AL30",
-      "terrain": "p",
+      "id": "AL30", "terrain": "p",
       "exits": {
-        "north": "AL29",
-        "south": "AL31",
-        "west": "AK30",
-        "east": "AM30"
+        "north": "AL29", "south": "AL31", "west": "AK30", "east": "AM30"
       }
     },
     {
-      "id": "AM30",
-      "terrain": "p",
+      "id": "AM30", "terrain": "p",
       "exits": {
-        "north": "AM29",
-        "south": "AM31",
-        "west": "AL30",
-        "east": "AN30"
+        "north": "AM29", "south": "AM31", "west": "AL30", "east": "AN30"
       }
     },
     {
-      "id": "AN30",
-      "terrain": "p",
+      "id": "AN30", "terrain": "p",
       "exits": {
-        "north": "AN29",
-        "south": "AN31",
-        "west": "AM30",
-        "east": "AO30"
+        "north": "AN29", "south": "AN31", "west": "AM30", "east": "AO30"
       }
     },
     {
-      "id": "AO30",
-      "terrain": "p",
+      "id": "AO30", "terrain": "p",
       "exits": {
-        "north": "AO29",
-        "south": "AO31",
-        "west": "AN30",
-        "east": "AP30"
+        "north": "AO29", "south": "AO31", "west": "AN30", "east": "AP30"
       }
     },
     {
-      "id": "AP30",
-      "terrain": "Pylus",
+      "id": "AP30", "terrain": "Pylus",
       "exits": {
-        "north": "AP29",
-        "south": "AP31",
-        "west": "AO30",
-        "east": "AQ30"
+        "north": "AP29", "south": "AP31", "west": "AO30", "east": "AQ30"
       }
     },
     {
-      "id": "AQ30",
-      "terrain": "p",
+      "id": "AQ30", "terrain": "p",
       "exits": {
-        "north": "AQ29",
-        "south": "AQ31",
-        "west": "AP30",
-        "east": "AR30"
+        "north": "AQ29", "south": "AQ31", "west": "AP30", "east": "AR30"
       }
     },
     {
-      "id": "AR30",
-      "terrain": "p",
+      "id": "AR30", "terrain": "p",
       "exits": {
-        "north": "AR29",
-        "south": "AR31",
-        "west": "AQ30",
-        "east": "AS30"
+        "north": "AR29", "south": "AR31", "west": "AQ30", "east": "AS30"
       }
     },
     {
-      "id": "AS30",
-      "terrain": "p",
+      "id": "AS30", "terrain": "p",
       "exits": {
-        "north": "AS29",
-        "south": "AS31",
-        "west": "AR30",
-        "east": "AT30"
+        "north": "AS29", "south": "AS31", "west": "AR30", "east": "AT30"
       }
     },
     {
-      "id": "AT30",
-      "terrain": "lf",
+      "id": "AT30", "terrain": "lf",
       "exits": {
-        "north": "AT29",
-        "south": "AT31",
-        "west": "AS30",
-        "east": "AU30"
+        "north": "AT29", "south": "AT31", "west": "AS30", "east": "AU30"
       }
     },
     {
-      "id": "AU30",
-      "terrain": "lf",
+      "id": "AU30", "terrain": "lf",
       "exits": {
-        "north": "AU29",
-        "south": "AU31",
-        "west": "AT30",
-        "east": "AV30"
+        "north": "AU29", "south": "AU31", "west": "AT30", "east": "AV30"
       }
     },
     {
-      "id": "AV30",
-      "terrain": "s",
+      "id": "AV30", "terrain": "s",
       "exits": {
-        "north": "AV29",
-        "south": "AV31",
-        "west": "AU30",
-        "east": "AW30"
+        "north": "AV29", "south": "AV31", "west": "AU30", "east": "AW30"
       }
     },
     {
-      "id": "AW30",
-      "terrain": "s",
+      "id": "AW30", "terrain": "s",
       "exits": {
-        "north": "AW29",
-        "south": "AW31",
-        "west": "AV30",
-        "east": "AX30"
+        "north": "AW29", "south": "AW31", "west": "AV30", "east": "AX30"
       }
     },
     {
-      "id": "AX30",
-      "terrain": "s",
+      "id": "AX30", "terrain": "s",
       "exits": {
-        "north": "AX29",
-        "south": "AX31",
-        "west": "AW30"
+        "north": "AX29", "south": "AX31", "west": "AW30"
       }
     },
     {
-      "id": "A31",
-      "terrain": "p",
+      "id": "A31", "terrain": "p",
       "exits": {
-        "north": "A30",
-        "south": "A32",
-        "east": "B31"
+        "north": "A30", "south": "A32", "east": "B31"
       }
     },
     {
-      "id": "B31",
-      "terrain": "p",
+      "id": "B31", "terrain": "p",
       "exits": {
-        "north": "B30",
-        "south": "B32",
-        "west": "A31",
-        "east": "C31"
+        "north": "B30", "south": "B32", "west": "A31", "east": "C31"
       }
     },
     {
-      "id": "C31",
-      "terrain": "p",
+      "id": "C31", "terrain": "p",
       "exits": {
-        "north": "C30",
-        "south": "C32",
-        "west": "B31",
-        "east": "D31"
+        "north": "C30", "south": "C32", "west": "B31", "east": "D31"
       }
     },
     {
-      "id": "D31",
-      "terrain": "p",
+      "id": "D31", "terrain": "p",
       "exits": {
-        "north": "D30",
-        "south": "D32",
-        "west": "C31",
-        "east": "E31"
+        "north": "D30", "south": "D32", "west": "C31", "east": "E31"
       }
     },
     {
-      "id": "E31",
-      "terrain": "p",
+      "id": "E31", "terrain": "p",
       "exits": {
-        "north": "E30",
-        "south": "E32",
-        "west": "D31",
-        "east": "F31"
+        "north": "E30", "south": "E32", "west": "D31", "east": "F31"
       }
     },
     {
-      "id": "F31",
-      "terrain": "p",
+      "id": "F31", "terrain": "p",
       "exits": {
-        "north": "F30",
-        "south": "F32",
-        "west": "E31",
-        "east": "G31"
+        "north": "F30", "south": "F32", "west": "E31", "east": "G31"
       }
     },
     {
-      "id": "G31",
-      "terrain": "m",
+      "id": "G31", "terrain": "m",
       "exits": {
-        "north": "G30",
-        "south": "G32",
-        "west": "F31",
-        "east": "H31"
+        "north": "G30", "south": "G32", "west": "F31", "east": "H31"
       }
     },
     {
-      "id": "H31",
-      "terrain": "d",
+      "id": "H31", "terrain": "d",
       "exits": {
-        "north": "H30",
-        "south": "H32",
-        "west": "G31",
-        "east": "I31"
+        "north": "H30", "south": "H32", "west": "G31", "east": "I31"
       }
     },
     {
-      "id": "I31",
-      "terrain": "dunes",
+      "id": "I31", "terrain": "dunes",
       "exits": {
-        "north": "I30",
-        "south": "I32",
-        "west": "H31",
-        "east": "J31"
+        "north": "I30", "south": "I32", "west": "H31", "east": "J31"
       }
     },
     {
-      "id": "J31",
-      "terrain": "d",
+      "id": "J31", "terrain": "d",
       "exits": {
-        "north": "J30",
-        "south": "J32",
-        "west": "I31",
-        "east": "K31"
+        "north": "J30", "south": "J32", "west": "I31", "east": "K31"
       }
     },
     {
-      "id": "K31",
-      "terrain": "d",
+      "id": "K31", "terrain": "d",
       "exits": {
-        "north": "K30",
-        "south": "K32",
-        "west": "J31",
-        "east": "L31"
+        "north": "K30", "south": "K32", "west": "J31", "east": "L31"
       }
     },
     {
-      "id": "L31",
-      "terrain": "d",
+      "id": "L31", "terrain": "d",
       "exits": {
-        "north": "L30",
-        "south": "L32",
-        "west": "K31",
-        "east": "M31"
+        "north": "L30", "south": "L32", "west": "K31", "east": "M31"
       }
     },
     {
-      "id": "M31",
-      "terrain": "d",
+      "id": "M31", "terrain": "d",
       "exits": {
-        "north": "M30",
-        "south": "M32",
-        "west": "L31",
-        "east": "N31"
+        "north": "M30", "south": "M32", "west": "L31", "east": "N31"
       }
     },
     {
-      "id": "N31",
-      "terrain": "m",
+      "id": "N31", "terrain": "m",
       "exits": {
-        "north": "N30",
-        "south": "N32",
-        "west": "M31",
-        "east": "O31"
+        "north": "N30", "south": "N32", "west": "M31", "east": "O31"
       }
     },
     {
-      "id": "O31",
-      "terrain": "m",
+      "id": "O31", "terrain": "m",
       "exits": {
-        "north": "O30",
-        "south": "O32",
-        "west": "N31",
-        "east": "P31"
+        "north": "O30", "south": "O32", "west": "N31", "east": "P31"
       }
     },
     {
-      "id": "P31",
-      "terrain": "m",
+      "id": "P31", "terrain": "m",
       "exits": {
-        "north": "P30",
-        "south": "P32",
-        "west": "O31",
-        "east": "Q31"
+        "north": "P30", "south": "P32", "west": "O31", "east": "Q31"
       }
     },
     {
-      "id": "Q31",
-      "terrain": "m",
+      "id": "Q31", "terrain": "m",
       "exits": {
-        "north": "Q30",
-        "south": "Q32",
-        "west": "P31",
-        "east": "R31"
+        "north": "Q30", "south": "Q32", "west": "P31", "east": "R31"
       }
     },
     {
-      "id": "R31",
-      "terrain": "p",
+      "id": "R31", "terrain": "p",
       "exits": {
-        "north": "R30",
-        "south": "R32",
-        "west": "Q31",
-        "east": "S31"
+        "north": "R30", "south": "R32", "west": "Q31", "east": "S31"
       }
     },
     {
-      "id": "S31",
-      "terrain": "p",
+      "id": "S31", "terrain": "p",
       "exits": {
-        "north": "S30",
-        "south": "S32",
-        "west": "R31",
-        "east": "T31"
+        "north": "S30", "south": "S32", "west": "R31", "east": "T31"
       }
     },
     {
-      "id": "T31",
-      "terrain": "p",
+      "id": "T31", "terrain": "p",
       "exits": {
-        "north": "T30",
-        "south": "T32",
-        "west": "S31",
-        "east": "U31"
+        "north": "T30", "south": "T32", "west": "S31", "east": "U31"
       }
     },
     {
-      "id": "U31",
-      "terrain": "p",
+      "id": "U31", "terrain": "p",
       "exits": {
-        "north": "U30",
-        "south": "U32",
-        "west": "T31",
-        "east": "V31"
+        "north": "U30", "south": "U32", "west": "T31", "east": "V31"
       }
     },
     {
-      "id": "V31",
-      "terrain": "p",
+      "id": "V31", "terrain": "p",
       "exits": {
-        "north": "V30",
-        "south": "V32",
-        "west": "U31",
-        "east": "W31"
+        "north": "V30", "south": "V32", "west": "U31", "east": "W31"
       }
     },
     {
-      "id": "W31",
-      "terrain": "p",
+      "id": "W31", "terrain": "p",
       "exits": {
-        "north": "W30",
-        "south": "W32",
-        "west": "V31",
-        "east": "X31"
+        "north": "W30", "south": "W32", "west": "V31", "east": "X31"
       }
     },
     {
-      "id": "X31",
-      "terrain": "p",
+      "id": "X31", "terrain": "p",
       "exits": {
-        "north": "X30",
-        "south": "X32",
-        "west": "W31",
-        "east": "Y31"
+        "north": "X30", "south": "X32", "west": "W31", "east": "Y31"
       }
     },
     {
-      "id": "Y31",
-      "terrain": "r",
+      "id": "Y31", "terrain": "r",
       "exits": {
-        "north": "Y30",
-        "south": "Y32",
-        "west": "X31",
-        "east": "Z31"
+        "north": "Y30", "south": "Y32", "west": "X31", "east": "Z31"
       }
     },
     {
-      "id": "Z31",
-      "terrain": "p",
+      "id": "Z31", "terrain": "p",
       "exits": {
-        "north": "Z30",
-        "south": "Z32",
-        "west": "Y31",
-        "east": "AA31"
+        "north": "Z30", "south": "Z32", "west": "Y31", "east": "AA31"
       }
     },
     {
-      "id": "AA31",
-      "terrain": "p",
+      "id": "AA31", "terrain": "p",
       "exits": {
-        "north": "AA30",
-        "south": "AA32",
-        "west": "Z31",
-        "east": "AB31"
+        "north": "AA30", "south": "AA32", "west": "Z31", "east": "AB31"
       }
     },
     {
-      "id": "AB31",
-      "terrain": "p",
+      "id": "AB31", "terrain": "p",
       "exits": {
-        "north": "AB30",
-        "south": "AB32",
-        "west": "AA31",
-        "east": "AC31"
+        "north": "AB30", "south": "AB32", "west": "AA31", "east": "AC31"
       }
     },
     {
-      "id": "AC31",
-      "terrain": "h",
+      "id": "AC31", "terrain": "h",
       "exits": {
-        "north": "AC30",
-        "south": "AC32",
-        "west": "AB31",
-        "east": "AD31"
+        "north": "AC30", "south": "AC32", "west": "AB31", "east": "AD31"
       }
     },
     {
-      "id": "AD31",
-      "terrain": "p",
+      "id": "AD31", "terrain": "p",
       "exits": {
-        "north": "AD30",
-        "south": "AD32",
-        "west": "AC31",
-        "east": "AE31"
+        "north": "AD30", "south": "AD32", "west": "AC31", "east": "AE31"
       }
     },
     {
-      "id": "AE31",
-      "terrain": "p",
+      "id": "AE31", "terrain": "p",
       "exits": {
-        "north": "AE30",
-        "south": "AE32",
-        "west": "AD31",
-        "east": "AF31"
+        "north": "AE30", "south": "AE32", "west": "AD31", "east": "AF31"
       }
     },
     {
-      "id": "AF31",
-      "terrain": "b",
+      "id": "AF31", "terrain": "b",
       "exits": {
-        "north": "AF30",
-        "south": "AF32",
-        "west": "AE31",
-        "east": "AG31"
+        "north": "AF30", "south": "AF32", "west": "AE31", "east": "AG31"
       }
     },
     {
-      "id": "AG31",
-      "terrain": "b",
+      "id": "AG31", "terrain": "b",
       "exits": {
-        "north": "AG30",
-        "south": "AG32",
-        "west": "AF31",
-        "east": "AH31"
+        "north": "AG30", "south": "AG32", "west": "AF31", "east": "AH31"
       }
     },
     {
-      "id": "AH31",
-      "terrain": "b",
+      "id": "AH31", "terrain": "b",
       "exits": {
-        "north": "AH30",
-        "south": "AH32",
-        "west": "AG31",
-        "east": "AI31"
+        "north": "AH30", "south": "AH32", "west": "AG31", "east": "AI31"
       }
     },
     {
-      "id": "AI31",
-      "terrain": "b",
+      "id": "AI31", "terrain": "b",
       "exits": {
-        "north": "AI30",
-        "south": "AI32",
-        "west": "AH31",
-        "east": "AJ31"
+        "north": "AI30", "south": "AI32", "west": "AH31", "east": "AJ31"
       }
     },
     {
-      "id": "AJ31",
-      "terrain": "b",
+      "id": "AJ31", "terrain": "b",
       "exits": {
-        "north": "AJ30",
-        "south": "AJ32",
-        "west": "AI31",
-        "east": "AK31"
+        "north": "AJ30", "south": "AJ32", "west": "AI31", "east": "AK31"
       }
     },
     {
-      "id": "AK31",
-      "terrain": "p",
+      "id": "AK31", "terrain": "p",
       "exits": {
-        "north": "AK30",
-        "south": "AK32",
-        "west": "AJ31",
-        "east": "AL31"
+        "north": "AK30", "south": "AK32", "west": "AJ31", "east": "AL31"
       }
     },
     {
-      "id": "AL31",
-      "terrain": "p",
+      "id": "AL31", "terrain": "p",
       "exits": {
-        "north": "AL30",
-        "south": "AL32",
-        "west": "AK31",
-        "east": "AM31"
+        "north": "AL30", "south": "AL32", "west": "AK31", "east": "AM31"
       }
     },
     {
-      "id": "AM31",
-      "terrain": "p",
+      "id": "AM31", "terrain": "p",
       "exits": {
-        "north": "AM30",
-        "south": "AM32",
-        "west": "AL31",
-        "east": "AN31"
+        "north": "AM30", "south": "AM32", "west": "AL31", "east": "AN31"
       }
     },
     {
-      "id": "AN31",
-      "terrain": "p",
+      "id": "AN31", "terrain": "p",
       "exits": {
-        "north": "AN30",
-        "south": "AN32",
-        "west": "AM31",
-        "east": "AO31"
+        "north": "AN30", "south": "AN32", "west": "AM31", "east": "AO31"
       }
     },
     {
-      "id": "AO31",
-      "terrain": "p",
+      "id": "AO31", "terrain": "p",
       "exits": {
-        "north": "AO30",
-        "south": "AO32",
-        "west": "AN31",
-        "east": "AP31"
+        "north": "AO30", "south": "AO32", "west": "AN31", "east": "AP31"
       }
     },
     {
-      "id": "AP31",
-      "terrain": "p",
+      "id": "AP31", "terrain": "p",
       "exits": {
-        "north": "AP30",
-        "south": "AP32",
-        "west": "AO31",
-        "east": "AQ31"
+        "north": "AP30", "south": "AP32", "west": "AO31", "east": "AQ31"
       }
     },
     {
-      "id": "AQ31",
-      "terrain": "p",
+      "id": "AQ31", "terrain": "p",
       "exits": {
-        "north": "AQ30",
-        "south": "AQ32",
-        "west": "AP31",
-        "east": "AR31"
+        "north": "AQ30", "south": "AQ32", "west": "AP31", "east": "AR31"
       }
     },
     {
-      "id": "AR31",
-      "terrain": "p",
+      "id": "AR31", "terrain": "p",
       "exits": {
-        "north": "AR30",
-        "south": "AR32",
-        "west": "AQ31",
-        "east": "AS31"
+        "north": "AR30", "south": "AR32", "west": "AQ31", "east": "AS31"
       }
     },
     {
-      "id": "AS31",
-      "terrain": "p",
+      "id": "AS31", "terrain": "p",
       "exits": {
-        "north": "AS30",
-        "south": "AS32",
-        "west": "AR31",
-        "east": "AT31"
+        "north": "AS30", "south": "AS32", "west": "AR31", "east": "AT31"
       }
     },
     {
-      "id": "AT31",
-      "terrain": "lf",
+      "id": "AT31", "terrain": "lf",
       "exits": {
-        "north": "AT30",
-        "south": "AT32",
-        "west": "AS31",
-        "east": "AU31"
+        "north": "AT30", "south": "AT32", "west": "AS31", "east": "AU31"
       }
     },
     {
-      "id": "AU31",
-      "terrain": "lf",
+      "id": "AU31", "terrain": "lf",
       "exits": {
-        "north": "AU30",
-        "south": "AU32",
-        "west": "AT31",
-        "east": "AV31"
+        "north": "AU30", "south": "AU32", "west": "AT31", "east": "AV31"
       }
     },
     {
-      "id": "AV31",
-      "terrain": "p",
+      "id": "AV31", "terrain": "p",
       "exits": {
-        "north": "AV30",
-        "south": "AV32",
-        "west": "AU31",
-        "east": "AW31"
+        "north": "AV30", "south": "AV32", "west": "AU31", "east": "AW31"
       }
     },
     {
-      "id": "AW31",
-      "terrain": "s",
+      "id": "AW31", "terrain": "s",
       "exits": {
-        "north": "AW30",
-        "south": "AW32",
-        "west": "AV31",
-        "east": "AX31"
+        "north": "AW30", "south": "AW32", "west": "AV31", "east": "AX31"
       }
     },
     {
-      "id": "AX31",
-      "terrain": "p",
+      "id": "AX31", "terrain": "p",
       "exits": {
-        "north": "AX30",
-        "south": "AX32",
-        "west": "AW31"
+        "north": "AX30", "south": "AX32", "west": "AW31"
       }
     },
     {
-      "id": "A32",
-      "terrain": "p",
+      "id": "A32", "terrain": "p",
       "exits": {
-        "north": "A31",
-        "south": "A33",
-        "east": "B32"
+        "north": "A31", "south": "A33", "east": "B32"
       }
     },
     {
-      "id": "B32",
-      "terrain": "p",
+      "id": "B32", "terrain": "p",
       "exits": {
-        "north": "B31",
-        "south": "B33",
-        "west": "A32",
-        "east": "C32"
+        "north": "B31", "south": "B33", "west": "A32", "east": "C32"
       }
     },
     {
-      "id": "C32",
-      "terrain": "p",
+      "id": "C32", "terrain": "p",
       "exits": {
-        "north": "C31",
-        "south": "C33",
-        "west": "B32",
-        "east": "D32"
+        "north": "C31", "south": "C33", "west": "B32", "east": "D32"
       }
     },
     {
-      "id": "D32",
-      "terrain": "p",
+      "id": "D32", "terrain": "p",
       "exits": {
-        "north": "D31",
-        "south": "D33",
-        "west": "C32",
-        "east": "E32"
+        "north": "D31", "south": "D33", "west": "C32", "east": "E32"
       }
     },
     {
-      "id": "E32",
-      "terrain": "p",
+      "id": "E32", "terrain": "p",
       "exits": {
-        "north": "E31",
-        "south": "E33",
-        "west": "D32",
-        "east": "F32"
+        "north": "E31", "south": "E33", "west": "D32", "east": "F32"
       }
     },
     {
-      "id": "F32",
-      "terrain": "m",
+      "id": "F32", "terrain": "m",
       "exits": {
-        "north": "F31",
-        "south": "F33",
-        "west": "E32",
-        "east": "G32"
+        "north": "F31", "south": "F33", "west": "E32", "east": "G32"
       }
     },
     {
-      "id": "G32",
-      "terrain": "m",
+      "id": "G32", "terrain": "m",
       "exits": {
-        "north": "G31",
-        "south": "G33",
-        "west": "F32",
-        "east": "H32"
+        "north": "G31", "south": "G33", "west": "F32", "east": "H32"
       }
     },
     {
-      "id": "H32",
-      "terrain": "m",
+      "id": "H32", "terrain": "m",
       "exits": {
-        "north": "H31",
-        "south": "H33",
-        "west": "G32",
-        "east": "I32"
+        "north": "H31", "south": "H33", "west": "G32", "east": "I32"
       }
     },
     {
-      "id": "I32",
-      "terrain": "d",
+      "id": "I32", "terrain": "d",
       "exits": {
-        "north": "I31",
-        "south": "I33",
-        "west": "H32",
-        "east": "J32"
+        "north": "I31", "south": "I33", "west": "H32", "east": "J32"
       }
     },
     {
-      "id": "J32",
-      "terrain": "d",
+      "id": "J32", "terrain": "d",
       "exits": {
-        "north": "J31",
-        "south": "J33",
-        "west": "I32",
-        "east": "K32"
+        "north": "J31", "south": "J33", "west": "I32", "east": "K32"
       }
     },
     {
-      "id": "K32",
-      "terrain": "d",
+      "id": "K32", "terrain": "d",
       "exits": {
-        "north": "K31",
-        "south": "K33",
-        "west": "J32",
-        "east": "L32"
+        "north": "K31", "south": "K33", "west": "J32", "east": "L32"
       }
     },
     {
-      "id": "L32",
-      "terrain": "d",
+      "id": "L32", "terrain": "d",
       "exits": {
-        "north": "L31",
-        "south": "L33",
-        "west": "K32",
-        "east": "M32"
+        "north": "L31", "south": "L33", "west": "K32", "east": "M32"
       }
     },
     {
-      "id": "M32",
-      "terrain": "b",
+      "id": "M32", "terrain": "b",
       "exits": {
-        "north": "M31",
-        "south": "M33",
-        "west": "L32",
-        "east": "N32"
+        "north": "M31", "south": "M33", "west": "L32", "east": "N32"
       }
     },
     {
-      "id": "N32",
-      "terrain": "p",
+      "id": "N32", "terrain": "p",
       "exits": {
-        "north": "N31",
-        "south": "N33",
-        "west": "M32",
-        "east": "O32"
+        "north": "N31", "south": "N33", "west": "M32", "east": "O32"
       }
     },
     {
-      "id": "O32",
-      "terrain": "p",
+      "id": "O32", "terrain": "p",
       "exits": {
-        "north": "O31",
-        "south": "O33",
-        "west": "N32",
-        "east": "P32"
+        "north": "O31", "south": "O33", "west": "N32", "east": "P32"
       }
     },
     {
-      "id": "P32",
-      "terrain": "p",
+      "id": "P32", "terrain": "p",
       "exits": {
-        "north": "P31",
-        "south": "P33",
-        "west": "O32",
-        "east": "Q32"
+        "north": "P31", "south": "P33", "west": "O32", "east": "Q32"
       }
     },
     {
-      "id": "Q32",
-      "terrain": "p",
+      "id": "Q32", "terrain": "p",
       "exits": {
-        "north": "Q31",
-        "south": "Q33",
-        "west": "P32",
-        "east": "R32"
+        "north": "Q31", "south": "Q33", "west": "P32", "east": "R32"
       }
     },
     {
-      "id": "R32",
-      "terrain": "p",
+      "id": "R32", "terrain": "p",
       "exits": {
-        "north": "R31",
-        "south": "R33",
-        "west": "Q32",
-        "east": "S32"
+        "north": "R31", "south": "R33", "west": "Q32", "east": "S32"
       }
     },
     {
-      "id": "S32",
-      "terrain": "p",
+      "id": "S32", "terrain": "p",
       "exits": {
-        "north": "S31",
-        "south": "S33",
-        "west": "R32",
-        "east": "T32"
+        "north": "S31", "south": "S33", "west": "R32", "east": "T32"
       }
     },
     {
-      "id": "T32",
-      "terrain": "p",
+      "id": "T32", "terrain": "p",
       "exits": {
-        "north": "T31",
-        "south": "T33",
-        "west": "S32",
-        "east": "U32"
+        "north": "T31", "south": "T33", "west": "S32", "east": "U32"
       }
     },
     {
-      "id": "U32",
-      "terrain": "p",
+      "id": "U32", "terrain": "p",
       "exits": {
-        "north": "U31",
-        "south": "U33",
-        "west": "T32",
-        "east": "V32"
+        "north": "U31", "south": "U33", "west": "T32", "east": "V32"
       }
     },
     {
-      "id": "V32",
-      "terrain": "p",
+      "id": "V32", "terrain": "p",
       "exits": {
-        "north": "V31",
-        "south": "V33",
-        "west": "U32",
-        "east": "W32"
+        "north": "V31", "south": "V33", "west": "U32", "east": "W32"
       }
     },
     {
-      "id": "W32",
-      "terrain": "p",
+      "id": "W32", "terrain": "p",
       "exits": {
-        "north": "W31",
-        "south": "W33",
-        "west": "V32",
-        "east": "X32"
+        "north": "W31", "south": "W33", "west": "V32", "east": "X32"
       }
     },
     {
-      "id": "X32",
-      "terrain": "p",
+      "id": "X32", "terrain": "p",
       "exits": {
-        "north": "X31",
-        "south": "X33",
-        "west": "W32",
-        "east": "Y32"
+        "north": "X31", "south": "X33", "west": "W32", "east": "Y32"
       }
     },
     {
-      "id": "Y32",
-      "terrain": "r",
+      "id": "Y32", "terrain": "r",
       "exits": {
-        "north": "Y31",
-        "south": "Y33",
-        "west": "X32",
-        "east": "Z32"
+        "north": "Y31", "south": "Y33", "west": "X32", "east": "Z32"
       }
     },
     {
-      "id": "Z32",
-      "terrain": "p",
+      "id": "Z32", "terrain": "p",
       "exits": {
-        "north": "Z31",
-        "south": "Z33",
-        "west": "Y32",
-        "east": "AA32"
+        "north": "Z31", "south": "Z33", "west": "Y32", "east": "AA32"
       }
     },
     {
-      "id": "AA32",
-      "terrain": "p",
+      "id": "AA32", "terrain": "p",
       "exits": {
-        "north": "AA31",
-        "south": "AA33",
-        "west": "Z32",
-        "east": "AB32"
+        "north": "AA31", "south": "AA33", "west": "Z32", "east": "AB32"
       }
     },
     {
-      "id": "AB32",
-      "terrain": "p",
+      "id": "AB32", "terrain": "p",
       "exits": {
-        "north": "AB31",
-        "south": "AB33",
-        "west": "AA32",
-        "east": "AC32"
+        "north": "AB31", "south": "AB33", "west": "AA32", "east": "AC32"
       }
     },
     {
-      "id": "AC32",
-      "terrain": "h",
+      "id": "AC32", "terrain": "h",
       "exits": {
-        "north": "AC31",
-        "south": "AC33",
-        "west": "AB32",
-        "east": "AD32"
+        "north": "AC31", "south": "AC33", "west": "AB32", "east": "AD32"
       }
     },
     {
-      "id": "AD32",
-      "terrain": "p",
+      "id": "AD32", "terrain": "p",
       "exits": {
-        "north": "AD31",
-        "south": "AD33",
-        "west": "AC32",
-        "east": "AE32"
+        "north": "AD31", "south": "AD33", "west": "AC32", "east": "AE32"
       }
     },
     {
-      "id": "AE32",
-      "terrain": "p",
+      "id": "AE32", "terrain": "p",
       "exits": {
-        "north": "AE31",
-        "south": "AE33",
-        "west": "AD32",
-        "east": "AF32"
+        "north": "AE31", "south": "AE33", "west": "AD32", "east": "AF32"
       }
     },
     {
-      "id": "AF32",
-      "terrain": "p",
+      "id": "AF32", "terrain": "p",
       "exits": {
-        "north": "AF31",
-        "south": "AF33",
-        "west": "AE32",
-        "east": "AG32"
+        "north": "AF31", "south": "AF33", "west": "AE32", "east": "AG32"
       }
     },
     {
-      "id": "AG32",
-      "terrain": "p",
+      "id": "AG32", "terrain": "p",
       "exits": {
-        "north": "AG31",
-        "south": "AG33",
-        "west": "AF32",
-        "east": "AH32"
+        "north": "AG31", "south": "AG33", "west": "AF32", "east": "AH32"
       }
     },
     {
-      "id": "AH32",
-      "terrain": "p",
+      "id": "AH32", "terrain": "p",
       "exits": {
-        "north": "AH31",
-        "south": "AH33",
-        "west": "AG32",
-        "east": "AI32"
+        "north": "AH31", "south": "AH33", "west": "AG32", "east": "AI32"
       }
     },
     {
-      "id": "AI32",
-      "terrain": "p",
+      "id": "AI32", "terrain": "p",
       "exits": {
-        "north": "AI31",
-        "south": "AI33",
-        "west": "AH32",
-        "east": "AJ32"
+        "north": "AI31", "south": "AI33", "west": "AH32", "east": "AJ32"
       }
     },
     {
-      "id": "AJ32",
-      "terrain": "p",
+      "id": "AJ32", "terrain": "p",
       "exits": {
-        "north": "AJ31",
-        "south": "AJ33",
-        "west": "AI32",
-        "east": "AK32"
+        "north": "AJ31", "south": "AJ33", "west": "AI32", "east": "AK32"
       }
     },
     {
-      "id": "AK32",
-      "terrain": "p",
+      "id": "AK32", "terrain": "p",
       "exits": {
-        "north": "AK31",
-        "south": "AK33",
-        "west": "AJ32",
-        "east": "AL32"
+        "north": "AK31", "south": "AK33", "west": "AJ32", "east": "AL32"
       }
     },
     {
-      "id": "AL32",
-      "terrain": "p",
+      "id": "AL32", "terrain": "p",
       "exits": {
-        "north": "AL31",
-        "south": "AL33",
-        "west": "AK32",
-        "east": "AM32"
+        "north": "AL31", "south": "AL33", "west": "AK32", "east": "AM32"
       }
     },
     {
-      "id": "AM32",
-      "terrain": "p",
+      "id": "AM32", "terrain": "p",
       "exits": {
-        "north": "AM31",
-        "south": "AM33",
-        "west": "AL32",
-        "east": "AN32"
+        "north": "AM31", "south": "AM33", "west": "AL32", "east": "AN32"
       }
     },
     {
-      "id": "AN32",
-      "terrain": "p",
+      "id": "AN32", "terrain": "p",
       "exits": {
-        "north": "AN31",
-        "south": "AN33",
-        "west": "AM32",
-        "east": "AO32"
+        "north": "AN31", "south": "AN33", "west": "AM32", "east": "AO32"
       }
     },
     {
-      "id": "AO32",
-      "terrain": "p",
+      "id": "AO32", "terrain": "p",
       "exits": {
-        "north": "AO31",
-        "south": "AO33",
-        "west": "AN32",
-        "east": "AP32"
+        "north": "AO31", "south": "AO33", "west": "AN32", "east": "AP32"
       }
     },
     {
-      "id": "AP32",
-      "terrain": "p",
+      "id": "AP32", "terrain": "p",
       "exits": {
-        "north": "AP31",
-        "south": "AP33",
-        "west": "AO32",
-        "east": "AQ32"
+        "north": "AP31", "south": "AP33", "west": "AO32", "east": "AQ32"
       }
     },
     {
-      "id": "AQ32",
-      "terrain": "p",
+      "id": "AQ32", "terrain": "p",
       "exits": {
-        "north": "AQ31",
-        "south": "AQ33",
-        "west": "AP32",
-        "east": "AR32"
+        "north": "AQ31", "south": "AQ33", "west": "AP32", "east": "AR32"
       }
     },
     {
-      "id": "AR32",
-      "terrain": "foothills",
+      "id": "AR32", "terrain": "foothills",
       "exits": {
-        "north": "AR31",
-        "south": "AR33",
-        "west": "AQ32",
-        "east": "AS32"
+        "north": "AR31", "south": "AR33", "west": "AQ32", "east": "AS32"
       }
     },
     {
-      "id": "AS32",
-      "terrain": "p",
+      "id": "AS32", "terrain": "p",
       "exits": {
-        "north": "AS31",
-        "south": "AS33",
-        "west": "AR32",
-        "east": "AT32"
+        "north": "AS31", "south": "AS33", "west": "AR32", "east": "AT32"
       }
     },
     {
-      "id": "AT32",
-      "terrain": "lf",
+      "id": "AT32", "terrain": "lf",
       "exits": {
-        "north": "AT31",
-        "south": "AT33",
-        "west": "AS32",
-        "east": "AU32"
+        "north": "AT31", "south": "AT33", "west": "AS32", "east": "AU32"
       }
     },
     {
-      "id": "AU32",
-      "terrain": "lf",
+      "id": "AU32", "terrain": "lf",
       "exits": {
-        "north": "AU31",
-        "south": "AU33",
-        "west": "AT32",
-        "east": "AV32"
+        "north": "AU31", "south": "AU33", "west": "AT32", "east": "AV32"
       }
     },
     {
-      "id": "AV32",
-      "terrain": "p",
+      "id": "AV32", "terrain": "p",
       "exits": {
-        "north": "AV31",
-        "south": "AV33",
-        "west": "AU32",
-        "east": "AW32"
+        "north": "AV31", "south": "AV33", "west": "AU32", "east": "AW32"
       }
     },
     {
-      "id": "AW32",
-      "terrain": "p",
+      "id": "AW32", "terrain": "p",
       "exits": {
-        "north": "AW31",
-        "south": "AW33",
-        "west": "AV32",
-        "east": "AX32"
+        "north": "AW31", "south": "AW33", "west": "AV32", "east": "AX32"
       }
     },
     {
-      "id": "AX32",
-      "terrain": "p",
+      "id": "AX32", "terrain": "p",
       "exits": {
-        "north": "AX31",
-        "south": "AX33",
-        "west": "AW32"
+        "north": "AX31", "south": "AX33", "west": "AW32"
       }
     },
     {
-      "id": "A33",
-      "terrain": "p",
+      "id": "A33", "terrain": "p",
       "exits": {
-        "north": "A32",
-        "south": "A34",
-        "east": "B33"
+        "north": "A32", "south": "A34", "east": "B33"
       }
     },
     {
-      "id": "B33",
-      "terrain": "p",
+      "id": "B33", "terrain": "p",
       "exits": {
-        "north": "B32",
-        "south": "B34",
-        "west": "A33",
-        "east": "C33"
+        "north": "B32", "south": "B34", "west": "A33", "east": "C33"
       }
     },
     {
-      "id": "C33",
-      "terrain": "p",
+      "id": "C33", "terrain": "p",
       "exits": {
-        "north": "C32",
-        "south": "C34",
-        "west": "B33",
-        "east": "D33"
+        "north": "C32", "south": "C34", "west": "B33", "east": "D33"
       }
     },
     {
-      "id": "D33",
-      "terrain": "m",
+      "id": "D33", "terrain": "m",
       "exits": {
-        "north": "D32",
-        "south": "D34",
-        "west": "C33",
-        "east": "E33"
+        "north": "D32", "south": "D34", "west": "C33", "east": "E33"
       }
     },
     {
-      "id": "E33",
-      "terrain": "m",
+      "id": "E33", "terrain": "m",
       "exits": {
-        "north": "E32",
-        "south": "E34",
-        "west": "D33",
-        "east": "F33"
+        "north": "E32", "south": "E34", "west": "D33", "east": "F33"
       }
     },
     {
-      "id": "F33",
-      "terrain": "m",
+      "id": "F33", "terrain": "m",
       "exits": {
-        "north": "F32",
-        "south": "F34",
-        "west": "E33",
-        "east": "G33"
+        "north": "F32", "south": "F34", "west": "E33", "east": "G33"
       }
     },
     {
-      "id": "G33",
-      "terrain": "m",
+      "id": "G33", "terrain": "m",
       "exits": {
-        "north": "G32",
-        "south": "G34",
-        "west": "F33",
-        "east": "H33"
+        "north": "G32", "south": "G34", "west": "F33", "east": "H33"
       }
     },
     {
-      "id": "H33",
-      "terrain": "m",
+      "id": "H33", "terrain": "m",
       "exits": {
-        "north": "H32",
-        "south": "H34",
-        "west": "G33",
-        "east": "I33"
+        "north": "H32", "south": "H34", "west": "G33", "east": "I33"
       }
     },
     {
-      "id": "I33",
-      "terrain": "p",
+      "id": "I33", "terrain": "p",
       "exits": {
-        "north": "I32",
-        "south": "I34",
-        "west": "H33",
-        "east": "J33"
+        "north": "I32", "south": "I34", "west": "H33", "east": "J33"
       }
     },
     {
-      "id": "J33",
-      "terrain": "p",
+      "id": "J33", "terrain": "p",
       "exits": {
-        "north": "J32",
-        "south": "J34",
-        "west": "I33",
-        "east": "K33"
+        "north": "J32", "south": "J34", "west": "I33", "east": "K33"
       }
     },
     {
-      "id": "K33",
-      "terrain": "p",
+      "id": "K33", "terrain": "p",
       "exits": {
-        "north": "K32",
-        "south": "K34",
-        "west": "J33",
-        "east": "L33"
+        "north": "K32", "south": "K34", "west": "J33", "east": "L33"
       }
     },
     {
-      "id": "L33",
-      "terrain": "b",
+      "id": "L33", "terrain": "b",
       "exits": {
-        "north": "L32",
-        "south": "L34",
-        "west": "K33",
-        "east": "M33"
+        "north": "L32", "south": "L34", "west": "K33", "east": "M33"
       }
     },
     {
-      "id": "M33",
-      "terrain": "b",
+      "id": "M33", "terrain": "b",
       "exits": {
-        "north": "M32",
-        "south": "M34",
-        "west": "L33",
-        "east": "N33"
+        "north": "M32", "south": "M34", "west": "L33", "east": "N33"
       }
     },
     {
-      "id": "N33",
-      "terrain": "b",
+      "id": "N33", "terrain": "b",
       "exits": {
-        "north": "N32",
-        "south": "N34",
-        "west": "M33",
-        "east": "O33"
+        "north": "N32", "south": "N34", "west": "M33", "east": "O33"
       }
     },
     {
-      "id": "O33",
-      "terrain": "p",
+      "id": "O33", "terrain": "p",
       "exits": {
-        "north": "O32",
-        "south": "O34",
-        "west": "N33",
-        "east": "P33"
+        "north": "O32", "south": "O34", "west": "N33", "east": "P33"
       }
     },
     {
-      "id": "P33",
-      "terrain": "p",
+      "id": "P33", "terrain": "p",
       "exits": {
-        "north": "P32",
-        "south": "P34",
-        "west": "O33",
-        "east": "Q33"
+        "north": "P32", "south": "P34", "west": "O33", "east": "Q33"
       }
     },
     {
-      "id": "Q33",
-      "terrain": "p",
+      "id": "Q33", "terrain": "p",
       "exits": {
-        "north": "Q32",
-        "south": "Q34",
-        "west": "P33",
-        "east": "R33"
+        "north": "Q32", "south": "Q34", "west": "P33", "east": "R33"
       }
     },
     {
-      "id": "R33",
-      "terrain": "p",
+      "id": "R33", "terrain": "p",
       "exits": {
-        "north": "R32",
-        "south": "R34",
-        "west": "Q33",
-        "east": "S33"
+        "north": "R32", "south": "R34", "west": "Q33", "east": "S33"
       }
     },
     {
-      "id": "S33",
-      "terrain": "p",
+      "id": "S33", "terrain": "p",
       "exits": {
-        "north": "S32",
-        "south": "S34",
-        "west": "R33",
-        "east": "T33"
+        "north": "S32", "south": "S34", "west": "R33", "east": "T33"
       }
     },
     {
-      "id": "T33",
-      "terrain": "p",
+      "id": "T33", "terrain": "p",
       "exits": {
-        "north": "T32",
-        "south": "T34",
-        "west": "S33",
-        "east": "U33"
+        "north": "T32", "south": "T34", "west": "S33", "east": "U33"
       }
     },
     {
-      "id": "U33",
-      "terrain": "p",
+      "id": "U33", "terrain": "p",
       "exits": {
-        "north": "U32",
-        "south": "U34",
-        "west": "T33",
-        "east": "V33"
+        "north": "U32", "south": "U34", "west": "T33", "east": "V33"
       }
     },
     {
-      "id": "V33",
-      "terrain": "p",
+      "id": "V33", "terrain": "p",
       "exits": {
-        "north": "V32",
-        "south": "V34",
-        "west": "U33",
-        "east": "W33"
+        "north": "V32", "south": "V34", "west": "U33", "east": "W33"
       }
     },
     {
-      "id": "W33",
-      "terrain": "p",
+      "id": "W33", "terrain": "p",
       "exits": {
-        "north": "W32",
-        "south": "W34",
-        "west": "V33",
-        "east": "X33"
+        "north": "W32", "south": "W34", "west": "V33", "east": "X33"
       }
     },
     {
-      "id": "X33",
-      "terrain": "p",
+      "id": "X33", "terrain": "p",
       "exits": {
-        "north": "X32",
-        "south": "X34",
-        "west": "W33",
-        "east": "Y33"
+        "north": "X32", "south": "X34", "west": "W33", "east": "Y33"
       }
     },
     {
-      "id": "Y33",
-      "terrain": "r",
+      "id": "Y33", "terrain": "r",
       "exits": {
-        "north": "Y32",
-        "south": "Y34",
-        "west": "X33",
-        "east": "Z33"
+        "north": "Y32", "south": "Y34", "west": "X33", "east": "Z33"
       }
     },
     {
-      "id": "Z33",
-      "terrain": "p",
+      "id": "Z33", "terrain": "p",
       "exits": {
-        "north": "Z32",
-        "south": "Z34",
-        "west": "Y33",
-        "east": "AA33"
+        "north": "Z32", "south": "Z34", "west": "Y33", "east": "AA33"
       }
     },
     {
-      "id": "AA33",
-      "terrain": "p",
+      "id": "AA33", "terrain": "p",
       "exits": {
-        "north": "AA32",
-        "south": "AA34",
-        "west": "Z33",
-        "east": "AB33"
+        "north": "AA32", "south": "AA34", "west": "Z33", "east": "AB33"
       }
     },
     {
-      "id": "AB33",
-      "terrain": "p",
+      "id": "AB33", "terrain": "p",
       "exits": {
-        "north": "AB32",
-        "south": "AB34",
-        "west": "AA33",
-        "east": "AC33"
+        "north": "AB32", "south": "AB34", "west": "AA33", "east": "AC33"
       }
     },
     {
-      "id": "AC33",
-      "terrain": "h",
+      "id": "AC33", "terrain": "h",
       "exits": {
-        "north": "AC32",
-        "south": "AC34",
-        "west": "AB33",
-        "east": "AD33"
+        "north": "AC32", "south": "AC34", "west": "AB33", "east": "AD33"
       }
     },
     {
-      "id": "AD33",
-      "terrain": "V Green",
+      "id": "AD33", "terrain": "V Green",
       "exits": {
-        "north": "AD32",
-        "south": "AD34",
-        "west": "AC33",
-        "east": "AE33"
+        "north": "AD32", "south": "AD34", "west": "AC33", "east": "AE33"
       }
     },
     {
-      "id": "AE33",
-      "terrain": "p",
+      "id": "AE33", "terrain": "p",
       "exits": {
-        "north": "AE32",
-        "south": "AE34",
-        "west": "AD33",
-        "east": "AF33"
+        "north": "AE32", "south": "AE34", "west": "AD33", "east": "AF33"
       }
     },
     {
-      "id": "AF33",
-      "terrain": "p",
+      "id": "AF33", "terrain": "p",
       "exits": {
-        "north": "AF32",
-        "south": "AF34",
-        "west": "AE33",
-        "east": "AG33"
+        "north": "AF32", "south": "AF34", "west": "AE33", "east": "AG33"
       }
     },
     {
-      "id": "AG33",
-      "terrain": "p",
+      "id": "AG33", "terrain": "p",
       "exits": {
-        "north": "AG32",
-        "south": "AG34",
-        "west": "AF33",
-        "east": "AH33"
+        "north": "AG32", "south": "AG34", "west": "AF33", "east": "AH33"
       }
     },
     {
-      "id": "AH33",
-      "terrain": "p",
+      "id": "AH33", "terrain": "p",
       "exits": {
-        "north": "AH32",
-        "south": "AH34",
-        "west": "AG33",
-        "east": "AI33"
+        "north": "AH32", "south": "AH34", "west": "AG33", "east": "AI33"
       }
     },
     {
-      "id": "AI33",
-      "terrain": "p",
+      "id": "AI33", "terrain": "p",
       "exits": {
-        "north": "AI32",
-        "south": "AI34",
-        "west": "AH33",
-        "east": "AJ33"
+        "north": "AI32", "south": "AI34", "west": "AH33", "east": "AJ33"
       }
     },
     {
-      "id": "AJ33",
-      "terrain": "p",
+      "id": "AJ33", "terrain": "p",
       "exits": {
-        "north": "AJ32",
-        "south": "AJ34",
-        "west": "AI33",
-        "east": "AK33"
+        "north": "AJ32", "south": "AJ34", "west": "AI33", "east": "AK33"
       }
     },
     {
-      "id": "AK33",
-      "terrain": "p",
+      "id": "AK33", "terrain": "p",
       "exits": {
-        "north": "AK32",
-        "south": "AK34",
-        "west": "AJ33",
-        "east": "AL33"
+        "north": "AK32", "south": "AK34", "west": "AJ33", "east": "AL33"
       }
     },
     {
-      "id": "AL33",
-      "terrain": "p",
+      "id": "AL33", "terrain": "p",
       "exits": {
-        "north": "AL32",
-        "south": "AL34",
-        "west": "AK33",
-        "east": "AM33"
+        "north": "AL32", "south": "AL34", "west": "AK33", "east": "AM33"
       }
     },
     {
-      "id": "AM33",
-      "terrain": "p",
+      "id": "AM33", "terrain": "p",
       "exits": {
-        "north": "AM32",
-        "south": "AM34",
-        "west": "AL33",
-        "east": "AN33"
+        "north": "AM32", "south": "AM34", "west": "AL33", "east": "AN33"
       }
     },
     {
-      "id": "AN33",
-      "terrain": "p",
+      "id": "AN33", "terrain": "p",
       "exits": {
-        "north": "AN32",
-        "south": "AN34",
-        "west": "AM33",
-        "east": "AO33"
+        "north": "AN32", "south": "AN34", "west": "AM33", "east": "AO33"
       }
     },
     {
-      "id": "AO33",
-      "terrain": "p",
+      "id": "AO33", "terrain": "p",
       "exits": {
-        "north": "AO32",
-        "south": "AO34",
-        "west": "AN33",
-        "east": "AP33"
+        "north": "AO32", "south": "AO34", "west": "AN33", "east": "AP33"
       }
     },
     {
-      "id": "AP33",
-      "terrain": "p",
+      "id": "AP33", "terrain": "p",
       "exits": {
-        "north": "AP32",
-        "south": "AP34",
-        "west": "AO33",
-        "east": "AQ33"
+        "north": "AP32", "south": "AP34", "west": "AO33", "east": "AQ33"
       }
     },
     {
-      "id": "AQ33",
-      "terrain": "p",
+      "id": "AQ33", "terrain": "p",
       "exits": {
-        "north": "AQ32",
-        "south": "AQ34",
-        "west": "AP33",
-        "east": "AR33"
+        "north": "AQ32", "south": "AQ34", "west": "AP33", "east": "AR33"
       }
     },
     {
-      "id": "AR33",
-      "terrain": "p",
+      "id": "AR33", "terrain": "p",
       "exits": {
-        "north": "AR32",
-        "south": "AR34",
-        "west": "AQ33",
-        "east": "AS33"
+        "north": "AR32", "south": "AR34", "west": "AQ33", "east": "AS33"
       }
     },
     {
-      "id": "AS33",
-      "terrain": "p",
+      "id": "AS33", "terrain": "p",
       "exits": {
-        "north": "AS32",
-        "south": "AS34",
-        "west": "AR33",
-        "east": "AT33"
+        "north": "AS32", "south": "AS34", "west": "AR33", "east": "AT33"
       }
     },
     {
-      "id": "AT33",
-      "terrain": "lf",
+      "id": "AT33", "terrain": "lf",
       "exits": {
-        "north": "AT32",
-        "south": "AT34",
-        "west": "AS33",
-        "east": "AU33"
+        "north": "AT32", "south": "AT34", "west": "AS33", "east": "AU33"
       }
     },
     {
-      "id": "AU33",
-      "terrain": "lf",
+      "id": "AU33", "terrain": "lf",
       "exits": {
-        "north": "AU32",
-        "south": "AU34",
-        "west": "AT33",
-        "east": "AV33"
+        "north": "AU32", "south": "AU34", "west": "AT33", "east": "AV33"
       }
     },
     {
-      "id": "AV33",
-      "terrain": "p",
+      "id": "AV33", "terrain": "p",
       "exits": {
-        "north": "AV32",
-        "south": "AV34",
-        "west": "AU33",
-        "east": "AW33"
+        "north": "AV32", "south": "AV34", "west": "AU33", "east": "AW33"
       }
     },
     {
-      "id": "AW33",
-      "terrain": "p",
+      "id": "AW33", "terrain": "p",
       "exits": {
-        "north": "AW32",
-        "south": "AW34",
-        "west": "AV33",
-        "east": "AX33"
+        "north": "AW32", "south": "AW34", "west": "AV33", "east": "AX33"
       }
     },
     {
-      "id": "AX33",
-      "terrain": "p",
+      "id": "AX33", "terrain": "p",
       "exits": {
-        "north": "AX32",
-        "south": "AX34",
-        "west": "AW33"
+        "north": "AX32", "south": "AX34", "west": "AW33"
       }
     },
     {
-      "id": "A34",
-      "terrain": "p",
+      "id": "A34", "terrain": "p",
       "exits": {
-        "north": "A33",
-        "south": "A35",
-        "east": "B34"
+        "north": "A33", "south": "A35", "east": "B34"
       }
     },
     {
-      "id": "B34",
-      "terrain": "p",
+      "id": "B34", "terrain": "p",
       "exits": {
-        "north": "B33",
-        "south": "B35",
-        "west": "A34",
-        "east": "C34"
+        "north": "B33", "south": "B35", "west": "A34", "east": "C34"
       }
     },
     {
-      "id": "C34",
-      "terrain": "m",
+      "id": "C34", "terrain": "m",
       "exits": {
-        "north": "C33",
-        "south": "C35",
-        "west": "B34",
-        "east": "D34"
+        "north": "C33", "south": "C35", "west": "B34", "east": "D34"
       }
     },
     {
-      "id": "D34",
-      "terrain": "m",
+      "id": "D34", "terrain": "m",
       "exits": {
-        "north": "D33",
-        "south": "D35",
-        "west": "C34",
-        "east": "E34"
+        "north": "D33", "south": "D35", "west": "C34", "east": "E34"
       }
     },
     {
-      "id": "E34",
-      "terrain": "m",
+      "id": "E34", "terrain": "m",
       "exits": {
-        "north": "E33",
-        "south": "E35",
-        "west": "D34",
-        "east": "F34"
+        "north": "E33", "south": "E35", "west": "D34", "east": "F34"
       }
     },
     {
-      "id": "F34",
-      "terrain": "m",
+      "id": "F34", "terrain": "m",
       "exits": {
-        "north": "F33",
-        "south": "F35",
-        "west": "E34",
-        "east": "G34"
+        "north": "F33", "south": "F35", "west": "E34", "east": "G34"
       }
     },
     {
-      "id": "G34",
-      "terrain": "m",
+      "id": "G34", "terrain": "m",
       "exits": {
-        "north": "G33",
-        "south": "G35",
-        "west": "F34",
-        "east": "H34"
+        "north": "G33", "south": "G35", "west": "F34", "east": "H34"
       }
     },
     {
-      "id": "H34",
-      "terrain": "p",
+      "id": "H34", "terrain": "p",
       "exits": {
-        "north": "H33",
-        "south": "H35",
-        "west": "G34",
-        "east": "I34"
+        "north": "H33", "south": "H35", "west": "G34", "east": "I34"
       }
     },
     {
-      "id": "I34",
-      "terrain": "p",
+      "id": "I34", "terrain": "p",
       "exits": {
-        "north": "I33",
-        "south": "I35",
-        "west": "H34",
-        "east": "J34"
+        "north": "I33", "south": "I35", "west": "H34", "east": "J34"
       }
     },
     {
-      "id": "J34",
-      "terrain": "p",
+      "id": "J34", "terrain": "p",
       "exits": {
-        "north": "J33",
-        "south": "J35",
-        "west": "I34",
-        "east": "K34"
+        "north": "J33", "south": "J35", "west": "I34", "east": "K34"
       }
     },
     {
-      "id": "K34",
-      "terrain": "b",
+      "id": "K34", "terrain": "b",
       "exits": {
-        "north": "K33",
-        "south": "K35",
-        "west": "J34",
-        "east": "L34"
+        "north": "K33", "south": "K35", "west": "J34", "east": "L34"
       }
     },
     {
-      "id": "L34",
-      "terrain": "b",
+      "id": "L34", "terrain": "b",
       "exits": {
-        "north": "L33",
-        "south": "L35",
-        "west": "K34",
-        "east": "M34"
+        "north": "L33", "south": "L35", "west": "K34", "east": "M34"
       }
     },
     {
-      "id": "M34",
-      "terrain": "b",
+      "id": "M34", "terrain": "b",
       "exits": {
-        "north": "M33",
-        "south": "M35",
-        "west": "L34",
-        "east": "N34"
+        "north": "M33", "south": "M35", "west": "L34", "east": "N34"
       }
     },
     {
-      "id": "N34",
-      "terrain": "b",
+      "id": "N34", "terrain": "b",
       "exits": {
-        "north": "N33",
-        "south": "N35",
-        "west": "M34",
-        "east": "O34"
+        "north": "N33", "south": "N35", "west": "M34", "east": "O34"
       }
     },
     {
-      "id": "O34",
-      "terrain": "p",
+      "id": "O34", "terrain": "p",
       "exits": {
-        "north": "O33",
-        "south": "O35",
-        "west": "N34",
-        "east": "P34"
+        "north": "O33", "south": "O35", "west": "N34", "east": "P34"
       }
     },
     {
-      "id": "P34",
-      "terrain": "p",
+      "id": "P34", "terrain": "p",
       "exits": {
-        "north": "P33",
-        "south": "P35",
-        "west": "O34",
-        "east": "Q34"
+        "north": "P33", "south": "P35", "west": "O34", "east": "Q34"
       }
     },
     {
-      "id": "Q34",
-      "terrain": "p",
+      "id": "Q34", "terrain": "p",
       "exits": {
-        "north": "Q33",
-        "south": "Q35",
-        "west": "P34",
-        "east": "R34"
+        "north": "Q33", "south": "Q35", "west": "P34", "east": "R34"
       }
     },
     {
-      "id": "R34",
-      "terrain": "p",
+      "id": "R34", "terrain": "p",
       "exits": {
-        "north": "R33",
-        "south": "R35",
-        "west": "Q34",
-        "east": "S34"
+        "north": "R33", "south": "R35", "west": "Q34", "east": "S34"
       }
     },
     {
-      "id": "S34",
-      "terrain": "p",
+      "id": "S34", "terrain": "p",
       "exits": {
-        "north": "S33",
-        "south": "S35",
-        "west": "R34",
-        "east": "T34"
+        "north": "S33", "south": "S35", "west": "R34", "east": "T34"
       }
     },
     {
-      "id": "T34",
-      "terrain": "w",
+      "id": "T34", "terrain": "w",
       "exits": {
-        "north": "T33",
-        "south": "T35",
-        "west": "S34",
-        "east": "U34"
+        "north": "T33", "south": "T35", "west": "S34", "east": "U34"
       }
     },
     {
-      "id": "U34",
-      "terrain": "p",
+      "id": "U34", "terrain": "p",
       "exits": {
-        "north": "U33",
-        "south": "U35",
-        "west": "T34",
-        "east": "V34"
+        "north": "U33", "south": "U35", "west": "T34", "east": "V34"
       }
     },
     {
-      "id": "V34",
-      "terrain": "w",
+      "id": "V34", "terrain": "w",
       "exits": {
-        "north": "V33",
-        "south": "V35",
-        "west": "U34",
-        "east": "W34"
+        "north": "V33", "south": "V35", "west": "U34", "east": "W34"
       }
     },
     {
-      "id": "W34",
-      "terrain": "path",
+      "id": "W34", "terrain": "path",
       "exits": {
-        "north": "W33",
-        "south": "W35",
-        "west": "V34",
-        "east": "X34"
+        "north": "W33", "south": "W35", "west": "V34", "east": "X34"
       }
     },
     {
-      "id": "X34",
-      "terrain": "p",
+      "id": "X34", "terrain": "p",
       "exits": {
-        "north": "X33",
-        "south": "X35",
-        "west": "W34",
-        "east": "Y34"
+        "north": "X33", "south": "X35", "west": "W34", "east": "Y34"
       }
     },
     {
-      "id": "Y34",
-      "terrain": "r",
+      "id": "Y34", "terrain": "r",
       "exits": {
-        "north": "Y33",
-        "south": "Y35",
-        "west": "X34",
-        "east": "Z34"
+        "north": "Y33", "south": "Y35", "west": "X34", "east": "Z34"
       }
     },
     {
-      "id": "Z34",
-      "terrain": "p",
+      "id": "Z34", "terrain": "p",
       "exits": {
-        "north": "Z33",
-        "south": "Z35",
-        "west": "Y34",
-        "east": "AA34"
+        "north": "Z33", "south": "Z35", "west": "Y34", "east": "AA34"
       }
     },
     {
-      "id": "AA34",
-      "terrain": "p",
+      "id": "AA34", "terrain": "p",
       "exits": {
-        "north": "AA33",
-        "south": "AA35",
-        "west": "Z34",
-        "east": "AB34"
+        "north": "AA33", "south": "AA35", "west": "Z34", "east": "AB34"
       }
     },
     {
-      "id": "AB34",
-      "terrain": "p",
+      "id": "AB34", "terrain": "p",
       "exits": {
-        "north": "AB33",
-        "south": "AB35",
-        "west": "AA34",
-        "east": "AC34"
+        "north": "AB33", "south": "AB35", "west": "AA34", "east": "AC34"
       }
     },
     {
-      "id": "AC34",
-      "terrain": "h",
+      "id": "AC34", "terrain": "h",
       "exits": {
-        "north": "AC33",
-        "south": "AC35",
-        "west": "AB34",
-        "east": "AD34"
+        "north": "AC33", "south": "AC35", "west": "AB34", "east": "AD34"
       }
     },
     {
-      "id": "AD34",
-      "terrain": "p",
+      "id": "AD34", "terrain": "p",
       "exits": {
-        "north": "AD33",
-        "south": "AD35",
-        "west": "AC34",
-        "east": "AE34"
+        "north": "AD33", "south": "AD35", "west": "AC34", "east": "AE34"
       }
     },
     {
-      "id": "AE34",
-      "terrain": "p",
+      "id": "AE34", "terrain": "p",
       "exits": {
-        "north": "AE33",
-        "south": "AE35",
-        "west": "AD34",
-        "east": "AF34"
+        "north": "AE33", "south": "AE35", "west": "AD34", "east": "AF34"
       }
     },
     {
-      "id": "AF34",
-      "terrain": "p",
+      "id": "AF34", "terrain": "p",
       "exits": {
-        "north": "AF33",
-        "south": "AF35",
-        "west": "AE34",
-        "east": "AG34"
+        "north": "AF33", "south": "AF35", "west": "AE34", "east": "AG34"
       }
     },
     {
-      "id": "AG34",
-      "terrain": "p",
+      "id": "AG34", "terrain": "p",
       "exits": {
-        "north": "AG33",
-        "south": "AG35",
-        "west": "AF34",
-        "east": "AH34"
+        "north": "AG33", "south": "AG35", "west": "AF34", "east": "AH34"
       }
     },
     {
-      "id": "AH34",
-      "terrain": "p",
+      "id": "AH34", "terrain": "p",
       "exits": {
-        "north": "AH33",
-        "south": "AH35",
-        "west": "AG34",
-        "east": "AI34"
+        "north": "AH33", "south": "AH35", "west": "AG34", "east": "AI34"
       }
     },
     {
-      "id": "AI34",
-      "terrain": "p",
+      "id": "AI34", "terrain": "p",
       "exits": {
-        "north": "AI33",
-        "south": "AI35",
-        "west": "AH34",
-        "east": "AJ34"
+        "north": "AI33", "south": "AI35", "west": "AH34", "east": "AJ34"
       }
     },
     {
-      "id": "AJ34",
-      "terrain": "lf",
+      "id": "AJ34", "terrain": "lf",
       "exits": {
-        "north": "AJ33",
-        "south": "AJ35",
-        "west": "AI34",
-        "east": "AK34"
+        "north": "AJ33", "south": "AJ35", "west": "AI34", "east": "AK34"
       }
     },
     {
-      "id": "AK34",
-      "terrain": "lf",
+      "id": "AK34", "terrain": "lf",
       "exits": {
-        "north": "AK33",
-        "south": "AK35",
-        "west": "AJ34",
-        "east": "AL34"
+        "north": "AK33", "south": "AK35", "west": "AJ34", "east": "AL34"
       }
     },
     {
-      "id": "AL34",
-      "terrain": "lf",
+      "id": "AL34", "terrain": "lf",
       "exits": {
-        "north": "AL33",
-        "south": "AL35",
-        "west": "AK34",
-        "east": "AM34"
+        "north": "AL33", "south": "AL35", "west": "AK34", "east": "AM34"
       }
     },
     {
-      "id": "AM34",
-      "terrain": "f",
+      "id": "AM34", "terrain": "f",
       "exits": {
-        "north": "AM33",
-        "south": "AM35",
-        "west": "AL34",
-        "east": "AN34"
+        "north": "AM33", "south": "AM35", "west": "AL34", "east": "AN34"
       }
     },
     {
-      "id": "AN34",
-      "terrain": "f",
+      "id": "AN34", "terrain": "f",
       "exits": {
-        "north": "AN33",
-        "south": "AN35",
-        "west": "AM34",
-        "east": "AO34"
+        "north": "AN33", "south": "AN35", "west": "AM34", "east": "AO34"
       }
     },
     {
-      "id": "AO34",
-      "terrain": "f",
+      "id": "AO34", "terrain": "f",
       "exits": {
-        "north": "AO33",
-        "south": "AO35",
-        "west": "AN34",
-        "east": "AP34"
+        "north": "AO33", "south": "AO35", "west": "AN34", "east": "AP34"
       }
     },
     {
-      "id": "AP34",
-      "terrain": "p",
+      "id": "AP34", "terrain": "p",
       "exits": {
-        "north": "AP33",
-        "south": "AP35",
-        "west": "AO34",
-        "east": "AQ34"
+        "north": "AP33", "south": "AP35", "west": "AO34", "east": "AQ34"
       }
     },
     {
-      "id": "AQ34",
-      "terrain": "p",
+      "id": "AQ34", "terrain": "p",
       "exits": {
-        "north": "AQ33",
-        "south": "AQ35",
-        "west": "AP34",
-        "east": "AR34"
+        "north": "AQ33", "south": "AQ35", "west": "AP34", "east": "AR34"
       }
     },
     {
-      "id": "AR34",
-      "terrain": "p",
+      "id": "AR34", "terrain": "p",
       "exits": {
-        "north": "AR33",
-        "south": "AR35",
-        "west": "AQ34",
-        "east": "AS34"
+        "north": "AR33", "south": "AR35", "west": "AQ34", "east": "AS34"
       }
     },
     {
-      "id": "AS34",
-      "terrain": "p",
+      "id": "AS34", "terrain": "p",
       "exits": {
-        "north": "AS33",
-        "south": "AS35",
-        "west": "AR34",
-        "east": "AT34"
+        "north": "AS33", "south": "AS35", "west": "AR34", "east": "AT34"
       }
     },
     {
-      "id": "AT34",
-      "terrain": "lf",
+      "id": "AT34", "terrain": "lf",
       "exits": {
-        "north": "AT33",
-        "south": "AT35",
-        "west": "AS34",
-        "east": "AU34"
+        "north": "AT33", "south": "AT35", "west": "AS34", "east": "AU34"
       }
     },
     {
-      "id": "AU34",
-      "terrain": "lf",
+      "id": "AU34", "terrain": "lf",
       "exits": {
-        "north": "AU33",
-        "south": "AU35",
-        "west": "AT34",
-        "east": "AV34"
+        "north": "AU33", "south": "AU35", "west": "AT34", "east": "AV34"
       }
     },
     {
-      "id": "AV34",
-      "terrain": "p",
+      "id": "AV34", "terrain": "p",
       "exits": {
-        "north": "AV33",
-        "south": "AV35",
-        "west": "AU34",
-        "east": "AW34"
+        "north": "AV33", "south": "AV35", "west": "AU34", "east": "AW34"
       }
     },
     {
-      "id": "AW34",
-      "terrain": "p",
+      "id": "AW34", "terrain": "p",
       "exits": {
-        "north": "AW33",
-        "south": "AW35",
-        "west": "AV34",
-        "east": "AX34"
+        "north": "AW33", "south": "AW35", "west": "AV34", "east": "AX34"
       }
     },
     {
-      "id": "AX34",
-      "terrain": "p",
+      "id": "AX34", "terrain": "p",
       "exits": {
-        "north": "AX33",
-        "south": "AX35",
-        "west": "AW34"
+        "north": "AX33", "south": "AX35", "west": "AW34"
       }
     },
     {
-      "id": "A35",
-      "terrain": "p",
+      "id": "A35", "terrain": "p",
       "exits": {
-        "north": "A34",
-        "south": "A36",
-        "east": "B35"
+        "north": "A34", "south": "A36", "east": "B35"
       }
     },
     {
-      "id": "B35",
-      "terrain": "p",
+      "id": "B35", "terrain": "p",
       "exits": {
-        "north": "B34",
-        "south": "B36",
-        "west": "A35",
-        "east": "C35"
+        "north": "B34", "south": "B36", "west": "A35", "east": "C35"
       }
     },
     {
-      "id": "C35",
-      "terrain": "m",
+      "id": "C35", "terrain": "m",
       "exits": {
-        "north": "C34",
-        "south": "C36",
-        "west": "B35",
-        "east": "D35"
+        "north": "C34", "south": "C36", "west": "B35", "east": "D35"
       }
     },
     {
-      "id": "D35",
-      "terrain": "m",
+      "id": "D35", "terrain": "m",
       "exits": {
-        "north": "D34",
-        "south": "D36",
-        "west": "C35",
-        "east": "E35"
+        "north": "D34", "south": "D36", "west": "C35", "east": "E35"
       }
     },
     {
-      "id": "E35",
-      "terrain": "m",
+      "id": "E35", "terrain": "m",
       "exits": {
-        "north": "E34",
-        "south": "E36",
-        "west": "D35",
-        "east": "F35"
+        "north": "E34", "south": "E36", "west": "D35", "east": "F35"
       }
     },
     {
-      "id": "F35",
-      "terrain": "m",
+      "id": "F35", "terrain": "m",
       "exits": {
-        "north": "F34",
-        "south": "F36",
-        "west": "E35",
-        "east": "G35"
+        "north": "F34", "south": "F36", "west": "E35", "east": "G35"
       }
     },
     {
-      "id": "G35",
-      "terrain": "m",
+      "id": "G35", "terrain": "m",
       "exits": {
-        "north": "G34",
-        "south": "G36",
-        "west": "F35",
-        "east": "H35"
+        "north": "G34", "south": "G36", "west": "F35", "east": "H35"
       }
     },
     {
-      "id": "H35",
-      "terrain": "p",
+      "id": "H35", "terrain": "p",
       "exits": {
-        "north": "H34",
-        "south": "H36",
-        "west": "G35",
-        "east": "I35"
+        "north": "H34", "south": "H36", "west": "G35", "east": "I35"
       }
     },
     {
-      "id": "I35",
-      "terrain": "p",
+      "id": "I35", "terrain": "p",
       "exits": {
-        "north": "I34",
-        "south": "I36",
-        "west": "H35",
-        "east": "J35"
+        "north": "I34", "south": "I36", "west": "H35", "east": "J35"
       }
     },
     {
-      "id": "J35",
-      "terrain": "b",
+      "id": "J35", "terrain": "b",
       "exits": {
-        "north": "J34",
-        "south": "J36",
-        "west": "I35",
-        "east": "K35"
+        "north": "J34", "south": "J36", "west": "I35", "east": "K35"
       }
     },
     {
-      "id": "K35",
-      "terrain": "b",
+      "id": "K35", "terrain": "b",
       "exits": {
-        "north": "K34",
-        "south": "K36",
-        "west": "J35",
-        "east": "L35"
+        "north": "K34", "south": "K36", "west": "J35", "east": "L35"
       }
     },
     {
-      "id": "L35",
-      "terrain": "b",
+      "id": "L35", "terrain": "b",
       "exits": {
-        "north": "L34",
-        "south": "L36",
-        "west": "K35",
-        "east": "M35"
+        "north": "L34", "south": "L36", "west": "K35", "east": "M35"
       }
     },
     {
-      "id": "M35",
-      "terrain": "b",
+      "id": "M35", "terrain": "b",
       "exits": {
-        "north": "M34",
-        "south": "M36",
-        "west": "L35",
-        "east": "N35"
+        "north": "M34", "south": "M36", "west": "L35", "east": "N35"
       }
     },
     {
-      "id": "N35",
-      "terrain": "b",
+      "id": "N35", "terrain": "b",
       "exits": {
-        "north": "N34",
-        "south": "N36",
-        "west": "M35",
-        "east": "O35"
+        "north": "N34", "south": "N36", "west": "M35", "east": "O35"
       }
     },
     {
-      "id": "O35",
-      "terrain": "b",
+      "id": "O35", "terrain": "b",
       "exits": {
-        "north": "O34",
-        "south": "O36",
-        "west": "N35",
-        "east": "P35"
+        "north": "O34", "south": "O36", "west": "N35", "east": "P35"
       }
     },
     {
-      "id": "P35",
-      "terrain": "p",
+      "id": "P35", "terrain": "p",
       "exits": {
-        "north": "P34",
-        "south": "P36",
-        "west": "O35",
-        "east": "Q35"
+        "north": "P34", "south": "P36", "west": "O35", "east": "Q35"
       }
     },
     {
-      "id": "Q35",
-      "terrain": "p",
+      "id": "Q35", "terrain": "p",
       "exits": {
-        "north": "Q34",
-        "south": "Q36",
-        "west": "P35",
-        "east": "R35"
+        "north": "Q34", "south": "Q36", "west": "P35", "east": "R35"
       }
     },
     {
-      "id": "R35",
-      "terrain": "p",
+      "id": "R35", "terrain": "p",
       "exits": {
-        "north": "R34",
-        "south": "R36",
-        "west": "Q35",
-        "east": "S35"
+        "north": "R34", "south": "R36", "west": "Q35", "east": "S35"
       }
     },
     {
-      "id": "S35",
-      "terrain": "hut",
+      "id": "S35", "terrain": "hut",
       "exits": {
-        "north": "S34",
-        "south": "S36",
-        "west": "R35",
-        "east": "T35"
+        "north": "S34", "south": "S36", "west": "R35", "east": "T35"
       }
     },
     {
-      "id": "T35",
-      "terrain": "w",
+      "id": "T35", "terrain": "w",
       "exits": {
-        "north": "T34",
-        "south": "T36",
-        "west": "S35",
-        "east": "U35"
+        "north": "T34", "south": "T36", "west": "S35", "east": "U35"
       }
     },
     {
-      "id": "U35",
-      "terrain": "p",
+      "id": "U35", "terrain": "p",
       "exits": {
-        "north": "U34",
-        "south": "U36",
-        "west": "T35",
-        "east": "V35"
+        "north": "U34", "south": "U36", "west": "T35", "east": "V35"
       }
     },
     {
-      "id": "V35",
-      "terrain": "w",
+      "id": "V35", "terrain": "w",
       "exits": {
-        "north": "V34",
-        "south": "V36",
-        "west": "U35",
-        "east": "W35"
+        "north": "V34", "south": "V36", "west": "U35", "east": "W35"
       }
     },
     {
-      "id": "W35",
-      "terrain": "p",
+      "id": "W35", "terrain": "p",
       "exits": {
-        "north": "W34",
-        "south": "W36",
-        "west": "V35",
-        "east": "X35"
+        "north": "W34", "south": "W36", "west": "V35", "east": "X35"
       }
     },
     {
-      "id": "X35",
-      "terrain": "p",
+      "id": "X35", "terrain": "p",
       "exits": {
-        "north": "X34",
-        "south": "X36",
-        "west": "W35",
-        "east": "Y35"
+        "north": "X34", "south": "X36", "west": "W35", "east": "Y35"
       }
     },
     {
-      "id": "Y35",
-      "terrain": "r",
+      "id": "Y35", "terrain": "r",
       "exits": {
-        "north": "Y34",
-        "south": "Y36",
-        "west": "X35",
-        "east": "Z35"
+        "north": "Y34", "south": "Y36", "west": "X35", "east": "Z35"
       }
     },
     {
-      "id": "Z35",
-      "terrain": "p",
+      "id": "Z35", "terrain": "p",
       "exits": {
-        "north": "Z34",
-        "south": "Z36",
-        "west": "Y35",
-        "east": "AA35"
+        "north": "Z34", "south": "Z36", "west": "Y35", "east": "AA35"
       }
     },
     {
-      "id": "AA35",
-      "terrain": "p",
+      "id": "AA35", "terrain": "p",
       "exits": {
-        "north": "AA34",
-        "south": "AA36",
-        "west": "Z35",
-        "east": "AB35"
+        "north": "AA34", "south": "AA36", "west": "Z35", "east": "AB35"
       }
     },
     {
-      "id": "AB35",
-      "terrain": "p",
+      "id": "AB35", "terrain": "p",
       "exits": {
-        "north": "AB34",
-        "south": "AB36",
-        "west": "AA35",
-        "east": "AC35"
+        "north": "AB34", "south": "AB36", "west": "AA35", "east": "AC35"
       }
     },
     {
-      "id": "AC35",
-      "terrain": "lf",
+      "id": "AC35", "terrain": "lf",
       "exits": {
-        "north": "AC34",
-        "south": "AC36",
-        "west": "AB35",
-        "east": "AD35"
+        "north": "AC34", "south": "AC36", "west": "AB35", "east": "AD35"
       }
     },
     {
-      "id": "AD35",
-      "terrain": "lf",
+      "id": "AD35", "terrain": "lf",
       "exits": {
-        "north": "AD34",
-        "south": "AD36",
-        "west": "AC35",
-        "east": "AE35"
+        "north": "AD34", "south": "AD36", "west": "AC35", "east": "AE35"
       }
     },
     {
-      "id": "AE35",
-      "terrain": "p",
+      "id": "AE35", "terrain": "p",
       "exits": {
-        "north": "AE34",
-        "south": "AE36",
-        "west": "AD35",
-        "east": "AF35"
+        "north": "AE34", "south": "AE36", "west": "AD35", "east": "AF35"
       }
     },
     {
-      "id": "AF35",
-      "terrain": "p",
+      "id": "AF35", "terrain": "p",
       "exits": {
-        "north": "AF34",
-        "south": "AF36",
-        "west": "AE35",
-        "east": "AG35"
+        "north": "AF34", "south": "AF36", "west": "AE35", "east": "AG35"
       }
     },
     {
-      "id": "AG35",
-      "terrain": "p",
+      "id": "AG35", "terrain": "p",
       "exits": {
-        "north": "AG34",
-        "south": "AG36",
-        "west": "AF35",
-        "east": "AH35"
+        "north": "AG34", "south": "AG36", "west": "AF35", "east": "AH35"
       }
     },
     {
-      "id": "AH35",
-      "terrain": "f",
+      "id": "AH35", "terrain": "f",
       "exits": {
-        "north": "AH34",
-        "south": "AH36",
-        "west": "AG35",
-        "east": "AI35"
+        "north": "AH34", "south": "AH36", "west": "AG35", "east": "AI35"
       }
     },
     {
-      "id": "AI35",
-      "terrain": "f",
+      "id": "AI35", "terrain": "f",
       "exits": {
-        "north": "AI34",
-        "south": "AI36",
-        "west": "AH35",
-        "east": "AJ35"
+        "north": "AI34", "south": "AI36", "west": "AH35", "east": "AJ35"
       }
     },
     {
-      "id": "AJ35",
-      "terrain": "lf",
+      "id": "AJ35", "terrain": "lf",
       "exits": {
-        "north": "AJ34",
-        "south": "AJ36",
-        "west": "AI35",
-        "east": "AK35"
+        "north": "AJ34", "south": "AJ36", "west": "AI35", "east": "AK35"
       }
     },
     {
-      "id": "AK35",
-      "terrain": "f",
+      "id": "AK35", "terrain": "f",
       "exits": {
-        "north": "AK34",
-        "south": "AK36",
-        "west": "AJ35",
-        "east": "AL35"
+        "north": "AK34", "south": "AK36", "west": "AJ35", "east": "AL35"
       }
     },
     {
-      "id": "AL35",
-      "terrain": "f",
+      "id": "AL35", "terrain": "f",
       "exits": {
-        "north": "AL34",
-        "south": "AL36",
-        "west": "AK35",
-        "east": "AM35"
+        "north": "AL34", "south": "AL36", "west": "AK35", "east": "AM35"
       }
     },
     {
-      "id": "AM35",
-      "terrain": "f",
+      "id": "AM35", "terrain": "f",
       "exits": {
-        "north": "AM34",
-        "south": "AM36",
-        "west": "AL35",
-        "east": "AN35"
+        "north": "AM34", "south": "AM36", "west": "AL35", "east": "AN35"
       }
     },
     {
-      "id": "AN35",
-      "terrain": "f",
+      "id": "AN35", "terrain": "f",
       "exits": {
-        "north": "AN34",
-        "south": "AN36",
-        "west": "AM35",
-        "east": "AO35"
+        "north": "AN34", "south": "AN36", "west": "AM35", "east": "AO35"
       }
     },
     {
-      "id": "AO35",
-      "terrain": "p",
+      "id": "AO35", "terrain": "p",
       "exits": {
-        "north": "AO34",
-        "south": "AO36",
-        "west": "AN35",
-        "east": "AP35"
+        "north": "AO34", "south": "AO36", "west": "AN35", "east": "AP35"
       }
     },
     {
-      "id": "AP35",
-      "terrain": "p",
+      "id": "AP35", "terrain": "p",
       "exits": {
-        "north": "AP34",
-        "south": "AP36",
-        "west": "AO35",
-        "east": "AQ35"
+        "north": "AP34", "south": "AP36", "west": "AO35", "east": "AQ35"
       }
     },
     {
-      "id": "AQ35",
-      "terrain": "p",
+      "id": "AQ35", "terrain": "p",
       "exits": {
-        "north": "AQ34",
-        "south": "AQ36",
-        "west": "AP35",
-        "east": "AR35"
+        "north": "AQ34", "south": "AQ36", "west": "AP35", "east": "AR35"
       }
     },
     {
-      "id": "AR35",
-      "terrain": "p",
+      "id": "AR35", "terrain": "p",
       "exits": {
-        "north": "AR34",
-        "south": "AR36",
-        "west": "AQ35",
-        "east": "AS35"
+        "north": "AR34", "south": "AR36", "west": "AQ35", "east": "AS35"
       }
     },
     {
-      "id": "AS35",
-      "terrain": "p",
+      "id": "AS35", "terrain": "p",
       "exits": {
-        "north": "AS34",
-        "south": "AS36",
-        "west": "AR35",
-        "east": "AT35"
+        "north": "AS34", "south": "AS36", "west": "AR35", "east": "AT35"
       }
     },
     {
-      "id": "AT35",
-      "terrain": "lf",
+      "id": "AT35", "terrain": "lf",
       "exits": {
-        "north": "AT34",
-        "south": "AT36",
-        "west": "AS35",
-        "east": "AU35"
+        "north": "AT34", "south": "AT36", "west": "AS35", "east": "AU35"
       }
     },
     {
-      "id": "AU35",
-      "terrain": "lf",
+      "id": "AU35", "terrain": "lf",
       "exits": {
-        "north": "AU34",
-        "south": "AU36",
-        "west": "AT35",
-        "east": "AV35"
+        "north": "AU34", "south": "AU36", "west": "AT35", "east": "AV35"
       }
     },
     {
-      "id": "AV35",
-      "terrain": "p",
+      "id": "AV35", "terrain": "p",
       "exits": {
-        "north": "AV34",
-        "south": "AV36",
-        "west": "AU35",
-        "east": "AW35"
+        "north": "AV34", "south": "AV36", "west": "AU35", "east": "AW35"
       }
     },
     {
-      "id": "AW35",
-      "terrain": "p",
+      "id": "AW35", "terrain": "p",
       "exits": {
-        "north": "AW34",
-        "south": "AW36",
-        "west": "AV35",
-        "east": "AX35"
+        "north": "AW34", "south": "AW36", "west": "AV35", "east": "AX35"
       }
     },
     {
-      "id": "AX35",
-      "terrain": "p",
+      "id": "AX35", "terrain": "p",
       "exits": {
-        "north": "AX34",
-        "south": "AX36",
-        "west": "AW35"
+        "north": "AX34", "south": "AX36", "west": "AW35"
       }
     },
     {
-      "id": "A36",
-      "terrain": "p",
+      "id": "A36", "terrain": "p",
       "exits": {
-        "north": "A35",
-        "south": "A37",
-        "east": "B36"
+        "north": "A35", "south": "A37", "east": "B36"
       }
     },
     {
-      "id": "B36",
-      "terrain": "m",
+      "id": "B36", "terrain": "m",
       "exits": {
-        "north": "B35",
-        "south": "B37",
-        "west": "A36",
-        "east": "C36"
+        "north": "B35", "south": "B37", "west": "A36", "east": "C36"
       }
     },
     {
-      "id": "C36",
-      "terrain": "m",
+      "id": "C36", "terrain": "m",
       "exits": {
-        "north": "C35",
-        "south": "C37",
-        "west": "B36",
-        "east": "D36"
+        "north": "C35", "south": "C37", "west": "B36", "east": "D36"
       }
     },
     {
-      "id": "D36",
-      "terrain": "m",
+      "id": "D36", "terrain": "m",
       "exits": {
-        "north": "D35",
-        "south": "D37",
-        "west": "C36",
-        "east": "E36"
+        "north": "D35", "south": "D37", "west": "C36", "east": "E36"
       }
     },
     {
-      "id": "E36",
-      "terrain": "m",
+      "id": "E36", "terrain": "m",
       "exits": {
-        "north": "E35",
-        "south": "E37",
-        "west": "D36",
-        "east": "F36"
+        "north": "E35", "south": "E37", "west": "D36", "east": "F36"
       }
     },
     {
-      "id": "F36",
-      "terrain": "p",
+      "id": "F36", "terrain": "p",
       "exits": {
-        "north": "F35",
-        "south": "F37",
-        "west": "E36",
-        "east": "G36"
+        "north": "F35", "south": "F37", "west": "E36", "east": "G36"
       }
     },
     {
-      "id": "G36",
-      "terrain": "p",
+      "id": "G36", "terrain": "p",
       "exits": {
-        "north": "G35",
-        "south": "G37",
-        "west": "F36",
-        "east": "H36"
+        "north": "G35", "south": "G37", "west": "F36", "east": "H36"
       }
     },
     {
-      "id": "H36",
-      "terrain": "p",
+      "id": "H36", "terrain": "p",
       "exits": {
-        "north": "H35",
-        "south": "H37",
-        "west": "G36",
-        "east": "I36"
+        "north": "H35", "south": "H37", "west": "G36", "east": "I36"
       }
     },
     {
-      "id": "I36",
-      "terrain": "p",
+      "id": "I36", "terrain": "p",
       "exits": {
-        "north": "I35",
-        "south": "I37",
-        "west": "H36",
-        "east": "J36"
+        "north": "I35", "south": "I37", "west": "H36", "east": "J36"
       }
     },
     {
-      "id": "J36",
-      "terrain": "b",
+      "id": "J36", "terrain": "b",
       "exits": {
-        "north": "J35",
-        "south": "J37",
-        "west": "I36",
-        "east": "K36"
+        "north": "J35", "south": "J37", "west": "I36", "east": "K36"
       }
     },
     {
-      "id": "K36",
-      "terrain": "b",
+      "id": "K36", "terrain": "b",
       "exits": {
-        "north": "K35",
-        "south": "K37",
-        "west": "J36",
-        "east": "L36"
+        "north": "K35", "south": "K37", "west": "J36", "east": "L36"
       }
     },
     {
-      "id": "L36",
-      "terrain": "b",
+      "id": "L36", "terrain": "b",
       "exits": {
-        "north": "L35",
-        "south": "L37",
-        "west": "K36",
-        "east": "M36"
+        "north": "L35", "south": "L37", "west": "K36", "east": "M36"
       }
     },
     {
-      "id": "M36",
-      "terrain": "b",
+      "id": "M36", "terrain": "b",
       "exits": {
-        "north": "M35",
-        "south": "M37",
-        "west": "L36",
-        "east": "N36"
+        "north": "M35", "south": "M37", "west": "L36", "east": "N36"
       }
     },
     {
-      "id": "N36",
-      "terrain": "b",
+      "id": "N36", "terrain": "b",
       "exits": {
-        "north": "N35",
-        "south": "N37",
-        "west": "M36",
-        "east": "O36"
+        "north": "N35", "south": "N37", "west": "M36", "east": "O36"
       }
     },
     {
-      "id": "O36",
-      "terrain": "b",
+      "id": "O36", "terrain": "b",
       "exits": {
-        "north": "O35",
-        "south": "O37",
-        "west": "N36",
-        "east": "P36"
+        "north": "O35", "south": "O37", "west": "N36", "east": "P36"
       }
     },
     {
-      "id": "P36",
-      "terrain": "b",
+      "id": "P36", "terrain": "b",
       "exits": {
-        "north": "P35",
-        "south": "P37",
-        "west": "O36",
-        "east": "Q36"
+        "north": "P35", "south": "P37", "west": "O36", "east": "Q36"
       }
     },
     {
-      "id": "Q36",
-      "terrain": "p",
+      "id": "Q36", "terrain": "p",
       "exits": {
-        "north": "Q35",
-        "south": "Q37",
-        "west": "P36",
-        "east": "R36"
+        "north": "Q35", "south": "Q37", "west": "P36", "east": "R36"
       }
     },
     {
-      "id": "R36",
-      "terrain": "p",
+      "id": "R36", "terrain": "p",
       "exits": {
-        "north": "R35",
-        "south": "R37",
-        "west": "Q36",
-        "east": "S36"
+        "north": "R35", "south": "R37", "west": "Q36", "east": "S36"
       }
     },
     {
-      "id": "S36",
-      "terrain": "w",
+      "id": "S36", "terrain": "w",
       "exits": {
-        "north": "S35",
-        "south": "S37",
-        "west": "R36",
-        "east": "T36"
+        "north": "S35", "south": "S37", "west": "R36", "east": "T36"
       }
     },
     {
-      "id": "T36",
-      "terrain": "w",
+      "id": "T36", "terrain": "w",
       "exits": {
-        "north": "T35",
-        "south": "T37",
-        "west": "S36",
-        "east": "U36"
+        "north": "T35", "south": "T37", "west": "S36", "east": "U36"
       }
     },
     {
-      "id": "U36",
-      "terrain": "w",
+      "id": "U36", "terrain": "w",
       "exits": {
-        "north": "U35",
-        "south": "U37",
-        "west": "T36",
-        "east": "V36"
+        "north": "U35", "south": "U37", "west": "T36", "east": "V36"
       }
     },
     {
-      "id": "V36",
-      "terrain": "p",
+      "id": "V36", "terrain": "p",
       "exits": {
-        "north": "V35",
-        "south": "V37",
-        "west": "U36",
-        "east": "W36"
+        "north": "V35", "south": "V37", "west": "U36", "east": "W36"
       }
     },
     {
-      "id": "W36",
-      "terrain": "p",
+      "id": "W36", "terrain": "p",
       "exits": {
-        "north": "W35",
-        "south": "W37",
-        "west": "V36",
-        "east": "X36"
+        "north": "W35", "south": "W37", "west": "V36", "east": "X36"
       }
     },
     {
-      "id": "X36",
-      "terrain": "p",
+      "id": "X36", "terrain": "p",
       "exits": {
-        "north": "X35",
-        "south": "X37",
-        "west": "W36",
-        "east": "Y36"
+        "north": "X35", "south": "X37", "west": "W36", "east": "Y36"
       }
     },
     {
-      "id": "Y36",
-      "terrain": "r",
+      "id": "Y36", "terrain": "r",
       "exits": {
-        "north": "Y35",
-        "south": "Y37",
-        "west": "X36",
-        "east": "Z36"
+        "north": "Y35", "south": "Y37", "west": "X36", "east": "Z36"
       }
     },
     {
-      "id": "Z36",
-      "terrain": "p",
+      "id": "Z36", "terrain": "p",
       "exits": {
-        "north": "Z35",
-        "south": "Z37",
-        "west": "Y36",
-        "east": "AA36"
+        "north": "Z35", "south": "Z37", "west": "Y36", "east": "AA36"
       }
     },
     {
-      "id": "AA36",
-      "terrain": "p",
+      "id": "AA36", "terrain": "p",
       "exits": {
-        "north": "AA35",
-        "south": "AA37",
-        "west": "Z36",
-        "east": "AB36"
+        "north": "AA35", "south": "AA37", "west": "Z36", "east": "AB36"
       }
     },
     {
-      "id": "AB36",
-      "terrain": "p",
+      "id": "AB36", "terrain": "p",
       "exits": {
-        "north": "AB35",
-        "south": "AB37",
-        "west": "AA36",
-        "east": "AC36"
+        "north": "AB35", "south": "AB37", "west": "AA36", "east": "AC36"
       }
     },
     {
-      "id": "AC36",
-      "terrain": "lf",
+      "id": "AC36", "terrain": "lf",
       "exits": {
-        "north": "AC35",
-        "south": "AC37",
-        "west": "AB36",
-        "east": "AD36"
+        "north": "AC35", "south": "AC37", "west": "AB36", "east": "AD36"
       }
     },
     {
-      "id": "AD36",
-      "terrain": "lf",
+      "id": "AD36", "terrain": "lf",
       "exits": {
-        "north": "AD35",
-        "south": "AD37",
-        "west": "AC36",
-        "east": "AE36"
+        "north": "AD35", "south": "AD37", "west": "AC36", "east": "AE36"
       }
     },
     {
-      "id": "AE36",
-      "terrain": "lf",
+      "id": "AE36", "terrain": "lf",
       "exits": {
-        "north": "AE35",
-        "south": "AE37",
-        "west": "AD36",
-        "east": "AF36"
+        "north": "AE35", "south": "AE37", "west": "AD36", "east": "AF36"
       }
     },
     {
-      "id": "AF36",
-      "terrain": "f",
+      "id": "AF36", "terrain": "f",
       "exits": {
-        "north": "AF35",
-        "south": "AF37",
-        "west": "AE36",
-        "east": "AG36"
+        "north": "AF35", "south": "AF37", "west": "AE36", "east": "AG36"
       }
     },
     {
-      "id": "AG36",
-      "terrain": "f",
+      "id": "AG36", "terrain": "f",
       "exits": {
-        "north": "AG35",
-        "south": "AG37",
-        "west": "AF36",
-        "east": "AH36"
+        "north": "AG35", "south": "AG37", "west": "AF36", "east": "AH36"
       }
     },
     {
-      "id": "AH36",
-      "terrain": "f",
+      "id": "AH36", "terrain": "f",
       "exits": {
-        "north": "AH35",
-        "south": "AH37",
-        "west": "AG36",
-        "east": "AI36"
+        "north": "AH35", "south": "AH37", "west": "AG36", "east": "AI36"
       }
     },
     {
-      "id": "AI36",
-      "terrain": "f",
+      "id": "AI36", "terrain": "f",
       "exits": {
-        "north": "AI35",
-        "south": "AI37",
-        "west": "AH36",
-        "east": "AJ36"
+        "north": "AI35", "south": "AI37", "west": "AH36", "east": "AJ36"
       }
     },
     {
-      "id": "AJ36",
-      "terrain": "lf",
+      "id": "AJ36", "terrain": "lf",
       "exits": {
-        "north": "AJ35",
-        "south": "AJ37",
-        "west": "AI36",
-        "east": "AK36"
+        "north": "AJ35", "south": "AJ37", "west": "AI36", "east": "AK36"
       }
     },
     {
-      "id": "AK36",
-      "terrain": "f",
+      "id": "AK36", "terrain": "f",
       "exits": {
-        "north": "AK35",
-        "south": "AK37",
-        "west": "AJ36",
-        "east": "AL36"
+        "north": "AK35", "south": "AK37", "west": "AJ36", "east": "AL36"
       }
     },
     {
-      "id": "AL36",
-      "terrain": "f",
+      "id": "AL36", "terrain": "f",
       "exits": {
-        "north": "AL35",
-        "south": "AL37",
-        "west": "AK36",
-        "east": "AM36"
+        "north": "AL35", "south": "AL37", "west": "AK36", "east": "AM36"
       }
     },
     {
-      "id": "AM36",
-      "terrain": "f",
+      "id": "AM36", "terrain": "f",
       "exits": {
-        "north": "AM35",
-        "south": "AM37",
-        "west": "AL36",
-        "east": "AN36"
+        "north": "AM35", "south": "AM37", "west": "AL36", "east": "AN36"
       }
     },
     {
-      "id": "AN36",
-      "terrain": "f",
+      "id": "AN36", "terrain": "f",
       "exits": {
-        "north": "AN35",
-        "south": "AN37",
-        "west": "AM36",
-        "east": "AO36"
+        "north": "AN35", "south": "AN37", "west": "AM36", "east": "AO36"
       }
     },
     {
-      "id": "AO36",
-      "terrain": "lf",
+      "id": "AO36", "terrain": "lf",
       "exits": {
-        "north": "AO35",
-        "south": "AO37",
-        "west": "AN36",
-        "east": "AP36"
+        "north": "AO35", "south": "AO37", "west": "AN36", "east": "AP36"
       }
     },
     {
-      "id": "AP36",
-      "terrain": "p",
+      "id": "AP36", "terrain": "p",
       "exits": {
-        "north": "AP35",
-        "south": "AP37",
-        "west": "AO36",
-        "east": "AQ36"
+        "north": "AP35", "south": "AP37", "west": "AO36", "east": "AQ36"
       }
     },
     {
-      "id": "AQ36",
-      "terrain": "p",
+      "id": "AQ36", "terrain": "p",
       "exits": {
-        "north": "AQ35",
-        "south": "AQ37",
-        "west": "AP36",
-        "east": "AR36"
+        "north": "AQ35", "south": "AQ37", "west": "AP36", "east": "AR36"
       }
     },
     {
-      "id": "AR36",
-      "terrain": "p",
+      "id": "AR36", "terrain": "p",
       "exits": {
-        "north": "AR35",
-        "south": "AR37",
-        "west": "AQ36",
-        "east": "AS36"
+        "north": "AR35", "south": "AR37", "west": "AQ36", "east": "AS36"
       }
     },
     {
-      "id": "AS36",
-      "terrain": "p",
+      "id": "AS36", "terrain": "p",
       "exits": {
-        "north": "AS35",
-        "south": "AS37",
-        "west": "AR36",
-        "east": "AT36"
+        "north": "AS35", "south": "AS37", "west": "AR36", "east": "AT36"
       }
     },
     {
-      "id": "AT36",
-      "terrain": "lf",
+      "id": "AT36", "terrain": "lf",
       "exits": {
-        "north": "AT35",
-        "south": "AT37",
-        "west": "AS36",
-        "east": "AU36"
+        "north": "AT35", "south": "AT37", "west": "AS36", "east": "AU36"
       }
     },
     {
-      "id": "AU36",
-      "terrain": "lf",
+      "id": "AU36", "terrain": "lf",
       "exits": {
-        "north": "AU35",
-        "south": "AU37",
-        "west": "AT36",
-        "east": "AV36"
+        "north": "AU35", "south": "AU37", "west": "AT36", "east": "AV36"
       }
     },
     {
-      "id": "AV36",
-      "terrain": "p",
+      "id": "AV36", "terrain": "p",
       "exits": {
-        "north": "AV35",
-        "south": "AV37",
-        "west": "AU36",
-        "east": "AW36"
+        "north": "AV35", "south": "AV37", "west": "AU36", "east": "AW36"
       }
     },
     {
-      "id": "AW36",
-      "terrain": "p",
+      "id": "AW36", "terrain": "p",
       "exits": {
-        "north": "AW35",
-        "south": "AW37",
-        "west": "AV36",
-        "east": "AX36"
+        "north": "AW35", "south": "AW37", "west": "AV36", "east": "AX36"
       }
     },
     {
-      "id": "AX36",
-      "terrain": "p",
+      "id": "AX36", "terrain": "p",
       "exits": {
-        "north": "AX35",
-        "south": "AX37",
-        "west": "AW36"
+        "north": "AX35", "south": "AX37", "west": "AW36"
       }
     },
     {
-      "id": "A37",
-      "terrain": "p",
+      "id": "A37", "terrain": "p",
       "exits": {
-        "north": "A36",
-        "south": "A38",
-        "east": "B37"
+        "north": "A36", "south": "A38", "east": "B37"
       }
     },
     {
-      "id": "B37",
-      "terrain": "m",
+      "id": "B37", "terrain": "m",
       "exits": {
-        "north": "B36",
-        "south": "B38",
-        "west": "A37",
-        "east": "C37"
+        "north": "B36", "south": "B38", "west": "A37", "east": "C37"
       }
     },
     {
-      "id": "C37",
-      "terrain": "m",
+      "id": "C37", "terrain": "m",
       "exits": {
-        "north": "C36",
-        "south": "C38",
-        "west": "B37",
-        "east": "D37"
+        "north": "C36", "south": "C38", "west": "B37", "east": "D37"
       }
     },
     {
-      "id": "D37",
-      "terrain": "m",
+      "id": "D37", "terrain": "m",
       "exits": {
-        "north": "D36",
-        "south": "D38",
-        "west": "C37",
-        "east": "E37"
+        "north": "D36", "south": "D38", "west": "C37", "east": "E37"
       }
     },
     {
-      "id": "E37",
-      "terrain": "m",
+      "id": "E37", "terrain": "m",
       "exits": {
-        "north": "E36",
-        "south": "E38",
-        "west": "D37",
-        "east": "F37"
+        "north": "E36", "south": "E38", "west": "D37", "east": "F37"
       }
     },
     {
-      "id": "F37",
-      "terrain": "p",
+      "id": "F37", "terrain": "p",
       "exits": {
-        "north": "F36",
-        "south": "F38",
-        "west": "E37",
-        "east": "G37"
+        "north": "F36", "south": "F38", "west": "E37", "east": "G37"
       }
     },
     {
-      "id": "G37",
-      "terrain": "p",
+      "id": "G37", "terrain": "p",
       "exits": {
-        "north": "G36",
-        "south": "G38",
-        "west": "F37",
-        "east": "H37"
+        "north": "G36", "south": "G38", "west": "F37", "east": "H37"
       }
     },
     {
-      "id": "H37",
-      "terrain": "battlefld",
+      "id": "H37", "terrain": "battlefld",
       "exits": {
-        "north": "H36",
-        "south": "H38",
-        "west": "G37",
-        "east": "I37"
+        "north": "H36", "south": "H38", "west": "G37", "east": "I37"
       }
     },
     {
-      "id": "I37",
-      "terrain": "p",
+      "id": "I37", "terrain": "p",
       "exits": {
-        "north": "I36",
-        "south": "I38",
-        "west": "H37",
-        "east": "J37"
+        "north": "I36", "south": "I38", "west": "H37", "east": "J37"
       }
     },
     {
-      "id": "J37",
-      "terrain": "p",
+      "id": "J37", "terrain": "p",
       "exits": {
-        "north": "J36",
-        "south": "J38",
-        "west": "I37",
-        "east": "K37"
+        "north": "J36", "south": "J38", "west": "I37", "east": "K37"
       }
     },
     {
-      "id": "K37",
-      "terrain": "b",
+      "id": "K37", "terrain": "b",
       "exits": {
-        "north": "K36",
-        "south": "K38",
-        "west": "J37",
-        "east": "L37"
+        "north": "K36", "south": "K38", "west": "J37", "east": "L37"
       }
     },
     {
-      "id": "L37",
-      "terrain": "b",
+      "id": "L37", "terrain": "b",
       "exits": {
-        "north": "L36",
-        "south": "L38",
-        "west": "K37",
-        "east": "M37"
+        "north": "L36", "south": "L38", "west": "K37", "east": "M37"
       }
     },
     {
-      "id": "M37",
-      "terrain": "b",
+      "id": "M37", "terrain": "b",
       "exits": {
-        "north": "M36",
-        "south": "M38",
-        "west": "L37",
-        "east": "N37"
+        "north": "M36", "south": "M38", "west": "L37", "east": "N37"
       }
     },
     {
-      "id": "N37",
-      "terrain": "b",
+      "id": "N37", "terrain": "b",
       "exits": {
-        "north": "N36",
-        "south": "N38",
-        "west": "M37",
-        "east": "O37"
+        "north": "N36", "south": "N38", "west": "M37", "east": "O37"
       }
     },
     {
-      "id": "O37",
-      "terrain": "b",
+      "id": "O37", "terrain": "b",
       "exits": {
-        "north": "O36",
-        "south": "O38",
-        "west": "N37",
-        "east": "P37"
+        "north": "O36", "south": "O38", "west": "N37", "east": "P37"
       }
     },
     {
-      "id": "P37",
-      "terrain": "b",
+      "id": "P37", "terrain": "b",
       "exits": {
-        "north": "P36",
-        "south": "P38",
-        "west": "O37",
-        "east": "Q37"
+        "north": "P36", "south": "P38", "west": "O37", "east": "Q37"
       }
     },
     {
-      "id": "Q37",
-      "terrain": "p",
+      "id": "Q37", "terrain": "p",
       "exits": {
-        "north": "Q36",
-        "south": "Q38",
-        "west": "P37",
-        "east": "R37"
+        "north": "Q36", "south": "Q38", "west": "P37", "east": "R37"
       }
     },
     {
-      "id": "R37",
-      "terrain": "w",
+      "id": "R37", "terrain": "w",
       "exits": {
-        "north": "R36",
-        "south": "R38",
-        "west": "Q37",
-        "east": "S37"
+        "north": "R36", "south": "R38", "west": "Q37", "east": "S37"
       }
     },
     {
-      "id": "S37",
-      "terrain": "w",
+      "id": "S37", "terrain": "w",
       "exits": {
-        "north": "S36",
-        "south": "S38",
-        "west": "R37",
-        "east": "T37"
+        "north": "S36", "south": "S38", "west": "R37", "east": "T37"
       }
     },
     {
-      "id": "T37",
-      "terrain": "w",
+      "id": "T37", "terrain": "w",
       "exits": {
-        "north": "T36",
-        "south": "T38",
-        "west": "S37",
-        "east": "U37"
+        "north": "T36", "south": "T38", "west": "S37", "east": "U37"
       }
     },
     {
-      "id": "U37",
-      "terrain": "w",
+      "id": "U37", "terrain": "w",
       "exits": {
-        "north": "U36",
-        "south": "U38",
-        "west": "T37",
-        "east": "V37"
+        "north": "U36", "south": "U38", "west": "T37", "east": "V37"
       }
     },
     {
-      "id": "V37",
-      "terrain": "p",
+      "id": "V37", "terrain": "p",
       "exits": {
-        "north": "V36",
-        "south": "V38",
-        "west": "U37",
-        "east": "W37"
+        "north": "V36", "south": "V38", "west": "U37", "east": "W37"
       }
     },
     {
-      "id": "W37",
-      "terrain": "p",
+      "id": "W37", "terrain": "p",
       "exits": {
-        "north": "W36",
-        "south": "W38",
-        "west": "V37",
-        "east": "X37"
+        "north": "W36", "south": "W38", "west": "V37", "east": "X37"
       }
     },
     {
-      "id": "X37",
-      "terrain": "p",
+      "id": "X37", "terrain": "p",
       "exits": {
-        "north": "X36",
-        "south": "X38",
-        "west": "W37",
-        "east": "Y37"
+        "north": "X36", "south": "X38", "west": "W37", "east": "Y37"
       }
     },
     {
-      "id": "Y37",
-      "terrain": "r",
+      "id": "Y37", "terrain": "r",
       "exits": {
-        "north": "Y36",
-        "south": "Y38",
-        "west": "X37",
-        "east": "Z37"
+        "north": "Y36", "south": "Y38", "west": "X37", "east": "Z37"
       }
     },
     {
-      "id": "Z37",
-      "terrain": "p",
+      "id": "Z37", "terrain": "p",
       "exits": {
-        "north": "Z36",
-        "south": "Z38",
-        "west": "Y37",
-        "east": "AA37"
+        "north": "Z36", "south": "Z38", "west": "Y37", "east": "AA37"
       }
     },
     {
-      "id": "AA37",
-      "terrain": "lf",
+      "id": "AA37", "terrain": "lf",
       "exits": {
-        "north": "AA36",
-        "south": "AA38",
-        "west": "Z37",
-        "east": "AB37"
+        "north": "AA36", "south": "AA38", "west": "Z37", "east": "AB37"
       }
     },
     {
-      "id": "AB37",
-      "terrain": "lf",
+      "id": "AB37", "terrain": "lf",
       "exits": {
-        "north": "AB36",
-        "south": "AB38",
-        "west": "AA37",
-        "east": "AC37"
+        "north": "AB36", "south": "AB38", "west": "AA37", "east": "AC37"
       }
     },
     {
-      "id": "AC37",
-      "terrain": "lf",
+      "id": "AC37", "terrain": "lf",
       "exits": {
-        "north": "AC36",
-        "south": "AC38",
-        "west": "AB37",
-        "east": "AD37"
+        "north": "AC36", "south": "AC38", "west": "AB37", "east": "AD37"
       }
     },
     {
-      "id": "AD37",
-      "terrain": "lf",
+      "id": "AD37", "terrain": "lf",
       "exits": {
-        "north": "AD36",
-        "south": "AD38",
-        "west": "AC37",
-        "east": "AE37"
+        "north": "AD36", "south": "AD38", "west": "AC37", "east": "AE37"
       }
     },
     {
-      "id": "AE37",
-      "terrain": "lf",
+      "id": "AE37", "terrain": "lf",
       "exits": {
-        "north": "AE36",
-        "south": "AE38",
-        "west": "AD37",
-        "east": "AF37"
+        "north": "AE36", "south": "AE38", "west": "AD37", "east": "AF37"
       }
     },
     {
-      "id": "AF37",
-      "terrain": "f",
+      "id": "AF37", "terrain": "f",
       "exits": {
-        "north": "AF36",
-        "south": "AF38",
-        "west": "AE37",
-        "east": "AG37"
+        "north": "AF36", "south": "AF38", "west": "AE37", "east": "AG37"
       }
     },
     {
-      "id": "AG37",
-      "terrain": "f",
+      "id": "AG37", "terrain": "f",
       "exits": {
-        "north": "AG36",
-        "south": "AG38",
-        "west": "AF37",
-        "east": "AH37"
+        "north": "AG36", "south": "AG38", "west": "AF37", "east": "AH37"
       }
     },
     {
-      "id": "AH37",
-      "terrain": "f",
+      "id": "AH37", "terrain": "f",
       "exits": {
-        "north": "AH36",
-        "south": "AH38",
-        "west": "AG37",
-        "east": "AI37"
+        "north": "AH36", "south": "AH38", "west": "AG37", "east": "AI37"
       }
     },
     {
-      "id": "AI37",
-      "terrain": "f",
+      "id": "AI37", "terrain": "f",
       "exits": {
-        "north": "AI36",
-        "south": "AI38",
-        "west": "AH37",
-        "east": "AJ37"
+        "north": "AI36", "south": "AI38", "west": "AH37", "east": "AJ37"
       }
     },
     {
-      "id": "AJ37",
-      "terrain": "f",
+      "id": "AJ37", "terrain": "f",
       "exits": {
-        "north": "AJ36",
-        "south": "AJ38",
-        "west": "AI37",
-        "east": "AK37"
+        "north": "AJ36", "south": "AJ38", "west": "AI37", "east": "AK37"
       }
     },
     {
-      "id": "AK37",
-      "terrain": "f",
+      "id": "AK37", "terrain": "f",
       "exits": {
-        "north": "AK36",
-        "south": "AK38",
-        "west": "AJ37",
-        "east": "AL37"
+        "north": "AK36", "south": "AK38", "west": "AJ37", "east": "AL37"
       }
     },
     {
-      "id": "AL37",
-      "terrain": "f",
+      "id": "AL37", "terrain": "f",
       "exits": {
-        "north": "AL36",
-        "south": "AL38",
-        "west": "AK37",
-        "east": "AM37"
+        "north": "AL36", "south": "AL38", "west": "AK37", "east": "AM37"
       }
     },
     {
-      "id": "AM37",
-      "terrain": "df",
+      "id": "AM37", "terrain": "df",
       "exits": {
-        "north": "AM36",
-        "south": "AM38",
-        "west": "AL37",
-        "east": "AN37"
+        "north": "AM36", "south": "AM38", "west": "AL37", "east": "AN37"
       }
     },
     {
-      "id": "AN37",
-      "terrain": "df",
+      "id": "AN37", "terrain": "df",
       "exits": {
-        "north": "AN36",
-        "south": "AN38",
-        "west": "AM37",
-        "east": "AO37"
+        "north": "AN36", "south": "AN38", "west": "AM37", "east": "AO37"
       }
     },
     {
-      "id": "AO37",
-      "terrain": "f",
+      "id": "AO37", "terrain": "f",
       "exits": {
-        "north": "AO36",
-        "south": "AO38",
-        "west": "AN37",
-        "east": "AP37"
+        "north": "AO36", "south": "AO38", "west": "AN37", "east": "AP37"
       }
     },
     {
-      "id": "AP37",
-      "terrain": "f",
+      "id": "AP37", "terrain": "f",
       "exits": {
-        "north": "AP36",
-        "south": "AP38",
-        "west": "AO37",
-        "east": "AQ37"
+        "north": "AP36", "south": "AP38", "west": "AO37", "east": "AQ37"
       }
     },
     {
-      "id": "AQ37",
-      "terrain": "f",
+      "id": "AQ37", "terrain": "f",
       "exits": {
-        "north": "AQ36",
-        "south": "AQ38",
-        "west": "AP37",
-        "east": "AR37"
+        "north": "AQ36", "south": "AQ38", "west": "AP37", "east": "AR37"
       }
     },
     {
-      "id": "AR37",
-      "terrain": "p",
+      "id": "AR37", "terrain": "p",
       "exits": {
-        "north": "AR36",
-        "south": "AR38",
-        "west": "AQ37",
-        "east": "AS37"
+        "north": "AR36", "south": "AR38", "west": "AQ37", "east": "AS37"
       }
     },
     {
-      "id": "AS37",
-      "terrain": "p",
+      "id": "AS37", "terrain": "p",
       "exits": {
-        "north": "AS36",
-        "south": "AS38",
-        "west": "AR37",
-        "east": "AT37"
+        "north": "AS36", "south": "AS38", "west": "AR37", "east": "AT37"
       }
     },
     {
-      "id": "AT37",
-      "terrain": "lf",
+      "id": "AT37", "terrain": "lf",
       "exits": {
-        "north": "AT36",
-        "south": "AT38",
-        "west": "AS37",
-        "east": "AU37"
+        "north": "AT36", "south": "AT38", "west": "AS37", "east": "AU37"
       }
     },
     {
-      "id": "AU37",
-      "terrain": "h",
+      "id": "AU37", "terrain": "h",
       "exits": {
-        "north": "AU36",
-        "south": "AU38",
-        "west": "AT37",
-        "east": "AV37"
+        "north": "AU36", "south": "AU38", "west": "AT37", "east": "AV37"
       }
     },
     {
-      "id": "AV37",
-      "terrain": "b",
+      "id": "AV37", "terrain": "b",
       "exits": {
-        "north": "AV36",
-        "south": "AV38",
-        "west": "AU37",
-        "east": "AW37"
+        "north": "AV36", "south": "AV38", "west": "AU37", "east": "AW37"
       }
     },
     {
-      "id": "AW37",
-      "terrain": "p",
+      "id": "AW37", "terrain": "p",
       "exits": {
-        "north": "AW36",
-        "south": "AW38",
-        "west": "AV37",
-        "east": "AX37"
+        "north": "AW36", "south": "AW38", "west": "AV37", "east": "AX37"
       }
     },
     {
-      "id": "AX37",
-      "terrain": "p",
+      "id": "AX37", "terrain": "p",
       "exits": {
-        "north": "AX36",
-        "south": "AX38",
-        "west": "AW37"
+        "north": "AX36", "south": "AX38", "west": "AW37"
       }
     },
     {
-      "id": "A38",
-      "terrain": "p",
+      "id": "A38", "terrain": "p",
       "exits": {
-        "north": "A37",
-        "south": "A39",
-        "east": "B38"
+        "north": "A37", "south": "A39", "east": "B38"
       }
     },
     {
-      "id": "B38",
-      "terrain": "m",
+      "id": "B38", "terrain": "m",
       "exits": {
-        "north": "B37",
-        "south": "B39",
-        "west": "A38",
-        "east": "C38"
+        "north": "B37", "south": "B39", "west": "A38", "east": "C38"
       }
     },
     {
-      "id": "C38",
-      "terrain": "m",
+      "id": "C38", "terrain": "m",
       "exits": {
-        "north": "C37",
-        "south": "C39",
-        "west": "B38",
-        "east": "D38"
+        "north": "C37", "south": "C39", "west": "B38", "east": "D38"
       }
     },
     {
-      "id": "D38",
-      "terrain": "m",
+      "id": "D38", "terrain": "m",
       "exits": {
-        "north": "D37",
-        "south": "D39",
-        "west": "C38",
-        "east": "E38"
+        "north": "D37", "south": "D39", "west": "C38", "east": "E38"
       }
     },
     {
-      "id": "E38",
-      "terrain": "p",
+      "id": "E38", "terrain": "p",
       "exits": {
-        "north": "E37",
-        "south": "E39",
-        "west": "D38",
-        "east": "F38"
+        "north": "E37", "south": "E39", "west": "D38", "east": "F38"
       }
     },
     {
-      "id": "F38",
-      "terrain": "m",
+      "id": "F38", "terrain": "m",
       "exits": {
-        "north": "F37",
-        "south": "F39",
-        "west": "E38",
-        "east": "G38"
+        "north": "F37", "south": "F39", "west": "E38", "east": "G38"
       }
     },
     {
-      "id": "G38",
-      "terrain": "p",
+      "id": "G38", "terrain": "p",
       "exits": {
-        "north": "G37",
-        "south": "G39",
-        "west": "F38",
-        "east": "H38"
+        "north": "G37", "south": "G39", "west": "F38", "east": "H38"
       }
     },
     {
-      "id": "H38",
-      "terrain": "p",
+      "id": "H38", "terrain": "p",
       "exits": {
-        "north": "H37",
-        "south": "H39",
-        "west": "G38",
-        "east": "I38"
+        "north": "H37", "south": "H39", "west": "G38", "east": "I38"
       }
     },
     {
-      "id": "I38",
-      "terrain": "p",
+      "id": "I38", "terrain": "p",
       "exits": {
-        "north": "I37",
-        "south": "I39",
-        "west": "H38",
-        "east": "J38"
+        "north": "I37", "south": "I39", "west": "H38", "east": "J38"
       }
     },
     {
-      "id": "J38",
-      "terrain": "p",
+      "id": "J38", "terrain": "p",
       "exits": {
-        "north": "J37",
-        "south": "J39",
-        "west": "I38",
-        "east": "K38"
+        "north": "J37", "south": "J39", "west": "I38", "east": "K38"
       }
     },
     {
-      "id": "K38",
-      "terrain": "p",
+      "id": "K38", "terrain": "p",
       "exits": {
-        "north": "K37",
-        "south": "K39",
-        "west": "J38",
-        "east": "L38"
+        "north": "K37", "south": "K39", "west": "J38", "east": "L38"
       }
     },
     {
-      "id": "L38",
-      "terrain": "b",
+      "id": "L38", "terrain": "b",
       "exits": {
-        "north": "L37",
-        "south": "L39",
-        "west": "K38",
-        "east": "M38"
+        "north": "L37", "south": "L39", "west": "K38", "east": "M38"
       }
     },
     {
-      "id": "M38",
-      "terrain": "b",
+      "id": "M38", "terrain": "b",
       "exits": {
-        "north": "M37",
-        "south": "M39",
-        "west": "L38",
-        "east": "N38"
+        "north": "M37", "south": "M39", "west": "L38", "east": "N38"
       }
     },
     {
-      "id": "N38",
-      "terrain": "b",
+      "id": "N38", "terrain": "b",
       "exits": {
-        "north": "N37",
-        "south": "N39",
-        "west": "M38",
-        "east": "O38"
+        "north": "N37", "south": "N39", "west": "M38", "east": "O38"
       }
     },
     {
-      "id": "O38",
-      "terrain": "b",
+      "id": "O38", "terrain": "b",
       "exits": {
-        "north": "O37",
-        "south": "O39",
-        "west": "N38",
-        "east": "P38"
+        "north": "O37", "south": "O39", "west": "N38", "east": "P38"
       }
     },
     {
-      "id": "P38",
-      "terrain": "b",
+      "id": "P38", "terrain": "b",
       "exits": {
-        "north": "P37",
-        "south": "P39",
-        "west": "O38",
-        "east": "Q38"
+        "north": "P37", "south": "P39", "west": "O38", "east": "Q38"
       }
     },
     {
-      "id": "Q38",
-      "terrain": "w",
+      "id": "Q38", "terrain": "w",
       "exits": {
-        "north": "Q37",
-        "south": "Q39",
-        "west": "P38",
-        "east": "R38"
+        "north": "Q37", "south": "Q39", "west": "P38", "east": "R38"
       }
     },
     {
-      "id": "R38",
-      "terrain": "dock",
+      "id": "R38", "terrain": "dock",
       "exits": {
-        "north": "R37",
-        "south": "R39",
-        "west": "Q38",
-        "east": "S38"
+        "north": "R37", "south": "R39", "west": "Q38", "east": "S38"
       }
     },
     {
-      "id": "S38",
-      "terrain": "w",
+      "id": "S38", "terrain": "w",
       "exits": {
-        "north": "S37",
-        "south": "S39",
-        "west": "R38",
-        "east": "T38"
+        "north": "S37", "south": "S39", "west": "R38", "east": "T38"
       }
     },
     {
-      "id": "T38",
-      "terrain": "w",
+      "id": "T38", "terrain": "w",
       "exits": {
-        "north": "T37",
-        "south": "T39",
-        "west": "S38",
-        "east": "U38"
+        "north": "T37", "south": "T39", "west": "S38", "east": "U38"
       }
     },
     {
-      "id": "U38",
-      "terrain": "w",
+      "id": "U38", "terrain": "w",
       "exits": {
-        "north": "U37",
-        "south": "U39",
-        "west": "T38",
-        "east": "V38"
+        "north": "U37", "south": "U39", "west": "T38", "east": "V38"
       }
     },
     {
-      "id": "V38",
-      "terrain": "p",
+      "id": "V38", "terrain": "p",
       "exits": {
-        "north": "V37",
-        "south": "V39",
-        "west": "U38",
-        "east": "W38"
+        "north": "V37", "south": "V39", "west": "U38", "east": "W38"
       }
     },
     {
-      "id": "W38",
-      "terrain": "p",
+      "id": "W38", "terrain": "p",
       "exits": {
-        "north": "W37",
-        "south": "W39",
-        "west": "V38",
-        "east": "X38"
+        "north": "W37", "south": "W39", "west": "V38", "east": "X38"
       }
     },
     {
-      "id": "X38",
-      "terrain": "p",
+      "id": "X38", "terrain": "p",
       "exits": {
-        "north": "X37",
-        "south": "X39",
-        "west": "W38",
-        "east": "Y38"
+        "north": "X37", "south": "X39", "west": "W38", "east": "Y38"
       }
     },
     {
-      "id": "Y38",
-      "terrain": "r",
+      "id": "Y38", "terrain": "r",
       "exits": {
-        "north": "Y37",
-        "south": "Y39",
-        "west": "X38",
-        "east": "Z38"
+        "north": "Y37", "south": "Y39", "west": "X38", "east": "Z38"
       }
     },
     {
-      "id": "Z38",
-      "terrain": "p",
+      "id": "Z38", "terrain": "p",
       "exits": {
-        "north": "Z37",
-        "south": "Z39",
-        "west": "Y38",
-        "east": "AA38"
+        "north": "Z37", "south": "Z39", "west": "Y38", "east": "AA38"
       }
     },
     {
-      "id": "AA38",
-      "terrain": "lf",
+      "id": "AA38", "terrain": "lf",
       "exits": {
-        "north": "AA37",
-        "south": "AA39",
-        "west": "Z38",
-        "east": "AB38"
+        "north": "AA37", "south": "AA39", "west": "Z38", "east": "AB38"
       }
     },
     {
-      "id": "AB38",
-      "terrain": "lf",
+      "id": "AB38", "terrain": "lf",
       "exits": {
-        "north": "AB37",
-        "south": "AB39",
-        "west": "AA38",
-        "east": "AC38"
+        "north": "AB37", "south": "AB39", "west": "AA38", "east": "AC38"
       }
     },
     {
-      "id": "AC38",
-      "terrain": "lf",
+      "id": "AC38", "terrain": "lf",
       "exits": {
-        "north": "AC37",
-        "south": "AC39",
-        "west": "AB38",
-        "east": "AD38"
+        "north": "AC37", "south": "AC39", "west": "AB38", "east": "AD38"
       }
     },
     {
-      "id": "AD38",
-      "terrain": "lf",
+      "id": "AD38", "terrain": "lf",
       "exits": {
-        "north": "AD37",
-        "south": "AD39",
-        "west": "AC38",
-        "east": "AE38"
+        "north": "AD37", "south": "AD39", "west": "AC38", "east": "AE38"
       }
     },
     {
-      "id": "AE38",
-      "terrain": "f",
+      "id": "AE38", "terrain": "f",
       "exits": {
-        "north": "AE37",
-        "south": "AE39",
-        "west": "AD38",
-        "east": "AF38"
+        "north": "AE37", "south": "AE39", "west": "AD38", "east": "AF38"
       }
     },
     {
-      "id": "AF38",
-      "terrain": "f",
+      "id": "AF38", "terrain": "f",
       "exits": {
-        "north": "AF37",
-        "south": "AF39",
-        "west": "AE38",
-        "east": "AG38"
+        "north": "AF37", "south": "AF39", "west": "AE38", "east": "AG38"
       }
     },
     {
-      "id": "AG38",
-      "terrain": "f",
+      "id": "AG38", "terrain": "f",
       "exits": {
-        "north": "AG37",
-        "south": "AG39",
-        "west": "AF38",
-        "east": "AH38"
+        "north": "AG37", "south": "AG39", "west": "AF38", "east": "AH38"
       }
     },
     {
-      "id": "AH38",
-      "terrain": "f",
+      "id": "AH38", "terrain": "f",
       "exits": {
-        "north": "AH37",
-        "south": "AH39",
-        "west": "AG38",
-        "east": "AI38"
+        "north": "AH37", "south": "AH39", "west": "AG38", "east": "AI38"
       }
     },
     {
-      "id": "AI38",
-      "terrain": "f",
+      "id": "AI38", "terrain": "f",
       "exits": {
-        "north": "AI37",
-        "south": "AI39",
-        "west": "AH38",
-        "east": "AJ38"
+        "north": "AI37", "south": "AI39", "west": "AH38", "east": "AJ38"
       }
     },
     {
-      "id": "AJ38",
-      "terrain": "f",
+      "id": "AJ38", "terrain": "f",
       "exits": {
-        "north": "AJ37",
-        "south": "AJ39",
-        "west": "AI38",
-        "east": "AK38"
+        "north": "AJ37", "south": "AJ39", "west": "AI38", "east": "AK38"
       }
     },
     {
-      "id": "AK38",
-      "terrain": "f",
+      "id": "AK38", "terrain": "f",
       "exits": {
-        "north": "AK37",
-        "south": "AK39",
-        "west": "AJ38",
-        "east": "AL38"
+        "north": "AK37", "south": "AK39", "west": "AJ38", "east": "AL38"
       }
     },
     {
-      "id": "AL38",
-      "terrain": "f",
+      "id": "AL38", "terrain": "f",
       "exits": {
-        "north": "AL37",
-        "south": "AL39",
-        "west": "AK38",
-        "east": "AM38"
+        "north": "AL37", "south": "AL39", "west": "AK38", "east": "AM38"
       }
     },
     {
-      "id": "AM38",
-      "terrain": "df",
+      "id": "AM38", "terrain": "df",
       "exits": {
-        "north": "AM37",
-        "south": "AM39",
-        "west": "AL38",
-        "east": "AN38"
+        "north": "AM37", "south": "AM39", "west": "AL38", "east": "AN38"
       }
     },
     {
-      "id": "AN38",
-      "terrain": "df",
+      "id": "AN38", "terrain": "df",
       "exits": {
-        "north": "AN37",
-        "south": "AN39",
-        "west": "AM38",
-        "east": "AO38"
+        "north": "AN37", "south": "AN39", "west": "AM38", "east": "AO38"
       }
     },
     {
-      "id": "AO38",
-      "terrain": "f",
+      "id": "AO38", "terrain": "f",
       "exits": {
-        "north": "AO37",
-        "south": "AO39",
-        "west": "AN38",
-        "east": "AP38"
+        "north": "AO37", "south": "AO39", "west": "AN38", "east": "AP38"
       }
     },
     {
-      "id": "AP38",
-      "terrain": "f",
+      "id": "AP38", "terrain": "f",
       "exits": {
-        "north": "AP37",
-        "south": "AP39",
-        "west": "AO38",
-        "east": "AQ38"
+        "north": "AP37", "south": "AP39", "west": "AO38", "east": "AQ38"
       }
     },
     {
-      "id": "AQ38",
-      "terrain": "f",
+      "id": "AQ38", "terrain": "f",
       "exits": {
-        "north": "AQ37",
-        "south": "AQ39",
-        "west": "AP38",
-        "east": "AR38"
+        "north": "AQ37", "south": "AQ39", "west": "AP38", "east": "AR38"
       }
     },
     {
-      "id": "AR38",
-      "terrain": "p",
+      "id": "AR38", "terrain": "p",
       "exits": {
-        "north": "AR37",
-        "south": "AR39",
-        "west": "AQ38",
-        "east": "AS38"
+        "north": "AR37", "south": "AR39", "west": "AQ38", "east": "AS38"
       }
     },
     {
-      "id": "AS38",
-      "terrain": "p",
+      "id": "AS38", "terrain": "p",
       "exits": {
-        "north": "AS37",
-        "south": "AS39",
-        "west": "AR38",
-        "east": "AT38"
+        "north": "AS37", "south": "AS39", "west": "AR38", "east": "AT38"
       }
     },
     {
-      "id": "AT38",
-      "terrain": "lf",
+      "id": "AT38", "terrain": "lf",
       "exits": {
-        "north": "AT37",
-        "south": "AT39",
-        "west": "AS38",
-        "east": "AU38"
+        "north": "AT37", "south": "AT39", "west": "AS38", "east": "AU38"
       }
     },
     {
-      "id": "AU38",
-      "terrain": "h",
+      "id": "AU38", "terrain": "h",
       "exits": {
-        "north": "AU37",
-        "south": "AU39",
-        "west": "AT38",
-        "east": "AV38"
+        "north": "AU37", "south": "AU39", "west": "AT38", "east": "AV38"
       }
     },
     {
-      "id": "AV38",
-      "terrain": "b",
+      "id": "AV38", "terrain": "b",
       "exits": {
-        "north": "AV37",
-        "south": "AV39",
-        "west": "AU38",
-        "east": "AW38"
+        "north": "AV37", "south": "AV39", "west": "AU38", "east": "AW38"
       }
     },
     {
-      "id": "AW38",
-      "terrain": "b",
+      "id": "AW38", "terrain": "b",
       "exits": {
-        "north": "AW37",
-        "south": "AW39",
-        "west": "AV38",
-        "east": "AX38"
+        "north": "AW37", "south": "AW39", "west": "AV38", "east": "AX38"
       }
     },
     {
-      "id": "AX38",
-      "terrain": "p",
+      "id": "AX38", "terrain": "p",
       "exits": {
-        "north": "AX37",
-        "south": "AX39",
-        "west": "AW38"
+        "north": "AX37", "south": "AX39", "west": "AW38"
       }
     },
     {
-      "id": "A39",
-      "terrain": "m",
+      "id": "A39", "terrain": "m",
       "exits": {
-        "north": "A38",
-        "south": "A40",
-        "east": "B39"
+        "north": "A38", "south": "A40", "east": "B39"
       }
     },
     {
-      "id": "B39",
-      "terrain": "m",
+      "id": "B39", "terrain": "m",
       "exits": {
-        "north": "B38",
-        "south": "B40",
-        "west": "A39",
-        "east": "C39"
+        "north": "B38", "south": "B40", "west": "A39", "east": "C39"
       }
     },
     {
-      "id": "C39",
-      "terrain": "m",
+      "id": "C39", "terrain": "m",
       "exits": {
-        "north": "C38",
-        "south": "C40",
-        "west": "B39",
-        "east": "D39"
+        "north": "C38", "south": "C40", "west": "B39", "east": "D39"
       }
     },
     {
-      "id": "D39",
-      "terrain": "p",
+      "id": "D39", "terrain": "p",
       "exits": {
-        "north": "D38",
-        "south": "D40",
-        "west": "C39",
-        "east": "E39"
+        "north": "D38", "south": "D40", "west": "C39", "east": "E39"
       }
     },
     {
-      "id": "E39",
-      "terrain": "p",
+      "id": "E39", "terrain": "p",
       "exits": {
-        "north": "E38",
-        "south": "E40",
-        "west": "D39",
-        "east": "F39"
+        "north": "E38", "south": "E40", "west": "D39", "east": "F39"
       }
     },
     {
-      "id": "F39",
-      "terrain": "m",
+      "id": "F39", "terrain": "m",
       "exits": {
-        "north": "F38",
-        "south": "F40",
-        "west": "E39",
-        "east": "G39"
+        "north": "F38", "south": "F40", "west": "E39", "east": "G39"
       }
     },
     {
-      "id": "G39",
-      "terrain": "m",
+      "id": "G39", "terrain": "m",
       "exits": {
-        "north": "G38",
-        "south": "G40",
-        "west": "F39",
-        "east": "H39"
+        "north": "G38", "south": "G40", "west": "F39", "east": "H39"
       }
     },
     {
-      "id": "H39",
-      "terrain": "p",
+      "id": "H39", "terrain": "p",
       "exits": {
-        "north": "H38",
-        "south": "H40",
-        "west": "G39",
-        "east": "I39"
+        "north": "H38", "south": "H40", "west": "G39", "east": "I39"
       }
     },
     {
-      "id": "I39",
-      "terrain": "p",
+      "id": "I39", "terrain": "p",
       "exits": {
-        "north": "I38",
-        "south": "I40",
-        "west": "H39",
-        "east": "J39"
+        "north": "I38", "south": "I40", "west": "H39", "east": "J39"
       }
     },
     {
-      "id": "J39",
-      "terrain": "p",
+      "id": "J39", "terrain": "p",
       "exits": {
-        "north": "J38",
-        "south": "J40",
-        "west": "I39",
-        "east": "K39"
+        "north": "J38", "south": "J40", "west": "I39", "east": "K39"
       }
     },
     {
-      "id": "K39",
-      "terrain": "p",
+      "id": "K39", "terrain": "p",
       "exits": {
-        "north": "K38",
-        "south": "K40",
-        "west": "J39",
-        "east": "L39"
+        "north": "K38", "south": "K40", "west": "J39", "east": "L39"
       }
     },
     {
-      "id": "L39",
-      "terrain": "b",
+      "id": "L39", "terrain": "b",
       "exits": {
-        "north": "L38",
-        "south": "L40",
-        "west": "K39",
-        "east": "M39"
+        "north": "L38", "south": "L40", "west": "K39", "east": "M39"
       }
     },
     {
-      "id": "M39",
-      "terrain": "b",
+      "id": "M39", "terrain": "b",
       "exits": {
-        "north": "M38",
-        "south": "M40",
-        "west": "L39",
-        "east": "N39"
+        "north": "M38", "south": "M40", "west": "L39", "east": "N39"
       }
     },
     {
-      "id": "N39",
-      "terrain": "b",
+      "id": "N39", "terrain": "b",
       "exits": {
-        "north": "N38",
-        "south": "N40",
-        "west": "M39",
-        "east": "O39"
+        "north": "N38", "south": "N40", "west": "M39", "east": "O39"
       }
     },
     {
-      "id": "O39",
-      "terrain": "b",
+      "id": "O39", "terrain": "b",
       "exits": {
-        "north": "O38",
-        "south": "O40",
-        "west": "N39",
-        "east": "P39"
+        "north": "O38", "south": "O40", "west": "N39", "east": "P39"
       }
     },
     {
-      "id": "P39",
-      "terrain": "b",
+      "id": "P39", "terrain": "b",
       "exits": {
-        "north": "P38",
-        "south": "P40",
-        "west": "O39",
-        "east": "Q39"
+        "north": "P38", "south": "P40", "west": "O39", "east": "Q39"
       }
     },
     {
-      "id": "Q39",
-      "terrain": "b",
+      "id": "Q39", "terrain": "b",
       "exits": {
-        "north": "Q38",
-        "south": "Q40",
-        "west": "P39",
-        "east": "R39"
+        "north": "Q38", "south": "Q40", "west": "P39", "east": "R39"
       }
     },
     {
-      "id": "R39",
-      "terrain": "w",
+      "id": "R39", "terrain": "w",
       "exits": {
-        "north": "R38",
-        "south": "R40",
-        "west": "Q39",
-        "east": "S39"
+        "north": "R38", "south": "R40", "west": "Q39", "east": "S39"
       }
     },
     {
-      "id": "S39",
-      "terrain": "w",
+      "id": "S39", "terrain": "w",
       "exits": {
-        "north": "S38",
-        "south": "S40",
-        "west": "R39",
-        "east": "T39"
+        "north": "S38", "south": "S40", "west": "R39", "east": "T39"
       }
     },
     {
-      "id": "T39",
-      "terrain": "w",
+      "id": "T39", "terrain": "w",
       "exits": {
-        "north": "T38",
-        "south": "T40",
-        "west": "S39",
-        "east": "U39"
+        "north": "T38", "south": "T40", "west": "S39", "east": "U39"
       }
     },
     {
-      "id": "U39",
-      "terrain": "w",
+      "id": "U39", "terrain": "w",
       "exits": {
-        "north": "U38",
-        "south": "U40",
-        "west": "T39",
-        "east": "V39"
+        "north": "U38", "south": "U40", "west": "T39", "east": "V39"
       }
     },
     {
-      "id": "V39",
-      "terrain": "p",
+      "id": "V39", "terrain": "p",
       "exits": {
-        "north": "V38",
-        "south": "V40",
-        "west": "U39",
-        "east": "W39"
+        "north": "V38", "south": "V40", "west": "U39", "east": "W39"
       }
     },
     {
-      "id": "W39",
-      "terrain": "p",
+      "id": "W39", "terrain": "p",
       "exits": {
-        "north": "W38",
-        "south": "W40",
-        "west": "V39",
-        "east": "X39"
+        "north": "W38", "south": "W40", "west": "V39", "east": "X39"
       }
     },
     {
-      "id": "X39",
-      "terrain": "p",
+      "id": "X39", "terrain": "p",
       "exits": {
-        "north": "X38",
-        "south": "X40",
-        "west": "W39",
-        "east": "Y39"
+        "north": "X38", "south": "X40", "west": "W39", "east": "Y39"
       }
     },
     {
-      "id": "Y39",
-      "terrain": "r",
+      "id": "Y39", "terrain": "r",
       "exits": {
-        "north": "Y38",
-        "south": "Y40",
-        "west": "X39",
-        "east": "Z39"
+        "north": "Y38", "south": "Y40", "west": "X39", "east": "Z39"
       }
     },
     {
-      "id": "Z39",
-      "terrain": "p",
+      "id": "Z39", "terrain": "p",
       "exits": {
-        "north": "Z38",
-        "south": "Z40",
-        "west": "Y39",
-        "east": "AA39"
+        "north": "Z38", "south": "Z40", "west": "Y39", "east": "AA39"
       }
     },
     {
-      "id": "AA39",
-      "terrain": "lf",
+      "id": "AA39", "terrain": "lf",
       "exits": {
-        "north": "AA38",
-        "south": "AA40",
-        "west": "Z39",
-        "east": "AB39"
+        "north": "AA38", "south": "AA40", "west": "Z39", "east": "AB39"
       }
     },
     {
-      "id": "AB39",
-      "terrain": "f",
+      "id": "AB39", "terrain": "f",
       "exits": {
-        "north": "AB38",
-        "south": "AB40",
-        "west": "AA39",
-        "east": "AC39"
+        "north": "AB38", "south": "AB40", "west": "AA39", "east": "AC39"
       }
     },
     {
-      "id": "AC39",
-      "terrain": "f",
+      "id": "AC39", "terrain": "f",
       "exits": {
-        "north": "AC38",
-        "south": "AC40",
-        "west": "AB39",
-        "east": "AD39"
+        "north": "AC38", "south": "AC40", "west": "AB39", "east": "AD39"
       }
     },
     {
-      "id": "AD39",
-      "terrain": "f",
+      "id": "AD39", "terrain": "f",
       "exits": {
-        "north": "AD38",
-        "south": "AD40",
-        "west": "AC39",
-        "east": "AE39"
+        "north": "AD38", "south": "AD40", "west": "AC39", "east": "AE39"
       }
     },
     {
-      "id": "AE39",
-      "terrain": "f",
+      "id": "AE39", "terrain": "f",
       "exits": {
-        "north": "AE38",
-        "south": "AE40",
-        "west": "AD39",
-        "east": "AF39"
+        "north": "AE38", "south": "AE40", "west": "AD39", "east": "AF39"
       }
     },
     {
-      "id": "AF39",
-      "terrain": "f",
+      "id": "AF39", "terrain": "f",
       "exits": {
-        "north": "AF38",
-        "south": "AF40",
-        "west": "AE39",
-        "east": "AG39"
+        "north": "AF38", "south": "AF40", "west": "AE39", "east": "AG39"
       }
     },
     {
-      "id": "AG39",
-      "terrain": "f",
+      "id": "AG39", "terrain": "f",
       "exits": {
-        "north": "AG38",
-        "south": "AG40",
-        "west": "AF39",
-        "east": "AH39"
+        "north": "AG38", "south": "AG40", "west": "AF39", "east": "AH39"
       }
     },
     {
-      "id": "AH39",
-      "terrain": "f",
+      "id": "AH39", "terrain": "f",
       "exits": {
-        "north": "AH38",
-        "south": "AH40",
-        "west": "AG39",
-        "east": "AI39"
+        "north": "AH38", "south": "AH40", "west": "AG39", "east": "AI39"
       }
     },
     {
-      "id": "AI39",
-      "terrain": "f",
+      "id": "AI39", "terrain": "f",
       "exits": {
-        "north": "AI38",
-        "south": "AI40",
-        "west": "AH39",
-        "east": "AJ39"
+        "north": "AI38", "south": "AI40", "west": "AH39", "east": "AJ39"
       }
     },
     {
-      "id": "AJ39",
-      "terrain": "f",
+      "id": "AJ39", "terrain": "f",
       "exits": {
-        "north": "AJ38",
-        "south": "AJ40",
-        "west": "AI39",
-        "east": "AK39"
+        "north": "AJ38", "south": "AJ40", "west": "AI39", "east": "AK39"
       }
     },
     {
-      "id": "AK39",
-      "terrain": "f",
+      "id": "AK39", "terrain": "f",
       "exits": {
-        "north": "AK38",
-        "south": "AK40",
-        "west": "AJ39",
-        "east": "AL39"
+        "north": "AK38", "south": "AK40", "west": "AJ39", "east": "AL39"
       }
     },
     {
-      "id": "AL39",
-      "terrain": "forest",
+      "id": "AL39", "terrain": "forest",
       "exits": {
-        "north": "AL38",
-        "south": "AL40",
-        "west": "AK39",
-        "east": "AM39"
+        "north": "AL38", "south": "AL40", "west": "AK39", "east": "AM39"
       }
     },
     {
-      "id": "AM39",
-      "terrain": "df",
+      "id": "AM39", "terrain": "df",
       "exits": {
-        "north": "AM38",
-        "south": "AM40",
-        "west": "AL39",
-        "east": "AN39"
+        "north": "AM38", "south": "AM40", "west": "AL39", "east": "AN39"
       }
     },
     {
-      "id": "AN39",
-      "terrain": "forest",
+      "id": "AN39", "terrain": "forest",
       "exits": {
-        "north": "AN38",
-        "south": "AN40",
-        "west": "AM39",
-        "east": "AO39"
+        "north": "AN38", "south": "AN40", "west": "AM39", "east": "AO39"
       }
     },
     {
-      "id": "AO39",
-      "terrain": "df",
+      "id": "AO39", "terrain": "df",
       "exits": {
-        "north": "AO38",
-        "south": "AO40",
-        "west": "AN39",
-        "east": "AP39"
+        "north": "AO38", "south": "AO40", "west": "AN39", "east": "AP39"
       }
     },
     {
-      "id": "AP39",
-      "terrain": "df",
+      "id": "AP39", "terrain": "df",
       "exits": {
-        "north": "AP38",
-        "south": "AP40",
-        "west": "AO39",
-        "east": "AQ39"
+        "north": "AP38", "south": "AP40", "west": "AO39", "east": "AQ39"
       }
     },
     {
-      "id": "AQ39",
-      "terrain": "f",
+      "id": "AQ39", "terrain": "f",
       "exits": {
-        "north": "AQ38",
-        "south": "AQ40",
-        "west": "AP39",
-        "east": "AR39"
+        "north": "AQ38", "south": "AQ40", "west": "AP39", "east": "AR39"
       }
     },
     {
-      "id": "AR39",
-      "terrain": "f",
+      "id": "AR39", "terrain": "f",
       "exits": {
-        "north": "AR38",
-        "south": "AR40",
-        "west": "AQ39",
-        "east": "AS39"
+        "north": "AR38", "south": "AR40", "west": "AQ39", "east": "AS39"
       }
     },
     {
-      "id": "AS39",
-      "terrain": "p",
+      "id": "AS39", "terrain": "p",
       "exits": {
-        "north": "AS38",
-        "south": "AS40",
-        "west": "AR39",
-        "east": "AT39"
+        "north": "AS38", "south": "AS40", "west": "AR39", "east": "AT39"
       }
     },
     {
-      "id": "AT39",
-      "terrain": "h",
+      "id": "AT39", "terrain": "h",
       "exits": {
-        "north": "AT38",
-        "south": "AT40",
-        "west": "AS39",
-        "east": "AU39"
+        "north": "AT38", "south": "AT40", "west": "AS39", "east": "AU39"
       }
     },
     {
-      "id": "AU39",
-      "terrain": "h",
+      "id": "AU39", "terrain": "h",
       "exits": {
-        "north": "AU38",
-        "south": "AU40",
-        "west": "AT39",
-        "east": "AV39"
+        "north": "AU38", "south": "AU40", "west": "AT39", "east": "AV39"
       }
     },
     {
-      "id": "AV39",
-      "terrain": "b",
+      "id": "AV39", "terrain": "b",
       "exits": {
-        "north": "AV38",
-        "south": "AV40",
-        "west": "AU39",
-        "east": "AW39"
+        "north": "AV38", "south": "AV40", "west": "AU39", "east": "AW39"
       }
     },
     {
-      "id": "AW39",
-      "terrain": "b",
+      "id": "AW39", "terrain": "b",
       "exits": {
-        "north": "AW38",
-        "south": "AW40",
-        "west": "AV39",
-        "east": "AX39"
+        "north": "AW38", "south": "AW40", "west": "AV39", "east": "AX39"
       }
     },
     {
-      "id": "AX39",
-      "terrain": "b",
+      "id": "AX39", "terrain": "b",
       "exits": {
-        "north": "AX38",
-        "south": "AX40",
-        "west": "AW39"
+        "north": "AX38", "south": "AX40", "west": "AW39"
       }
     },
     {
-      "id": "A40",
-      "terrain": "m",
+      "id": "A40", "terrain": "m",
       "exits": {
-        "north": "A39",
-        "south": "A41",
-        "east": "B40"
+        "north": "A39", "south": "A41", "east": "B40"
       }
     },
     {
-      "id": "B40",
-      "terrain": "m",
+      "id": "B40", "terrain": "m",
       "exits": {
-        "north": "B39",
-        "south": "B41",
-        "west": "A40",
-        "east": "C40"
+        "north": "B39", "south": "B41", "west": "A40", "east": "C40"
       }
     },
     {
-      "id": "C40",
-      "terrain": "p",
+      "id": "C40", "terrain": "p",
       "exits": {
-        "north": "C39",
-        "south": "C41",
-        "west": "B40",
-        "east": "D40"
+        "north": "C39", "south": "C41", "west": "B40", "east": "D40"
       }
     },
     {
-      "id": "D40",
-      "terrain": "p",
+      "id": "D40", "terrain": "p",
       "exits": {
-        "north": "D39",
-        "south": "D41",
-        "west": "C40",
-        "east": "E40"
+        "north": "D39", "south": "D41", "west": "C40", "east": "E40"
       }
     },
     {
-      "id": "E40",
-      "terrain": "p",
+      "id": "E40", "terrain": "p",
       "exits": {
-        "north": "E39",
-        "south": "E41",
-        "west": "D40",
-        "east": "F40"
+        "north": "E39", "south": "E41", "west": "D40", "east": "F40"
       }
     },
     {
-      "id": "F40",
-      "terrain": "p",
+      "id": "F40", "terrain": "p",
       "exits": {
-        "north": "F39",
-        "south": "F41",
-        "west": "E40",
-        "east": "G40"
+        "north": "F39", "south": "F41", "west": "E40", "east": "G40"
       }
     },
     {
-      "id": "G40",
-      "terrain": "p",
+      "id": "G40", "terrain": "p",
       "exits": {
-        "north": "G39",
-        "south": "G41",
-        "west": "F40",
-        "east": "H40"
+        "north": "G39", "south": "G41", "west": "F40", "east": "H40"
       }
     },
     {
-      "id": "H40",
-      "terrain": "p",
+      "id": "H40", "terrain": "p",
       "exits": {
-        "north": "H39",
-        "south": "H41",
-        "west": "G40",
-        "east": "I40"
+        "north": "H39", "south": "H41", "west": "G40", "east": "I40"
       }
     },
     {
-      "id": "I40",
-      "terrain": "p",
+      "id": "I40", "terrain": "p",
       "exits": {
-        "north": "I39",
-        "south": "I41",
-        "west": "H40",
-        "east": "J40"
+        "north": "I39", "south": "I41", "west": "H40", "east": "J40"
       }
     },
     {
-      "id": "J40",
-      "terrain": "p",
+      "id": "J40", "terrain": "p",
       "exits": {
-        "north": "J39",
-        "south": "J41",
-        "west": "I40",
-        "east": "K40"
+        "north": "J39", "south": "J41", "west": "I40", "east": "K40"
       }
     },
     {
-      "id": "K40",
-      "terrain": "b",
+      "id": "K40", "terrain": "b",
       "exits": {
-        "north": "K39",
-        "south": "K41",
-        "west": "J40",
-        "east": "L40"
+        "north": "K39", "south": "K41", "west": "J40", "east": "L40"
       }
     },
     {
-      "id": "L40",
-      "terrain": "b",
+      "id": "L40", "terrain": "b",
       "exits": {
-        "north": "L39",
-        "south": "L41",
-        "west": "K40",
-        "east": "M40"
+        "north": "L39", "south": "L41", "west": "K40", "east": "M40"
       }
     },
     {
-      "id": "M40",
-      "terrain": "b",
+      "id": "M40", "terrain": "b",
       "exits": {
-        "north": "M39",
-        "south": "M41",
-        "west": "L40",
-        "east": "N40"
+        "north": "M39", "south": "M41", "west": "L40", "east": "N40"
       }
     },
     {
-      "id": "N40",
-      "terrain": "b",
+      "id": "N40", "terrain": "b",
       "exits": {
-        "north": "N39",
-        "south": "N41",
-        "west": "M40",
-        "east": "O40"
+        "north": "N39", "south": "N41", "west": "M40", "east": "O40"
       }
     },
     {
-      "id": "O40",
-      "terrain": "b",
+      "id": "O40", "terrain": "b",
       "exits": {
-        "north": "O39",
-        "south": "O41",
-        "west": "N40",
-        "east": "P40"
+        "north": "O39", "south": "O41", "west": "N40", "east": "P40"
       }
     },
     {
-      "id": "P40",
-      "terrain": "b",
+      "id": "P40", "terrain": "b",
       "exits": {
-        "north": "P39",
-        "south": "P41",
-        "west": "O40",
-        "east": "Q40"
+        "north": "P39", "south": "P41", "west": "O40", "east": "Q40"
       }
     },
     {
-      "id": "Q40",
-      "terrain": "w",
+      "id": "Q40", "terrain": "w",
       "exits": {
-        "north": "Q39",
-        "south": "Q41",
-        "west": "P40",
-        "east": "R40"
+        "north": "Q39", "south": "Q41", "west": "P40", "east": "R40"
       }
     },
     {
-      "id": "R40",
-      "terrain": "w",
+      "id": "R40", "terrain": "w",
       "exits": {
-        "north": "R39",
-        "south": "R41",
-        "west": "Q40",
-        "east": "S40"
+        "north": "R39", "south": "R41", "west": "Q40", "east": "S40"
       }
     },
     {
-      "id": "S40",
-      "terrain": "Island",
+      "id": "S40", "terrain": "Island",
       "exits": {
-        "north": "S39",
-        "south": "S41",
-        "west": "R40",
-        "east": "T40"
+        "north": "S39", "south": "S41", "west": "R40", "east": "T40"
       }
     },
     {
-      "id": "T40",
-      "terrain": "w",
+      "id": "T40", "terrain": "w",
       "exits": {
-        "north": "T39",
-        "south": "T41",
-        "west": "S40",
-        "east": "U40"
+        "north": "T39", "south": "T41", "west": "S40", "east": "U40"
       }
     },
     {
-      "id": "U40",
-      "terrain": "w",
+      "id": "U40", "terrain": "w",
       "exits": {
-        "north": "U39",
-        "south": "U41",
-        "west": "T40",
-        "east": "V40"
+        "north": "U39", "south": "U41", "west": "T40", "east": "V40"
       }
     },
     {
-      "id": "V40",
-      "terrain": "p",
+      "id": "V40", "terrain": "p",
       "exits": {
-        "north": "V39",
-        "south": "V41",
-        "west": "U40",
-        "east": "W40"
+        "north": "V39", "south": "V41", "west": "U40", "east": "W40"
       }
     },
     {
-      "id": "W40",
-      "terrain": "p",
+      "id": "W40", "terrain": "p",
       "exits": {
-        "north": "W39",
-        "south": "W41",
-        "west": "V40",
-        "east": "X40"
+        "north": "W39", "south": "W41", "west": "V40", "east": "X40"
       }
     },
     {
-      "id": "X40",
-      "terrain": "p",
+      "id": "X40", "terrain": "p",
       "exits": {
-        "north": "X39",
-        "south": "X41",
-        "west": "W40",
-        "east": "Y40"
+        "north": "X39", "south": "X41", "west": "W40", "east": "Y40"
       }
     },
     {
-      "id": "Y40",
-      "terrain": "r",
+      "id": "Y40", "terrain": "r",
       "exits": {
-        "north": "Y39",
-        "south": "Y41",
-        "west": "X40",
-        "east": "Z40"
+        "north": "Y39", "south": "Y41", "west": "X40", "east": "Z40"
       }
     },
     {
-      "id": "Z40",
-      "terrain": "p",
+      "id": "Z40", "terrain": "p",
       "exits": {
-        "north": "Z39",
-        "south": "Z41",
-        "west": "Y40",
-        "east": "AA40"
+        "north": "Z39", "south": "Z41", "west": "Y40", "east": "AA40"
       }
     },
     {
-      "id": "AA40",
-      "terrain": "p",
+      "id": "AA40", "terrain": "p",
       "exits": {
-        "north": "AA39",
-        "south": "AA41",
-        "west": "Z40",
-        "east": "AB40"
+        "north": "AA39", "south": "AA41", "west": "Z40", "east": "AB40"
       }
     },
     {
-      "id": "AB40",
-      "terrain": "f",
+      "id": "AB40", "terrain": "f",
       "exits": {
-        "north": "AB39",
-        "south": "AB41",
-        "west": "AA40",
-        "east": "AC40"
+        "north": "AB39", "south": "AB41", "west": "AA40", "east": "AC40"
       }
     },
     {
-      "id": "AC40",
-      "terrain": "f",
+      "id": "AC40", "terrain": "f",
       "exits": {
-        "north": "AC39",
-        "south": "AC41",
-        "west": "AB40",
-        "east": "AD40"
+        "north": "AC39", "south": "AC41", "west": "AB40", "east": "AD40"
       }
     },
     {
-      "id": "AD40",
-      "terrain": "f",
+      "id": "AD40", "terrain": "f",
       "exits": {
-        "north": "AD39",
-        "south": "AD41",
-        "west": "AC40",
-        "east": "AE40"
+        "north": "AD39", "south": "AD41", "west": "AC40", "east": "AE40"
       }
     },
     {
-      "id": "AE40",
-      "terrain": "f",
+      "id": "AE40", "terrain": "f",
       "exits": {
-        "north": "AE39",
-        "south": "AE41",
-        "west": "AD40",
-        "east": "AF40"
+        "north": "AE39", "south": "AE41", "west": "AD40", "east": "AF40"
       }
     },
     {
-      "id": "AF40",
-      "terrain": "f",
+      "id": "AF40", "terrain": "f",
       "exits": {
-        "north": "AF39",
-        "south": "AF41",
-        "west": "AE40",
-        "east": "AG40"
+        "north": "AF39", "south": "AF41", "west": "AE40", "east": "AG40"
       }
     },
     {
-      "id": "AG40",
-      "terrain": "f",
+      "id": "AG40", "terrain": "f",
       "exits": {
-        "north": "AG39",
-        "south": "AG41",
-        "west": "AF40",
-        "east": "AH40"
+        "north": "AG39", "south": "AG41", "west": "AF40", "east": "AH40"
       }
     },
     {
-      "id": "AH40",
-      "terrain": "df",
+      "id": "AH40", "terrain": "df",
       "exits": {
-        "north": "AH39",
-        "south": "AH41",
-        "west": "AG40",
-        "east": "AI40"
+        "north": "AH39", "south": "AH41", "west": "AG40", "east": "AI40"
       }
     },
     {
-      "id": "AI40",
-      "terrain": "df",
+      "id": "AI40", "terrain": "df",
       "exits": {
-        "north": "AI39",
-        "south": "AI41",
-        "west": "AH40",
-        "east": "AJ40"
+        "north": "AI39", "south": "AI41", "west": "AH40", "east": "AJ40"
       }
     },
     {
-      "id": "AJ40",
-      "terrain": "f",
+      "id": "AJ40", "terrain": "f",
       "exits": {
-        "north": "AJ39",
-        "south": "AJ41",
-        "west": "AI40",
-        "east": "AK40"
+        "north": "AJ39", "south": "AJ41", "west": "AI40", "east": "AK40"
       }
     },
     {
-      "id": "AK40",
-      "terrain": "df",
+      "id": "AK40", "terrain": "df",
       "exits": {
-        "north": "AK39",
-        "south": "AK41",
-        "west": "AJ40",
-        "east": "AL40"
+        "north": "AK39", "south": "AK41", "west": "AJ40", "east": "AL40"
       }
     },
     {
-      "id": "AL40",
-      "terrain": "df",
+      "id": "AL40", "terrain": "df",
       "exits": {
-        "north": "AL39",
-        "south": "AL41",
-        "west": "AK40",
-        "east": "AM40"
+        "north": "AL39", "south": "AL41", "west": "AK40", "east": "AM40"
       }
     },
     {
-      "id": "AM40",
-      "terrain": "df",
+      "id": "AM40", "terrain": "df",
       "exits": {
-        "north": "AM39",
-        "south": "AM41",
-        "west": "AL40",
-        "east": "AN40"
+        "north": "AM39", "south": "AM41", "west": "AL40", "east": "AN40"
       }
     },
     {
-      "id": "AN40",
-      "terrain": "df",
+      "id": "AN40", "terrain": "df",
       "exits": {
-        "north": "AN39",
-        "south": "AN41",
-        "west": "AM40",
-        "east": "AO40"
+        "north": "AN39", "south": "AN41", "west": "AM40", "east": "AO40"
       }
     },
     {
-      "id": "AO40",
-      "terrain": "f",
+      "id": "AO40", "terrain": "f",
       "exits": {
-        "north": "AO39",
-        "south": "AO41",
-        "west": "AN40",
-        "east": "AP40"
+        "north": "AO39", "south": "AO41", "west": "AN40", "east": "AP40"
       }
     },
     {
-      "id": "AP40",
-      "terrain": "f",
+      "id": "AP40", "terrain": "f",
       "exits": {
-        "north": "AP39",
-        "south": "AP41",
-        "west": "AO40",
-        "east": "AQ40"
+        "north": "AP39", "south": "AP41", "west": "AO40", "east": "AQ40"
       }
     },
     {
-      "id": "AQ40",
-      "terrain": "p",
+      "id": "AQ40", "terrain": "p",
       "exits": {
-        "north": "AQ39",
-        "south": "AQ41",
-        "west": "AP40",
-        "east": "AR40"
+        "north": "AQ39", "south": "AQ41", "west": "AP40", "east": "AR40"
       }
     },
     {
-      "id": "AR40",
-      "terrain": "p",
+      "id": "AR40", "terrain": "p",
       "exits": {
-        "north": "AR39",
-        "south": "AR41",
-        "west": "AQ40",
-        "east": "AS40"
+        "north": "AR39", "south": "AR41", "west": "AQ40", "east": "AS40"
       }
     },
     {
-      "id": "AS40",
-      "terrain": "lf",
+      "id": "AS40", "terrain": "lf",
       "exits": {
-        "north": "AS39",
-        "south": "AS41",
-        "west": "AR40",
-        "east": "AT40"
+        "north": "AS39", "south": "AS41", "west": "AR40", "east": "AT40"
       }
     },
     {
-      "id": "AT40",
-      "terrain": "h",
+      "id": "AT40", "terrain": "h",
       "exits": {
-        "north": "AT39",
-        "south": "AT41",
-        "west": "AS40",
-        "east": "AU40"
+        "north": "AT39", "south": "AT41", "west": "AS40", "east": "AU40"
       }
     },
     {
-      "id": "AU40",
-      "terrain": "h",
+      "id": "AU40", "terrain": "h",
       "exits": {
-        "north": "AU39",
-        "south": "AU41",
-        "west": "AT40",
-        "east": "AV40"
+        "north": "AU39", "south": "AU41", "west": "AT40", "east": "AV40"
       }
     },
     {
-      "id": "AV40",
-      "terrain": "h",
+      "id": "AV40", "terrain": "h",
       "exits": {
-        "north": "AV39",
-        "south": "AV41",
-        "west": "AU40",
-        "east": "AW40"
+        "north": "AV39", "south": "AV41", "west": "AU40", "east": "AW40"
       }
     },
     {
-      "id": "AW40",
-      "terrain": "m",
+      "id": "AW40", "terrain": "m",
       "exits": {
-        "north": "AW39",
-        "south": "AW41",
-        "west": "AV40",
-        "east": "AX40"
+        "north": "AW39", "south": "AW41", "west": "AV40", "east": "AX40"
       }
     },
     {
-      "id": "AX40",
-      "terrain": "m",
+      "id": "AX40", "terrain": "m",
       "exits": {
-        "north": "AX39",
-        "south": "AX41",
-        "west": "AW40"
+        "north": "AX39", "south": "AX41", "west": "AW40"
       }
     },
     {
-      "id": "A41",
-      "terrain": "p",
+      "id": "A41", "terrain": "p",
       "exits": {
-        "north": "A40",
-        "south": "A42",
-        "east": "B41"
+        "north": "A40", "south": "A42", "east": "B41"
       }
     },
     {
-      "id": "B41",
-      "terrain": "p",
+      "id": "B41", "terrain": "p",
       "exits": {
-        "north": "B40",
-        "south": "B42",
-        "west": "A41",
-        "east": "C41"
+        "north": "B40", "south": "B42", "west": "A41", "east": "C41"
       }
     },
     {
-      "id": "C41",
-      "terrain": "p",
+      "id": "C41", "terrain": "p",
       "exits": {
-        "north": "C40",
-        "south": "C42",
-        "west": "B41",
-        "east": "D41"
+        "north": "C40", "south": "C42", "west": "B41", "east": "D41"
       }
     },
     {
-      "id": "D41",
-      "terrain": "p",
+      "id": "D41", "terrain": "p",
       "exits": {
-        "north": "D40",
-        "south": "D42",
-        "west": "C41",
-        "east": "E41"
+        "north": "D40", "south": "D42", "west": "C41", "east": "E41"
       }
     },
     {
-      "id": "E41",
-      "terrain": "p",
+      "id": "E41", "terrain": "p",
       "exits": {
-        "north": "E40",
-        "south": "E42",
-        "west": "D41",
-        "east": "F41"
+        "north": "E40", "south": "E42", "west": "D41", "east": "F41"
       }
     },
     {
-      "id": "F41",
-      "terrain": "p",
+      "id": "F41", "terrain": "p",
       "exits": {
-        "north": "F40",
-        "south": "F42",
-        "west": "E41",
-        "east": "G41"
+        "north": "F40", "south": "F42", "west": "E41", "east": "G41"
       }
     },
     {
-      "id": "G41",
-      "terrain": "p",
+      "id": "G41", "terrain": "p",
       "exits": {
-        "north": "G40",
-        "south": "G42",
-        "west": "F41",
-        "east": "H41"
+        "north": "G40", "south": "G42", "west": "F41", "east": "H41"
       }
     },
     {
-      "id": "H41",
-      "terrain": "p",
+      "id": "H41", "terrain": "p",
       "exits": {
-        "north": "H40",
-        "south": "H42",
-        "west": "G41",
-        "east": "I41"
+        "north": "H40", "south": "H42", "west": "G41", "east": "I41"
       }
     },
     {
-      "id": "I41",
-      "terrain": "p",
+      "id": "I41", "terrain": "p",
       "exits": {
-        "north": "I40",
-        "south": "I42",
-        "west": "H41",
-        "east": "J41"
+        "north": "I40", "south": "I42", "west": "H41", "east": "J41"
       }
     },
     {
-      "id": "J41",
-      "terrain": "p",
+      "id": "J41", "terrain": "p",
       "exits": {
-        "north": "J40",
-        "south": "J42",
-        "west": "I41",
-        "east": "K41"
+        "north": "J40", "south": "J42", "west": "I41", "east": "K41"
       }
     },
     {
-      "id": "K41",
-      "terrain": "b",
+      "id": "K41", "terrain": "b",
       "exits": {
-        "north": "K40",
-        "south": "K42",
-        "west": "J41",
-        "east": "L41"
+        "north": "K40", "south": "K42", "west": "J41", "east": "L41"
       }
     },
     {
-      "id": "L41",
-      "terrain": "b",
+      "id": "L41", "terrain": "b",
       "exits": {
-        "north": "L40",
-        "south": "L42",
-        "west": "K41",
-        "east": "M41"
+        "north": "L40", "south": "L42", "west": "K41", "east": "M41"
       }
     },
     {
-      "id": "M41",
-      "terrain": "b",
+      "id": "M41", "terrain": "b",
       "exits": {
-        "north": "M40",
-        "south": "M42",
-        "west": "L41",
-        "east": "N41"
+        "north": "M40", "south": "M42", "west": "L41", "east": "N41"
       }
     },
     {
-      "id": "N41",
-      "terrain": "b",
+      "id": "N41", "terrain": "b",
       "exits": {
-        "north": "N40",
-        "south": "N42",
-        "west": "M41",
-        "east": "O41"
+        "north": "N40", "south": "N42", "west": "M41", "east": "O41"
       }
     },
     {
-      "id": "O41",
-      "terrain": "p",
+      "id": "O41", "terrain": "p",
       "exits": {
-        "north": "O40",
-        "south": "O42",
-        "west": "N41",
-        "east": "P41"
+        "north": "O40", "south": "O42", "west": "N41", "east": "P41"
       }
     },
     {
-      "id": "P41",
-      "terrain": "w",
+      "id": "P41", "terrain": "w",
       "exits": {
-        "north": "P40",
-        "south": "P42",
-        "west": "O41",
-        "east": "Q41"
+        "north": "P40", "south": "P42", "west": "O41", "east": "Q41"
       }
     },
     {
-      "id": "Q41",
-      "terrain": "b",
+      "id": "Q41", "terrain": "b",
       "exits": {
-        "north": "Q40",
-        "south": "Q42",
-        "west": "P41",
-        "east": "R41"
+        "north": "Q40", "south": "Q42", "west": "P41", "east": "R41"
       }
     },
     {
-      "id": "R41",
-      "terrain": "w",
+      "id": "R41", "terrain": "w",
       "exits": {
-        "north": "R40",
-        "south": "R42",
-        "west": "Q41",
-        "east": "S41"
+        "north": "R40", "south": "R42", "west": "Q41", "east": "S41"
       }
     },
     {
-      "id": "S41",
-      "terrain": "w",
+      "id": "S41", "terrain": "w",
       "exits": {
-        "north": "S40",
-        "south": "S42",
-        "west": "R41",
-        "east": "T41"
+        "north": "S40", "south": "S42", "west": "R41", "east": "T41"
       }
     },
     {
-      "id": "T41",
-      "terrain": "w",
+      "id": "T41", "terrain": "w",
       "exits": {
-        "north": "T40",
-        "south": "T42",
-        "west": "S41",
-        "east": "U41"
+        "north": "T40", "south": "T42", "west": "S41", "east": "U41"
       }
     },
     {
-      "id": "U41",
-      "terrain": "cove",
+      "id": "U41", "terrain": "cove",
       "exits": {
-        "north": "U40",
-        "south": "U42",
-        "west": "T41",
-        "east": "V41"
+        "north": "U40", "south": "U42", "west": "T41", "east": "V41"
       }
     },
     {
-      "id": "V41",
-      "terrain": "path",
+      "id": "V41", "terrain": "path",
       "exits": {
-        "north": "V40",
-        "south": "V42",
-        "west": "U41",
-        "east": "W41"
+        "north": "V40", "south": "V42", "west": "U41", "east": "W41"
       }
     },
     {
-      "id": "W41",
-      "terrain": "p",
+      "id": "W41", "terrain": "p",
       "exits": {
-        "north": "W40",
-        "south": "W42",
-        "west": "V41",
-        "east": "X41"
+        "north": "W40", "south": "W42", "west": "V41", "east": "X41"
       }
     },
     {
-      "id": "X41",
-      "terrain": "p",
+      "id": "X41", "terrain": "p",
       "exits": {
-        "north": "X40",
-        "south": "X42",
-        "west": "W41",
-        "east": "Y41"
+        "north": "X40", "south": "X42", "west": "W41", "east": "Y41"
       }
     },
     {
-      "id": "Y41",
-      "terrain": "r",
+      "id": "Y41", "terrain": "r",
       "exits": {
-        "north": "Y40",
-        "south": "Y42",
-        "west": "X41",
-        "east": "Z41"
+        "north": "Y40", "south": "Y42", "west": "X41", "east": "Z41"
       }
     },
     {
-      "id": "Z41",
-      "terrain": "p",
+      "id": "Z41", "terrain": "p",
       "exits": {
-        "north": "Z40",
-        "south": "Z42",
-        "west": "Y41",
-        "east": "AA41"
+        "north": "Z40", "south": "Z42", "west": "Y41", "east": "AA41"
       }
     },
     {
-      "id": "AA41",
-      "terrain": "p",
+      "id": "AA41", "terrain": "p",
       "exits": {
-        "north": "AA40",
-        "south": "AA42",
-        "west": "Z41",
-        "east": "AB41"
+        "north": "AA40", "south": "AA42", "west": "Z41", "east": "AB41"
       }
     },
     {
-      "id": "AB41",
-      "terrain": "p",
+      "id": "AB41", "terrain": "p",
       "exits": {
-        "north": "AB40",
-        "south": "AB42",
-        "west": "AA41",
-        "east": "AC41"
+        "north": "AB40", "south": "AB42", "west": "AA41", "east": "AC41"
       }
     },
     {
-      "id": "AC41",
-      "terrain": "f",
+      "id": "AC41", "terrain": "f",
       "exits": {
-        "north": "AC40",
-        "south": "AC42",
-        "west": "AB41",
-        "east": "AD41"
+        "north": "AC40", "south": "AC42", "west": "AB41", "east": "AD41"
       }
     },
     {
-      "id": "AD41",
-      "terrain": "f",
+      "id": "AD41", "terrain": "f",
       "exits": {
-        "north": "AD40",
-        "south": "AD42",
-        "west": "AC41",
-        "east": "AE41"
+        "north": "AD40", "south": "AD42", "west": "AC41", "east": "AE41"
       }
     },
     {
-      "id": "AE41",
-      "terrain": "df",
+      "id": "AE41", "terrain": "df",
       "exits": {
-        "north": "AE40",
-        "south": "AE42",
-        "west": "AD41",
-        "east": "AF41"
+        "north": "AE40", "south": "AE42", "west": "AD41", "east": "AF41"
       }
     },
     {
-      "id": "AF41",
-      "terrain": "f",
+      "id": "AF41", "terrain": "f",
       "exits": {
-        "north": "AF40",
-        "south": "AF42",
-        "west": "AE41",
-        "east": "AG41"
+        "north": "AF40", "south": "AF42", "west": "AE41", "east": "AG41"
       }
     },
     {
-      "id": "AG41",
-      "terrain": "df",
+      "id": "AG41", "terrain": "df",
       "exits": {
-        "north": "AG40",
-        "south": "AG42",
-        "west": "AF41",
-        "east": "AH41"
+        "north": "AG40", "south": "AG42", "west": "AF41", "east": "AH41"
       }
     },
     {
-      "id": "AH41",
-      "terrain": "df",
+      "id": "AH41", "terrain": "df",
       "exits": {
-        "north": "AH40",
-        "south": "AH42",
-        "west": "AG41",
-        "east": "AI41"
+        "north": "AH40", "south": "AH42", "west": "AG41", "east": "AI41"
       }
     },
     {
-      "id": "AI41",
-      "terrain": "df",
+      "id": "AI41", "terrain": "df",
       "exits": {
-        "north": "AI40",
-        "south": "AI42",
-        "west": "AH41",
-        "east": "AJ41"
+        "north": "AI40", "south": "AI42", "west": "AH41", "east": "AJ41"
       }
     },
     {
-      "id": "AJ41",
-      "terrain": "df",
+      "id": "AJ41", "terrain": "df",
       "exits": {
-        "north": "AJ40",
-        "south": "AJ42",
-        "west": "AI41",
-        "east": "AK41"
+        "north": "AJ40", "south": "AJ42", "west": "AI41", "east": "AK41"
       }
     },
     {
-      "id": "AK41",
-      "terrain": "df",
+      "id": "AK41", "terrain": "df",
       "exits": {
-        "north": "AK40",
-        "south": "AK42",
-        "west": "AJ41",
-        "east": "AL41"
+        "north": "AK40", "south": "AK42", "west": "AJ41", "east": "AL41"
       }
     },
     {
-      "id": "AL41",
-      "terrain": "df",
+      "id": "AL41", "terrain": "df",
       "exits": {
-        "north": "AL40",
-        "south": "AL42",
-        "west": "AK41",
-        "east": "AM41"
+        "north": "AL40", "south": "AL42", "west": "AK41", "east": "AM41"
       }
     },
     {
-      "id": "AM41",
-      "terrain": "df",
+      "id": "AM41", "terrain": "df",
       "exits": {
-        "north": "AM40",
-        "south": "AM42",
-        "west": "AL41",
-        "east": "AN41"
+        "north": "AM40", "south": "AM42", "west": "AL41", "east": "AN41"
       }
     },
     {
-      "id": "AN41",
-      "terrain": "df",
+      "id": "AN41", "terrain": "df",
       "exits": {
-        "north": "AN40",
-        "south": "AN42",
-        "west": "AM41",
-        "east": "AO41"
+        "north": "AN40", "south": "AN42", "west": "AM41", "east": "AO41"
       }
     },
     {
-      "id": "AO41",
-      "terrain": "f",
+      "id": "AO41", "terrain": "f",
       "exits": {
-        "north": "AO40",
-        "south": "AO42",
-        "west": "AN41",
-        "east": "AP41"
+        "north": "AO40", "south": "AO42", "west": "AN41", "east": "AP41"
       }
     },
     {
-      "id": "AP41",
-      "terrain": "f",
+      "id": "AP41", "terrain": "f",
       "exits": {
-        "north": "AP40",
-        "south": "AP42",
-        "west": "AO41",
-        "east": "AQ41"
+        "north": "AP40", "south": "AP42", "west": "AO41", "east": "AQ41"
       }
     },
     {
-      "id": "AQ41",
-      "terrain": "lf",
+      "id": "AQ41", "terrain": "lf",
       "exits": {
-        "north": "AQ40",
-        "south": "AQ42",
-        "west": "AP41",
-        "east": "AR41"
+        "north": "AQ40", "south": "AQ42", "west": "AP41", "east": "AR41"
       }
     },
     {
-      "id": "AR41",
-      "terrain": "lf",
+      "id": "AR41", "terrain": "lf",
       "exits": {
-        "north": "AR40",
-        "south": "AR42",
-        "west": "AQ41",
-        "east": "AS41"
+        "north": "AR40", "south": "AR42", "west": "AQ41", "east": "AS41"
       }
     },
     {
-      "id": "AS41",
-      "terrain": "lf",
+      "id": "AS41", "terrain": "lf",
       "exits": {
-        "north": "AS40",
-        "south": "AS42",
-        "west": "AR41",
-        "east": "AT41"
+        "north": "AS40", "south": "AS42", "west": "AR41", "east": "AT41"
       }
     },
     {
-      "id": "AT41",
-      "terrain": "lf",
+      "id": "AT41", "terrain": "lf",
       "exits": {
-        "north": "AT40",
-        "south": "AT42",
-        "west": "AS41",
-        "east": "AU41"
+        "north": "AT40", "south": "AT42", "west": "AS41", "east": "AU41"
       }
     },
     {
-      "id": "AU41",
-      "terrain": "h",
+      "id": "AU41", "terrain": "h",
       "exits": {
-        "north": "AU40",
-        "south": "AU42",
-        "west": "AT41",
-        "east": "AV41"
+        "north": "AU40", "south": "AU42", "west": "AT41", "east": "AV41"
       }
     },
     {
-      "id": "AV41",
-      "terrain": "m",
+      "id": "AV41", "terrain": "m",
       "exits": {
-        "north": "AV40",
-        "south": "AV42",
-        "west": "AU41",
-        "east": "AW41"
+        "north": "AV40", "south": "AV42", "west": "AU41", "east": "AW41"
       }
     },
     {
-      "id": "AW41",
-      "terrain": "m",
+      "id": "AW41", "terrain": "m",
       "exits": {
-        "north": "AW40",
-        "south": "AW42",
-        "west": "AV41",
-        "east": "AX41"
+        "north": "AW40", "south": "AW42", "west": "AV41", "east": "AX41"
       }
     },
     {
-      "id": "AX41",
-      "terrain": "m",
+      "id": "AX41", "terrain": "m",
       "exits": {
-        "north": "AX40",
-        "south": "AX42",
-        "west": "AW41"
+        "north": "AX40", "south": "AX42", "west": "AW41"
       }
     },
     {
-      "id": "A42",
-      "terrain": "p",
+      "id": "A42", "terrain": "p",
       "exits": {
-        "north": "A41",
-        "south": "A43",
-        "east": "B42"
+        "north": "A41", "south": "A43", "east": "B42"
       }
     },
     {
-      "id": "B42",
-      "terrain": "p",
+      "id": "B42", "terrain": "p",
       "exits": {
-        "north": "B41",
-        "south": "B43",
-        "west": "A42",
-        "east": "C42"
+        "north": "B41", "south": "B43", "west": "A42", "east": "C42"
       }
     },
     {
-      "id": "C42",
-      "terrain": "p",
+      "id": "C42", "terrain": "p",
       "exits": {
-        "north": "C41",
-        "south": "C43",
-        "west": "B42",
-        "east": "D42"
+        "north": "C41", "south": "C43", "west": "B42", "east": "D42"
       }
     },
     {
-      "id": "D42",
-      "terrain": "p",
+      "id": "D42", "terrain": "p",
       "exits": {
-        "north": "D41",
-        "south": "D43",
-        "west": "C42",
-        "east": "E42"
+        "north": "D41", "south": "D43", "west": "C42", "east": "E42"
       }
     },
     {
-      "id": "E42",
-      "terrain": "p",
+      "id": "E42", "terrain": "p",
       "exits": {
-        "north": "E41",
-        "south": "E43",
-        "west": "D42",
-        "east": "F42"
+        "north": "E41", "south": "E43", "west": "D42", "east": "F42"
       }
     },
     {
-      "id": "F42",
-      "terrain": "p",
+      "id": "F42", "terrain": "p",
       "exits": {
-        "north": "F41",
-        "south": "F43",
-        "west": "E42",
-        "east": "G42"
+        "north": "F41", "south": "F43", "west": "E42", "east": "G42"
       }
     },
     {
-      "id": "G42",
-      "terrain": "p",
+      "id": "G42", "terrain": "p",
       "exits": {
-        "north": "G41",
-        "south": "G43",
-        "west": "F42",
-        "east": "H42"
+        "north": "G41", "south": "G43", "west": "F42", "east": "H42"
       }
     },
     {
-      "id": "H42",
-      "terrain": "p",
+      "id": "H42", "terrain": "p",
       "exits": {
-        "north": "H41",
-        "south": "H43",
-        "west": "G42",
-        "east": "I42"
+        "north": "H41", "south": "H43", "west": "G42", "east": "I42"
       }
     },
     {
-      "id": "I42",
-      "terrain": "p",
+      "id": "I42", "terrain": "p",
       "exits": {
-        "north": "I41",
-        "south": "I43",
-        "west": "H42",
-        "east": "J42"
+        "north": "I41", "south": "I43", "west": "H42", "east": "J42"
       }
     },
     {
-      "id": "J42",
-      "terrain": "p",
+      "id": "J42", "terrain": "p",
       "exits": {
-        "north": "J41",
-        "south": "J43",
-        "west": "I42",
-        "east": "K42"
+        "north": "J41", "south": "J43", "west": "I42", "east": "K42"
       }
     },
     {
-      "id": "K42",
-      "terrain": "p",
+      "id": "K42", "terrain": "p",
       "exits": {
-        "north": "K41",
-        "south": "K43",
-        "west": "J42",
-        "east": "L42"
+        "north": "K41", "south": "K43", "west": "J42", "east": "L42"
       }
     },
     {
-      "id": "L42",
-      "terrain": "b",
+      "id": "L42", "terrain": "b",
       "exits": {
-        "north": "L41",
-        "south": "L43",
-        "west": "K42",
-        "east": "M42"
+        "north": "L41", "south": "L43", "west": "K42", "east": "M42"
       }
     },
     {
-      "id": "M42",
-      "terrain": "b",
+      "id": "M42", "terrain": "b",
       "exits": {
-        "north": "M41",
-        "south": "M43",
-        "west": "L42",
-        "east": "N42"
+        "north": "M41", "south": "M43", "west": "L42", "east": "N42"
       }
     },
     {
-      "id": "N42",
-      "terrain": "p",
+      "id": "N42", "terrain": "p",
       "exits": {
-        "north": "N41",
-        "south": "N43",
-        "west": "M42",
-        "east": "O42"
+        "north": "N41", "south": "N43", "west": "M42", "east": "O42"
       }
     },
     {
-      "id": "O42",
-      "terrain": "p",
+      "id": "O42", "terrain": "p",
       "exits": {
-        "north": "O41",
-        "south": "O43",
-        "west": "N42",
-        "east": "P42"
+        "north": "O41", "south": "O43", "west": "N42", "east": "P42"
       }
     },
     {
-      "id": "P42",
-      "terrain": "w",
+      "id": "P42", "terrain": "w",
       "exits": {
-        "north": "P41",
-        "south": "P43",
-        "west": "O42",
-        "east": "Q42"
+        "north": "P41", "south": "P43", "west": "O42", "east": "Q42"
       }
     },
     {
-      "id": "Q42",
-      "terrain": "b",
+      "id": "Q42", "terrain": "b",
       "exits": {
-        "north": "Q41",
-        "south": "Q43",
-        "west": "P42",
-        "east": "R42"
+        "north": "Q41", "south": "Q43", "west": "P42", "east": "R42"
       }
     },
     {
-      "id": "R42",
-      "terrain": "b",
+      "id": "R42", "terrain": "b",
       "exits": {
-        "north": "R41",
-        "south": "R43",
-        "west": "Q42",
-        "east": "S42"
+        "north": "R41", "south": "R43", "west": "Q42", "east": "S42"
       }
     },
     {
-      "id": "S42",
-      "terrain": "w",
+      "id": "S42", "terrain": "w",
       "exits": {
-        "north": "S41",
-        "south": "S43",
-        "west": "R42",
-        "east": "T42"
+        "north": "S41", "south": "S43", "west": "R42", "east": "T42"
       }
     },
     {
-      "id": "T42",
-      "terrain": "w",
+      "id": "T42", "terrain": "w",
       "exits": {
-        "north": "T41",
-        "south": "T43",
-        "west": "S42",
-        "east": "U42"
+        "north": "T41", "south": "T43", "west": "S42", "east": "U42"
       }
     },
     {
-      "id": "U42",
-      "terrain": "w",
+      "id": "U42", "terrain": "w",
       "exits": {
-        "north": "U41",
-        "south": "U43",
-        "west": "T42",
-        "east": "V42"
+        "north": "U41", "south": "U43", "west": "T42", "east": "V42"
       }
     },
     {
-      "id": "V42",
-      "terrain": "w",
+      "id": "V42", "terrain": "w",
       "exits": {
-        "north": "V41",
-        "south": "V43",
-        "west": "U42",
-        "east": "W42"
+        "north": "V41", "south": "V43", "west": "U42", "east": "W42"
       }
     },
     {
-      "id": "W42",
-      "terrain": "w",
+      "id": "W42", "terrain": "w",
       "exits": {
-        "north": "W41",
-        "south": "W43",
-        "west": "V42",
-        "east": "X42"
+        "north": "W41", "south": "W43", "west": "V42", "east": "X42"
       }
     },
     {
-      "id": "X42",
-      "terrain": "p",
+      "id": "X42", "terrain": "p",
       "exits": {
-        "north": "X41",
-        "south": "X43",
-        "west": "W42",
-        "east": "Y42"
+        "north": "X41", "south": "X43", "west": "W42", "east": "Y42"
       }
     },
     {
-      "id": "Y42",
-      "terrain": "r",
+      "id": "Y42", "terrain": "r",
       "exits": {
-        "north": "Y41",
-        "south": "Y43",
-        "west": "X42",
-        "east": "Z42"
+        "north": "Y41", "south": "Y43", "west": "X42", "east": "Z42"
       }
     },
     {
-      "id": "Z42",
-      "terrain": "p",
+      "id": "Z42", "terrain": "p",
       "exits": {
-        "north": "Z41",
-        "south": "Z43",
-        "west": "Y42",
-        "east": "AA42"
+        "north": "Z41", "south": "Z43", "west": "Y42", "east": "AA42"
       }
     },
     {
-      "id": "AA42",
-      "terrain": "p",
+      "id": "AA42", "terrain": "p",
       "exits": {
-        "north": "AA41",
-        "south": "AA43",
-        "west": "Z42",
-        "east": "AB42"
+        "north": "AA41", "south": "AA43", "west": "Z42", "east": "AB42"
       }
     },
     {
-      "id": "AB42",
-      "terrain": "f",
+      "id": "AB42", "terrain": "f",
       "exits": {
-        "north": "AB41",
-        "south": "AB43",
-        "west": "AA42",
-        "east": "AC42"
+        "north": "AB41", "south": "AB43", "west": "AA42", "east": "AC42"
       }
     },
     {
-      "id": "AC42",
-      "terrain": "f",
+      "id": "AC42", "terrain": "f",
       "exits": {
-        "north": "AC41",
-        "south": "AC43",
-        "west": "AB42",
-        "east": "AD42"
+        "north": "AC41", "south": "AC43", "west": "AB42", "east": "AD42"
       }
     },
     {
-      "id": "AD42",
-      "terrain": "f",
+      "id": "AD42", "terrain": "f",
       "exits": {
-        "north": "AD41",
-        "south": "AD43",
-        "west": "AC42",
-        "east": "AE42"
+        "north": "AD41", "south": "AD43", "west": "AC42", "east": "AE42"
       }
     },
     {
-      "id": "AE42",
-      "terrain": "f",
+      "id": "AE42", "terrain": "f",
       "exits": {
-        "north": "AE41",
-        "south": "AE43",
-        "west": "AD42",
-        "east": "AF42"
+        "north": "AE41", "south": "AE43", "west": "AD42", "east": "AF42"
       }
     },
     {
-      "id": "AF42",
-      "terrain": "f",
+      "id": "AF42", "terrain": "f",
       "exits": {
-        "north": "AF41",
-        "south": "AF43",
-        "west": "AE42",
-        "east": "AG42"
+        "north": "AF41", "south": "AF43", "west": "AE42", "east": "AG42"
       }
     },
     {
-      "id": "AG42",
-      "terrain": "df",
+      "id": "AG42", "terrain": "df",
       "exits": {
-        "north": "AG41",
-        "south": "AG43",
-        "west": "AF42",
-        "east": "AH42"
+        "north": "AG41", "south": "AG43", "west": "AF42", "east": "AH42"
       }
     },
     {
-      "id": "AH42",
-      "terrain": "df",
+      "id": "AH42", "terrain": "df",
       "exits": {
-        "north": "AH41",
-        "south": "AH43",
-        "west": "AG42",
-        "east": "AI42"
+        "north": "AH41", "south": "AH43", "west": "AG42", "east": "AI42"
       }
     },
     {
-      "id": "AI42",
-      "terrain": "df",
+      "id": "AI42", "terrain": "df",
       "exits": {
-        "north": "AI41",
-        "south": "AI43",
-        "west": "AH42",
-        "east": "AJ42"
+        "north": "AI41", "south": "AI43", "west": "AH42", "east": "AJ42"
       }
     },
     {
-      "id": "AJ42",
-      "terrain": "df",
+      "id": "AJ42", "terrain": "df",
       "exits": {
-        "north": "AJ41",
-        "south": "AJ43",
-        "west": "AI42",
-        "east": "AK42"
+        "north": "AJ41", "south": "AJ43", "west": "AI42", "east": "AK42"
       }
     },
     {
-      "id": "AK42",
-      "terrain": "df",
+      "id": "AK42", "terrain": "df",
       "exits": {
-        "north": "AK41",
-        "south": "AK43",
-        "west": "AJ42",
-        "east": "AL42"
+        "north": "AK41", "south": "AK43", "west": "AJ42", "east": "AL42"
       }
     },
     {
-      "id": "AL42",
-      "terrain": "df",
+      "id": "AL42", "terrain": "df",
       "exits": {
-        "north": "AL41",
-        "south": "AL43",
-        "west": "AK42",
-        "east": "AM42"
+        "north": "AL41", "south": "AL43", "west": "AK42", "east": "AM42"
       }
     },
     {
-      "id": "AM42",
-      "terrain": "df",
+      "id": "AM42", "terrain": "df",
       "exits": {
-        "north": "AM41",
-        "south": "AM43",
-        "west": "AL42",
-        "east": "AN42"
+        "north": "AM41", "south": "AM43", "west": "AL42", "east": "AN42"
       }
     },
     {
-      "id": "AN42",
-      "terrain": "f",
+      "id": "AN42", "terrain": "f",
       "exits": {
-        "north": "AN41",
-        "south": "AN43",
-        "west": "AM42",
-        "east": "AO42"
+        "north": "AN41", "south": "AN43", "west": "AM42", "east": "AO42"
       }
     },
     {
-      "id": "AO42",
-      "terrain": "f",
+      "id": "AO42", "terrain": "f",
       "exits": {
-        "north": "AO41",
-        "south": "AO43",
-        "west": "AN42",
-        "east": "AP42"
+        "north": "AO41", "south": "AO43", "west": "AN42", "east": "AP42"
       }
     },
     {
-      "id": "AP42",
-      "terrain": "f",
+      "id": "AP42", "terrain": "f",
       "exits": {
-        "north": "AP41",
-        "south": "AP43",
-        "west": "AO42",
-        "east": "AQ42"
+        "north": "AP41", "south": "AP43", "west": "AO42", "east": "AQ42"
       }
     },
     {
-      "id": "AQ42",
-      "terrain": "f",
+      "id": "AQ42", "terrain": "f",
       "exits": {
-        "north": "AQ41",
-        "south": "AQ43",
-        "west": "AP42",
-        "east": "AR42"
+        "north": "AQ41", "south": "AQ43", "west": "AP42", "east": "AR42"
       }
     },
     {
-      "id": "AR42",
-      "terrain": "lf",
+      "id": "AR42", "terrain": "lf",
       "exits": {
-        "north": "AR41",
-        "south": "AR43",
-        "west": "AQ42",
-        "east": "AS42"
+        "north": "AR41", "south": "AR43", "west": "AQ42", "east": "AS42"
       }
     },
     {
-      "id": "AS42",
-      "terrain": "lf",
+      "id": "AS42", "terrain": "lf",
       "exits": {
-        "north": "AS41",
-        "south": "AS43",
-        "west": "AR42",
-        "east": "AT42"
+        "north": "AS41", "south": "AS43", "west": "AR42", "east": "AT42"
       }
     },
     {
-      "id": "AT42",
-      "terrain": "lf",
+      "id": "AT42", "terrain": "lf",
       "exits": {
-        "north": "AT41",
-        "south": "AT43",
-        "west": "AS42",
-        "east": "AU42"
+        "north": "AT41", "south": "AT43", "west": "AS42", "east": "AU42"
       }
     },
     {
-      "id": "AU42",
-      "terrain": "lf",
+      "id": "AU42", "terrain": "lf",
       "exits": {
-        "north": "AU41",
-        "south": "AU43",
-        "west": "AT42",
-        "east": "AV42"
+        "north": "AU41", "south": "AU43", "west": "AT42", "east": "AV42"
       }
     },
     {
-      "id": "AV42",
-      "terrain": "m",
+      "id": "AV42", "terrain": "m",
       "exits": {
-        "north": "AV41",
-        "south": "AV43",
-        "west": "AU42",
-        "east": "AW42"
+        "north": "AV41", "south": "AV43", "west": "AU42", "east": "AW42"
       }
     },
     {
-      "id": "AW42",
-      "terrain": "m",
+      "id": "AW42", "terrain": "m",
       "exits": {
-        "north": "AW41",
-        "south": "AW43",
-        "west": "AV42",
-        "east": "AX42"
+        "north": "AW41", "south": "AW43", "west": "AV42", "east": "AX42"
       }
     },
     {
-      "id": "AX42",
-      "terrain": "m",
+      "id": "AX42", "terrain": "m",
       "exits": {
-        "north": "AX41",
-        "south": "AX43",
-        "west": "AW42"
+        "north": "AX41", "south": "AX43", "west": "AW42"
       }
     },
     {
-      "id": "A43",
-      "terrain": "p",
+      "id": "A43", "terrain": "p",
       "exits": {
-        "north": "A42",
-        "south": "A44",
-        "east": "B43"
+        "north": "A42", "south": "A44", "east": "B43"
       }
     },
     {
-      "id": "B43",
-      "terrain": "p",
+      "id": "B43", "terrain": "p",
       "exits": {
-        "north": "B42",
-        "south": "B44",
-        "west": "A43",
-        "east": "C43"
+        "north": "B42", "south": "B44", "west": "A43", "east": "C43"
       }
     },
     {
-      "id": "C43",
-      "terrain": "p",
+      "id": "C43", "terrain": "p",
       "exits": {
-        "north": "C42",
-        "south": "C44",
-        "west": "B43",
-        "east": "D43"
+        "north": "C42", "south": "C44", "west": "B43", "east": "D43"
       }
     },
     {
-      "id": "D43",
-      "terrain": "p",
+      "id": "D43", "terrain": "p",
       "exits": {
-        "north": "D42",
-        "south": "D44",
-        "west": "C43",
-        "east": "E43"
+        "north": "D42", "south": "D44", "west": "C43", "east": "E43"
       }
     },
     {
-      "id": "E43",
-      "terrain": "p",
+      "id": "E43", "terrain": "p",
       "exits": {
-        "north": "E42",
-        "south": "E44",
-        "west": "D43",
-        "east": "F43"
+        "north": "E42", "south": "E44", "west": "D43", "east": "F43"
       }
     },
     {
-      "id": "F43",
-      "terrain": "p",
+      "id": "F43", "terrain": "p",
       "exits": {
-        "north": "F42",
-        "south": "F44",
-        "west": "E43",
-        "east": "G43"
+        "north": "F42", "south": "F44", "west": "E43", "east": "G43"
       }
     },
     {
-      "id": "G43",
-      "terrain": "p",
+      "id": "G43", "terrain": "p",
       "exits": {
-        "north": "G42",
-        "south": "G44",
-        "west": "F43",
-        "east": "H43"
+        "north": "G42", "south": "G44", "west": "F43", "east": "H43"
       }
     },
     {
-      "id": "H43",
-      "terrain": "p",
+      "id": "H43", "terrain": "p",
       "exits": {
-        "north": "H42",
-        "south": "H44",
-        "west": "G43",
-        "east": "I43"
+        "north": "H42", "south": "H44", "west": "G43", "east": "I43"
       }
     },
     {
-      "id": "I43",
-      "terrain": "p",
+      "id": "I43", "terrain": "p",
       "exits": {
-        "north": "I42",
-        "south": "I44",
-        "west": "H43",
-        "east": "J43"
+        "north": "I42", "south": "I44", "west": "H43", "east": "J43"
       }
     },
     {
-      "id": "J43",
-      "terrain": "p",
+      "id": "J43", "terrain": "p",
       "exits": {
-        "north": "J42",
-        "south": "J44",
-        "west": "I43",
-        "east": "K43"
+        "north": "J42", "south": "J44", "west": "I43", "east": "K43"
       }
     },
     {
-      "id": "K43",
-      "terrain": "j",
+      "id": "K43", "terrain": "j",
       "exits": {
-        "north": "K42",
-        "south": "K44",
-        "west": "J43",
-        "east": "L43"
+        "north": "K42", "south": "K44", "west": "J43", "east": "L43"
       }
     },
     {
-      "id": "L43",
-      "terrain": "p",
+      "id": "L43", "terrain": "p",
       "exits": {
-        "north": "L42",
-        "south": "L44",
-        "west": "K43",
-        "east": "M43"
+        "north": "L42", "south": "L44", "west": "K43", "east": "M43"
       }
     },
     {
-      "id": "M43",
-      "terrain": "p",
+      "id": "M43", "terrain": "p",
       "exits": {
-        "north": "M42",
-        "south": "M44",
-        "west": "L43",
-        "east": "N43"
+        "north": "M42", "south": "M44", "west": "L43", "east": "N43"
       }
     },
     {
-      "id": "N43",
-      "terrain": "p",
+      "id": "N43", "terrain": "p",
       "exits": {
-        "north": "N42",
-        "south": "N44",
-        "west": "M43",
-        "east": "O43"
+        "north": "N42", "south": "N44", "west": "M43", "east": "O43"
       }
     },
     {
-      "id": "O43",
-      "terrain": "p",
+      "id": "O43", "terrain": "p",
       "exits": {
-        "north": "O42",
-        "south": "O44",
-        "west": "N43",
-        "east": "P43"
+        "north": "O42", "south": "O44", "west": "N43", "east": "P43"
       }
     },
     {
-      "id": "P43",
-      "terrain": "w",
+      "id": "P43", "terrain": "w",
       "exits": {
-        "north": "P42",
-        "south": "P44",
-        "west": "O43",
-        "east": "Q43"
+        "north": "P42", "south": "P44", "west": "O43", "east": "Q43"
       }
     },
     {
-      "id": "Q43",
-      "terrain": "b",
+      "id": "Q43", "terrain": "b",
       "exits": {
-        "north": "Q42",
-        "south": "Q44",
-        "west": "P43",
-        "east": "R43"
+        "north": "Q42", "south": "Q44", "west": "P43", "east": "R43"
       }
     },
     {
-      "id": "R43",
-      "terrain": "p",
+      "id": "R43", "terrain": "p",
       "exits": {
-        "north": "R42",
-        "south": "R44",
-        "west": "Q43",
-        "east": "S43"
+        "north": "R42", "south": "R44", "west": "Q43", "east": "S43"
       }
     },
     {
-      "id": "S43",
-      "terrain": "p",
+      "id": "S43", "terrain": "p",
       "exits": {
-        "north": "S42",
-        "south": "S44",
-        "west": "R43",
-        "east": "T43"
+        "north": "S42", "south": "S44", "west": "R43", "east": "T43"
       }
     },
     {
-      "id": "T43",
-      "terrain": "w",
+      "id": "T43", "terrain": "w",
       "exits": {
-        "north": "T42",
-        "south": "T44",
-        "west": "S43",
-        "east": "U43"
+        "north": "T42", "south": "T44", "west": "S43", "east": "U43"
       }
     },
     {
-      "id": "U43",
-      "terrain": "w",
+      "id": "U43", "terrain": "w",
       "exits": {
-        "north": "U42",
-        "south": "U44",
-        "west": "T43",
-        "east": "V43"
+        "north": "U42", "south": "U44", "west": "T43", "east": "V43"
       }
     },
     {
-      "id": "V43",
-      "terrain": "w",
+      "id": "V43", "terrain": "w",
       "exits": {
-        "north": "V42",
-        "south": "V44",
-        "west": "U43",
-        "east": "W43"
+        "north": "V42", "south": "V44", "west": "U43", "east": "W43"
       }
     },
     {
-      "id": "W43",
-      "terrain": "w",
+      "id": "W43", "terrain": "w",
       "exits": {
-        "north": "W42",
-        "south": "W44",
-        "west": "V43",
-        "east": "X43"
+        "north": "W42", "south": "W44", "west": "V43", "east": "X43"
       }
     },
     {
-      "id": "X43",
-      "terrain": "p",
+      "id": "X43", "terrain": "p",
       "exits": {
-        "north": "X42",
-        "south": "X44",
-        "west": "W43",
-        "east": "Y43"
+        "north": "X42", "south": "X44", "west": "W43", "east": "Y43"
       }
     },
     {
-      "id": "Y43",
-      "terrain": "r",
+      "id": "Y43", "terrain": "r",
       "exits": {
-        "north": "Y42",
-        "south": "Y44",
-        "west": "X43",
-        "east": "Z43"
+        "north": "Y42", "south": "Y44", "west": "X43", "east": "Z43"
       }
     },
     {
-      "id": "Z43",
-      "terrain": "p",
+      "id": "Z43", "terrain": "p",
       "exits": {
-        "north": "Z42",
-        "south": "Z44",
-        "west": "Y43",
-        "east": "AA43"
+        "north": "Z42", "south": "Z44", "west": "Y43", "east": "AA43"
       }
     },
     {
-      "id": "AA43",
-      "terrain": "p",
+      "id": "AA43", "terrain": "p",
       "exits": {
-        "north": "AA42",
-        "south": "AA44",
-        "west": "Z43",
-        "east": "AB43"
+        "north": "AA42", "south": "AA44", "west": "Z43", "east": "AB43"
       }
     },
     {
-      "id": "AB43",
-      "terrain": "p",
+      "id": "AB43", "terrain": "p",
       "exits": {
-        "north": "AB42",
-        "south": "AB44",
-        "west": "AA43",
-        "east": "AC43"
+        "north": "AB42", "south": "AB44", "west": "AA43", "east": "AC43"
       }
     },
     {
-      "id": "AC43",
-      "terrain": "df",
+      "id": "AC43", "terrain": "df",
       "exits": {
-        "north": "AC42",
-        "south": "AC44",
-        "west": "AB43",
-        "east": "AD43"
+        "north": "AC42", "south": "AC44", "west": "AB43", "east": "AD43"
       }
     },
     {
-      "id": "AD43",
-      "terrain": "df",
+      "id": "AD43", "terrain": "df",
       "exits": {
-        "north": "AD42",
-        "south": "AD44",
-        "west": "AC43",
-        "east": "AE43"
+        "north": "AD42", "south": "AD44", "west": "AC43", "east": "AE43"
       }
     },
     {
-      "id": "AE43",
-      "terrain": "df",
+      "id": "AE43", "terrain": "df",
       "exits": {
-        "north": "AE42",
-        "south": "AE44",
-        "west": "AD43",
-        "east": "AF43"
+        "north": "AE42", "south": "AE44", "west": "AD43", "east": "AF43"
       }
     },
     {
-      "id": "AF43",
-      "terrain": "df",
+      "id": "AF43", "terrain": "df",
       "exits": {
-        "north": "AF42",
-        "south": "AF44",
-        "west": "AE43",
-        "east": "AG43"
+        "north": "AF42", "south": "AF44", "west": "AE43", "east": "AG43"
       }
     },
     {
-      "id": "AG43",
-      "terrain": "df",
+      "id": "AG43", "terrain": "df",
       "exits": {
-        "north": "AG42",
-        "south": "AG44",
-        "west": "AF43",
-        "east": "AH43"
+        "north": "AG42", "south": "AG44", "west": "AF43", "east": "AH43"
       }
     },
     {
-      "id": "AH43",
-      "terrain": "df",
+      "id": "AH43", "terrain": "df",
       "exits": {
-        "north": "AH42",
-        "south": "AH44",
-        "west": "AG43",
-        "east": "AI43"
+        "north": "AH42", "south": "AH44", "west": "AG43", "east": "AI43"
       }
     },
     {
-      "id": "AI43",
-      "terrain": "df",
+      "id": "AI43", "terrain": "df",
       "exits": {
-        "north": "AI42",
-        "south": "AI44",
-        "west": "AH43",
-        "east": "AJ43"
+        "north": "AI42", "south": "AI44", "west": "AH43", "east": "AJ43"
       }
     },
     {
-      "id": "AJ43",
-      "terrain": "df",
+      "id": "AJ43", "terrain": "df",
       "exits": {
-        "north": "AJ42",
-        "south": "AJ44",
-        "west": "AI43",
-        "east": "AK43"
+        "north": "AJ42", "south": "AJ44", "west": "AI43", "east": "AK43"
       }
     },
     {
-      "id": "AK43",
-      "terrain": "df",
+      "id": "AK43", "terrain": "df",
       "exits": {
-        "north": "AK42",
-        "south": "AK44",
-        "west": "AJ43",
-        "east": "AL43"
+        "north": "AK42", "south": "AK44", "west": "AJ43", "east": "AL43"
       }
     },
     {
-      "id": "AL43",
-      "terrain": "df",
+      "id": "AL43", "terrain": "df",
       "exits": {
-        "north": "AL42",
-        "south": "AL44",
-        "west": "AK43",
-        "east": "AM43"
+        "north": "AL42", "south": "AL44", "west": "AK43", "east": "AM43"
       }
     },
     {
-      "id": "AM43",
-      "terrain": "df",
+      "id": "AM43", "terrain": "df",
       "exits": {
-        "north": "AM42",
-        "south": "AM44",
-        "west": "AL43",
-        "east": "AN43"
+        "north": "AM42", "south": "AM44", "west": "AL43", "east": "AN43"
       }
     },
     {
-      "id": "AN43",
-      "terrain": "f",
+      "id": "AN43", "terrain": "f",
       "exits": {
-        "north": "AN42",
-        "south": "AN44",
-        "west": "AM43",
-        "east": "AO43"
+        "north": "AN42", "south": "AN44", "west": "AM43", "east": "AO43"
       }
     },
     {
-      "id": "AO43",
-      "terrain": "f",
+      "id": "AO43", "terrain": "f",
       "exits": {
-        "north": "AO42",
-        "south": "AO44",
-        "west": "AN43",
-        "east": "AP43"
+        "north": "AO42", "south": "AO44", "west": "AN43", "east": "AP43"
       }
     },
     {
-      "id": "AP43",
-      "terrain": "f",
+      "id": "AP43", "terrain": "f",
       "exits": {
-        "north": "AP42",
-        "south": "AP44",
-        "west": "AO43",
-        "east": "AQ43"
+        "north": "AP42", "south": "AP44", "west": "AO43", "east": "AQ43"
       }
     },
     {
-      "id": "AQ43",
-      "terrain": "lf",
+      "id": "AQ43", "terrain": "lf",
       "exits": {
-        "north": "AQ42",
-        "south": "AQ44",
-        "west": "AP43",
-        "east": "AR43"
+        "north": "AQ42", "south": "AQ44", "west": "AP43", "east": "AR43"
       }
     },
     {
-      "id": "AR43",
-      "terrain": "lf",
+      "id": "AR43", "terrain": "lf",
       "exits": {
-        "north": "AR42",
-        "south": "AR44",
-        "west": "AQ43",
-        "east": "AS43"
+        "north": "AR42", "south": "AR44", "west": "AQ43", "east": "AS43"
       }
     },
     {
-      "id": "AS43",
-      "terrain": "f",
+      "id": "AS43", "terrain": "f",
       "exits": {
-        "north": "AS42",
-        "south": "AS44",
-        "west": "AR43",
-        "east": "AT43"
+        "north": "AS42", "south": "AS44", "west": "AR43", "east": "AT43"
       }
     },
     {
-      "id": "AT43",
-      "terrain": "lf",
+      "id": "AT43", "terrain": "lf",
       "exits": {
-        "north": "AT42",
-        "south": "AT44",
-        "west": "AS43",
-        "east": "AU43"
+        "north": "AT42", "south": "AT44", "west": "AS43", "east": "AU43"
       }
     },
     {
-      "id": "AU43",
-      "terrain": "m",
+      "id": "AU43", "terrain": "m",
       "exits": {
-        "north": "AU42",
-        "south": "AU44",
-        "west": "AT43",
-        "east": "AV43"
+        "north": "AU42", "south": "AU44", "west": "AT43", "east": "AV43"
       }
     },
     {
-      "id": "AV43",
-      "terrain": "m",
+      "id": "AV43", "terrain": "m",
       "exits": {
-        "north": "AV42",
-        "south": "AV44",
-        "west": "AU43",
-        "east": "AW43"
+        "north": "AV42", "south": "AV44", "west": "AU43", "east": "AW43"
       }
     },
     {
-      "id": "AW43",
-      "terrain": "m",
+      "id": "AW43", "terrain": "m",
       "exits": {
-        "north": "AW42",
-        "south": "AW44",
-        "west": "AV43",
-        "east": "AX43"
+        "north": "AW42", "south": "AW44", "west": "AV43", "east": "AX43"
       }
     },
     {
-      "id": "AX43",
-      "terrain": "m",
+      "id": "AX43", "terrain": "m",
       "exits": {
-        "north": "AX42",
-        "south": "AX44",
-        "west": "AW43"
+        "north": "AX42", "south": "AX44", "west": "AW43"
       }
     },
     {
-      "id": "A44",
-      "terrain": "p",
+      "id": "A44", "terrain": "p",
       "exits": {
-        "north": "A43",
-        "south": "A45",
-        "east": "B44"
+        "north": "A43", "south": "A45", "east": "B44"
       }
     },
     {
-      "id": "B44",
-      "terrain": "p",
+      "id": "B44", "terrain": "p",
       "exits": {
-        "north": "B43",
-        "south": "B45",
-        "west": "A44",
-        "east": "C44"
+        "north": "B43", "south": "B45", "west": "A44", "east": "C44"
       }
     },
     {
-      "id": "C44",
-      "terrain": "p",
+      "id": "C44", "terrain": "p",
       "exits": {
-        "north": "C43",
-        "south": "C45",
-        "west": "B44",
-        "east": "D44"
+        "north": "C43", "south": "C45", "west": "B44", "east": "D44"
       }
     },
     {
-      "id": "D44",
-      "terrain": "p",
+      "id": "D44", "terrain": "p",
       "exits": {
-        "north": "D43",
-        "south": "D45",
-        "west": "C44",
-        "east": "E44"
+        "north": "D43", "south": "D45", "west": "C44", "east": "E44"
       }
     },
     {
-      "id": "E44",
-      "terrain": "p",
+      "id": "E44", "terrain": "p",
       "exits": {
-        "north": "E43",
-        "south": "E45",
-        "west": "D44",
-        "east": "F44"
+        "north": "E43", "south": "E45", "west": "D44", "east": "F44"
       }
     },
     {
-      "id": "F44",
-      "terrain": "p",
+      "id": "F44", "terrain": "p",
       "exits": {
-        "north": "F43",
-        "south": "F45",
-        "west": "E44",
-        "east": "G44"
+        "north": "F43", "south": "F45", "west": "E44", "east": "G44"
       }
     },
     {
-      "id": "G44",
-      "terrain": "p",
+      "id": "G44", "terrain": "p",
       "exits": {
-        "north": "G43",
-        "south": "G45",
-        "west": "F44",
-        "east": "H44"
+        "north": "G43", "south": "G45", "west": "F44", "east": "H44"
       }
     },
     {
-      "id": "H44",
-      "terrain": "p",
+      "id": "H44", "terrain": "p",
       "exits": {
-        "north": "H43",
-        "south": "H45",
-        "west": "G44",
-        "east": "I44"
+        "north": "H43", "south": "H45", "west": "G44", "east": "I44"
       }
     },
     {
-      "id": "I44",
-      "terrain": "p",
+      "id": "I44", "terrain": "p",
       "exits": {
-        "north": "I43",
-        "south": "I45",
-        "west": "H44",
-        "east": "J44"
+        "north": "I43", "south": "I45", "west": "H44", "east": "J44"
       }
     },
     {
-      "id": "J44",
-      "terrain": "j",
+      "id": "J44", "terrain": "j",
       "exits": {
-        "north": "J43",
-        "south": "J45",
-        "west": "I44",
-        "east": "K44"
+        "north": "J43", "south": "J45", "west": "I44", "east": "K44"
       }
     },
     {
-      "id": "K44",
-      "terrain": "j",
+      "id": "K44", "terrain": "j",
       "exits": {
-        "north": "K43",
-        "south": "K45",
-        "west": "J44",
-        "east": "L44"
+        "north": "K43", "south": "K45", "west": "J44", "east": "L44"
       }
     },
     {
-      "id": "L44",
-      "terrain": "j",
+      "id": "L44", "terrain": "j",
       "exits": {
-        "north": "L43",
-        "south": "L45",
-        "west": "K44",
-        "east": "M44"
+        "north": "L43", "south": "L45", "west": "K44", "east": "M44"
       }
     },
     {
-      "id": "M44",
-      "terrain": "p",
+      "id": "M44", "terrain": "p",
       "exits": {
-        "north": "M43",
-        "south": "M45",
-        "west": "L44",
-        "east": "N44"
+        "north": "M43", "south": "M45", "west": "L44", "east": "N44"
       }
     },
     {
-      "id": "N44",
-      "terrain": "p",
+      "id": "N44", "terrain": "p",
       "exits": {
-        "north": "N43",
-        "south": "N45",
-        "west": "M44",
-        "east": "O44"
+        "north": "N43", "south": "N45", "west": "M44", "east": "O44"
       }
     },
     {
-      "id": "O44",
-      "terrain": "p",
+      "id": "O44", "terrain": "p",
       "exits": {
-        "north": "O43",
-        "south": "O45",
-        "west": "N44",
-        "east": "P44"
+        "north": "O43", "south": "O45", "west": "N44", "east": "P44"
       }
     },
     {
-      "id": "P44",
-      "terrain": "w",
+      "id": "P44", "terrain": "w",
       "exits": {
-        "north": "P43",
-        "south": "P45",
-        "west": "O44",
-        "east": "Q44"
+        "north": "P43", "south": "P45", "west": "O44", "east": "Q44"
       }
     },
     {
-      "id": "Q44",
-      "terrain": "p",
+      "id": "Q44", "terrain": "p",
       "exits": {
-        "north": "Q43",
-        "south": "Q45",
-        "west": "P44",
-        "east": "R44"
+        "north": "Q43", "south": "Q45", "west": "P44", "east": "R44"
       }
     },
     {
-      "id": "R44",
-      "terrain": "p",
+      "id": "R44", "terrain": "p",
       "exits": {
-        "north": "R43",
-        "south": "R45",
-        "west": "Q44",
-        "east": "S44"
+        "north": "R43", "south": "R45", "west": "Q44", "east": "S44"
       }
     },
     {
-      "id": "S44",
-      "terrain": "p",
+      "id": "S44", "terrain": "p",
       "exits": {
-        "north": "S43",
-        "south": "S45",
-        "west": "R44",
-        "east": "T44"
+        "north": "S43", "south": "S45", "west": "R44", "east": "T44"
       }
     },
     {
-      "id": "T44",
-      "terrain": "p",
+      "id": "T44", "terrain": "p",
       "exits": {
-        "north": "T43",
-        "south": "T45",
-        "west": "S44",
-        "east": "U44"
+        "north": "T43", "south": "T45", "west": "S44", "east": "U44"
       }
     },
     {
-      "id": "U44",
-      "terrain": "p",
+      "id": "U44", "terrain": "p",
       "exits": {
-        "north": "U43",
-        "south": "U45",
-        "west": "T44",
-        "east": "V44"
+        "north": "U43", "south": "U45", "west": "T44", "east": "V44"
       }
     },
     {
-      "id": "V44",
-      "terrain": "w",
+      "id": "V44", "terrain": "w",
       "exits": {
-        "north": "V43",
-        "south": "V45",
-        "west": "U44",
-        "east": "W44"
+        "north": "V43", "south": "V45", "west": "U44", "east": "W44"
       }
     },
     {
-      "id": "W44",
-      "terrain": "w",
+      "id": "W44", "terrain": "w",
       "exits": {
-        "north": "W43",
-        "south": "W45",
-        "west": "V44",
-        "east": "X44"
+        "north": "W43", "south": "W45", "west": "V44", "east": "X44"
       }
     },
     {
-      "id": "X44",
-      "terrain": "w",
+      "id": "X44", "terrain": "w",
       "exits": {
-        "north": "X43",
-        "south": "X45",
-        "west": "W44",
-        "east": "Y44"
+        "north": "X43", "south": "X45", "west": "W44", "east": "Y44"
       }
     },
     {
-      "id": "Y44",
-      "terrain": "r",
+      "id": "Y44", "terrain": "r",
       "exits": {
-        "north": "Y43",
-        "south": "Y45",
-        "west": "X44",
-        "east": "Z44"
+        "north": "Y43", "south": "Y45", "west": "X44", "east": "Z44"
       }
     },
     {
-      "id": "Z44",
-      "terrain": "p",
+      "id": "Z44", "terrain": "p",
       "exits": {
-        "north": "Z43",
-        "south": "Z45",
-        "west": "Y44",
-        "east": "AA44"
+        "north": "Z43", "south": "Z45", "west": "Y44", "east": "AA44"
       }
     },
     {
-      "id": "AA44",
-      "terrain": "p",
+      "id": "AA44", "terrain": "p",
       "exits": {
-        "north": "AA43",
-        "south": "AA45",
-        "west": "Z44",
-        "east": "AB44"
+        "north": "AA43", "south": "AA45", "west": "Z44", "east": "AB44"
       }
     },
     {
-      "id": "AB44",
-      "terrain": "p",
+      "id": "AB44", "terrain": "p",
       "exits": {
-        "north": "AB43",
-        "south": "AB45",
-        "west": "AA44",
-        "east": "AC44"
+        "north": "AB43", "south": "AB45", "west": "AA44", "east": "AC44"
       }
     },
     {
-      "id": "AC44",
-      "terrain": "h",
+      "id": "AC44", "terrain": "h",
       "exits": {
-        "north": "AC43",
-        "south": "AC45",
-        "west": "AB44",
-        "east": "AD44"
+        "north": "AC43", "south": "AC45", "west": "AB44", "east": "AD44"
       }
     },
     {
-      "id": "AD44",
-      "terrain": "h",
+      "id": "AD44", "terrain": "h",
       "exits": {
-        "north": "AD43",
-        "south": "AD45",
-        "west": "AC44",
-        "east": "AE44"
+        "north": "AD43", "south": "AD45", "west": "AC44", "east": "AE44"
       }
     },
     {
-      "id": "AE44",
-      "terrain": "f",
+      "id": "AE44", "terrain": "f",
       "exits": {
-        "north": "AE43",
-        "south": "AE45",
-        "west": "AD44",
-        "east": "AF44"
+        "north": "AE43", "south": "AE45", "west": "AD44", "east": "AF44"
       }
     },
     {
-      "id": "AF44",
-      "terrain": "f",
+      "id": "AF44", "terrain": "f",
       "exits": {
-        "north": "AF43",
-        "south": "AF45",
-        "west": "AE44",
-        "east": "AG44"
+        "north": "AF43", "south": "AF45", "west": "AE44", "east": "AG44"
       }
     },
     {
-      "id": "AG44",
-      "terrain": "df",
+      "id": "AG44", "terrain": "df",
       "exits": {
-        "north": "AG43",
-        "south": "AG45",
-        "west": "AF44",
-        "east": "AH44"
+        "north": "AG43", "south": "AG45", "west": "AF44", "east": "AH44"
       }
     },
     {
-      "id": "AH44",
-      "terrain": "df",
+      "id": "AH44", "terrain": "df",
       "exits": {
-        "north": "AH43",
-        "south": "AH45",
-        "west": "AG44",
-        "east": "AI44"
+        "north": "AH43", "south": "AH45", "west": "AG44", "east": "AI44"
       }
     },
     {
-      "id": "AI44",
-      "terrain": "df",
+      "id": "AI44", "terrain": "df",
       "exits": {
-        "north": "AI43",
-        "south": "AI45",
-        "west": "AH44",
-        "east": "AJ44"
+        "north": "AI43", "south": "AI45", "west": "AH44", "east": "AJ44"
       }
     },
     {
-      "id": "AJ44",
-      "terrain": "f",
+      "id": "AJ44", "terrain": "f",
       "exits": {
-        "north": "AJ43",
-        "south": "AJ45",
-        "west": "AI44",
-        "east": "AK44"
+        "north": "AJ43", "south": "AJ45", "west": "AI44", "east": "AK44"
       }
     },
     {
-      "id": "AK44",
-      "terrain": "df",
+      "id": "AK44", "terrain": "df",
       "exits": {
-        "north": "AK43",
-        "south": "AK45",
-        "west": "AJ44",
-        "east": "AL44"
+        "north": "AK43", "south": "AK45", "west": "AJ44", "east": "AL44"
       }
     },
     {
-      "id": "AL44",
-      "terrain": "df",
+      "id": "AL44", "terrain": "df",
       "exits": {
-        "north": "AL43",
-        "south": "AL45",
-        "west": "AK44",
-        "east": "AM44"
+        "north": "AL43", "south": "AL45", "west": "AK44", "east": "AM44"
       }
     },
     {
-      "id": "AM44",
-      "terrain": "df",
+      "id": "AM44", "terrain": "df",
       "exits": {
-        "north": "AM43",
-        "south": "AM45",
-        "west": "AL44",
-        "east": "AN44"
+        "north": "AM43", "south": "AM45", "west": "AL44", "east": "AN44"
       }
     },
     {
-      "id": "AN44",
-      "terrain": "df",
+      "id": "AN44", "terrain": "df",
       "exits": {
-        "north": "AN43",
-        "south": "AN45",
-        "west": "AM44",
-        "east": "AO44"
+        "north": "AN43", "south": "AN45", "west": "AM44", "east": "AO44"
       }
     },
     {
-      "id": "AO44",
-      "terrain": "lf",
+      "id": "AO44", "terrain": "lf",
       "exits": {
-        "north": "AO43",
-        "south": "AO45",
-        "west": "AN44",
-        "east": "AP44"
+        "north": "AO43", "south": "AO45", "west": "AN44", "east": "AP44"
       }
     },
     {
-      "id": "AP44",
-      "terrain": "lf",
+      "id": "AP44", "terrain": "lf",
       "exits": {
-        "north": "AP43",
-        "south": "AP45",
-        "west": "AO44",
-        "east": "AQ44"
+        "north": "AP43", "south": "AP45", "west": "AO44", "east": "AQ44"
       }
     },
     {
-      "id": "AQ44",
-      "terrain": "f",
+      "id": "AQ44", "terrain": "f",
       "exits": {
-        "north": "AQ43",
-        "south": "AQ45",
-        "west": "AP44",
-        "east": "AR44"
+        "north": "AQ43", "south": "AQ45", "west": "AP44", "east": "AR44"
       }
     },
     {
-      "id": "AR44",
-      "terrain": "lf",
+      "id": "AR44", "terrain": "lf",
       "exits": {
-        "north": "AR43",
-        "south": "AR45",
-        "west": "AQ44",
-        "east": "AS44"
+        "north": "AR43", "south": "AR45", "west": "AQ44", "east": "AS44"
       }
     },
     {
-      "id": "AS44",
-      "terrain": "p",
+      "id": "AS44", "terrain": "p",
       "exits": {
-        "north": "AS43",
-        "south": "AS45",
-        "west": "AR44",
-        "east": "AT44"
+        "north": "AS43", "south": "AS45", "west": "AR44", "east": "AT44"
       }
     },
     {
-      "id": "AT44",
-      "terrain": "lf",
+      "id": "AT44", "terrain": "lf",
       "exits": {
-        "north": "AT43",
-        "south": "AT45",
-        "west": "AS44",
-        "east": "AU44"
+        "north": "AT43", "south": "AT45", "west": "AS44", "east": "AU44"
       }
     },
     {
-      "id": "AU44",
-      "terrain": "lf",
+      "id": "AU44", "terrain": "lf",
       "exits": {
-        "north": "AU43",
-        "south": "AU45",
-        "west": "AT44",
-        "east": "AV44"
+        "north": "AU43", "south": "AU45", "west": "AT44", "east": "AV44"
       }
     },
     {
-      "id": "AV44",
-      "terrain": "p",
+      "id": "AV44", "terrain": "p",
       "exits": {
-        "north": "AV43",
-        "south": "AV45",
-        "west": "AU44",
-        "east": "AW44"
+        "north": "AV43", "south": "AV45", "west": "AU44", "east": "AW44"
       }
     },
     {
-      "id": "AW44",
-      "terrain": "p",
+      "id": "AW44", "terrain": "p",
       "exits": {
-        "north": "AW43",
-        "south": "AW45",
-        "west": "AV44",
-        "east": "AX44"
+        "north": "AW43", "south": "AW45", "west": "AV44", "east": "AX44"
       }
     },
     {
-      "id": "AX44",
-      "terrain": "p",
+      "id": "AX44", "terrain": "p",
       "exits": {
-        "north": "AX43",
-        "south": "AX45",
-        "west": "AW44"
+        "north": "AX43", "south": "AX45", "west": "AW44"
       }
     },
     {
-      "id": "A45",
-      "terrain": "p",
+      "id": "A45", "terrain": "p",
       "exits": {
-        "north": "A44",
-        "south": "A46",
-        "east": "B45"
+        "north": "A44", "south": "A46", "east": "B45"
       }
     },
     {
-      "id": "B45",
-      "terrain": "p",
+      "id": "B45", "terrain": "p",
       "exits": {
-        "north": "B44",
-        "south": "B46",
-        "west": "A45",
-        "east": "C45"
+        "north": "B44", "south": "B46", "west": "A45", "east": "C45"
       }
     },
     {
-      "id": "C45",
-      "terrain": "p",
+      "id": "C45", "terrain": "p",
       "exits": {
-        "north": "C44",
-        "south": "C46",
-        "west": "B45",
-        "east": "D45"
+        "north": "C44", "south": "C46", "west": "B45", "east": "D45"
       }
     },
     {
-      "id": "D45",
-      "terrain": "p",
+      "id": "D45", "terrain": "p",
       "exits": {
-        "north": "D44",
-        "south": "D46",
-        "west": "C45",
-        "east": "E45"
+        "north": "D44", "south": "D46", "west": "C45", "east": "E45"
       }
     },
     {
-      "id": "E45",
-      "terrain": "p",
+      "id": "E45", "terrain": "p",
       "exits": {
-        "north": "E44",
-        "south": "E46",
-        "west": "D45",
-        "east": "F45"
+        "north": "E44", "south": "E46", "west": "D45", "east": "F45"
       }
     },
     {
-      "id": "F45",
-      "terrain": "p",
+      "id": "F45", "terrain": "p",
       "exits": {
-        "north": "F44",
-        "south": "F46",
-        "west": "E45",
-        "east": "G45"
+        "north": "F44", "south": "F46", "west": "E45", "east": "G45"
       }
     },
     {
-      "id": "G45",
-      "terrain": "p",
+      "id": "G45", "terrain": "p",
       "exits": {
-        "north": "G44",
-        "south": "G46",
-        "west": "F45",
-        "east": "H45"
+        "north": "G44", "south": "G46", "west": "F45", "east": "H45"
       }
     },
     {
-      "id": "H45",
-      "terrain": "p",
+      "id": "H45", "terrain": "p",
       "exits": {
-        "north": "H44",
-        "south": "H46",
-        "west": "G45",
-        "east": "I45"
+        "north": "H44", "south": "H46", "west": "G45", "east": "I45"
       }
     },
     {
-      "id": "I45",
-      "terrain": "j",
+      "id": "I45", "terrain": "j",
       "exits": {
-        "north": "I44",
-        "south": "I46",
-        "west": "H45",
-        "east": "J45"
+        "north": "I44", "south": "I46", "west": "H45", "east": "J45"
       }
     },
     {
-      "id": "J45",
-      "terrain": "j",
+      "id": "J45", "terrain": "j",
       "exits": {
-        "north": "J44",
-        "south": "J46",
-        "west": "I45",
-        "east": "K45"
+        "north": "J44", "south": "J46", "west": "I45", "east": "K45"
       }
     },
     {
-      "id": "K45",
-      "terrain": "j",
+      "id": "K45", "terrain": "j",
       "exits": {
-        "north": "K44",
-        "south": "K46",
-        "west": "J45",
-        "east": "L45"
+        "north": "K44", "south": "K46", "west": "J45", "east": "L45"
       }
     },
     {
-      "id": "L45",
-      "terrain": "j",
+      "id": "L45", "terrain": "j",
       "exits": {
-        "north": "L44",
-        "south": "L46",
-        "west": "K45",
-        "east": "M45"
+        "north": "L44", "south": "L46", "west": "K45", "east": "M45"
       }
     },
     {
-      "id": "M45",
-      "terrain": "p",
+      "id": "M45", "terrain": "p",
       "exits": {
-        "north": "M44",
-        "south": "M46",
-        "west": "L45",
-        "east": "N45"
+        "north": "M44", "south": "M46", "west": "L45", "east": "N45"
       }
     },
     {
-      "id": "N45",
-      "terrain": "p",
+      "id": "N45", "terrain": "p",
       "exits": {
-        "north": "N44",
-        "south": "N46",
-        "west": "M45",
-        "east": "O45"
+        "north": "N44", "south": "N46", "west": "M45", "east": "O45"
       }
     },
     {
-      "id": "O45",
-      "terrain": "w",
+      "id": "O45", "terrain": "w",
       "exits": {
-        "north": "O44",
-        "south": "O46",
-        "west": "N45",
-        "east": "P45"
+        "north": "O44", "south": "O46", "west": "N45", "east": "P45"
       }
     },
     {
-      "id": "P45",
-      "terrain": "j",
+      "id": "P45", "terrain": "j",
       "exits": {
-        "north": "P44",
-        "south": "P46",
-        "west": "O45",
-        "east": "Q45"
+        "north": "P44", "south": "P46", "west": "O45", "east": "Q45"
       }
     },
     {
-      "id": "Q45",
-      "terrain": "p",
+      "id": "Q45", "terrain": "p",
       "exits": {
-        "north": "Q44",
-        "south": "Q46",
-        "west": "P45",
-        "east": "R45"
+        "north": "Q44", "south": "Q46", "west": "P45", "east": "R45"
       }
     },
     {
-      "id": "R45",
-      "terrain": "p",
+      "id": "R45", "terrain": "p",
       "exits": {
-        "north": "R44",
-        "south": "R46",
-        "west": "Q45",
-        "east": "S45"
+        "north": "R44", "south": "R46", "west": "Q45", "east": "S45"
       }
     },
     {
-      "id": "S45",
-      "terrain": "p",
+      "id": "S45", "terrain": "p",
       "exits": {
-        "north": "S44",
-        "south": "S46",
-        "west": "R45",
-        "east": "T45"
+        "north": "S44", "south": "S46", "west": "R45", "east": "T45"
       }
     },
     {
-      "id": "T45",
-      "terrain": "p",
+      "id": "T45", "terrain": "p",
       "exits": {
-        "north": "T44",
-        "south": "T46",
-        "west": "S45",
-        "east": "U45"
+        "north": "T44", "south": "T46", "west": "S45", "east": "U45"
       }
     },
     {
-      "id": "U45",
-      "terrain": "p",
+      "id": "U45", "terrain": "p",
       "exits": {
-        "north": "U44",
-        "south": "U46",
-        "west": "T45",
-        "east": "V45"
+        "north": "U44", "south": "U46", "west": "T45", "east": "V45"
       }
     },
     {
-      "id": "V45",
-      "terrain": "p",
+      "id": "V45", "terrain": "p",
       "exits": {
-        "north": "V44",
-        "south": "V46",
-        "west": "U45",
-        "east": "W45"
+        "north": "V44", "south": "V46", "west": "U45", "east": "W45"
       }
     },
     {
-      "id": "W45",
-      "terrain": "w",
+      "id": "W45", "terrain": "w",
       "exits": {
-        "north": "W44",
-        "south": "W46",
-        "west": "V45",
-        "east": "X45"
+        "north": "W44", "south": "W46", "west": "V45", "east": "X45"
       }
     },
     {
-      "id": "X45",
-      "terrain": "w",
+      "id": "X45", "terrain": "w",
       "exits": {
-        "north": "X44",
-        "south": "X46",
-        "west": "W45",
-        "east": "Y45"
+        "north": "X44", "south": "X46", "west": "W45", "east": "Y45"
       }
     },
     {
-      "id": "Y45",
-      "terrain": "Indel",
+      "id": "Y45", "terrain": "Indel",
       "exits": {
-        "north": "Y44",
-        "south": "Y46",
-        "west": "X45",
-        "east": "Z45"
+        "north": "Y44", "south": "Y46", "west": "X45", "east": "Z45"
       }
     },
     {
-      "id": "Z45",
-      "terrain": "p",
+      "id": "Z45", "terrain": "p",
       "exits": {
-        "north": "Z44",
-        "south": "Z46",
-        "west": "Y45",
-        "east": "AA45"
+        "north": "Z44", "south": "Z46", "west": "Y45", "east": "AA45"
       }
     },
     {
-      "id": "AA45",
-      "terrain": "p",
+      "id": "AA45", "terrain": "p",
       "exits": {
-        "north": "AA44",
-        "south": "AA46",
-        "west": "Z45",
-        "east": "AB45"
+        "north": "AA44", "south": "AA46", "west": "Z45", "east": "AB45"
       }
     },
     {
-      "id": "AB45",
-      "terrain": "h",
+      "id": "AB45", "terrain": "h",
       "exits": {
-        "north": "AB44",
-        "south": "AB46",
-        "west": "AA45",
-        "east": "AC45"
+        "north": "AB44", "south": "AB46", "west": "AA45", "east": "AC45"
       }
     },
     {
-      "id": "AC45",
-      "terrain": "h",
+      "id": "AC45", "terrain": "h",
       "exits": {
-        "north": "AC44",
-        "south": "AC46",
-        "west": "AB45",
-        "east": "AD45"
+        "north": "AC44", "south": "AC46", "west": "AB45", "east": "AD45"
       }
     },
     {
-      "id": "AD45",
-      "terrain": "s",
+      "id": "AD45", "terrain": "s",
       "exits": {
-        "north": "AD44",
-        "south": "AD46",
-        "west": "AC45",
-        "east": "AE45"
+        "north": "AD44", "south": "AD46", "west": "AC45", "east": "AE45"
       }
     },
     {
-      "id": "AE45",
-      "terrain": "lf",
+      "id": "AE45", "terrain": "lf",
       "exits": {
-        "north": "AE44",
-        "south": "AE46",
-        "west": "AD45",
-        "east": "AF45"
+        "north": "AE44", "south": "AE46", "west": "AD45", "east": "AF45"
       }
     },
     {
-      "id": "AF45",
-      "terrain": "f",
+      "id": "AF45", "terrain": "f",
       "exits": {
-        "north": "AF44",
-        "south": "AF46",
-        "west": "AE45",
-        "east": "AG45"
+        "north": "AF44", "south": "AF46", "west": "AE45", "east": "AG45"
       }
     },
     {
-      "id": "AG45",
-      "terrain": "lf",
+      "id": "AG45", "terrain": "lf",
       "exits": {
-        "north": "AG44",
-        "south": "AG46",
-        "west": "AF45",
-        "east": "AH45"
+        "north": "AG44", "south": "AG46", "west": "AF45", "east": "AH45"
       }
     },
     {
-      "id": "AH45",
-      "terrain": "lf",
+      "id": "AH45", "terrain": "lf",
       "exits": {
-        "north": "AH44",
-        "south": "AH46",
-        "west": "AG45",
-        "east": "AI45"
+        "north": "AH44", "south": "AH46", "west": "AG45", "east": "AI45"
       }
     },
     {
-      "id": "AI45",
-      "terrain": "f",
+      "id": "AI45", "terrain": "f",
       "exits": {
-        "north": "AI44",
-        "south": "AI46",
-        "west": "AH45",
-        "east": "AJ45"
+        "north": "AI44", "south": "AI46", "west": "AH45", "east": "AJ45"
       }
     },
     {
-      "id": "AJ45",
-      "terrain": "lf",
+      "id": "AJ45", "terrain": "lf",
       "exits": {
-        "north": "AJ44",
-        "south": "AJ46",
-        "west": "AI45",
-        "east": "AK45"
+        "north": "AJ44", "south": "AJ46", "west": "AI45", "east": "AK45"
       }
     },
     {
-      "id": "AK45",
-      "terrain": "f",
+      "id": "AK45", "terrain": "f",
       "exits": {
-        "north": "AK44",
-        "south": "AK46",
-        "west": "AJ45",
-        "east": "AL45"
+        "north": "AK44", "south": "AK46", "west": "AJ45", "east": "AL45"
       }
     },
     {
-      "id": "AL45",
-      "terrain": "f",
+      "id": "AL45", "terrain": "f",
       "exits": {
-        "north": "AL44",
-        "south": "AL46",
-        "west": "AK45",
-        "east": "AM45"
+        "north": "AL44", "south": "AL46", "west": "AK45", "east": "AM45"
       }
     },
     {
-      "id": "AM45",
-      "terrain": "f",
+      "id": "AM45", "terrain": "f",
       "exits": {
-        "north": "AM44",
-        "south": "AM46",
-        "west": "AL45",
-        "east": "AN45"
+        "north": "AM44", "south": "AM46", "west": "AL45", "east": "AN45"
       }
     },
     {
-      "id": "AN45",
-      "terrain": "f",
+      "id": "AN45", "terrain": "f",
       "exits": {
-        "north": "AN44",
-        "south": "AN46",
-        "west": "AM45",
-        "east": "AO45"
+        "north": "AN44", "south": "AN46", "west": "AM45", "east": "AO45"
       }
     },
     {
-      "id": "AO45",
-      "terrain": "f",
+      "id": "AO45", "terrain": "f",
       "exits": {
-        "north": "AO44",
-        "south": "AO46",
-        "west": "AN45",
-        "east": "AP45"
+        "north": "AO44", "south": "AO46", "west": "AN45", "east": "AP45"
       }
     },
     {
-      "id": "AP45",
-      "terrain": "f",
+      "id": "AP45", "terrain": "f",
       "exits": {
-        "north": "AP44",
-        "south": "AP46",
-        "west": "AO45",
-        "east": "AQ45"
+        "north": "AP44", "south": "AP46", "west": "AO45", "east": "AQ45"
       }
     },
     {
-      "id": "AQ45",
-      "terrain": "f",
+      "id": "AQ45", "terrain": "f",
       "exits": {
-        "north": "AQ44",
-        "south": "AQ46",
-        "west": "AP45",
-        "east": "AR45"
+        "north": "AQ44", "south": "AQ46", "west": "AP45", "east": "AR45"
       }
     },
     {
-      "id": "AR45",
-      "terrain": "f",
+      "id": "AR45", "terrain": "f",
       "exits": {
-        "north": "AR44",
-        "south": "AR46",
-        "west": "AQ45",
-        "east": "AS45"
+        "north": "AR44", "south": "AR46", "west": "AQ45", "east": "AS45"
       }
     },
     {
-      "id": "AS45",
-      "terrain": "p",
+      "id": "AS45", "terrain": "p",
       "exits": {
-        "north": "AS44",
-        "south": "AS46",
-        "west": "AR45",
-        "east": "AT45"
+        "north": "AS44", "south": "AS46", "west": "AR45", "east": "AT45"
       }
     },
     {
-      "id": "AT45",
-      "terrain": "lf",
+      "id": "AT45", "terrain": "lf",
       "exits": {
-        "north": "AT44",
-        "south": "AT46",
-        "west": "AS45",
-        "east": "AU45"
+        "north": "AT44", "south": "AT46", "west": "AS45", "east": "AU45"
       }
     },
     {
-      "id": "AU45",
-      "terrain": "lf",
+      "id": "AU45", "terrain": "lf",
       "exits": {
-        "north": "AU44",
-        "south": "AU46",
-        "west": "AT45",
-        "east": "AV45"
+        "north": "AU44", "south": "AU46", "west": "AT45", "east": "AV45"
       }
     },
     {
-      "id": "AV45",
-      "terrain": "p",
+      "id": "AV45", "terrain": "p",
       "exits": {
-        "north": "AV44",
-        "south": "AV46",
-        "west": "AU45",
-        "east": "AW45"
+        "north": "AV44", "south": "AV46", "west": "AU45", "east": "AW45"
       }
     },
     {
-      "id": "AW45",
-      "terrain": "p",
+      "id": "AW45", "terrain": "p",
       "exits": {
-        "north": "AW44",
-        "south": "AW46",
-        "west": "AV45",
-        "east": "AX45"
+        "north": "AW44", "south": "AW46", "west": "AV45", "east": "AX45"
       }
     },
     {
-      "id": "AX45",
-      "terrain": "p",
+      "id": "AX45", "terrain": "p",
       "exits": {
-        "north": "AX44",
-        "south": "AX46",
-        "west": "AW45"
+        "north": "AX44", "south": "AX46", "west": "AW45"
       }
     },
     {
-      "id": "A46",
-      "terrain": "p",
+      "id": "A46", "terrain": "p",
       "exits": {
-        "north": "A45",
-        "south": "A47",
-        "east": "B46"
+        "north": "A45", "south": "A47", "east": "B46"
       }
     },
     {
-      "id": "B46",
-      "terrain": "p",
+      "id": "B46", "terrain": "p",
       "exits": {
-        "north": "B45",
-        "south": "B47",
-        "west": "A46",
-        "east": "C46"
+        "north": "B45", "south": "B47", "west": "A46", "east": "C46"
       }
     },
     {
-      "id": "C46",
-      "terrain": "p",
+      "id": "C46", "terrain": "p",
       "exits": {
-        "north": "C45",
-        "south": "C47",
-        "west": "B46",
-        "east": "D46"
+        "north": "C45", "south": "C47", "west": "B46", "east": "D46"
       }
     },
     {
-      "id": "D46",
-      "terrain": "p",
+      "id": "D46", "terrain": "p",
       "exits": {
-        "north": "D45",
-        "south": "D47",
-        "west": "C46",
-        "east": "E46"
+        "north": "D45", "south": "D47", "west": "C46", "east": "E46"
       }
     },
     {
-      "id": "E46",
-      "terrain": "p",
+      "id": "E46", "terrain": "p",
       "exits": {
-        "north": "E45",
-        "south": "E47",
-        "west": "D46",
-        "east": "F46"
+        "north": "E45", "south": "E47", "west": "D46", "east": "F46"
       }
     },
     {
-      "id": "F46",
-      "terrain": "p",
+      "id": "F46", "terrain": "p",
       "exits": {
-        "north": "F45",
-        "south": "F47",
-        "west": "E46",
-        "east": "G46"
+        "north": "F45", "south": "F47", "west": "E46", "east": "G46"
       }
     },
     {
-      "id": "G46",
-      "terrain": "p",
+      "id": "G46", "terrain": "p",
       "exits": {
-        "north": "G45",
-        "south": "G47",
-        "west": "F46",
-        "east": "H46"
+        "north": "G45", "south": "G47", "west": "F46", "east": "H46"
       }
     },
     {
-      "id": "H46",
-      "terrain": "j",
+      "id": "H46", "terrain": "j",
       "exits": {
-        "north": "H45",
-        "south": "H47",
-        "west": "G46",
-        "east": "I46"
+        "north": "H45", "south": "H47", "west": "G46", "east": "I46"
       }
     },
     {
-      "id": "I46",
-      "terrain": "j",
+      "id": "I46", "terrain": "j",
       "exits": {
-        "north": "I45",
-        "south": "I47",
-        "west": "H46",
-        "east": "J46"
+        "north": "I45", "south": "I47", "west": "H46", "east": "J46"
       }
     },
     {
-      "id": "J46",
-      "terrain": "j",
+      "id": "J46", "terrain": "j",
       "exits": {
-        "north": "J45",
-        "south": "J47",
-        "west": "I46",
-        "east": "K46"
+        "north": "J45", "south": "J47", "west": "I46", "east": "K46"
       }
     },
     {
-      "id": "K46",
-      "terrain": "j",
+      "id": "K46", "terrain": "j",
       "exits": {
-        "north": "K45",
-        "south": "K47",
-        "west": "J46",
-        "east": "L46"
+        "north": "K45", "south": "K47", "west": "J46", "east": "L46"
       }
     },
     {
-      "id": "L46",
-      "terrain": "j",
+      "id": "L46", "terrain": "j",
       "exits": {
-        "north": "L45",
-        "south": "L47",
-        "west": "K46",
-        "east": "M46"
+        "north": "L45", "south": "L47", "west": "K46", "east": "M46"
       }
     },
     {
-      "id": "M46",
-      "terrain": "p",
+      "id": "M46", "terrain": "p",
       "exits": {
-        "north": "M45",
-        "south": "M47",
-        "west": "L46",
-        "east": "N46"
+        "north": "M45", "south": "M47", "west": "L46", "east": "N46"
       }
     },
     {
-      "id": "N46",
-      "terrain": "p",
+      "id": "N46", "terrain": "p",
       "exits": {
-        "north": "N45",
-        "south": "N47",
-        "west": "M46",
-        "east": "O46"
+        "north": "N45", "south": "N47", "west": "M46", "east": "O46"
       }
     },
     {
-      "id": "O46",
-      "terrain": "w",
+      "id": "O46", "terrain": "w",
       "exits": {
-        "north": "O45",
-        "south": "O47",
-        "west": "N46",
-        "east": "P46"
+        "north": "O45", "south": "O47", "west": "N46", "east": "P46"
       }
     },
     {
-      "id": "P46",
-      "terrain": "j",
+      "id": "P46", "terrain": "j",
       "exits": {
-        "north": "P45",
-        "south": "P47",
-        "west": "O46",
-        "east": "Q46"
+        "north": "P45", "south": "P47", "west": "O46", "east": "Q46"
       }
     },
     {
-      "id": "Q46",
-      "terrain": "j",
+      "id": "Q46", "terrain": "j",
       "exits": {
-        "north": "Q45",
-        "south": "Q47",
-        "west": "P46",
-        "east": "R46"
+        "north": "Q45", "south": "Q47", "west": "P46", "east": "R46"
       }
     },
     {
-      "id": "R46",
-      "terrain": "p",
+      "id": "R46", "terrain": "p",
       "exits": {
-        "north": "R45",
-        "south": "R47",
-        "west": "Q46",
-        "east": "S46"
+        "north": "R45", "south": "R47", "west": "Q46", "east": "S46"
       }
     },
     {
-      "id": "S46",
-      "terrain": "p",
+      "id": "S46", "terrain": "p",
       "exits": {
-        "north": "S45",
-        "south": "S47",
-        "west": "R46",
-        "east": "T46"
+        "north": "S45", "south": "S47", "west": "R46", "east": "T46"
       }
     },
     {
-      "id": "T46",
-      "terrain": "p",
+      "id": "T46", "terrain": "p",
       "exits": {
-        "north": "T45",
-        "south": "T47",
-        "west": "S46",
-        "east": "U46"
+        "north": "T45", "south": "T47", "west": "S46", "east": "U46"
       }
     },
     {
-      "id": "U46",
-      "terrain": "p",
+      "id": "U46", "terrain": "p",
       "exits": {
-        "north": "U45",
-        "south": "U47",
-        "west": "T46",
-        "east": "V46"
+        "north": "U45", "south": "U47", "west": "T46", "east": "V46"
       }
     },
     {
-      "id": "V46",
-      "terrain": "p",
+      "id": "V46", "terrain": "p",
       "exits": {
-        "north": "V45",
-        "south": "V47",
-        "west": "U46",
-        "east": "W46"
+        "north": "V45", "south": "V47", "west": "U46", "east": "W46"
       }
     },
     {
-      "id": "W46",
-      "terrain": "p",
+      "id": "W46", "terrain": "p",
       "exits": {
-        "north": "W45",
-        "south": "W47",
-        "west": "V46",
-        "east": "X46"
+        "north": "W45", "south": "W47", "west": "V46", "east": "X46"
       }
     },
     {
-      "id": "X46",
-      "terrain": "p",
+      "id": "X46", "terrain": "p",
       "exits": {
-        "north": "X45",
-        "south": "X47",
-        "west": "W46",
-        "east": "Y46"
+        "north": "X45", "south": "X47", "west": "W46", "east": "Y46"
       }
     },
     {
-      "id": "Y46",
-      "terrain": "p",
+      "id": "Y46", "terrain": "p",
       "exits": {
-        "north": "Y45",
-        "south": "Y47",
-        "west": "X46",
-        "east": "Z46"
+        "north": "Y45", "south": "Y47", "west": "X46", "east": "Z46"
       }
     },
     {
-      "id": "Z46",
-      "terrain": "p",
+      "id": "Z46", "terrain": "p",
       "exits": {
-        "north": "Z45",
-        "south": "Z47",
-        "west": "Y46",
-        "east": "AA46"
+        "north": "Z45", "south": "Z47", "west": "Y46", "east": "AA46"
       }
     },
     {
-      "id": "AA46",
-      "terrain": "p",
+      "id": "AA46", "terrain": "p",
       "exits": {
-        "north": "AA45",
-        "south": "AA47",
-        "west": "Z46",
-        "east": "AB46"
+        "north": "AA45", "south": "AA47", "west": "Z46", "east": "AB46"
       }
     },
     {
-      "id": "AB46",
-      "terrain": "p",
+      "id": "AB46", "terrain": "p",
       "exits": {
-        "north": "AB45",
-        "south": "AB47",
-        "west": "AA46",
-        "east": "AC46"
+        "north": "AB45", "south": "AB47", "west": "AA46", "east": "AC46"
       }
     },
     {
-      "id": "AC46",
-      "terrain": "s",
+      "id": "AC46", "terrain": "s",
       "exits": {
-        "north": "AC45",
-        "south": "AC47",
-        "west": "AB46",
-        "east": "AD46"
+        "north": "AC45", "south": "AC47", "west": "AB46", "east": "AD46"
       }
     },
     {
-      "id": "AD46",
-      "terrain": "s",
+      "id": "AD46", "terrain": "s",
       "exits": {
-        "north": "AD45",
-        "south": "AD47",
-        "west": "AC46",
-        "east": "AE46"
+        "north": "AD45", "south": "AD47", "west": "AC46", "east": "AE46"
       }
     },
     {
-      "id": "AE46",
-      "terrain": "lf",
+      "id": "AE46", "terrain": "lf",
       "exits": {
-        "north": "AE45",
-        "south": "AE47",
-        "west": "AD46",
-        "east": "AF46"
+        "north": "AE45", "south": "AE47", "west": "AD46", "east": "AF46"
       }
     },
     {
-      "id": "AF46",
-      "terrain": "m",
+      "id": "AF46", "terrain": "m",
       "exits": {
-        "north": "AF45",
-        "south": "AF47",
-        "west": "AE46",
-        "east": "AG46"
+        "north": "AF45", "south": "AF47", "west": "AE46", "east": "AG46"
       }
     },
     {
-      "id": "AG46",
-      "terrain": "lf",
+      "id": "AG46", "terrain": "lf",
       "exits": {
-        "north": "AG45",
-        "south": "AG47",
-        "west": "AF46",
-        "east": "AH46"
+        "north": "AG45", "south": "AG47", "west": "AF46", "east": "AH46"
       }
     },
     {
-      "id": "AH46",
-      "terrain": "lf",
+      "id": "AH46", "terrain": "lf",
       "exits": {
-        "north": "AH45",
-        "south": "AH47",
-        "west": "AG46",
-        "east": "AI46"
+        "north": "AH45", "south": "AH47", "west": "AG46", "east": "AI46"
       }
     },
     {
-      "id": "AI46",
-      "terrain": "lf",
+      "id": "AI46", "terrain": "lf",
       "exits": {
-        "north": "AI45",
-        "south": "AI47",
-        "west": "AH46",
-        "east": "AJ46"
+        "north": "AI45", "south": "AI47", "west": "AH46", "east": "AJ46"
       }
     },
     {
-      "id": "AJ46",
-      "terrain": "lf",
+      "id": "AJ46", "terrain": "lf",
       "exits": {
-        "north": "AJ45",
-        "south": "AJ47",
-        "west": "AI46",
-        "east": "AK46"
+        "north": "AJ45", "south": "AJ47", "west": "AI46", "east": "AK46"
       }
     },
     {
-      "id": "AK46",
-      "terrain": "f",
+      "id": "AK46", "terrain": "f",
       "exits": {
-        "north": "AK45",
-        "south": "AK47",
-        "west": "AJ46",
-        "east": "AL46"
+        "north": "AK45", "south": "AK47", "west": "AJ46", "east": "AL46"
       }
     },
     {
-      "id": "AL46",
-      "terrain": "f",
+      "id": "AL46", "terrain": "f",
       "exits": {
-        "north": "AL45",
-        "south": "AL47",
-        "west": "AK46",
-        "east": "AM46"
+        "north": "AL45", "south": "AL47", "west": "AK46", "east": "AM46"
       }
     },
     {
-      "id": "AM46",
-      "terrain": "f",
+      "id": "AM46", "terrain": "f",
       "exits": {
-        "north": "AM45",
-        "south": "AM47",
-        "west": "AL46",
-        "east": "AN46"
+        "north": "AM45", "south": "AM47", "west": "AL46", "east": "AN46"
       }
     },
     {
-      "id": "AN46",
-      "terrain": "f",
+      "id": "AN46", "terrain": "f",
       "exits": {
-        "north": "AN45",
-        "south": "AN47",
-        "west": "AM46",
-        "east": "AO46"
+        "north": "AN45", "south": "AN47", "west": "AM46", "east": "AO46"
       }
     },
     {
-      "id": "AO46",
-      "terrain": "f",
+      "id": "AO46", "terrain": "f",
       "exits": {
-        "north": "AO45",
-        "south": "AO47",
-        "west": "AN46",
-        "east": "AP46"
+        "north": "AO45", "south": "AO47", "west": "AN46", "east": "AP46"
       }
     },
     {
-      "id": "AP46",
-      "terrain": "f",
+      "id": "AP46", "terrain": "f",
       "exits": {
-        "north": "AP45",
-        "south": "AP47",
-        "west": "AO46",
-        "east": "AQ46"
+        "north": "AP45", "south": "AP47", "west": "AO46", "east": "AQ46"
       }
     },
     {
-      "id": "AQ46",
-      "terrain": "f",
+      "id": "AQ46", "terrain": "f",
       "exits": {
-        "north": "AQ45",
-        "south": "AQ47",
-        "west": "AP46",
-        "east": "AR46"
+        "north": "AQ45", "south": "AQ47", "west": "AP46", "east": "AR46"
       }
     },
     {
-      "id": "AR46",
-      "terrain": "f",
+      "id": "AR46", "terrain": "f",
       "exits": {
-        "north": "AR45",
-        "south": "AR47",
-        "west": "AQ46",
-        "east": "AS46"
+        "north": "AR45", "south": "AR47", "west": "AQ46", "east": "AS46"
       }
     },
     {
-      "id": "AS46",
-      "terrain": "p",
+      "id": "AS46", "terrain": "p",
       "exits": {
-        "north": "AS45",
-        "south": "AS47",
-        "west": "AR46",
-        "east": "AT46"
+        "north": "AS45", "south": "AS47", "west": "AR46", "east": "AT46"
       }
     },
     {
-      "id": "AT46",
-      "terrain": "lf",
+      "id": "AT46", "terrain": "lf",
       "exits": {
-        "north": "AT45",
-        "south": "AT47",
-        "west": "AS46",
-        "east": "AU46"
+        "north": "AT45", "south": "AT47", "west": "AS46", "east": "AU46"
       }
     },
     {
-      "id": "AU46",
-      "terrain": "lf",
+      "id": "AU46", "terrain": "lf",
       "exits": {
-        "north": "AU45",
-        "south": "AU47",
-        "west": "AT46",
-        "east": "AV46"
+        "north": "AU45", "south": "AU47", "west": "AT46", "east": "AV46"
       }
     },
     {
-      "id": "AV46",
-      "terrain": "p",
+      "id": "AV46", "terrain": "p",
       "exits": {
-        "north": "AV45",
-        "south": "AV47",
-        "west": "AU46",
-        "east": "AW46"
+        "north": "AV45", "south": "AV47", "west": "AU46", "east": "AW46"
       }
     },
     {
-      "id": "AW46",
-      "terrain": "p",
+      "id": "AW46", "terrain": "p",
       "exits": {
-        "north": "AW45",
-        "south": "AW47",
-        "west": "AV46",
-        "east": "AX46"
+        "north": "AW45", "south": "AW47", "west": "AV46", "east": "AX46"
       }
     },
     {
-      "id": "AX46",
-      "terrain": "p",
+      "id": "AX46", "terrain": "p",
       "exits": {
-        "north": "AX45",
-        "south": "AX47",
-        "west": "AW46"
+        "north": "AX45", "south": "AX47", "west": "AW46"
       }
     },
     {
-      "id": "A47",
-      "terrain": "p",
+      "id": "A47", "terrain": "p",
       "exits": {
-        "north": "A46",
-        "south": "A48",
-        "east": "B47"
+        "north": "A46", "south": "A48", "east": "B47"
       }
     },
     {
-      "id": "B47",
-      "terrain": "p",
+      "id": "B47", "terrain": "p",
       "exits": {
-        "north": "B46",
-        "south": "B48",
-        "west": "A47",
-        "east": "C47"
+        "north": "B46", "south": "B48", "west": "A47", "east": "C47"
       }
     },
     {
-      "id": "C47",
-      "terrain": "p",
+      "id": "C47", "terrain": "p",
       "exits": {
-        "north": "C46",
-        "south": "C48",
-        "west": "B47",
-        "east": "D47"
+        "north": "C46", "south": "C48", "west": "B47", "east": "D47"
       }
     },
     {
-      "id": "D47",
-      "terrain": "p",
+      "id": "D47", "terrain": "p",
       "exits": {
-        "north": "D46",
-        "south": "D48",
-        "west": "C47",
-        "east": "E47"
+        "north": "D46", "south": "D48", "west": "C47", "east": "E47"
       }
     },
     {
-      "id": "E47",
-      "terrain": "p",
+      "id": "E47", "terrain": "p",
       "exits": {
-        "north": "E46",
-        "south": "E48",
-        "west": "D47",
-        "east": "F47"
+        "north": "E46", "south": "E48", "west": "D47", "east": "F47"
       }
     },
     {
-      "id": "F47",
-      "terrain": "p",
+      "id": "F47", "terrain": "p",
       "exits": {
-        "north": "F46",
-        "south": "F48",
-        "west": "E47",
-        "east": "G47"
+        "north": "F46", "south": "F48", "west": "E47", "east": "G47"
       }
     },
     {
-      "id": "G47",
-      "terrain": "p",
+      "id": "G47", "terrain": "p",
       "exits": {
-        "north": "G46",
-        "south": "G48",
-        "west": "F47",
-        "east": "H47"
+        "north": "G46", "south": "G48", "west": "F47", "east": "H47"
       }
     },
     {
-      "id": "H47",
-      "terrain": "p",
+      "id": "H47", "terrain": "p",
       "exits": {
-        "north": "H46",
-        "south": "H48",
-        "west": "G47",
-        "east": "I47"
+        "north": "H46", "south": "H48", "west": "G47", "east": "I47"
       }
     },
     {
-      "id": "I47",
-      "terrain": "j",
+      "id": "I47", "terrain": "j",
       "exits": {
-        "north": "I46",
-        "south": "I48",
-        "west": "H47",
-        "east": "J47"
+        "north": "I46", "south": "I48", "west": "H47", "east": "J47"
       }
     },
     {
-      "id": "J47",
-      "terrain": "j",
+      "id": "J47", "terrain": "j",
       "exits": {
-        "north": "J46",
-        "south": "J48",
-        "west": "I47",
-        "east": "K47"
+        "north": "J46", "south": "J48", "west": "I47", "east": "K47"
       }
     },
     {
-      "id": "K47",
-      "terrain": "j",
+      "id": "K47", "terrain": "j",
       "exits": {
-        "north": "K46",
-        "south": "K48",
-        "west": "J47",
-        "east": "L47"
+        "north": "K46", "south": "K48", "west": "J47", "east": "L47"
       }
     },
     {
-      "id": "L47",
-      "terrain": "j",
+      "id": "L47", "terrain": "j",
       "exits": {
-        "north": "L46",
-        "south": "L48",
-        "west": "K47",
-        "east": "M47"
+        "north": "L46", "south": "L48", "west": "K47", "east": "M47"
       }
     },
     {
-      "id": "M47",
-      "terrain": "j",
+      "id": "M47", "terrain": "j",
       "exits": {
-        "north": "M46",
-        "south": "M48",
-        "west": "L47",
-        "east": "N47"
+        "north": "M46", "south": "M48", "west": "L47", "east": "N47"
       }
     },
     {
-      "id": "N47",
-      "terrain": "j",
+      "id": "N47", "terrain": "j",
       "exits": {
-        "north": "N46",
-        "south": "N48",
-        "west": "M47",
-        "east": "O47"
+        "north": "N46", "south": "N48", "west": "M47", "east": "O47"
       }
     },
     {
-      "id": "O47",
-      "terrain": "w",
+      "id": "O47", "terrain": "w",
       "exits": {
-        "north": "O46",
-        "south": "O48",
-        "west": "N47",
-        "east": "P47"
+        "north": "O46", "south": "O48", "west": "N47", "east": "P47"
       }
     },
     {
-      "id": "P47",
-      "terrain": "j",
+      "id": "P47", "terrain": "j",
       "exits": {
-        "north": "P46",
-        "south": "P48",
-        "west": "O47",
-        "east": "Q47"
+        "north": "P46", "south": "P48", "west": "O47", "east": "Q47"
       }
     },
     {
-      "id": "Q47",
-      "terrain": "j",
+      "id": "Q47", "terrain": "j",
       "exits": {
-        "north": "Q46",
-        "south": "Q48",
-        "west": "P47",
-        "east": "R47"
+        "north": "Q46", "south": "Q48", "west": "P47", "east": "R47"
       }
     },
     {
-      "id": "R47",
-      "terrain": "p",
+      "id": "R47", "terrain": "p",
       "exits": {
-        "north": "R46",
-        "south": "R48",
-        "west": "Q47",
-        "east": "S47"
+        "north": "R46", "south": "R48", "west": "Q47", "east": "S47"
       }
     },
     {
-      "id": "S47",
-      "terrain": "p",
+      "id": "S47", "terrain": "p",
       "exits": {
-        "north": "S46",
-        "south": "S48",
-        "west": "R47",
-        "east": "T47"
+        "north": "S46", "south": "S48", "west": "R47", "east": "T47"
       }
     },
     {
-      "id": "T47",
-      "terrain": "p",
+      "id": "T47", "terrain": "p",
       "exits": {
-        "north": "T46",
-        "south": "T48",
-        "west": "S47",
-        "east": "U47"
+        "north": "T46", "south": "T48", "west": "S47", "east": "U47"
       }
     },
     {
-      "id": "U47",
-      "terrain": "p",
+      "id": "U47", "terrain": "p",
       "exits": {
-        "north": "U46",
-        "south": "U48",
-        "west": "T47",
-        "east": "V47"
+        "north": "U46", "south": "U48", "west": "T47", "east": "V47"
       }
     },
     {
-      "id": "V47",
-      "terrain": "p",
+      "id": "V47", "terrain": "p",
       "exits": {
-        "north": "V46",
-        "south": "V48",
-        "west": "U47",
-        "east": "W47"
+        "north": "V46", "south": "V48", "west": "U47", "east": "W47"
       }
     },
     {
-      "id": "W47",
-      "terrain": "p",
+      "id": "W47", "terrain": "p",
       "exits": {
-        "north": "W46",
-        "south": "W48",
-        "west": "V47",
-        "east": "X47"
+        "north": "W46", "south": "W48", "west": "V47", "east": "X47"
       }
     },
     {
-      "id": "X47",
-      "terrain": "p",
+      "id": "X47", "terrain": "p",
       "exits": {
-        "north": "X46",
-        "south": "X48",
-        "west": "W47",
-        "east": "Y47"
+        "north": "X46", "south": "X48", "west": "W47", "east": "Y47"
       }
     },
     {
-      "id": "Y47",
-      "terrain": "p",
+      "id": "Y47", "terrain": "p",
       "exits": {
-        "north": "Y46",
-        "south": "Y48",
-        "west": "X47",
-        "east": "Z47"
+        "north": "Y46", "south": "Y48", "west": "X47", "east": "Z47"
       }
     },
     {
-      "id": "Z47",
-      "terrain": "p",
+      "id": "Z47", "terrain": "p",
       "exits": {
-        "north": "Z46",
-        "south": "Z48",
-        "west": "Y47",
-        "east": "AA47"
+        "north": "Z46", "south": "Z48", "west": "Y47", "east": "AA47"
       }
     },
     {
-      "id": "AA47",
-      "terrain": "s",
+      "id": "AA47", "terrain": "s",
       "exits": {
-        "north": "AA46",
-        "south": "AA48",
-        "west": "Z47",
-        "east": "AB47"
+        "north": "AA46", "south": "AA48", "west": "Z47", "east": "AB47"
       }
     },
     {
-      "id": "AB47",
-      "terrain": "s",
+      "id": "AB47", "terrain": "s",
       "exits": {
-        "north": "AB46",
-        "south": "AB48",
-        "west": "AA47",
-        "east": "AC47"
+        "north": "AB46", "south": "AB48", "west": "AA47", "east": "AC47"
       }
     },
     {
-      "id": "AC47",
-      "terrain": "s",
+      "id": "AC47", "terrain": "s",
       "exits": {
-        "north": "AC46",
-        "south": "AC48",
-        "west": "AB47",
-        "east": "AD47"
+        "north": "AC46", "south": "AC48", "west": "AB47", "east": "AD47"
       }
     },
     {
-      "id": "AD47",
-      "terrain": "s",
+      "id": "AD47", "terrain": "s",
       "exits": {
-        "north": "AD46",
-        "south": "AD48",
-        "west": "AC47",
-        "east": "AE47"
+        "north": "AD46", "south": "AD48", "west": "AC47", "east": "AE47"
       }
     },
     {
-      "id": "AE47",
-      "terrain": "m",
+      "id": "AE47", "terrain": "m",
       "exits": {
-        "north": "AE46",
-        "south": "AE48",
-        "west": "AD47",
-        "east": "AF47"
+        "north": "AE46", "south": "AE48", "west": "AD47", "east": "AF47"
       }
     },
     {
-      "id": "AF47",
-      "terrain": "m",
+      "id": "AF47", "terrain": "m",
       "exits": {
-        "north": "AF46",
-        "south": "AF48",
-        "west": "AE47",
-        "east": "AG47"
+        "north": "AF46", "south": "AF48", "west": "AE47", "east": "AG47"
       }
     },
     {
-      "id": "AG47",
-      "terrain": "m",
+      "id": "AG47", "terrain": "m",
       "exits": {
-        "north": "AG46",
-        "south": "AG48",
-        "west": "AF47",
-        "east": "AH47"
+        "north": "AG46", "south": "AG48", "west": "AF47", "east": "AH47"
       }
     },
     {
-      "id": "AH47",
-      "terrain": "lf",
+      "id": "AH47", "terrain": "lf",
       "exits": {
-        "north": "AH46",
-        "south": "AH48",
-        "west": "AG47",
-        "east": "AI47"
+        "north": "AH46", "south": "AH48", "west": "AG47", "east": "AI47"
       }
     },
     {
-      "id": "AI47",
-      "terrain": "lf",
+      "id": "AI47", "terrain": "lf",
       "exits": {
-        "north": "AI46",
-        "south": "AI48",
-        "west": "AH47",
-        "east": "AJ47"
+        "north": "AI46", "south": "AI48", "west": "AH47", "east": "AJ47"
       }
     },
     {
-      "id": "AJ47",
-      "terrain": "lf",
+      "id": "AJ47", "terrain": "lf",
       "exits": {
-        "north": "AJ46",
-        "south": "AJ48",
-        "west": "AI47",
-        "east": "AK47"
+        "north": "AJ46", "south": "AJ48", "west": "AI47", "east": "AK47"
       }
     },
     {
-      "id": "AK47",
-      "terrain": "lf",
+      "id": "AK47", "terrain": "lf",
       "exits": {
-        "north": "AK46",
-        "south": "AK48",
-        "west": "AJ47",
-        "east": "AL47"
+        "north": "AK46", "south": "AK48", "west": "AJ47", "east": "AL47"
       }
     },
     {
-      "id": "AL47",
-      "terrain": "lf",
+      "id": "AL47", "terrain": "lf",
       "exits": {
-        "north": "AL46",
-        "south": "AL48",
-        "west": "AK47",
-        "east": "AM47"
+        "north": "AL46", "south": "AL48", "west": "AK47", "east": "AM47"
       }
     },
     {
-      "id": "AM47",
-      "terrain": "lf",
+      "id": "AM47", "terrain": "lf",
       "exits": {
-        "north": "AM46",
-        "south": "AM48",
-        "west": "AL47",
-        "east": "AN47"
+        "north": "AM46", "south": "AM48", "west": "AL47", "east": "AN47"
       }
     },
     {
-      "id": "AN47",
-      "terrain": "lf",
+      "id": "AN47", "terrain": "lf",
       "exits": {
-        "north": "AN46",
-        "south": "AN48",
-        "west": "AM47",
-        "east": "AO47"
+        "north": "AN46", "south": "AN48", "west": "AM47", "east": "AO47"
       }
     },
     {
-      "id": "AO47",
-      "terrain": "lf",
+      "id": "AO47", "terrain": "lf",
       "exits": {
-        "north": "AO46",
-        "south": "AO48",
-        "west": "AN47",
-        "east": "AP47"
+        "north": "AO46", "south": "AO48", "west": "AN47", "east": "AP47"
       }
     },
     {
-      "id": "AP47",
-      "terrain": "lf",
+      "id": "AP47", "terrain": "lf",
       "exits": {
-        "north": "AP46",
-        "south": "AP48",
-        "west": "AO47",
-        "east": "AQ47"
+        "north": "AP46", "south": "AP48", "west": "AO47", "east": "AQ47"
       }
     },
     {
-      "id": "AQ47",
-      "terrain": "lf",
+      "id": "AQ47", "terrain": "lf",
       "exits": {
-        "north": "AQ46",
-        "south": "AQ48",
-        "west": "AP47",
-        "east": "AR47"
+        "north": "AQ46", "south": "AQ48", "west": "AP47", "east": "AR47"
       }
     },
     {
-      "id": "AR47",
-      "terrain": "lf",
+      "id": "AR47", "terrain": "lf",
       "exits": {
-        "north": "AR46",
-        "south": "AR48",
-        "west": "AQ47",
-        "east": "AS47"
+        "north": "AR46", "south": "AR48", "west": "AQ47", "east": "AS47"
       }
     },
     {
-      "id": "AS47",
-      "terrain": "p",
+      "id": "AS47", "terrain": "p",
       "exits": {
-        "north": "AS46",
-        "south": "AS48",
-        "west": "AR47",
-        "east": "AT47"
+        "north": "AS46", "south": "AS48", "west": "AR47", "east": "AT47"
       }
     },
     {
-      "id": "AT47",
-      "terrain": "lf",
+      "id": "AT47", "terrain": "lf",
       "exits": {
-        "north": "AT46",
-        "south": "AT48",
-        "west": "AS47",
-        "east": "AU47"
+        "north": "AT46", "south": "AT48", "west": "AS47", "east": "AU47"
       }
     },
     {
-      "id": "AU47",
-      "terrain": "lf",
+      "id": "AU47", "terrain": "lf",
       "exits": {
-        "north": "AU46",
-        "south": "AU48",
-        "west": "AT47",
-        "east": "AV47"
+        "north": "AU46", "south": "AU48", "west": "AT47", "east": "AV47"
       }
     },
     {
-      "id": "AV47",
-      "terrain": "p",
+      "id": "AV47", "terrain": "p",
       "exits": {
-        "north": "AV46",
-        "south": "AV48",
-        "west": "AU47",
-        "east": "AW47"
+        "north": "AV46", "south": "AV48", "west": "AU47", "east": "AW47"
       }
     },
     {
-      "id": "AW47",
-      "terrain": "p",
+      "id": "AW47", "terrain": "p",
       "exits": {
-        "north": "AW46",
-        "south": "AW48",
-        "west": "AV47",
-        "east": "AX47"
+        "north": "AW46", "south": "AW48", "west": "AV47", "east": "AX47"
       }
     },
     {
-      "id": "AX47",
-      "terrain": "p",
+      "id": "AX47", "terrain": "p",
       "exits": {
-        "north": "AX46",
-        "south": "AX48",
-        "west": "AW47"
+        "north": "AX46", "south": "AX48", "west": "AW47"
       }
     },
     {
-      "id": "A48",
-      "terrain": "p",
+      "id": "A48", "terrain": "p",
       "exits": {
-        "north": "A47",
-        "south": "A49",
-        "east": "B48"
+        "north": "A47", "south": "A49", "east": "B48"
       }
     },
     {
-      "id": "B48",
-      "terrain": "p",
+      "id": "B48", "terrain": "p",
       "exits": {
-        "north": "B47",
-        "south": "B49",
-        "west": "A48",
-        "east": "C48"
+        "north": "B47", "south": "B49", "west": "A48", "east": "C48"
       }
     },
     {
-      "id": "C48",
-      "terrain": "p",
+      "id": "C48", "terrain": "p",
       "exits": {
-        "north": "C47",
-        "south": "C49",
-        "west": "B48",
-        "east": "D48"
+        "north": "C47", "south": "C49", "west": "B48", "east": "D48"
       }
     },
     {
-      "id": "D48",
-      "terrain": "p",
+      "id": "D48", "terrain": "p",
       "exits": {
-        "north": "D47",
-        "south": "D49",
-        "west": "C48",
-        "east": "E48"
+        "north": "D47", "south": "D49", "west": "C48", "east": "E48"
       }
     },
     {
-      "id": "E48",
-      "terrain": "p",
+      "id": "E48", "terrain": "p",
       "exits": {
-        "north": "E47",
-        "south": "E49",
-        "west": "D48",
-        "east": "F48"
+        "north": "E47", "south": "E49", "west": "D48", "east": "F48"
       }
     },
     {
-      "id": "F48",
-      "terrain": "p",
+      "id": "F48", "terrain": "p",
       "exits": {
-        "north": "F47",
-        "south": "F49",
-        "west": "E48",
-        "east": "G48"
+        "north": "F47", "south": "F49", "west": "E48", "east": "G48"
       }
     },
     {
-      "id": "G48",
-      "terrain": "p",
+      "id": "G48", "terrain": "p",
       "exits": {
-        "north": "G47",
-        "south": "G49",
-        "west": "F48",
-        "east": "H48"
+        "north": "G47", "south": "G49", "west": "F48", "east": "H48"
       }
     },
     {
-      "id": "H48",
-      "terrain": "p",
+      "id": "H48", "terrain": "p",
       "exits": {
-        "north": "H47",
-        "south": "H49",
-        "west": "G48",
-        "east": "I48"
+        "north": "H47", "south": "H49", "west": "G48", "east": "I48"
       }
     },
     {
-      "id": "I48",
-      "terrain": "p",
+      "id": "I48", "terrain": "p",
       "exits": {
-        "north": "I47",
-        "south": "I49",
-        "west": "H48",
-        "east": "J48"
+        "north": "I47", "south": "I49", "west": "H48", "east": "J48"
       }
     },
     {
-      "id": "J48",
-      "terrain": "j",
+      "id": "J48", "terrain": "j",
       "exits": {
-        "north": "J47",
-        "south": "J49",
-        "west": "I48",
-        "east": "K48"
+        "north": "J47", "south": "J49", "west": "I48", "east": "K48"
       }
     },
     {
-      "id": "K48",
-      "terrain": "p",
+      "id": "K48", "terrain": "p",
       "exits": {
-        "north": "K47",
-        "south": "K49",
-        "west": "J48",
-        "east": "L48"
+        "north": "K47", "south": "K49", "west": "J48", "east": "L48"
       }
     },
     {
-      "id": "L48",
-      "terrain": "p",
+      "id": "L48", "terrain": "p",
       "exits": {
-        "north": "L47",
-        "south": "L49",
-        "west": "K48",
-        "east": "M48"
+        "north": "L47", "south": "L49", "west": "K48", "east": "M48"
       }
     },
     {
-      "id": "M48",
-      "terrain": "j",
+      "id": "M48", "terrain": "j",
       "exits": {
-        "north": "M47",
-        "south": "M49",
-        "west": "L48",
-        "east": "N48"
+        "north": "M47", "south": "M49", "west": "L48", "east": "N48"
       }
     },
     {
-      "id": "N48",
-      "terrain": "w",
+      "id": "N48", "terrain": "w",
       "exits": {
-        "north": "N47",
-        "south": "N49",
-        "west": "M48",
-        "east": "O48"
+        "north": "N47", "south": "N49", "west": "M48", "east": "O48"
       }
     },
     {
-      "id": "O48",
-      "terrain": "j",
+      "id": "O48", "terrain": "j",
       "exits": {
-        "north": "O47",
-        "south": "O49",
-        "west": "N48",
-        "east": "P48"
+        "north": "O47", "south": "O49", "west": "N48", "east": "P48"
       }
     },
     {
-      "id": "P48",
-      "terrain": "j",
+      "id": "P48", "terrain": "j",
       "exits": {
-        "north": "P47",
-        "south": "P49",
-        "west": "O48",
-        "east": "Q48"
+        "north": "P47", "south": "P49", "west": "O48", "east": "Q48"
       }
     },
     {
-      "id": "Q48",
-      "terrain": "j",
+      "id": "Q48", "terrain": "j",
       "exits": {
-        "north": "Q47",
-        "south": "Q49",
-        "west": "P48",
-        "east": "R48"
+        "north": "Q47", "south": "Q49", "west": "P48", "east": "R48"
       }
     },
     {
-      "id": "R48",
-      "terrain": "p",
+      "id": "R48", "terrain": "p",
       "exits": {
-        "north": "R47",
-        "south": "R49",
-        "west": "Q48",
-        "east": "S48"
+        "north": "R47", "south": "R49", "west": "Q48", "east": "S48"
       }
     },
     {
-      "id": "S48",
-      "terrain": "p",
+      "id": "S48", "terrain": "p",
       "exits": {
-        "north": "S47",
-        "south": "S49",
-        "west": "R48",
-        "east": "T48"
+        "north": "S47", "south": "S49", "west": "R48", "east": "T48"
       }
     },
     {
-      "id": "T48",
-      "terrain": "p",
+      "id": "T48", "terrain": "p",
       "exits": {
-        "north": "T47",
-        "south": "T49",
-        "west": "S48",
-        "east": "U48"
+        "north": "T47", "south": "T49", "west": "S48", "east": "U48"
       }
     },
     {
-      "id": "U48",
-      "terrain": "p",
+      "id": "U48", "terrain": "p",
       "exits": {
-        "north": "U47",
-        "south": "U49",
-        "west": "T48",
-        "east": "V48"
+        "north": "U47", "south": "U49", "west": "T48", "east": "V48"
       }
     },
     {
-      "id": "V48",
-      "terrain": "p",
+      "id": "V48", "terrain": "p",
       "exits": {
-        "north": "V47",
-        "south": "V49",
-        "west": "U48",
-        "east": "W48"
+        "north": "V47", "south": "V49", "west": "U48", "east": "W48"
       }
     },
     {
-      "id": "W48",
-      "terrain": "p",
+      "id": "W48", "terrain": "p",
       "exits": {
-        "north": "W47",
-        "south": "W49",
-        "west": "V48",
-        "east": "X48"
+        "north": "W47", "south": "W49", "west": "V48", "east": "X48"
       }
     },
     {
-      "id": "X48",
-      "terrain": "p",
+      "id": "X48", "terrain": "p",
       "exits": {
-        "north": "X47",
-        "south": "X49",
-        "west": "W48",
-        "east": "Y48"
+        "north": "X47", "south": "X49", "west": "W48", "east": "Y48"
       }
     },
     {
-      "id": "Y48",
-      "terrain": "s",
+      "id": "Y48", "terrain": "s",
       "exits": {
-        "north": "Y47",
-        "south": "Y49",
-        "west": "X48",
-        "east": "Z48"
+        "north": "Y47", "south": "Y49", "west": "X48", "east": "Z48"
       }
     },
     {
-      "id": "Z48",
-      "terrain": "s",
+      "id": "Z48", "terrain": "s",
       "exits": {
-        "north": "Z47",
-        "south": "Z49",
-        "west": "Y48",
-        "east": "AA48"
+        "north": "Z47", "south": "Z49", "west": "Y48", "east": "AA48"
       }
     },
     {
-      "id": "AA48",
-      "terrain": "s",
+      "id": "AA48", "terrain": "s",
       "exits": {
-        "north": "AA47",
-        "south": "AA49",
-        "west": "Z48",
-        "east": "AB48"
+        "north": "AA47", "south": "AA49", "west": "Z48", "east": "AB48"
       }
     },
     {
-      "id": "AB48",
-      "terrain": "s",
+      "id": "AB48", "terrain": "s",
       "exits": {
-        "north": "AB47",
-        "south": "AB49",
-        "west": "AA48",
-        "east": "AC48"
+        "north": "AB47", "south": "AB49", "west": "AA48", "east": "AC48"
       }
     },
     {
-      "id": "AC48",
-      "terrain": "s",
+      "id": "AC48", "terrain": "s",
       "exits": {
-        "north": "AC47",
-        "south": "AC49",
-        "west": "AB48",
-        "east": "AD48"
+        "north": "AC47", "south": "AC49", "west": "AB48", "east": "AD48"
       }
     },
     {
-      "id": "AD48",
-      "terrain": "s",
+      "id": "AD48", "terrain": "s",
       "exits": {
-        "north": "AD47",
-        "south": "AD49",
-        "west": "AC48",
-        "east": "AE48"
+        "north": "AD47", "south": "AD49", "west": "AC48", "east": "AE48"
       }
     },
     {
-      "id": "AE48",
-      "terrain": "s",
+      "id": "AE48", "terrain": "s",
       "exits": {
-        "north": "AE47",
-        "south": "AE49",
-        "west": "AD48",
-        "east": "AF48"
+        "north": "AE47", "south": "AE49", "west": "AD48", "east": "AF48"
       }
     },
     {
-      "id": "AF48",
-      "terrain": "m",
+      "id": "AF48", "terrain": "m",
       "exits": {
-        "north": "AF47",
-        "south": "AF49",
-        "west": "AE48",
-        "east": "AG48"
+        "north": "AF47", "south": "AF49", "west": "AE48", "east": "AG48"
       }
     },
     {
-      "id": "AG48",
-      "terrain": "m",
+      "id": "AG48", "terrain": "m",
       "exits": {
-        "north": "AG47",
-        "south": "AG49",
-        "west": "AF48",
-        "east": "AH48"
+        "north": "AG47", "south": "AG49", "west": "AF48", "east": "AH48"
       }
     },
     {
-      "id": "AH48",
-      "terrain": "m",
+      "id": "AH48", "terrain": "m",
       "exits": {
-        "north": "AH47",
-        "south": "AH49",
-        "west": "AG48",
-        "east": "AI48"
+        "north": "AH47", "south": "AH49", "west": "AG48", "east": "AI48"
       }
     },
     {
-      "id": "AI48",
-      "terrain": "m",
+      "id": "AI48", "terrain": "m",
       "exits": {
-        "north": "AI47",
-        "south": "AI49",
-        "west": "AH48",
-        "east": "AJ48"
+        "north": "AI47", "south": "AI49", "west": "AH48", "east": "AJ48"
       }
     },
     {
-      "id": "AJ48",
-      "terrain": "lf",
+      "id": "AJ48", "terrain": "lf",
       "exits": {
-        "north": "AJ47",
-        "south": "AJ49",
-        "west": "AI48",
-        "east": "AK48"
+        "north": "AJ47", "south": "AJ49", "west": "AI48", "east": "AK48"
       }
     },
     {
-      "id": "AK48",
-      "terrain": "lf",
+      "id": "AK48", "terrain": "lf",
       "exits": {
-        "north": "AK47",
-        "south": "AK49",
-        "west": "AJ48",
-        "east": "AL48"
+        "north": "AK47", "south": "AK49", "west": "AJ48", "east": "AL48"
       }
     },
     {
-      "id": "AL48",
-      "terrain": "lf",
+      "id": "AL48", "terrain": "lf",
       "exits": {
-        "north": "AL47",
-        "south": "AL49",
-        "west": "AK48",
-        "east": "AM48"
+        "north": "AL47", "south": "AL49", "west": "AK48", "east": "AM48"
       }
     },
     {
-      "id": "AM48",
-      "terrain": "lf",
+      "id": "AM48", "terrain": "lf",
       "exits": {
-        "north": "AM47",
-        "south": "AM49",
-        "west": "AL48",
-        "east": "AN48"
+        "north": "AM47", "south": "AM49", "west": "AL48", "east": "AN48"
       }
     },
     {
-      "id": "AN48",
-      "terrain": "lf",
+      "id": "AN48", "terrain": "lf",
       "exits": {
-        "north": "AN47",
-        "south": "AN49",
-        "west": "AM48",
-        "east": "AO48"
+        "north": "AN47", "south": "AN49", "west": "AM48", "east": "AO48"
       }
     },
     {
-      "id": "AO48",
-      "terrain": "lf",
+      "id": "AO48", "terrain": "lf",
       "exits": {
-        "north": "AO47",
-        "south": "AO49",
-        "west": "AN48",
-        "east": "AP48"
+        "north": "AO47", "south": "AO49", "west": "AN48", "east": "AP48"
       }
     },
     {
-      "id": "AP48",
-      "terrain": "lf",
+      "id": "AP48", "terrain": "lf",
       "exits": {
-        "north": "AP47",
-        "south": "AP49",
-        "west": "AO48",
-        "east": "AQ48"
+        "north": "AP47", "south": "AP49", "west": "AO48", "east": "AQ48"
       }
     },
     {
-      "id": "AQ48",
-      "terrain": "lf",
+      "id": "AQ48", "terrain": "lf",
       "exits": {
-        "north": "AQ47",
-        "south": "AQ49",
-        "west": "AP48",
-        "east": "AR48"
+        "north": "AQ47", "south": "AQ49", "west": "AP48", "east": "AR48"
       }
     },
     {
-      "id": "AR48",
-      "terrain": "p",
+      "id": "AR48", "terrain": "p",
       "exits": {
-        "north": "AR47",
-        "south": "AR49",
-        "west": "AQ48",
-        "east": "AS48"
+        "north": "AR47", "south": "AR49", "west": "AQ48", "east": "AS48"
       }
     },
     {
-      "id": "AS48",
-      "terrain": "p",
+      "id": "AS48", "terrain": "p",
       "exits": {
-        "north": "AS47",
-        "south": "AS49",
-        "west": "AR48",
-        "east": "AT48"
+        "north": "AS47", "south": "AS49", "west": "AR48", "east": "AT48"
       }
     },
     {
-      "id": "AT48",
-      "terrain": "lf",
+      "id": "AT48", "terrain": "lf",
       "exits": {
-        "north": "AT47",
-        "south": "AT49",
-        "west": "AS48",
-        "east": "AU48"
+        "north": "AT47", "south": "AT49", "west": "AS48", "east": "AU48"
       }
     },
     {
-      "id": "AU48",
-      "terrain": "lf",
+      "id": "AU48", "terrain": "lf",
       "exits": {
-        "north": "AU47",
-        "south": "AU49",
-        "west": "AT48",
-        "east": "AV48"
+        "north": "AU47", "south": "AU49", "west": "AT48", "east": "AV48"
       }
     },
     {
-      "id": "AV48",
-      "terrain": "m",
+      "id": "AV48", "terrain": "m",
       "exits": {
-        "north": "AV47",
-        "south": "AV49",
-        "west": "AU48",
-        "east": "AW48"
+        "north": "AV47", "south": "AV49", "west": "AU48", "east": "AW48"
       }
     },
     {
-      "id": "AW48",
-      "terrain": "m",
+      "id": "AW48", "terrain": "m",
       "exits": {
-        "north": "AW47",
-        "south": "AW49",
-        "west": "AV48",
-        "east": "AX48"
+        "north": "AW47", "south": "AW49", "west": "AV48", "east": "AX48"
       }
     },
     {
-      "id": "AX48",
-      "terrain": "m",
+      "id": "AX48", "terrain": "m",
       "exits": {
-        "north": "AX47",
-        "south": "AX49",
-        "west": "AW48"
+        "north": "AX47", "south": "AX49", "west": "AW48"
       }
     },
     {
-      "id": "A49",
-      "terrain": "w",
+      "id": "A49", "terrain": "w",
       "exits": {
-        "north": "A48",
-        "south": "A50",
-        "east": "B49"
+        "north": "A48", "south": "A50", "east": "B49"
       }
     },
     {
-      "id": "B49",
-      "terrain": "w",
+      "id": "B49", "terrain": "w",
       "exits": {
-        "north": "B48",
-        "south": "B50",
-        "west": "A49",
-        "east": "C49"
+        "north": "B48", "south": "B50", "west": "A49", "east": "C49"
       }
     },
     {
-      "id": "C49",
-      "terrain": "w",
+      "id": "C49", "terrain": "w",
       "exits": {
-        "north": "C48",
-        "south": "C50",
-        "west": "B49",
-        "east": "D49"
+        "north": "C48", "south": "C50", "west": "B49", "east": "D49"
       }
     },
     {
-      "id": "D49",
-      "terrain": "p",
+      "id": "D49", "terrain": "p",
       "exits": {
-        "north": "D48",
-        "south": "D50",
-        "west": "C49",
-        "east": "E49"
+        "north": "D48", "south": "D50", "west": "C49", "east": "E49"
       }
     },
     {
-      "id": "E49",
-      "terrain": "p",
+      "id": "E49", "terrain": "p",
       "exits": {
-        "north": "E48",
-        "south": "E50",
-        "west": "D49",
-        "east": "F49"
+        "north": "E48", "south": "E50", "west": "D49", "east": "F49"
       }
     },
     {
-      "id": "F49",
-      "terrain": "p",
+      "id": "F49", "terrain": "p",
       "exits": {
-        "north": "F48",
-        "south": "F50",
-        "west": "E49",
-        "east": "G49"
+        "north": "F48", "south": "F50", "west": "E49", "east": "G49"
       }
     },
     {
-      "id": "G49",
-      "terrain": "p",
+      "id": "G49", "terrain": "p",
       "exits": {
-        "north": "G48",
-        "south": "G50",
-        "west": "F49",
-        "east": "H49"
+        "north": "G48", "south": "G50", "west": "F49", "east": "H49"
       }
     },
     {
-      "id": "H49",
-      "terrain": "p",
+      "id": "H49", "terrain": "p",
       "exits": {
-        "north": "H48",
-        "south": "H50",
-        "west": "G49",
-        "east": "I49"
+        "north": "H48", "south": "H50", "west": "G49", "east": "I49"
       }
     },
     {
-      "id": "I49",
-      "terrain": "p",
+      "id": "I49", "terrain": "p",
       "exits": {
-        "north": "I48",
-        "south": "I50",
-        "west": "H49",
-        "east": "J49"
+        "north": "I48", "south": "I50", "west": "H49", "east": "J49"
       }
     },
     {
-      "id": "J49",
-      "terrain": "p",
+      "id": "J49", "terrain": "p",
       "exits": {
-        "north": "J48",
-        "south": "J50",
-        "west": "I49",
-        "east": "K49"
+        "north": "J48", "south": "J50", "west": "I49", "east": "K49"
       }
     },
     {
-      "id": "K49",
-      "terrain": "p",
+      "id": "K49", "terrain": "p",
       "exits": {
-        "north": "K48",
-        "south": "K50",
-        "west": "J49",
-        "east": "L49"
+        "north": "K48", "south": "K50", "west": "J49", "east": "L49"
       }
     },
     {
-      "id": "L49",
-      "terrain": "w",
+      "id": "L49", "terrain": "w",
       "exits": {
-        "north": "L48",
-        "south": "L50",
-        "west": "K49",
-        "east": "M49"
+        "north": "L48", "south": "L50", "west": "K49", "east": "M49"
       }
     },
     {
-      "id": "M49",
-      "terrain": "w",
+      "id": "M49", "terrain": "w",
       "exits": {
-        "north": "M48",
-        "south": "M50",
-        "west": "L49",
-        "east": "N49"
+        "north": "M48", "south": "M50", "west": "L49", "east": "N49"
       }
     },
     {
-      "id": "N49",
-      "terrain": "p",
+      "id": "N49", "terrain": "p",
       "exits": {
-        "north": "N48",
-        "south": "N50",
-        "west": "M49",
-        "east": "O49"
+        "north": "N48", "south": "N50", "west": "M49", "east": "O49"
       }
     },
     {
-      "id": "O49",
-      "terrain": "p",
+      "id": "O49", "terrain": "p",
       "exits": {
-        "north": "O48",
-        "south": "O50",
-        "west": "N49",
-        "east": "P49"
+        "north": "O48", "south": "O50", "west": "N49", "east": "P49"
       }
     },
     {
-      "id": "P49",
-      "terrain": "p",
+      "id": "P49", "terrain": "p",
       "exits": {
-        "north": "P48",
-        "south": "P50",
-        "west": "O49",
-        "east": "Q49"
+        "north": "P48", "south": "P50", "west": "O49", "east": "Q49"
       }
     },
     {
-      "id": "Q49",
-      "terrain": "p",
+      "id": "Q49", "terrain": "p",
       "exits": {
-        "north": "Q48",
-        "south": "Q50",
-        "west": "P49",
-        "east": "R49"
+        "north": "Q48", "south": "Q50", "west": "P49", "east": "R49"
       }
     },
     {
-      "id": "R49",
-      "terrain": "p",
+      "id": "R49", "terrain": "p",
       "exits": {
-        "north": "R48",
-        "south": "R50",
-        "west": "Q49",
-        "east": "S49"
+        "north": "R48", "south": "R50", "west": "Q49", "east": "S49"
       }
     },
     {
-      "id": "S49",
-      "terrain": "p",
+      "id": "S49", "terrain": "p",
       "exits": {
-        "north": "S48",
-        "south": "S50",
-        "west": "R49",
-        "east": "T49"
+        "north": "S48", "south": "S50", "west": "R49", "east": "T49"
       }
     },
     {
-      "id": "T49",
-      "terrain": "p",
+      "id": "T49", "terrain": "p",
       "exits": {
-        "north": "T48",
-        "south": "T50",
-        "west": "S49",
-        "east": "U49"
+        "north": "T48", "south": "T50", "west": "S49", "east": "U49"
       }
     },
     {
-      "id": "U49",
-      "terrain": "p",
+      "id": "U49", "terrain": "p",
       "exits": {
-        "north": "U48",
-        "south": "U50",
-        "west": "T49",
-        "east": "V49"
+        "north": "U48", "south": "U50", "west": "T49", "east": "V49"
       }
     },
     {
-      "id": "V49",
-      "terrain": "p",
+      "id": "V49", "terrain": "p",
       "exits": {
-        "north": "V48",
-        "south": "V50",
-        "west": "U49",
-        "east": "W49"
+        "north": "V48", "south": "V50", "west": "U49", "east": "W49"
       }
     },
     {
-      "id": "W49",
-      "terrain": "p",
+      "id": "W49", "terrain": "p",
       "exits": {
-        "north": "W48",
-        "south": "W50",
-        "west": "V49",
-        "east": "X49"
+        "north": "W48", "south": "W50", "west": "V49", "east": "X49"
       }
     },
     {
-      "id": "X49",
-      "terrain": "p",
+      "id": "X49", "terrain": "p",
       "exits": {
-        "north": "X48",
-        "south": "X50",
-        "west": "W49",
-        "east": "Y49"
+        "north": "X48", "south": "X50", "west": "W49", "east": "Y49"
       }
     },
     {
-      "id": "Y49",
-      "terrain": "p",
+      "id": "Y49", "terrain": "p",
       "exits": {
-        "north": "Y48",
-        "south": "Y50",
-        "west": "X49",
-        "east": "Z49"
+        "north": "Y48", "south": "Y50", "west": "X49", "east": "Z49"
       }
     },
     {
-      "id": "Z49",
-      "terrain": "s",
+      "id": "Z49", "terrain": "s",
       "exits": {
-        "north": "Z48",
-        "south": "Z50",
-        "west": "Y49",
-        "east": "AA49"
+        "north": "Z48", "south": "Z50", "west": "Y49", "east": "AA49"
       }
     },
     {
-      "id": "AA49",
-      "terrain": "s",
+      "id": "AA49", "terrain": "s",
       "exits": {
-        "north": "AA48",
-        "south": "AA50",
-        "west": "Z49",
-        "east": "AB49"
+        "north": "AA48", "south": "AA50", "west": "Z49", "east": "AB49"
       }
     },
     {
-      "id": "AB49",
-      "terrain": "s",
+      "id": "AB49", "terrain": "s",
       "exits": {
-        "north": "AB48",
-        "south": "AB50",
-        "west": "AA49",
-        "east": "AC49"
+        "north": "AB48", "south": "AB50", "west": "AA49", "east": "AC49"
       }
     },
     {
-      "id": "AC49",
-      "terrain": "s",
+      "id": "AC49", "terrain": "s",
       "exits": {
-        "north": "AC48",
-        "south": "AC50",
-        "west": "AB49",
-        "east": "AD49"
+        "north": "AC48", "south": "AC50", "west": "AB49", "east": "AD49"
       }
     },
     {
-      "id": "AD49",
-      "terrain": "s",
+      "id": "AD49", "terrain": "s",
       "exits": {
-        "north": "AD48",
-        "south": "AD50",
-        "west": "AC49",
-        "east": "AE49"
+        "north": "AD48", "south": "AD50", "west": "AC49", "east": "AE49"
       }
     },
     {
-      "id": "AE49",
-      "terrain": "s",
+      "id": "AE49", "terrain": "s",
       "exits": {
-        "north": "AE48",
-        "south": "AE50",
-        "west": "AD49",
-        "east": "AF49"
+        "north": "AE48", "south": "AE50", "west": "AD49", "east": "AF49"
       }
     },
     {
-      "id": "AF49",
-      "terrain": "s",
+      "id": "AF49", "terrain": "s",
       "exits": {
-        "north": "AF48",
-        "south": "AF50",
-        "west": "AE49",
-        "east": "AG49"
+        "north": "AF48", "south": "AF50", "west": "AE49", "east": "AG49"
       }
     },
     {
-      "id": "AG49",
-      "terrain": "m",
+      "id": "AG49", "terrain": "m",
       "exits": {
-        "north": "AG48",
-        "south": "AG50",
-        "west": "AF49",
-        "east": "AH49"
+        "north": "AG48", "south": "AG50", "west": "AF49", "east": "AH49"
       }
     },
     {
-      "id": "AH49",
-      "terrain": "m",
+      "id": "AH49", "terrain": "m",
       "exits": {
-        "north": "AH48",
-        "south": "AH50",
-        "west": "AG49",
-        "east": "AI49"
+        "north": "AH48", "south": "AH50", "west": "AG49", "east": "AI49"
       }
     },
     {
-      "id": "AI49",
-      "terrain": "m",
+      "id": "AI49", "terrain": "m",
       "exits": {
-        "north": "AI48",
-        "south": "AI50",
-        "west": "AH49",
-        "east": "AJ49"
+        "north": "AI48", "south": "AI50", "west": "AH49", "east": "AJ49"
       }
     },
     {
-      "id": "AJ49",
-      "terrain": "lf",
+      "id": "AJ49", "terrain": "lf",
       "exits": {
-        "north": "AJ48",
-        "south": "AJ50",
-        "west": "AI49",
-        "east": "AK49"
+        "north": "AJ48", "south": "AJ50", "west": "AI49", "east": "AK49"
       }
     },
     {
-      "id": "AK49",
-      "terrain": "b",
+      "id": "AK49", "terrain": "b",
       "exits": {
-        "north": "AK48",
-        "south": "AK50",
-        "west": "AJ49",
-        "east": "AL49"
+        "north": "AK48", "south": "AK50", "west": "AJ49", "east": "AL49"
       }
     },
     {
-      "id": "AL49",
-      "terrain": "b",
+      "id": "AL49", "terrain": "b",
       "exits": {
-        "north": "AL48",
-        "south": "AL50",
-        "west": "AK49",
-        "east": "AM49"
+        "north": "AL48", "south": "AL50", "west": "AK49", "east": "AM49"
       }
     },
     {
-      "id": "AM49",
-      "terrain": "b",
+      "id": "AM49", "terrain": "b",
       "exits": {
-        "north": "AM48",
-        "south": "AM50",
-        "west": "AL49",
-        "east": "AN49"
+        "north": "AM48", "south": "AM50", "west": "AL49", "east": "AN49"
       }
     },
     {
-      "id": "AN49",
-      "terrain": "lf",
+      "id": "AN49", "terrain": "lf",
       "exits": {
-        "north": "AN48",
-        "south": "AN50",
-        "west": "AM49",
-        "east": "AO49"
+        "north": "AN48", "south": "AN50", "west": "AM49", "east": "AO49"
       }
     },
     {
-      "id": "AO49",
-      "terrain": "b",
+      "id": "AO49", "terrain": "b",
       "exits": {
-        "north": "AO48",
-        "south": "AO50",
-        "west": "AN49",
-        "east": "AP49"
+        "north": "AO48", "south": "AO50", "west": "AN49", "east": "AP49"
       }
     },
     {
-      "id": "AP49",
-      "terrain": "lf",
+      "id": "AP49", "terrain": "lf",
       "exits": {
-        "north": "AP48",
-        "south": "AP50",
-        "west": "AO49",
-        "east": "AQ49"
+        "north": "AP48", "south": "AP50", "west": "AO49", "east": "AQ49"
       }
     },
     {
-      "id": "AQ49",
-      "terrain": "lf",
+      "id": "AQ49", "terrain": "lf",
       "exits": {
-        "north": "AQ48",
-        "south": "AQ50",
-        "west": "AP49",
-        "east": "AR49"
+        "north": "AQ48", "south": "AQ50", "west": "AP49", "east": "AR49"
       }
     },
     {
-      "id": "AR49",
-      "terrain": "p",
+      "id": "AR49", "terrain": "p",
       "exits": {
-        "north": "AR48",
-        "south": "AR50",
-        "west": "AQ49",
-        "east": "AS49"
+        "north": "AR48", "south": "AR50", "west": "AQ49", "east": "AS49"
       }
     },
     {
-      "id": "AS49",
-      "terrain": "p",
+      "id": "AS49", "terrain": "p",
       "exits": {
-        "north": "AS48",
-        "south": "AS50",
-        "west": "AR49",
-        "east": "AT49"
+        "north": "AS48", "south": "AS50", "west": "AR49", "east": "AT49"
       }
     },
     {
-      "id": "AT49",
-      "terrain": "lf",
+      "id": "AT49", "terrain": "lf",
       "exits": {
-        "north": "AT48",
-        "south": "AT50",
-        "west": "AS49",
-        "east": "AU49"
+        "north": "AT48", "south": "AT50", "west": "AS49", "east": "AU49"
       }
     },
     {
-      "id": "AU49",
-      "terrain": "lf",
+      "id": "AU49", "terrain": "lf",
       "exits": {
-        "north": "AU48",
-        "south": "AU50",
-        "west": "AT49",
-        "east": "AV49"
+        "north": "AU48", "south": "AU50", "west": "AT49", "east": "AV49"
       }
     },
     {
-      "id": "AV49",
-      "terrain": "m",
+      "id": "AV49", "terrain": "m",
       "exits": {
-        "north": "AV48",
-        "south": "AV50",
-        "west": "AU49",
-        "east": "AW49"
+        "north": "AV48", "south": "AV50", "west": "AU49", "east": "AW49"
       }
     },
     {
-      "id": "AW49",
-      "terrain": "m",
+      "id": "AW49", "terrain": "m",
       "exits": {
-        "north": "AW48",
-        "south": "AW50",
-        "west": "AV49",
-        "east": "AX49"
+        "north": "AW48", "south": "AW50", "west": "AV49", "east": "AX49"
       }
     },
     {
-      "id": "AX49",
-      "terrain": "m",
+      "id": "AX49", "terrain": "m",
       "exits": {
-        "north": "AX48",
-        "south": "AX50",
-        "west": "AW49"
+        "north": "AX48", "south": "AX50", "west": "AW49"
       }
     },
     {
-      "id": "A50",
-      "terrain": "p",
+      "id": "A50", "terrain": "p",
       "exits": {
-        "north": "A49",
-        "south": "A51",
-        "east": "B50"
+        "north": "A49", "south": "A51", "east": "B50"
       }
     },
     {
-      "id": "B50",
-      "terrain": "p",
+      "id": "B50", "terrain": "p",
       "exits": {
-        "north": "B49",
-        "south": "B51",
-        "west": "A50",
-        "east": "C50"
+        "north": "B49", "south": "B51", "west": "A50", "east": "C50"
       }
     },
     {
-      "id": "C50",
-      "terrain": "p",
+      "id": "C50", "terrain": "p",
       "exits": {
-        "north": "C49",
-        "south": "C51",
-        "west": "B50",
-        "east": "D50"
+        "north": "C49", "south": "C51", "west": "B50", "east": "D50"
       }
     },
     {
-      "id": "D50",
-      "terrain": "p",
+      "id": "D50", "terrain": "p",
       "exits": {
-        "north": "D49",
-        "south": "D51",
-        "west": "C50",
-        "east": "E50"
+        "north": "D49", "south": "D51", "west": "C50", "east": "E50"
       }
     },
     {
-      "id": "E50",
-      "terrain": "p",
+      "id": "E50", "terrain": "p",
       "exits": {
-        "north": "E49",
-        "south": "E51",
-        "west": "D50",
-        "east": "F50"
+        "north": "E49", "south": "E51", "west": "D50", "east": "F50"
       }
     },
     {
-      "id": "F50",
-      "terrain": "p",
+      "id": "F50", "terrain": "p",
       "exits": {
-        "north": "F49",
-        "south": "F51",
-        "west": "E50",
-        "east": "G50"
+        "north": "F49", "south": "F51", "west": "E50", "east": "G50"
       }
     },
     {
-      "id": "G50",
-      "terrain": "p",
+      "id": "G50", "terrain": "p",
       "exits": {
-        "north": "G49",
-        "south": "G51",
-        "west": "F50",
-        "east": "H50"
+        "north": "G49", "south": "G51", "west": "F50", "east": "H50"
       }
     },
     {
-      "id": "H50",
-      "terrain": "p",
+      "id": "H50", "terrain": "p",
       "exits": {
-        "north": "H49",
-        "south": "H51",
-        "west": "G50",
-        "east": "I50"
+        "north": "H49", "south": "H51", "west": "G50", "east": "I50"
       }
     },
     {
-      "id": "I50",
-      "terrain": "p",
+      "id": "I50", "terrain": "p",
       "exits": {
-        "north": "I49",
-        "south": "I51",
-        "west": "H50",
-        "east": "J50"
+        "north": "I49", "south": "I51", "west": "H50", "east": "J50"
       }
     },
     {
-      "id": "J50",
-      "terrain": "Corsair",
+      "id": "J50", "terrain": "Corsair",
       "exits": {
-        "north": "J49",
-        "south": "J51",
-        "west": "I50",
-        "east": "K50"
+        "north": "J49", "south": "J51", "west": "I50", "east": "K50"
       }
     },
     {
-      "id": "K50",
-      "terrain": "w",
+      "id": "K50", "terrain": "w",
       "exits": {
-        "north": "K49",
-        "south": "K51",
-        "west": "J50",
-        "east": "L50"
+        "north": "K49", "south": "K51", "west": "J50", "east": "L50"
       }
     },
     {
-      "id": "L50",
-      "terrain": "path",
+      "id": "L50", "terrain": "path",
       "exits": {
-        "north": "L49",
-        "south": "L51",
-        "west": "K50",
-        "east": "M50"
+        "north": "L49", "south": "L51", "west": "K50", "east": "M50"
       }
     },
     {
-      "id": "M50",
-      "terrain": "p",
+      "id": "M50", "terrain": "p",
       "exits": {
-        "north": "M49",
-        "south": "M51",
-        "west": "L50",
-        "east": "N50"
+        "north": "M49", "south": "M51", "west": "L50", "east": "N50"
       }
     },
     {
-      "id": "N50",
-      "terrain": "p",
+      "id": "N50", "terrain": "p",
       "exits": {
-        "north": "N49",
-        "south": "N51",
-        "west": "M50",
-        "east": "O50"
+        "north": "N49", "south": "N51", "west": "M50", "east": "O50"
       }
     },
     {
-      "id": "O50",
-      "terrain": "p",
+      "id": "O50", "terrain": "p",
       "exits": {
-        "north": "O49",
-        "south": "O51",
-        "west": "N50",
-        "east": "P50"
+        "north": "O49", "south": "O51", "west": "N50", "east": "P50"
       }
     },
     {
-      "id": "P50",
-      "terrain": "p",
+      "id": "P50", "terrain": "p",
       "exits": {
-        "north": "P49",
-        "south": "P51",
-        "west": "O50",
-        "east": "Q50"
+        "north": "P49", "south": "P51", "west": "O50", "east": "Q50"
       }
     },
     {
-      "id": "Q50",
-      "terrain": "p",
+      "id": "Q50", "terrain": "p",
       "exits": {
-        "north": "Q49",
-        "south": "Q51",
-        "west": "P50",
-        "east": "R50"
+        "north": "Q49", "south": "Q51", "west": "P50", "east": "R50"
       }
     },
     {
-      "id": "R50",
-      "terrain": "p",
+      "id": "R50", "terrain": "p",
       "exits": {
-        "north": "R49",
-        "south": "R51",
-        "west": "Q50",
-        "east": "S50"
+        "north": "R49", "south": "R51", "west": "Q50", "east": "S50"
       }
     },
     {
-      "id": "S50",
-      "terrain": "p",
+      "id": "S50", "terrain": "p",
       "exits": {
-        "north": "S49",
-        "south": "S51",
-        "west": "R50",
-        "east": "T50"
+        "north": "S49", "south": "S51", "west": "R50", "east": "T50"
       }
     },
     {
-      "id": "T50",
-      "terrain": "p",
+      "id": "T50", "terrain": "p",
       "exits": {
-        "north": "T49",
-        "south": "T51",
-        "west": "S50",
-        "east": "U50"
+        "north": "T49", "south": "T51", "west": "S50", "east": "U50"
       }
     },
     {
-      "id": "U50",
-      "terrain": "p",
+      "id": "U50", "terrain": "p",
       "exits": {
-        "north": "U49",
-        "south": "U51",
-        "west": "T50",
-        "east": "V50"
+        "north": "U49", "south": "U51", "west": "T50", "east": "V50"
       }
     },
     {
-      "id": "V50",
-      "terrain": "p",
+      "id": "V50", "terrain": "p",
       "exits": {
-        "north": "V49",
-        "south": "V51",
-        "west": "U50",
-        "east": "W50"
+        "north": "V49", "south": "V51", "west": "U50", "east": "W50"
       }
     },
     {
-      "id": "W50",
-      "terrain": "p",
+      "id": "W50", "terrain": "p",
       "exits": {
-        "north": "W49",
-        "south": "W51",
-        "west": "V50",
-        "east": "X50"
+        "north": "W49", "south": "W51", "west": "V50", "east": "X50"
       }
     },
     {
-      "id": "X50",
-      "terrain": "p",
+      "id": "X50", "terrain": "p",
       "exits": {
-        "north": "X49",
-        "south": "X51",
-        "west": "W50",
-        "east": "Y50"
+        "north": "X49", "south": "X51", "west": "W50", "east": "Y50"
       }
     },
     {
-      "id": "Y50",
-      "terrain": "p",
+      "id": "Y50", "terrain": "p",
       "exits": {
-        "north": "Y49",
-        "south": "Y51",
-        "west": "X50",
-        "east": "Z50"
+        "north": "Y49", "south": "Y51", "west": "X50", "east": "Z50"
       }
     },
     {
-      "id": "Z50",
-      "terrain": "s",
+      "id": "Z50", "terrain": "s",
       "exits": {
-        "north": "Z49",
-        "south": "Z51",
-        "west": "Y50",
-        "east": "AA50"
+        "north": "Z49", "south": "Z51", "west": "Y50", "east": "AA50"
       }
     },
     {
-      "id": "AA50",
-      "terrain": "s",
+      "id": "AA50", "terrain": "s",
       "exits": {
-        "north": "AA49",
-        "south": "AA51",
-        "west": "Z50",
-        "east": "AB50"
+        "north": "AA49", "south": "AA51", "west": "Z50", "east": "AB50"
       }
     },
     {
-      "id": "AB50",
-      "terrain": "s",
+      "id": "AB50", "terrain": "s",
       "exits": {
-        "north": "AB49",
-        "south": "AB51",
-        "west": "AA50",
-        "east": "AC50"
+        "north": "AB49", "south": "AB51", "west": "AA50", "east": "AC50"
       }
     },
     {
-      "id": "AC50",
-      "terrain": "s",
+      "id": "AC50", "terrain": "s",
       "exits": {
-        "north": "AC49",
-        "south": "AC51",
-        "west": "AB50",
-        "east": "AD50"
+        "north": "AC49", "south": "AC51", "west": "AB50", "east": "AD50"
       }
     },
     {
-      "id": "AD50",
-      "terrain": "s",
+      "id": "AD50", "terrain": "s",
       "exits": {
-        "north": "AD49",
-        "south": "AD51",
-        "west": "AC50",
-        "east": "AE50"
+        "north": "AD49", "south": "AD51", "west": "AC50", "east": "AE50"
       }
     },
     {
-      "id": "AE50",
-      "terrain": "s",
+      "id": "AE50", "terrain": "s",
       "exits": {
-        "north": "AE49",
-        "south": "AE51",
-        "west": "AD50",
-        "east": "AF50"
+        "north": "AE49", "south": "AE51", "west": "AD50", "east": "AF50"
       }
     },
     {
-      "id": "AF50",
-      "terrain": "s",
+      "id": "AF50", "terrain": "s",
       "exits": {
-        "north": "AF49",
-        "south": "AF51",
-        "west": "AE50",
-        "east": "AG50"
+        "north": "AF49", "south": "AF51", "west": "AE50", "east": "AG50"
       }
     },
     {
-      "id": "AG50",
-      "terrain": "m",
+      "id": "AG50", "terrain": "m",
       "exits": {
-        "north": "AG49",
-        "south": "AG51",
-        "west": "AF50",
-        "east": "AH50"
+        "north": "AG49", "south": "AG51", "west": "AF50", "east": "AH50"
       }
     },
     {
-      "id": "AH50",
-      "terrain": "m",
+      "id": "AH50", "terrain": "m",
       "exits": {
-        "north": "AH49",
-        "south": "AH51",
-        "west": "AG50",
-        "east": "AI50"
+        "north": "AH49", "south": "AH51", "west": "AG50", "east": "AI50"
       }
     },
     {
-      "id": "AI50",
-      "terrain": "m",
+      "id": "AI50", "terrain": "m",
       "exits": {
-        "north": "AI49",
-        "south": "AI51",
-        "west": "AH50",
-        "east": "AJ50"
+        "north": "AI49", "south": "AI51", "west": "AH50", "east": "AJ50"
       }
     },
     {
-      "id": "AJ50",
-      "terrain": "lf",
+      "id": "AJ50", "terrain": "lf",
       "exits": {
-        "north": "AJ49",
-        "south": "AJ51",
-        "west": "AI50",
-        "east": "AK50"
+        "north": "AJ49", "south": "AJ51", "west": "AI50", "east": "AK50"
       }
     },
     {
-      "id": "AK50",
-      "terrain": "b",
+      "id": "AK50", "terrain": "b",
       "exits": {
-        "north": "AK49",
-        "south": "AK51",
-        "west": "AJ50",
-        "east": "AL50"
+        "north": "AK49", "south": "AK51", "west": "AJ50", "east": "AL50"
       }
     },
     {
-      "id": "AL50",
-      "terrain": "b",
+      "id": "AL50", "terrain": "b",
       "exits": {
-        "north": "AL49",
-        "south": "AL51",
-        "west": "AK50",
-        "east": "AM50"
+        "north": "AL49", "south": "AL51", "west": "AK50", "east": "AM50"
       }
     },
     {
-      "id": "AM50",
-      "terrain": "b",
+      "id": "AM50", "terrain": "b",
       "exits": {
-        "north": "AM49",
-        "south": "AM51",
-        "west": "AL50",
-        "east": "AN50"
+        "north": "AM49", "south": "AM51", "west": "AL50", "east": "AN50"
       }
     },
     {
-      "id": "AN50",
-      "terrain": "b",
+      "id": "AN50", "terrain": "b",
       "exits": {
-        "north": "AN49",
-        "south": "AN51",
-        "west": "AM50",
-        "east": "AO50"
+        "north": "AN49", "south": "AN51", "west": "AM50", "east": "AO50"
       }
     },
     {
-      "id": "AO50",
-      "terrain": "b",
+      "id": "AO50", "terrain": "b",
       "exits": {
-        "north": "AO49",
-        "south": "AO51",
-        "west": "AN50",
-        "east": "AP50"
+        "north": "AO49", "south": "AO51", "west": "AN50", "east": "AP50"
       }
     },
     {
-      "id": "AP50",
-      "terrain": "b",
+      "id": "AP50", "terrain": "b",
       "exits": {
-        "north": "AP49",
-        "south": "AP51",
-        "west": "AO50",
-        "east": "AQ50"
+        "north": "AP49", "south": "AP51", "west": "AO50", "east": "AQ50"
       }
     },
     {
-      "id": "AQ50",
-      "terrain": "lf",
+      "id": "AQ50", "terrain": "lf",
       "exits": {
-        "north": "AQ49",
-        "south": "AQ51",
-        "west": "AP50",
-        "east": "AR50"
+        "north": "AQ49", "south": "AQ51", "west": "AP50", "east": "AR50"
       }
     },
     {
-      "id": "AR50",
-      "terrain": "b",
+      "id": "AR50", "terrain": "b",
       "exits": {
-        "north": "AR49",
-        "south": "AR51",
-        "west": "AQ50",
-        "east": "AS50"
+        "north": "AR49", "south": "AR51", "west": "AQ50", "east": "AS50"
       }
     },
     {
-      "id": "AS50",
-      "terrain": "b",
+      "id": "AS50", "terrain": "b",
       "exits": {
-        "north": "AS49",
-        "south": "AS51",
-        "west": "AR50",
-        "east": "AT50"
+        "north": "AS49", "south": "AS51", "west": "AR50", "east": "AT50"
       }
     },
     {
-      "id": "AT50",
-      "terrain": "b",
+      "id": "AT50", "terrain": "b",
       "exits": {
-        "north": "AT49",
-        "south": "AT51",
-        "west": "AS50",
-        "east": "AU50"
+        "north": "AT49", "south": "AT51", "west": "AS50", "east": "AU50"
       }
     },
     {
-      "id": "AU50",
-      "terrain": "b",
+      "id": "AU50", "terrain": "b",
       "exits": {
-        "north": "AU49",
-        "south": "AU51",
-        "west": "AT50",
-        "east": "AV50"
+        "north": "AU49", "south": "AU51", "west": "AT50", "east": "AV50"
       }
     },
     {
-      "id": "AV50",
-      "terrain": "m",
+      "id": "AV50", "terrain": "m",
       "exits": {
-        "north": "AV49",
-        "south": "AV51",
-        "west": "AU50",
-        "east": "AW50"
+        "north": "AV49", "south": "AV51", "west": "AU50", "east": "AW50"
       }
     },
     {
-      "id": "AW50",
-      "terrain": "m",
+      "id": "AW50", "terrain": "m",
       "exits": {
-        "north": "AW49",
-        "south": "AW51",
-        "west": "AV50",
-        "east": "AX50"
+        "north": "AW49", "south": "AW51", "west": "AV50", "east": "AX50"
       }
     },
     {
-      "id": "AX50",
-      "terrain": "w",
+      "id": "AX50", "terrain": "w",
       "exits": {
-        "north": "AX49",
-        "south": "AX51",
-        "west": "AW50"
+        "north": "AX49", "south": "AX51", "west": "AW50"
       }
     },
     {
-      "id": "A51",
-      "terrain": "b",
+      "id": "A51", "terrain": "b",
       "exits": {
-        "north": "A50",
-        "south": "A52",
-        "east": "B51"
+        "north": "A50", "south": "A52", "east": "B51"
       }
     },
     {
-      "id": "B51",
-      "terrain": "p",
+      "id": "B51", "terrain": "p",
       "exits": {
-        "north": "B50",
-        "south": "B52",
-        "west": "A51",
-        "east": "C51"
+        "north": "B50", "south": "B52", "west": "A51", "east": "C51"
       }
     },
     {
-      "id": "C51",
-      "terrain": "w",
+      "id": "C51", "terrain": "w",
       "exits": {
-        "north": "C50",
-        "south": "C52",
-        "west": "B51",
-        "east": "D51"
+        "north": "C50", "south": "C52", "west": "B51", "east": "D51"
       }
     },
     {
-      "id": "D51",
-      "terrain": "p",
+      "id": "D51", "terrain": "p",
       "exits": {
-        "north": "D50",
-        "south": "D52",
-        "west": "C51",
-        "east": "E51"
+        "north": "D50", "south": "D52", "west": "C51", "east": "E51"
       }
     },
     {
-      "id": "E51",
-      "terrain": "p",
+      "id": "E51", "terrain": "p",
       "exits": {
-        "north": "E50",
-        "south": "E52",
-        "west": "D51",
-        "east": "F51"
+        "north": "E50", "south": "E52", "west": "D51", "east": "F51"
       }
     },
     {
-      "id": "F51",
-      "terrain": "p",
+      "id": "F51", "terrain": "p",
       "exits": {
-        "north": "F50",
-        "south": "F52",
-        "west": "E51",
-        "east": "G51"
+        "north": "F50", "south": "F52", "west": "E51", "east": "G51"
       }
     },
     {
-      "id": "G51",
-      "terrain": "p",
+      "id": "G51", "terrain": "p",
       "exits": {
-        "north": "G50",
-        "south": "G52",
-        "west": "F51",
-        "east": "H51"
+        "north": "G50", "south": "G52", "west": "F51", "east": "H51"
       }
     },
     {
-      "id": "H51",
-      "terrain": "p",
+      "id": "H51", "terrain": "p",
       "exits": {
-        "north": "H50",
-        "south": "H52",
-        "west": "G51",
-        "east": "I51"
+        "north": "H50", "south": "H52", "west": "G51", "east": "I51"
       }
     },
     {
-      "id": "I51",
-      "terrain": "p",
+      "id": "I51", "terrain": "p",
       "exits": {
-        "north": "I50",
-        "south": "I52",
-        "west": "H51",
-        "east": "J51"
+        "north": "I50", "south": "I52", "west": "H51", "east": "J51"
       }
     },
     {
-      "id": "J51",
-      "terrain": "w",
+      "id": "J51", "terrain": "w",
       "exits": {
-        "north": "J50",
-        "south": "J52",
-        "west": "I51",
-        "east": "K51"
+        "north": "J50", "south": "J52", "west": "I51", "east": "K51"
       }
     },
     {
-      "id": "K51",
-      "terrain": "p",
+      "id": "K51", "terrain": "p",
       "exits": {
-        "north": "K50",
-        "south": "K52",
-        "west": "J51",
-        "east": "L51"
+        "north": "K50", "south": "K52", "west": "J51", "east": "L51"
       }
     },
     {
-      "id": "L51",
-      "terrain": "p",
+      "id": "L51", "terrain": "p",
       "exits": {
-        "north": "L50",
-        "south": "L52",
-        "west": "K51",
-        "east": "M51"
+        "north": "L50", "south": "L52", "west": "K51", "east": "M51"
       }
     },
     {
-      "id": "M51",
-      "terrain": "p",
+      "id": "M51", "terrain": "p",
       "exits": {
-        "north": "M50",
-        "south": "M52",
-        "west": "L51",
-        "east": "N51"
+        "north": "M50", "south": "M52", "west": "L51", "east": "N51"
       }
     },
     {
-      "id": "N51",
-      "terrain": "p",
+      "id": "N51", "terrain": "p",
       "exits": {
-        "north": "N50",
-        "south": "N52",
-        "west": "M51",
-        "east": "O51"
+        "north": "N50", "south": "N52", "west": "M51", "east": "O51"
       }
     },
     {
-      "id": "O51",
-      "terrain": "p",
+      "id": "O51", "terrain": "p",
       "exits": {
-        "north": "O50",
-        "south": "O52",
-        "west": "N51",
-        "east": "P51"
+        "north": "O50", "south": "O52", "west": "N51", "east": "P51"
       }
     },
     {
-      "id": "P51",
-      "terrain": "p",
+      "id": "P51", "terrain": "p",
       "exits": {
-        "north": "P50",
-        "south": "P52",
-        "west": "O51",
-        "east": "Q51"
+        "north": "P50", "south": "P52", "west": "O51", "east": "Q51"
       }
     },
     {
-      "id": "Q51",
-      "terrain": "p",
+      "id": "Q51", "terrain": "p",
       "exits": {
-        "north": "Q50",
-        "south": "Q52",
-        "west": "P51",
-        "east": "R51"
+        "north": "Q50", "south": "Q52", "west": "P51", "east": "R51"
       }
     },
     {
-      "id": "R51",
-      "terrain": "p",
+      "id": "R51", "terrain": "p",
       "exits": {
-        "north": "R50",
-        "south": "R52",
-        "west": "Q51",
-        "east": "S51"
+        "north": "R50", "south": "R52", "west": "Q51", "east": "S51"
       }
     },
     {
-      "id": "S51",
-      "terrain": "p",
+      "id": "S51", "terrain": "p",
       "exits": {
-        "north": "S50",
-        "south": "S52",
-        "west": "R51",
-        "east": "T51"
+        "north": "S50", "south": "S52", "west": "R51", "east": "T51"
       }
     },
     {
-      "id": "T51",
-      "terrain": "p",
+      "id": "T51", "terrain": "p",
       "exits": {
-        "north": "T50",
-        "south": "T52",
-        "west": "S51",
-        "east": "U51"
+        "north": "T50", "south": "T52", "west": "S51", "east": "U51"
       }
     },
     {
-      "id": "U51",
-      "terrain": "p",
+      "id": "U51", "terrain": "p",
       "exits": {
-        "north": "U50",
-        "south": "U52",
-        "west": "T51",
-        "east": "V51"
+        "north": "U50", "south": "U52", "west": "T51", "east": "V51"
       }
     },
     {
-      "id": "V51",
-      "terrain": "p",
+      "id": "V51", "terrain": "p",
       "exits": {
-        "north": "V50",
-        "south": "V52",
-        "west": "U51",
-        "east": "W51"
+        "north": "V50", "south": "V52", "west": "U51", "east": "W51"
       }
     },
     {
-      "id": "W51",
-      "terrain": "p",
+      "id": "W51", "terrain": "p",
       "exits": {
-        "north": "W50",
-        "south": "W52",
-        "west": "V51",
-        "east": "X51"
+        "north": "W50", "south": "W52", "west": "V51", "east": "X51"
       }
     },
     {
-      "id": "X51",
-      "terrain": "p",
+      "id": "X51", "terrain": "p",
       "exits": {
-        "north": "X50",
-        "south": "X52",
-        "west": "W51",
-        "east": "Y51"
+        "north": "X50", "south": "X52", "west": "W51", "east": "Y51"
       }
     },
     {
-      "id": "Y51",
-      "terrain": "p",
+      "id": "Y51", "terrain": "p",
       "exits": {
-        "north": "Y50",
-        "south": "Y52",
-        "west": "X51",
-        "east": "Z51"
+        "north": "Y50", "south": "Y52", "west": "X51", "east": "Z51"
       }
     },
     {
-      "id": "Z51",
-      "terrain": "s",
+      "id": "Z51", "terrain": "s",
       "exits": {
-        "north": "Z50",
-        "south": "Z52",
-        "west": "Y51",
-        "east": "AA51"
+        "north": "Z50", "south": "Z52", "west": "Y51", "east": "AA51"
       }
     },
     {
-      "id": "AA51",
-      "terrain": "s",
+      "id": "AA51", "terrain": "s",
       "exits": {
-        "north": "AA50",
-        "south": "AA52",
-        "west": "Z51",
-        "east": "AB51"
+        "north": "AA50", "south": "AA52", "west": "Z51", "east": "AB51"
       }
     },
     {
-      "id": "AB51",
-      "terrain": "s",
+      "id": "AB51", "terrain": "s",
       "exits": {
-        "north": "AB50",
-        "south": "AB52",
-        "west": "AA51",
-        "east": "AC51"
+        "north": "AB50", "south": "AB52", "west": "AA51", "east": "AC51"
       }
     },
     {
-      "id": "AC51",
-      "terrain": "s",
+      "id": "AC51", "terrain": "s",
       "exits": {
-        "north": "AC50",
-        "south": "AC52",
-        "west": "AB51",
-        "east": "AD51"
+        "north": "AC50", "south": "AC52", "west": "AB51", "east": "AD51"
       }
     },
     {
-      "id": "AD51",
-      "terrain": "h",
+      "id": "AD51", "terrain": "h",
       "exits": {
-        "north": "AD50",
-        "south": "AD52",
-        "west": "AC51",
-        "east": "AE51"
+        "north": "AD50", "south": "AD52", "west": "AC51", "east": "AE51"
       }
     },
     {
-      "id": "AE51",
-      "terrain": "h",
+      "id": "AE51", "terrain": "h",
       "exits": {
-        "north": "AE50",
-        "south": "AE52",
-        "west": "AD51",
-        "east": "AF51"
+        "north": "AE50", "south": "AE52", "west": "AD51", "east": "AF51"
       }
     },
     {
-      "id": "AF51",
-      "terrain": "p",
+      "id": "AF51", "terrain": "p",
       "exits": {
-        "north": "AF50",
-        "south": "AF52",
-        "west": "AE51",
-        "east": "AG51"
+        "north": "AF50", "south": "AF52", "west": "AE51", "east": "AG51"
       }
     },
     {
-      "id": "AG51",
-      "terrain": "m",
+      "id": "AG51", "terrain": "m",
       "exits": {
-        "north": "AG50",
-        "south": "AG52",
-        "west": "AF51",
-        "east": "AH51"
+        "north": "AG50", "south": "AG52", "west": "AF51", "east": "AH51"
       }
     },
     {
-      "id": "AH51",
-      "terrain": "m",
+      "id": "AH51", "terrain": "m",
       "exits": {
-        "north": "AH50",
-        "south": "AH52",
-        "west": "AG51",
-        "east": "AI51"
+        "north": "AH50", "south": "AH52", "west": "AG51", "east": "AI51"
       }
     },
     {
-      "id": "AI51",
-      "terrain": "m",
+      "id": "AI51", "terrain": "m",
       "exits": {
-        "north": "AI50",
-        "south": "AI52",
-        "west": "AH51",
-        "east": "AJ51"
+        "north": "AI50", "south": "AI52", "west": "AH51", "east": "AJ51"
       }
     },
     {
-      "id": "AJ51",
-      "terrain": "m",
+      "id": "AJ51", "terrain": "m",
       "exits": {
-        "north": "AJ50",
-        "south": "AJ52",
-        "west": "AI51",
-        "east": "AK51"
+        "north": "AJ50", "south": "AJ52", "west": "AI51", "east": "AK51"
       }
     },
     {
-      "id": "AK51",
-      "terrain": "m",
+      "id": "AK51", "terrain": "m",
       "exits": {
-        "north": "AK50",
-        "south": "AK52",
-        "west": "AJ51",
-        "east": "AL51"
+        "north": "AK50", "south": "AK52", "west": "AJ51", "east": "AL51"
       }
     },
     {
-      "id": "AL51",
-      "terrain": "m",
+      "id": "AL51", "terrain": "m",
       "exits": {
-        "north": "AL50",
-        "south": "AL52",
-        "west": "AK51",
-        "east": "AM51"
+        "north": "AL50", "south": "AL52", "west": "AK51", "east": "AM51"
       }
     },
     {
-      "id": "AM51",
-      "terrain": "m",
+      "id": "AM51", "terrain": "m",
       "exits": {
-        "north": "AM50",
-        "south": "AM52",
-        "west": "AL51",
-        "east": "AN51"
+        "north": "AM50", "south": "AM52", "west": "AL51", "east": "AN51"
       }
     },
     {
-      "id": "AN51",
-      "terrain": "m",
+      "id": "AN51", "terrain": "m",
       "exits": {
-        "north": "AN50",
-        "south": "AN52",
-        "west": "AM51",
-        "east": "AO51"
+        "north": "AN50", "south": "AN52", "west": "AM51", "east": "AO51"
       }
     },
     {
-      "id": "AO51",
-      "terrain": "b",
+      "id": "AO51", "terrain": "b",
       "exits": {
-        "north": "AO50",
-        "south": "AO52",
-        "west": "AN51",
-        "east": "AP51"
+        "north": "AO50", "south": "AO52", "west": "AN51", "east": "AP51"
       }
     },
     {
-      "id": "AP51",
-      "terrain": "b",
+      "id": "AP51", "terrain": "b",
       "exits": {
-        "north": "AP50",
-        "south": "AP52",
-        "west": "AO51",
-        "east": "AQ51"
+        "north": "AP50", "south": "AP52", "west": "AO51", "east": "AQ51"
       }
     },
     {
-      "id": "AQ51",
-      "terrain": "b",
+      "id": "AQ51", "terrain": "b",
       "exits": {
-        "north": "AQ50",
-        "south": "AQ52",
-        "west": "AP51",
-        "east": "AR51"
+        "north": "AQ50", "south": "AQ52", "west": "AP51", "east": "AR51"
       }
     },
     {
-      "id": "AR51",
-      "terrain": "b",
+      "id": "AR51", "terrain": "b",
       "exits": {
-        "north": "AR50",
-        "south": "AR52",
-        "west": "AQ51",
-        "east": "AS51"
+        "north": "AR50", "south": "AR52", "west": "AQ51", "east": "AS51"
       }
     },
     {
-      "id": "AS51",
-      "terrain": "b",
+      "id": "AS51", "terrain": "b",
       "exits": {
-        "north": "AS50",
-        "south": "AS52",
-        "west": "AR51",
-        "east": "AT51"
+        "north": "AS50", "south": "AS52", "west": "AR51", "east": "AT51"
       }
     },
     {
-      "id": "AT51",
-      "terrain": "b",
+      "id": "AT51", "terrain": "b",
       "exits": {
-        "north": "AT50",
-        "south": "AT52",
-        "west": "AS51",
-        "east": "AU51"
+        "north": "AT50", "south": "AT52", "west": "AS51", "east": "AU51"
       }
     },
     {
-      "id": "AU51",
-      "terrain": "b",
+      "id": "AU51", "terrain": "b",
       "exits": {
-        "north": "AU50",
-        "south": "AU52",
-        "west": "AT51",
-        "east": "AV51"
+        "north": "AU50", "south": "AU52", "west": "AT51", "east": "AV51"
       }
     },
     {
-      "id": "AV51",
-      "terrain": "b",
+      "id": "AV51", "terrain": "b",
       "exits": {
-        "north": "AV50",
-        "south": "AV52",
-        "west": "AU51",
-        "east": "AW51"
+        "north": "AV50", "south": "AV52", "west": "AU51", "east": "AW51"
       }
     },
     {
-      "id": "AW51",
-      "terrain": "w",
+      "id": "AW51", "terrain": "w",
       "exits": {
-        "north": "AW50",
-        "south": "AW52",
-        "west": "AV51",
-        "east": "AX51"
+        "north": "AW50", "south": "AW52", "west": "AV51", "east": "AX51"
       }
     },
     {
-      "id": "AX51",
-      "terrain": "w",
+      "id": "AX51", "terrain": "w",
       "exits": {
-        "north": "AX50",
-        "south": "AX52",
-        "west": "AW51"
+        "north": "AX50", "south": "AX52", "west": "AW51"
       }
     },
     {
-      "id": "A52",
-      "terrain": "b",
+      "id": "A52", "terrain": "b",
       "exits": {
-        "north": "A51",
-        "east": "B52"
+        "north": "A51", "east": "B52"
       }
     },
     {
-      "id": "B52",
-      "terrain": "b",
+      "id": "B52", "terrain": "b",
       "exits": {
-        "north": "B51",
-        "west": "A52",
-        "east": "C52"
+        "north": "B51", "west": "A52", "east": "C52"
       }
     },
     {
-      "id": "C52",
-      "terrain": "w",
+      "id": "C52", "terrain": "w",
       "exits": {
-        "north": "C51",
-        "west": "B52",
-        "east": "D52"
+        "north": "C51", "west": "B52", "east": "D52"
       }
     },
     {
-      "id": "D52",
-      "terrain": "w",
+      "id": "D52", "terrain": "w",
       "exits": {
-        "north": "D51",
-        "west": "C52",
-        "east": "E52"
+        "north": "D51", "west": "C52", "east": "E52"
       }
     },
     {
-      "id": "E52",
-      "terrain": "p",
+      "id": "E52", "terrain": "p",
       "exits": {
-        "north": "E51",
-        "west": "D52",
-        "east": "F52"
+        "north": "E51", "west": "D52", "east": "F52"
       }
     },
     {
-      "id": "F52",
-      "terrain": "p",
+      "id": "F52", "terrain": "p",
       "exits": {
-        "north": "F51",
-        "west": "E52",
-        "east": "G52"
+        "north": "F51", "west": "E52", "east": "G52"
       }
     },
     {
-      "id": "G52",
-      "terrain": "p",
+      "id": "G52", "terrain": "p",
       "exits": {
-        "north": "G51",
-        "west": "F52",
-        "east": "H52"
+        "north": "G51", "west": "F52", "east": "H52"
       }
     },
     {
-      "id": "H52",
-      "terrain": "p",
+      "id": "H52", "terrain": "p",
       "exits": {
-        "north": "H51",
-        "west": "G52",
-        "east": "I52"
+        "north": "H51", "west": "G52", "east": "I52"
       }
     },
     {
-      "id": "I52",
-      "terrain": "w",
+      "id": "I52", "terrain": "w",
       "exits": {
-        "north": "I51",
-        "west": "H52",
-        "east": "J52"
+        "north": "I51", "west": "H52", "east": "J52"
       }
     },
     {
-      "id": "J52",
-      "terrain": "p",
+      "id": "J52", "terrain": "p",
       "exits": {
-        "north": "J51",
-        "west": "I52",
-        "east": "K52"
+        "north": "J51", "west": "I52", "east": "K52"
       }
     },
     {
-      "id": "K52",
-      "terrain": "p",
+      "id": "K52", "terrain": "p",
       "exits": {
-        "north": "K51",
-        "west": "J52",
-        "east": "L52"
+        "north": "K51", "west": "J52", "east": "L52"
       }
     },
     {
-      "id": "L52",
-      "terrain": "p",
+      "id": "L52", "terrain": "p",
       "exits": {
-        "north": "L51",
-        "west": "K52",
-        "east": "M52"
+        "north": "L51", "west": "K52", "east": "M52"
       }
     },
     {
-      "id": "M52",
-      "terrain": "p",
+      "id": "M52", "terrain": "p",
       "exits": {
-        "north": "M51",
-        "west": "L52",
-        "east": "N52"
+        "north": "M51", "west": "L52", "east": "N52"
       }
     },
     {
-      "id": "N52",
-      "terrain": "p",
+      "id": "N52", "terrain": "p",
       "exits": {
-        "north": "N51",
-        "west": "M52",
-        "east": "O52"
+        "north": "N51", "west": "M52", "east": "O52"
       }
     },
     {
-      "id": "O52",
-      "terrain": "p",
+      "id": "O52", "terrain": "p",
       "exits": {
-        "north": "O51",
-        "west": "N52",
-        "east": "P52"
+        "north": "O51", "west": "N52", "east": "P52"
       }
     },
     {
-      "id": "P52",
-      "terrain": "p",
+      "id": "P52", "terrain": "p",
       "exits": {
-        "north": "P51",
-        "west": "O52",
-        "east": "Q52"
+        "north": "P51", "west": "O52", "east": "Q52"
       }
     },
     {
-      "id": "Q52",
-      "terrain": "p",
+      "id": "Q52", "terrain": "p",
       "exits": {
-        "north": "Q51",
-        "west": "P52",
-        "east": "R52"
+        "north": "Q51", "west": "P52", "east": "R52"
       }
     },
     {
-      "id": "R52",
-      "terrain": "p",
+      "id": "R52", "terrain": "p",
       "exits": {
-        "north": "R51",
-        "west": "Q52",
-        "east": "S52"
+        "north": "R51", "west": "Q52", "east": "S52"
       }
     },
     {
-      "id": "S52",
-      "terrain": "p",
+      "id": "S52", "terrain": "p",
       "exits": {
-        "north": "S51",
-        "west": "R52",
-        "east": "T52"
+        "north": "S51", "west": "R52", "east": "T52"
       }
     },
     {
-      "id": "T52",
-      "terrain": "p",
+      "id": "T52", "terrain": "p",
       "exits": {
-        "north": "T51",
-        "west": "S52",
-        "east": "U52"
+        "north": "T51", "west": "S52", "east": "U52"
       }
     },
     {
-      "id": "U52",
-      "terrain": "p",
+      "id": "U52", "terrain": "p",
       "exits": {
-        "north": "U51",
-        "west": "T52",
-        "east": "V52"
+        "north": "U51", "west": "T52", "east": "V52"
       }
     },
     {
-      "id": "V52",
-      "terrain": "p",
+      "id": "V52", "terrain": "p",
       "exits": {
-        "north": "V51",
-        "west": "U52",
-        "east": "W52"
+        "north": "V51", "west": "U52", "east": "W52"
       }
     },
     {
-      "id": "W52",
-      "terrain": "p",
+      "id": "W52", "terrain": "p",
       "exits": {
-        "north": "W51",
-        "west": "V52",
-        "east": "X52"
+        "north": "W51", "west": "V52", "east": "X52"
       }
     },
     {
-      "id": "X52",
-      "terrain": "p",
+      "id": "X52", "terrain": "p",
       "exits": {
-        "north": "X51",
-        "west": "W52",
-        "east": "Y52"
+        "north": "X51", "west": "W52", "east": "Y52"
       }
     },
     {
-      "id": "Y52",
-      "terrain": "p",
+      "id": "Y52", "terrain": "p",
       "exits": {
-        "north": "Y51",
-        "west": "X52",
-        "east": "Z52"
+        "north": "Y51", "west": "X52", "east": "Z52"
       }
     },
     {
-      "id": "Z52",
-      "terrain": "p",
+      "id": "Z52", "terrain": "p",
       "exits": {
-        "north": "Z51",
-        "west": "Y52",
-        "east": "AA52"
+        "north": "Z51", "west": "Y52", "east": "AA52"
       }
     },
     {
-      "id": "AA52",
-      "terrain": "p",
+      "id": "AA52", "terrain": "p",
       "exits": {
-        "north": "AA51",
-        "west": "Z52",
-        "east": "AB52"
+        "north": "AA51", "west": "Z52", "east": "AB52"
       }
     },
     {
-      "id": "AB52",
-      "terrain": "h",
+      "id": "AB52", "terrain": "h",
       "exits": {
-        "north": "AB51",
-        "west": "AA52",
-        "east": "AC52"
+        "north": "AB51", "west": "AA52", "east": "AC52"
       }
     },
     {
-      "id": "AC52",
-      "terrain": "h",
+      "id": "AC52", "terrain": "h",
       "exits": {
-        "north": "AC51",
-        "west": "AB52",
-        "east": "AD52"
+        "north": "AC51", "west": "AB52", "east": "AD52"
       }
     },
     {
-      "id": "AD52",
-      "terrain": "h",
+      "id": "AD52", "terrain": "h",
       "exits": {
-        "north": "AD51",
-        "west": "AC52",
-        "east": "AE52"
+        "north": "AD51", "west": "AC52", "east": "AE52"
       }
     },
     {
-      "id": "AE52",
-      "terrain": "h",
+      "id": "AE52", "terrain": "h",
       "exits": {
-        "north": "AE51",
-        "west": "AD52",
-        "east": "AF52"
+        "north": "AE51", "west": "AD52", "east": "AF52"
       }
     },
     {
-      "id": "AF52",
-      "terrain": "p",
+      "id": "AF52", "terrain": "p",
       "exits": {
-        "north": "AF51",
-        "west": "AE52",
-        "east": "AG52"
+        "north": "AF51", "west": "AE52", "east": "AG52"
       }
     },
     {
-      "id": "AG52",
-      "terrain": "p",
+      "id": "AG52", "terrain": "p",
       "exits": {
-        "north": "AG51",
-        "west": "AF52",
-        "east": "AH52"
+        "north": "AG51", "west": "AF52", "east": "AH52"
       }
     },
     {
-      "id": "AH52",
-      "terrain": "p",
+      "id": "AH52", "terrain": "p",
       "exits": {
-        "north": "AH51",
-        "west": "AG52",
-        "east": "AI52"
+        "north": "AH51", "west": "AG52", "east": "AI52"
       }
     },
     {
-      "id": "AI52",
-      "terrain": "p",
+      "id": "AI52", "terrain": "p",
       "exits": {
-        "north": "AI51",
-        "west": "AH52",
-        "east": "AJ52"
+        "north": "AI51", "west": "AH52", "east": "AJ52"
       }
     },
     {
-      "id": "AJ52",
-      "terrain": "m",
+      "id": "AJ52", "terrain": "m",
       "exits": {
-        "north": "AJ51",
-        "west": "AI52",
-        "east": "AK52"
+        "north": "AJ51", "west": "AI52", "east": "AK52"
       }
     },
     {
-      "id": "AK52",
-      "terrain": "trail",
+      "id": "AK52", "terrain": "trail",
       "exits": {
-        "north": "AK51",
-        "west": "AJ52",
-        "east": "AL52"
+        "north": "AK51", "west": "AJ52", "east": "AL52"
       }
     },
     {
-      "id": "AL52",
-      "terrain": "m",
+      "id": "AL52", "terrain": "m",
       "exits": {
-        "north": "AL51",
-        "west": "AK52",
-        "east": "AM52"
+        "north": "AL51", "west": "AK52", "east": "AM52"
       }
     },
     {
-      "id": "AM52",
-      "terrain": "m",
+      "id": "AM52", "terrain": "m",
       "exits": {
-        "north": "AM51",
-        "west": "AL52",
-        "east": "AN52"
+        "north": "AM51", "west": "AL52", "east": "AN52"
       }
     },
     {
-      "id": "AN52",
-      "terrain": "m",
+      "id": "AN52", "terrain": "m",
       "exits": {
-        "north": "AN51",
-        "west": "AM52",
-        "east": "AO52"
+        "north": "AN51", "west": "AM52", "east": "AO52"
       }
     },
     {
-      "id": "AO52",
-      "terrain": "b",
+      "id": "AO52", "terrain": "b",
       "exits": {
-        "north": "AO51",
-        "west": "AN52",
-        "east": "AP52"
+        "north": "AO51", "west": "AN52", "east": "AP52"
       }
     },
     {
-      "id": "AP52",
-      "terrain": "b",
+      "id": "AP52", "terrain": "b",
       "exits": {
-        "north": "AP51",
-        "west": "AO52",
-        "east": "AQ52"
+        "north": "AP51", "west": "AO52", "east": "AQ52"
       }
     },
     {
-      "id": "AQ52",
-      "terrain": "b",
+      "id": "AQ52", "terrain": "b",
       "exits": {
-        "north": "AQ51",
-        "west": "AP52",
-        "east": "AR52"
+        "north": "AQ51", "west": "AP52", "east": "AR52"
       }
     },
     {
-      "id": "AR52",
-      "terrain": "b",
+      "id": "AR52", "terrain": "b",
       "exits": {
-        "north": "AR51",
-        "west": "AQ52",
-        "east": "AS52"
+        "north": "AR51", "west": "AQ52", "east": "AS52"
       }
     },
     {
-      "id": "AS52",
-      "terrain": "b",
+      "id": "AS52", "terrain": "b",
       "exits": {
-        "north": "AS51",
-        "west": "AR52",
-        "east": "AT52"
+        "north": "AS51", "west": "AR52", "east": "AT52"
       }
     },
     {
-      "id": "AT52",
-      "terrain": "b",
+      "id": "AT52", "terrain": "b",
       "exits": {
-        "north": "AT51",
-        "west": "AS52",
-        "east": "AU52"
+        "north": "AT51", "west": "AS52", "east": "AU52"
       }
     },
     {
-      "id": "AU52",
-      "terrain": "b",
+      "id": "AU52", "terrain": "b",
       "exits": {
-        "north": "AU51",
-        "west": "AT52",
-        "east": "AV52"
+        "north": "AU51", "west": "AT52", "east": "AV52"
       }
     },
     {
-      "id": "AV52",
-      "terrain": "b",
+      "id": "AV52", "terrain": "b",
       "exits": {
-        "north": "AV51",
-        "west": "AU52",
-        "east": "AW52"
+        "north": "AV51", "west": "AU52", "east": "AW52"
       }
     },
     {
-      "id": "AW52",
-      "terrain": "b",
+      "id": "AW52", "terrain": "b",
       "exits": {
-        "north": "AW51",
-        "west": "AV52",
-        "east": "AX52"
+        "north": "AW51", "west": "AV52", "east": "AX52"
       }
     },
     {
-      "id": "AX52",
-      "terrain": "b",
+      "id": "AX52", "terrain": "b",
       "exits": {
-        "north": "AX51",
-        "west": "AW52"
+        "north": "AX51", "west": "AW52"
       }
     }
   ]


### PR DESCRIPTION
### Motivation
- Improve readability and compactness of the Edaw globe map JSON by placing `id` and `terrain` on the same line and collapsing each room's `exits` onto a single line.
- Make the file easier to skim and diff for future map edits without changing any room data semantics.

### Description
- Rewrote `maps/globe-edaw.json` formatting so each room entry has `"id": ..., "terrain": ...` on one line and its `exits` mapping is rendered on a single line per room while preserving all keys and values.
- The change is formatting-only and preserves the original JSON structure and room data semantics.
- The reformatting was performed by a small Python read/modify/write script that loaded the JSON and emitted the new layout to `maps/globe-edaw.json`.

### Testing
- Performed an automated JSON load/write roundtrip with `python` to validate the file parses as JSON and the room data is intact, and the roundtrip succeeded. 
- No other automated test suites were run because this is a formatting-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bfd644ad48327a41ea92130eb2b0a)