### PR TITLE
Guard wilderness map path before load

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -36,6 +36,10 @@ void load_wilderness() {
     return;
   }
 
+  if (!stringp(map_file)) {
+    map_file = "/domain/original/wilderness.json";
+  }
+
   contents = read_file(map_file);
   if (!contents) {
     loaded = 1;


### PR DESCRIPTION
### Motivation
- Prevent `read_file` from receiving a non-string `map_file` value and avoid runtime errors when loading the wilderness JSON in `daemon/wilderness_d.c`.

### Description
- Add a guard in `load_wilderness()` that sets `map_file = "/domain/original/wilderness.json"` when `map_file` is not a string, placed before the call to `read_file(map_file)`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c249d0dc8832798368d09f254d330)