### PR TITLE
Add debug logging and stats for wilderness virtual rooms

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -8,16 +8,65 @@
 string map_file;
 mapping rooms_by_id;
 int loaded;
+int debug_enabled;
+int room_count;
 
 void create() {
   map_file = "/domain/original/wilderness.json";
   rooms_by_id = ([]);
   loaded = 0;
+  debug_enabled = 0;
+  room_count = 0;
 
   /* Preloaded at startup so player movement never parses JSON. */
   load_wilderness();
 
   return;
+}
+
+void set_debug(int enabled) {
+  if (enabled) {
+    debug_enabled = 1;
+  } else {
+    debug_enabled = 0;
+  }
+
+  debug_log("debug set to " + debug_enabled);
+
+  return;
+}
+
+int query_debug() {
+  return debug_enabled;
+}
+
+void debug_log(string message) {
+  string entry;
+
+  if (!debug_enabled) {
+    return;
+  }
+
+  if (!stringp(message)) {
+    return;
+  }
+
+  entry = ctime(time()) + " " + message + "\n";
+  log_file("wilderness", entry);
+
+  return;
+}
+
+mapping query_stats() {
+  mapping stats;
+
+  stats = ([]);
+  stats["map_file"] = map_file;
+  stats["loaded"] = loaded;
+  stats["rooms"] = room_count;
+  stats["debug"] = debug_enabled;
+
+  return stats;
 }
 
 void load_wilderness() {
@@ -43,24 +92,28 @@ void load_wilderness() {
 
   size = file_size(map_file);
   if (size <= 0) {
+    debug_log("map file missing or empty: " + map_file);
     loaded = 1;
     return;
   }
 
   contents = read_file(map_file);
   if (!contents) {
+    debug_log("map file unreadable: " + map_file);
     loaded = 1;
     return;
   }
 
   data = json_parse(contents);
   if (!mappingp(data)) {
+    debug_log("map file parse failed: " + map_file);
     loaded = 1;
     return;
   }
 
   rooms = data["rooms"];
   if (!pointerp(rooms)) {
+    debug_log("map file missing rooms array: " + map_file);
     loaded = 1;
     return;
   }
@@ -73,13 +126,26 @@ void load_wilderness() {
       room_id = room["id"];
       if (stringp(room_id)) {
         rooms_by_id[room_id] = room;
+        room_count += 1;
       }
     }
 
     i += 1;
   }
 
+  debug_log("loaded wilderness rooms: " + room_count);
   loaded = 1;
+  return;
+}
+
+void reload_wilderness() {
+  rooms_by_id = ([]);
+  loaded = 0;
+  room_count = 0;
+
+  debug_log("reload requested");
+  load_wilderness();
+
   return;
 }
 
@@ -101,6 +167,7 @@ mapping query_room(string room_id) {
 
   room = rooms_by_id[room_id];
   if (!mappingp(room)) {
+    debug_log("room id not found: " + room_id);
     return 0;
   }
 

--- a/daemon/wilderness_d.h
+++ b/daemon/wilderness_d.h
@@ -1,1 +1,6 @@
 void load_wilderness();
+void reload_wilderness();
+void set_debug(int enabled);
+int query_debug();
+void debug_log(string message);
+mapping query_stats();

--- a/room/vmaster.c
+++ b/room/vmaster.c
@@ -1,3 +1,5 @@
+#define WILDERNESS_D "/daemon/wilderness_d"
+
 /*
  * Virtual object handler for rooms.
  */
@@ -8,6 +10,8 @@ object compile_object(string filename) {
   if (sscanf(filename, "wilderness_room#%s", id) != 1) {
     return 0;
   }
+
+  WILDERNESS_D->debug_log("compile_object: " + filename + " id=" + id);
 
   room = clone_object("room/wilderness_room");
   if (!room) {

--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -31,6 +31,10 @@ void reset(int arg) {
 void set_room_id(string id) {
   room_id = id;
 
+  if (stringp(room_id)) {
+    WILDERNESS_D->debug_log("set_room_id: " + room_id);
+  }
+
   set_descriptions();
 
   return;
@@ -102,6 +106,7 @@ void set_exits() {
 
   if (!pointerp(dirs)) {
     dest_dir = ({});
+    WILDERNESS_D->debug_log("no exits for room: " + room_id);
     return;
   }
 
@@ -116,6 +121,8 @@ void set_exits() {
         resolved = "room/wilderness_room#" + destination;
       } else {
         resolved = destination;
+        WILDERNESS_D->debug_log("exit points outside wilderness: "
+          + room_id + " -> " + destination);
       }
 
       dest_dir += ({ resolved, dirs[i] });


### PR DESCRIPTION
### Motivation
- The virtual wilderness room system is failing to meet expectations during instantiation and navigation, so lightweight runtime diagnostics were needed to observe map loading, room lookup, and exit resolution behavior.

### Description
- Added debug API and bookkeeping to `daemon/wilderness_d` including `set_debug`, `query_debug`, `debug_log`, `reload_wilderness`, `query_stats`, and a `room_count` counter; the header `daemon/wilderness_d.h` was updated with prototypes.
- Instrumented `load_wilderness` to log file/parse/read errors and to report total rooms loaded, and made `reload_wilderness` reset and reload the in-memory map.
- Added debug calls where room lookups fail (`room id not found`) and when the map file is missing/unreadable to help triage data issues.
- Logged virtual room compilation in `room/vmaster.c` and added debug traces in `room/wilderness_room.c` for `set_room_id`, absence of exits, and exits pointing outside the wilderness to trace instantiation and exit resolution flows.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c45f98f808327994cf710df9818b8)