### PR TITLE
Move terrain descriptions into wilderness JSON

### DIFF
--- a/daemon/wilderness_d.c
+++ b/daemon/wilderness_d.c
@@ -7,6 +7,7 @@
  */
 string map_json;
 mapping rooms_by_id;
+mapping terrain_by_code;
 int loaded, room_count;
 
 string read_wilderness_file(string file) {
@@ -52,6 +53,7 @@ void reset(int arg) {
 
 void reload_wilderness() {
   rooms_by_id = ([]);
+  terrain_by_code = ([]);
   loaded = 0;
   room_count = 0;
 
@@ -62,6 +64,7 @@ void reload_wilderness() {
 
 void load_wilderness() {
   mixed data, rooms;
+  mapping terrain;
   mapping room;
   string contents, room_id;
   int size, i;
@@ -99,6 +102,12 @@ void load_wilderness() {
     loaded = 1;
 
     return;
+  }
+
+  terrain = data["terrain"];
+
+  if (mappingp(terrain)) {
+    terrain_by_code = terrain;
   }
 
   rooms = data["rooms"];
@@ -176,6 +185,20 @@ string query_terrain(string room_id) {
   terrain = room["terrain"];
 
   if (!stringp(terrain)) return 0;
+
+  return terrain;
+}
+
+mapping query_terrain_info(string terrain_code) {
+  mapping terrain;
+
+  if (!stringp(terrain_code)) return 0;
+
+  if (!mappingp(terrain_by_code)) return 0;
+
+  terrain = terrain_by_code[terrain_code];
+
+  if (!mappingp(terrain)) return 0;
 
   return terrain;
 }

--- a/daemon/wilderness_d.h
+++ b/daemon/wilderness_d.h
@@ -1,2 +1,3 @@
 void load_wilderness();
 void reload_wilderness();
+mapping query_terrain_info(string terrain_code);

--- a/domain/original/wilderness.json
+++ b/domain/original/wilderness.json
@@ -1,4 +1,50 @@
 {
+  "terrain": {
+    "lf": {
+      "short": "Light Forest",
+      "long": "Thin trunks rise with wide gaps between them. Dull light falls across dry needles and scattered brush."
+    },
+    "p": {
+      "short": "Open Plain",
+      "long": "A flat plain stretches out in every direction. Wind presses through short grass."
+    },
+    "f": {
+      "short": "Forest",
+      "long": "Trees gather close, their limbs tangled above the ground. The understory is thin and uneven."
+    },
+    "df": {
+      "short": "Deep Forest",
+      "long": "Dense growth closes in on all sides. The canopy blocks most of the light."
+    },
+    "w": {
+      "short": "Open Water",
+      "long": "Dark water spreads without clear edge. Low ripples drift across the surface."
+    },
+    "d": {
+      "short": "Desert",
+      "long": "Pale sand runs out in hard waves. The air hangs dry and still."
+    },
+    "h": {
+      "short": "Low Hills",
+      "long": "Low hills roll in soft, broken lines. Stone shows through thin soil."
+    },
+    "m": {
+      "short": "Marsh",
+      "long": "Wet ground shifts beneath a cover of reeds. Shallow pools gleam between mud and grass."
+    },
+    "s": {
+      "short": "Swamp",
+      "long": "Dark water sits between heavy growth. Rotting trunks lean over the still surface."
+    },
+    "b": {
+      "short": "Barrens",
+      "long": "Bare earth stretches out with little sign of growth. Scattered stones lie exposed to the wind."
+    },
+    "default": {
+      "short": "Wilderness",
+      "long": "The land here is quiet and open. No clear paths remain."
+    }
+  },
   "rooms": [
     {
       "id": "A3", "terrain": "p",

--- a/room/wilderness_room.c
+++ b/room/wilderness_room.c
@@ -44,64 +44,34 @@ string query_terrain() {
 }
 
 void set_descriptions() {
+  mapping terrain_info;
+  string short_name, long_name;
+
   if (!room_id) return;
 
   terrain = WILDERNESS_D->query_terrain(room_id);
 
-  switch (terrain) {
-    case "lf":
-      short_desc = "Light Forest";
-      long_desc = "Thin trunks rise with wide gaps between them. Dull light falls"
-        + " across dry needles and scattered brush.";
-      break;
-    case "p":
-      short_desc = "Open Plain";
-      long_desc = "A flat plain stretches out in every direction. Wind presses"
-        + " through short grass.";
-      break;
-    case "f":
-      short_desc = "Forest";
-      long_desc = "Trees gather close, their limbs tangled above the ground."
-        + " The understory is thin and uneven.";
-      break;
-    case "df":
-      short_desc = "Deep Forest";
-      long_desc = "Dense growth closes in on all sides. The canopy blocks most"
-        + " of the light.";
-      break;
-    case "w":
-      short_desc = "Open Water";
-      long_desc = "Dark water spreads without clear edge. Low ripples drift"
-        + " across the surface.";
-      break;
-    case "d":
-      short_desc = "Desert";
-      long_desc = "Pale sand runs out in hard waves. The air hangs dry and still.";
-      break;
-    case "h":
-      short_desc = "Low Hills";
-      long_desc = "Low hills roll in soft, broken lines. Stone shows through"
-        + " thin soil.";
-      break;
-    case "m":
-      short_desc = "Marsh";
-      long_desc = "Wet ground shifts beneath a cover of reeds. Shallow pools"
-        + " gleam between mud and grass.";
-      break;
-    case "s":
-      short_desc = "Swamp";
-      long_desc = "Dark water sits between heavy growth. Rotting trunks lean"
-        + " over the still surface.";
-      break;
-    case "b":
-      short_desc = "Barrens";
-      long_desc = "Bare earth stretches out with little sign of growth. Scattered"
-        + " stones lie exposed to the wind.";
-      break;
-    default:
-      short_desc = "Wilderness";
-      long_desc = "The land here is quiet and open. No clear paths remain.";
-      break;
+  terrain_info = WILDERNESS_D->query_terrain_info(terrain);
+
+  if (!mappingp(terrain_info)) {
+    terrain_info = WILDERNESS_D->query_terrain_info("default");
+  }
+
+  if (mappingp(terrain_info)) {
+    short_name = terrain_info["short"];
+    long_name = terrain_info["long"];
+  }
+
+  if (stringp(short_name)) {
+    short_desc = short_name;
+  } else {
+    short_desc = "Wilderness";
+  }
+
+  if (stringp(long_name)) {
+    long_desc = long_name;
+  } else {
+    long_desc = "The land here is quiet and open. No clear paths remain.";
   }
 
   return;


### PR DESCRIPTION
### Motivation
- Centralize terrain prose so terrain codes map to reusable `short`/`long` descriptions rather than being hard-coded in the room implementation.
- Make terrain metadata available to other systems via the wilderness daemon for future reuse and easier maintenance.

### Description
- Added a `terrain` entity to `domain/original/wilderness.json` that maps terrain codes (eg. `"p"`, `"w"`, `"lf"`) to `short` and `long` description strings.
- Extended `daemon/wilderness_d.c` to load the terrain table into a `terrain_by_code` mapping during `load_wilderness()` and to expose `query_terrain_info(string terrain_code)`; added the prototype to `daemon/wilderness_d.h`.
- Updated `room/wilderness_room.c` to call `WILDERNESS_D->query_terrain_info()` and derive `short_desc` and `long_desc` from the JSON data with safe fallbacks to the previous defaults.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0c7561ec832793f47ac2a29e03aa)