### PR TITLE
Add room vmaster for wilderness virtual rooms

### DIFF
--- a/room/vmaster.c
+++ b/room/vmaster.c
@@ -1,0 +1,20 @@
+/*
+ * Virtual object handler for rooms.
+ */
+object compile_object(string filename) {
+  object room;
+  string id;
+
+  if (sscanf(filename, "wilderness_room#%s", id) != 1) {
+    return 0;
+  }
+
+  room = clone_object("room/wilderness_room");
+  if (!room) {
+    return 0;
+  }
+
+  room->set_room_id(id);
+
+  return room;
+}


### PR DESCRIPTION
### Motivation

- Introduce a room vmaster providing `compile_object` for virtual `wilderness_room#%s` filenames so cloned wilderness rooms get their `room_id` set and load correctly.

### Description

- Add `room/vmaster.c` implementing `object compile_object(string filename)` that matches `wilderness_room#%s`, clones `room/wilderness_room`, calls `set_room_id(id)`, and returns the instance, returning `0` for non-matching filenames or clone failure.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c1c47ea708327a26bf8fc81be6abd)