### PR TITLE
Block land-to-water movement in Wilderness

### DIFF
--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -15,6 +15,9 @@ string query_terrain();
 void set_exits();
 void set_descriptions();
 int sort_dirs(string a, string b);
+int move(string str);
+int move_alias(string str);
+int move_direction(string direction);
 
 void reset(int arg) {
   if (arg) return;
@@ -150,6 +153,59 @@ void set_exits() {
   }
 
   return;
+}
+
+int move(string str) {
+  string direction;
+
+  direction = query_verb();
+
+  return move_direction(direction);
+}
+
+int move_alias(string str) {
+  string canonical;
+
+  if (!exit_aliases) return 0;
+
+  canonical = exit_aliases[query_verb()];
+
+  if (!canonical) return 0;
+
+  return move_direction(canonical);
+}
+
+int move_direction(string direction) {
+  int i;
+  string destination, target_id, target_terrain;
+
+  i = 1;
+
+  while (i < sizeof(dest_dir)) {
+    if (direction == dest_dir[i]) {
+      destination = dest_dir[i - 1];
+
+      if (terrain != "w") {
+        if (sscanf(destination, "room/wilderness_room#%s", target_id) == 1) {
+          target_terrain = WILDERNESS_D->query_terrain(target_id);
+
+          if (target_terrain == "w") {
+            write("There is a body of water there.\n");
+
+            return 1;
+          }
+        }
+      }
+
+      this_player()->move_player(dest_dir[i] + "#" + dest_dir[i - 1]);
+
+      return 1;
+    }
+
+    i += 2;
+  }
+
+  return 1;
 }
 
 int sort_dirs(string a, string b) {


### PR DESCRIPTION
### Motivation

- Prevent players from traversing from non-"w" (land) wilderness tiles into "w" (water) tiles and provide a clear message when such moves are attempted.
- Ensure exit alias movement behaves consistently with direct direction movement by centralizing movement logic.

### Description

- Updated `room/wilderness_room.c` to add `move`, `move_alias`, and `move_direction` helpers and declared them at the top of the file.
- Centralized movement handling in `move_direction` which resolves the destination id and, when the current room terrain is not `"w"`, checks the target room terrain via `WILDERNESS_D->query_terrain()` and blocks the move if the target is `"w"`.
- When a land-to-water move is blocked the player receives the message: `There is a body of water there.`
- Existing exit setup in `set_exits()` and other room descriptions remain unchanged.

### Testing

- No automated tests were executed against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0ae641c48327a37b4ee023523759)