### PR TITLE
Ensure wilderness data loads before room lookups

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -93,6 +93,9 @@ mapping query_room(string room_id) {
   if (!mappingp(rooms_by_id)) {
     rooms_by_id = ([]);
     loaded = 0;
+  }
+
+  if (!loaded) {
     load_wilderness();
   }
 


### PR DESCRIPTION
### Motivation
- Virtual wilderness rooms could show incorrect terrain or missing exits when the wilderness daemon had not yet preloaded its JSON map, because lookups proceeded without ensuring the cache was loaded.
- Fixing on-demand loading prevents stale or empty room data from being returned by `query_room` and related queries.

### Description
- Modified `query_room` in `daemon/wilderness_d.c` to call `load_wilderness()` when the daemon's cache is not marked as loaded, and to initialize `rooms_by_id` if needed.
- This change ensures `query_exits` and `query_terrain` (which call `query_room`) receive valid room mappings without requiring eager preload elsewhere.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c446e15848327b3046732d9d5e6ab)