### PR TITLE
Refactor wilderness_room to inherit room base and restore X27→roadway exit

### DIFF
--- a/domain/original/wilderness.json
+++ b/domain/original/wilderness.json
@@ -7341,7 +7341,8 @@
     {
       "id": "X27", "terrain": "p",
       "exits": {
-        "north": "X26", "south": "X28", "west": "W27", "east": "Y27"
+        "north": "X26", "south": "X28", "west": "W27", "east": "Y27",
+        "southeast": "domain/original/area/roadway/room14"
       }
     },
     {


### PR DESCRIPTION
### Motivation
- Make wilderness rooms fully behave like standard rooms by inheriting `room/room` and exposing the same lifecycle and properties.
- Centralize wilderness state and simplify maintenance by pulling exits and terrain metadata from the `WILDERNESS_D` daemon while storing `room_id`/`terrain` on the room instance.
- Restore the missing return path from wilderness cell `X27` back into the roadway at `domain/original/area/roadway/room14`.

### Description
- Replaced the old virtual implementation with `room/wilderness_room.c` that `inherit`s `room/room` and stores `room_id` and `terrain` on the object.
- Added `set_descriptions` to derive `short_desc`/`long_desc` from `terrain` and `set_exits` to build `dest_dir` from `WILDERNESS_D->query_exits(room_id)`, resolving wilderness destinations to `room/wilderness_room#<id>` and leaving non-wilderness targets as-is.
- Updated initialization to use `reset`/`init` properly, call `::init()` when appropriate, and compute descriptions and exits when the `room_id` is set.
- Updated `domain/original/wilderness.json` to add a `southeast` exit for `X27` pointing to `domain/original/area/roadway/room14` to restore the roadway return.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c26665f0c832795131f63cfdc7813)