### PR TITLE
Fix wilderness JSON loading for large files

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -10,6 +10,36 @@ string map_json;
 mapping rooms_by_id;
 int loaded, room_count;
 
+string read_wilderness_file(string file) {
+  string contents, chunk;
+  int line, line_count;
+
+  if (!stringp(file)) {
+    return 0;
+  }
+
+  contents = "";
+  line = 1;
+  line_count = 500;
+
+  while (1) {
+    chunk = read_file(file, line, line_count);
+
+    if (!chunk) {
+      break;
+    }
+
+    contents += chunk;
+    line += line_count;
+  }
+
+  if (contents == "") {
+    return 0;
+  }
+
+  return contents;
+}
+
 void reset(int arg) {
   if(arg) return;
 
@@ -68,7 +98,7 @@ debug_message("size <= 0!\n");
   }
 
 debug_message("reading: " + map_json);
-  contents = read_file(map_json);
+  contents = read_wilderness_file(map_json);
 
   if (!contents) {
     loaded = 1;


### PR DESCRIPTION
### Motivation
- The wilderness JSON file can be large enough to hit the driver's `read_file` limits and return no contents, causing `load_wilderness` to abort early.  
- Provide a robust reader that can stream the map file in chunks so the daemon can parse the JSON reliably at startup.

### Description
- Add a chunked reader function `read_wilderness_file(string file)` that calls `read_file` in a loop and accumulates the result.  
- Replace the direct `read_file(map_json)` call in `load_wilderness()` with `read_wilderness_file(map_json)`.  
- Keep existing normalization logic that builds the `rooms_by_id` mapping and room count unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ce5010df48327ad49907f29c86889)