### PR TITLE
Strip trailing .c from virtual wilderness room ids

### DIFF
--- a/room/vmaster.c
+++ b/room/vmaster.c
@@ -6,9 +6,14 @@
 object compile_object(string filename) {
   object room;
   string id;
+  string base_id;
 
   if (sscanf(filename, "wilderness_room#%s", id) != 1) {
     return 0;
+  }
+
+  if (sscanf(id, "%s.c", base_id) == 1) {
+    id = base_id;
   }
 
   WILDERNESS_D->debug_log("compile_object: " + filename + " id=" + id);


### PR DESCRIPTION
### Motivation
- Prevent lookup and resolution errors when `compile_object` is given virtual room filenames that include a `.c` suffix (for example `wilderness_room#X27.c`).

### Description
- Add a `base_id` variable and strip a trailing `.c` from the parsed id using `sscanf(id, "%s.c", base_id)` before logging and calling `room->set_room_id(id)` in `room/vmaster.c`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4af001b4832793f2c4cbb2a5c569)