### PR TITLE
Add wilderness daemon and virtual wilderness room (JSON-backed map)

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -1,0 +1,128 @@
+/*
+ * Wilderness data is JSON-backed but normalized into a room-id mapping.
+ * This keeps virtual room lookups fast and predictable as the map grows
+ * while leaving room for future overlay layers keyed by the same ids.
+ */
+string map_file;
+mapping rooms_by_id;
+int loaded;
+
+void create() {
+  map_file = "/maps/moraldecay.json";
+  rooms_by_id = ([]);
+  loaded = 0;
+
+  /* Preloaded at startup so player movement never parses JSON. */
+  load_wilderness();
+
+  return;
+}
+
+void load_wilderness() {
+  mixed data;
+  mixed rooms;
+  mapping room;
+  string contents;
+  string room_id;
+  int i;
+
+  if (loaded) {
+    return;
+  }
+
+  contents = read_file(map_file);
+  if (!contents) {
+    loaded = 1;
+    return;
+  }
+
+  data = json_parse(contents);
+  if (!mapp(data)) {
+    loaded = 1;
+    return;
+  }
+
+  rooms = data["rooms"];
+  if (!pointerp(rooms)) {
+    loaded = 1;
+    return;
+  }
+
+  /* Normalize room data for O(1) lookup and future overlay layers. */
+  i = 0;
+  while (i < sizeof(rooms)) {
+    room = rooms[i];
+    if (mapp(room)) {
+      room_id = room["id"];
+      if (stringp(room_id)) {
+        rooms_by_id[room_id] = room;
+      }
+    }
+
+    i += 1;
+  }
+
+  loaded = 1;
+  return;
+}
+
+mapping query_room(string room_id) {
+  mapping room;
+
+  if (!room_id) {
+    return 0;
+  }
+
+  room = rooms_by_id[room_id];
+  if (!mapp(room)) {
+    return 0;
+  }
+
+  return room;
+}
+
+mapping query_exits(string room_id) {
+  mapping room;
+  mapping exits;
+
+  room = query_room(room_id);
+  if (!room) {
+    return ([]);
+  }
+
+  exits = room["exits"];
+  if (!mapp(exits)) {
+    return ([]);
+  }
+
+  return exits;
+}
+
+string query_terrain(string room_id) {
+  mapping room;
+  string terrain;
+
+  room = query_room(room_id);
+  if (!room) {
+    return 0;
+  }
+
+  terrain = room["terrain"];
+  if (!stringp(terrain)) {
+    return 0;
+  }
+
+  return terrain;
+}
+
+int room_exists(string room_id) {
+  if (!stringp(room_id)) {
+    return 0;
+  }
+
+  if (mapp(rooms_by_id[room_id])) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/room/init_file
+++ b/room/init_file
@@ -6,4 +6,5 @@ obj/monster
 obj/treasure
 obj/weapon
 obj/armour
+daemon/wilderness_d
 domain/original/area/vesla/sanctuary.c

--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -1,0 +1,122 @@
+#define WILDERNESS_D "/daemon/wilderness_d"
+
+/*
+ * Virtual wilderness room. It stores only a room id and queries the daemon
+ * for all state, keeping room data centralized and easy to extend.
+ */
+string room_id;
+
+void create() {
+  string name;
+  string id;
+
+  name = object_name(this_object());
+
+  if (sscanf(name, "room/wilderness_room#%s", id) == 1) {
+    set_room_id(id);
+  }
+
+  return;
+}
+
+void set_room_id(string id) {
+  room_id = id;
+
+  return;
+}
+
+string query_room_id() {
+  return room_id;
+}
+
+void init() {
+  mapping exits;
+  string *dirs;
+  int i;
+
+  if (!room_id) {
+    return;
+  }
+
+  exits = WILDERNESS_D->query_exits(room_id);
+  dirs = m_indices(exits);
+
+  i = 0;
+  while (i < sizeof(dirs)) {
+    add_action("move", dirs[i]);
+    i += 1;
+  }
+
+  return;
+}
+
+int move(string arg) {
+  mapping exits;
+  string destination;
+
+  if (!room_id) {
+    return 0;
+  }
+
+  exits = WILDERNESS_D->query_exits(room_id);
+  destination = exits[query_verb()];
+  if (!stringp(destination)) {
+    return 0;
+  }
+
+  this_player()->move_player(query_verb() + "#room/wilderness_room#" + destination);
+
+  return 1;
+}
+
+string short() {
+  string terrain;
+
+  terrain = WILDERNESS_D->query_terrain(room_id);
+
+  if (terrain == "p") {
+    return "Open Plain";
+  }
+
+  if (terrain == "f") {
+    return "Thin Forest";
+  }
+
+  if (terrain == "h") {
+    return "Low Hills";
+  }
+
+  return "Wilderness";
+}
+
+string long() {
+  string terrain;
+
+  terrain = WILDERNESS_D->query_terrain(room_id);
+
+  if (terrain == "p") {
+    return "A flat plain stretches out in every direction. "
+      + "Wind presses through short grass.";
+  }
+
+  if (terrain == "f") {
+    return "Sparse trees stand in uneven clusters. "
+      + "The ground is shaded and quiet.";
+  }
+
+  if (terrain == "h") {
+    return "Low hills roll in soft, broken lines. "
+      + "Stone shows through thin soil.";
+  }
+
+  return "The land here is quiet and open. "
+    + "No clear path remains.";
+}
+
+mapping query_exits() {
+  if (!room_id) {
+    return ([]);
+  }
+
+  return WILDERNESS_D->query_exits(room_id);
+}


### PR DESCRIPTION
### Motivation

- Provide infrastructure to load a large JSON wilderness map once at startup, keep parsed room data in memory, and serve room state to a virtual-room system so the world can scale without creating thousands of LPC room files.

### Description

- Add `daemon/wilderness_d.c` which loads `/maps/moraldecay.json` in `create()` with `json_parse()`, normalizes the parsed `rooms` array into a `mapping rooms_by_id` for O(1) lookups, and exposes `mapping query_room(string)`, `mapping query_exits(string)`, `string query_terrain(string)`, and `int room_exists(string)` while gracefully returning `0` or empty mappings for missing/invalid ids.
- Add `room/wilderness_room.c`, a minimal virtual room that stores only a `room_id`, sets the id from `object_name()` when created or via `set_room_id()`, pulls all state from `WILDERNESS_D` (exits and terrain), builds action verbs in `init()` from `query_exits()`, implements `move()` to route players via the virtual room pattern, and implements `short()`/`long()` using `query_terrain()` to demonstrate terrain-influenced descriptions.
- Ensure preload at boot by adding `daemon/wilderness_d` to `room/init_file` so JSON parsing occurs exactly once during startup rather than during player movement.
- Include concise comments explaining the architecture choice (centralized JSON -> normalized mapping -> fast lookups) and how the design supports future overlay layers keyed by room id.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c04798350832781ccbafe32f55c47)