### PR TITLE
Use `strstr` for wilderness exit ordering

### DIFF
--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -14,6 +14,7 @@ string query_room_id();
 string query_terrain();
 void set_exits();
 void set_descriptions();
+int sort_dirs(string a, string b);
 
 void reset(int arg) {
   if (arg) {
@@ -104,7 +105,7 @@ void set_exits() {
     return;
   }
 
-  dirs = sort_array(dirs, #'strcmp);
+  dirs = sort_array(dirs, #'sort_dirs);
   dest_dir = ({});
 
   i = 0;
@@ -124,4 +125,24 @@ void set_exits() {
   }
 
   return;
+}
+
+int sort_dirs(string a, string b) {
+  if (a == b) {
+    return 0;
+  }
+
+  if (strstr(a, b) == 0) {
+    return 1;
+  }
+
+  if (strstr(b, a) == 0) {
+    return -1;
+  }
+
+  if (a < b) {
+    return -1;
+  }
+
+  return 1;
 }


### PR DESCRIPTION
### Motivation
- Replace reliance on an unavailable comparator and ensure deterministic ordering of wilderness exits when one exit name is a prefix of another by using available efuns.

### Description
- Replace `sort_array(dirs, #'strcmp)` with `sort_array(dirs, #'sort_dirs)` in `room/wilderness_room.c`.
- Add a new comparator `int sort_dirs(string a, string b)` that uses `strstr` to detect prefix relationships and returns a lexical comparison otherwise.
- Add a forward declaration for `sort_dirs` near the top of the file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c2c0b8fcc832787db09865d13c79f)