### PR TITLE
Guard wilderness room cache initialization

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -28,6 +28,10 @@ void load_wilderness() {
   string room_id;
   int i;
 
+  if (!mappingp(rooms_by_id)) {
+    rooms_by_id = ([]);
+  }
+
   if (loaded) {
     return;
   }
@@ -73,6 +77,12 @@ mapping query_room(string room_id) {
 
   if (!room_id) {
     return 0;
+  }
+
+  if (!mappingp(rooms_by_id)) {
+    rooms_by_id = ([]);
+    loaded = 0;
+    load_wilderness();
   }
 
   room = rooms_by_id[room_id];


### PR DESCRIPTION
### Motivation
- Prevent crashes when the wilderness room cache is missing or corrupted so indexing like `rooms_by_id[room_id]` cannot attempt to index a non-mapping.

### Description
- Initialize `rooms_by_id` defensively in `load_wilderness()` and add a guard in `query_room()` that resets `loaded` and calls `load_wilderness()` to rebuild the cache if `rooms_by_id` is not a mapping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c23e2ee5c83278c8a0dbf5a52fc0d)