### PR TITLE
Fix wilderness JSON load type mismatch

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -47,7 +47,7 @@ void load_wilderness() {
     return;
   }
 
-  contents = read_bytes(map_file, 0, size);
+  contents = read_file(map_file);
   if (!contents) {
     loaded = 1;
     return;


### PR DESCRIPTION
### Motivation
- Prevent a startup runtime error where the wilderness loader passed bytes to `json_parse`, causing a `Bad assignment (string vs bytes)` and failing to load `daemon/wilderness_d` and wilderness rooms.

### Description
- Replace `read_bytes(map_file, 0, size)` with `read_file(map_file)` in `daemon/wilderness_d.c` so `contents` is a proper string for `json_parse` and room normalization proceeds unchanged.

### Testing
- No automated tests were run for this trivial fix; the change was committed and is intended to resolve the driver type error observed at startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c42e88a888327ad72ccbc9574334b)