### PR TITLE
Fix wilderness JSON loading

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -26,6 +26,7 @@ void load_wilderness() {
   mapping room;
   string contents;
   string room_id;
+  int size;
   int i;
 
   if (!mappingp(rooms_by_id)) {
@@ -40,7 +41,13 @@ void load_wilderness() {
     map_file = "/domain/original/wilderness.json";
   }
 
-  contents = read_file(map_file);
+  size = file_size(map_file);
+  if (size <= 0) {
+    loaded = 1;
+    return;
+  }
+
+  contents = read_bytes(map_file, 0, size);
   if (!contents) {
     loaded = 1;
     return;


### PR DESCRIPTION
### Motivation
- Prevent partial or truncated reads of `/domain/original/wilderness.json` so virtual wilderness rooms can load their full data and populate exits correctly.

### Description
- Replace `read_file` with a `file_size` check and `read_bytes` to read the exact file length, add an `int size` local, and bail early (setting `loaded`) when the map file is missing or empty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c405608a4832794ab1a259bd2e617)