### PR TITLE
Extend wilderness terrain codes and descriptions

### DIFF
--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -46,17 +46,54 @@ void set_descriptions() {
   terrain = WILDERNESS_D->query_terrain(room_id);
 
   switch (terrain) {
+    case "lf":
+      short_desc = "Light Forest";
+      long_desc = "Thin trunks rise with wide gaps between them. Dull light falls"
+        + " across dry needles and scattered brush.";
+      break;
     case "p":
       short_desc = "Open Plain";
-      long_desc = "A flat plain stretches out in every direction. Wind presses through short grass.";
+      long_desc = "A flat plain stretches out in every direction. Wind presses"
+        + " through short grass.";
       break;
     case "f":
-      short_desc = "Thin Forest";
-      long_desc = "Sparse trees stand in uneven clusters. The ground is shaded and quiet.";
+      short_desc = "Forest";
+      long_desc = "Trees gather close, their limbs tangled above the ground."
+        + " The understory is thin and uneven.";
+      break;
+    case "df":
+      short_desc = "Deep Forest";
+      long_desc = "Dense growth closes in on all sides. The canopy blocks most"
+        + " of the light.";
+      break;
+    case "w":
+      short_desc = "Open Water";
+      long_desc = "Dark water spreads without clear edge. Low ripples drift"
+        + " across the surface.";
+      break;
+    case "d":
+      short_desc = "Desert";
+      long_desc = "Pale sand runs out in hard waves. The air hangs dry and still.";
       break;
     case "h":
       short_desc = "Low Hills";
-      long_desc = "Low hills roll in soft, broken lines. Stone shows through thin soil.";
+      long_desc = "Low hills roll in soft, broken lines. Stone shows through"
+        + " thin soil.";
+      break;
+    case "m":
+      short_desc = "Marsh";
+      long_desc = "Wet ground shifts beneath a cover of reeds. Shallow pools"
+        + " gleam between mud and grass.";
+      break;
+    case "s":
+      short_desc = "Swamp";
+      long_desc = "Dark water sits between heavy growth. Rotting trunks lean"
+        + " over the still surface.";
+      break;
+    case "b":
+      short_desc = "Barrens";
+      long_desc = "Bare earth stretches out with little sign of growth. Scattered"
+        + " stones lie exposed to the wind.";
       break;
     default:
       short_desc = "Wilderness";


### PR DESCRIPTION
### Motivation
- Support a broader set of terrain codes used by the wilderness system, matching the requested mapping of `lf`, `f`, `df`, `w`, `d`, `p`, `h`, `m`, `s`, and `b`.
- Provide clearer, phase‑appropriate short and long descriptions for each terrain to improve player-facing room text consistency.
- Keep the virtual wilderness room lightweight by centralizing terrain lookup via `WILDERNESS_D->query_terrain` and only changing descriptive output here.

### Description
- Updated `room/wilderness_room.c` to add handling and descriptions for the new terrain codes: `lf` (Light Forest), `df` (Deep Forest), `w` (Open Water), `d` (Desert), `m` (Marsh), `s` (Swamp), and `b` (Barrens).
- Refined existing descriptions for `p` (Open Plain), `f` (Forest), and `h` (Low Hills) to improve tone and line-wrapping consistency.
- Preserved the default `Wilderness` fallback for unknown terrain values and left the terrain lookup via `WILDERNESS_D->query_terrain(room_id)` unchanged.
- Changes are limited to short and long description assignment inside `set_descriptions()` and do not alter exit resolution or other room logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf37af04c8327a613ebf5eb7fe601)