### PR TITLE
Add dead area links.json, comment legacy exits, and load in link_d

### DIFF
--- a/chapter/prologue/area/dead/entrance.c
+++ b/chapter/prologue/area/dead/entrance.c
@@ -5,6 +5,7 @@ void create() {
 
   short_desc = "City of the Dead";
   long_desc = "A city overtaken by the dead.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/roadway/room71",
     "west" : "/room/wilderness_room#X45",
@@ -12,4 +13,5 @@ void create() {
     "south" : "/room/wilderness_room#Y46",
     "city" : "/chapter/prologue/area/dead/room1401",
   ]);
+  */
 }

--- a/chapter/prologue/area/dead/links.json
+++ b/chapter/prologue/area/dead/links.json
@@ -1,0 +1,977 @@
+{
+  "area_prefix": "/chapter/prologue/area/dead",
+  "links": [
+    {
+      "link": {
+        "entrance": "city",
+        "room1401": "exit"
+      }
+    },
+    {
+      "link": {
+        "room1401": "south",
+        "room1402": "north"
+      }
+    },
+    {
+      "link": {
+        "room1401": "west",
+        "room1635": "east"
+      }
+    },
+    {
+      "link": {
+        "room1401": "east",
+        "room1636": "west"
+      }
+    },
+    {
+      "link": {
+        "room1402": "south",
+        "room1403": "north"
+      }
+    },
+    {
+      "link": {
+        "room1402": "west",
+        "room1631": "east"
+      }
+    },
+    {
+      "link": {
+        "room1402": "east",
+        "room1633": "west"
+      }
+    },
+    {
+      "link": {
+        "room1403": "south",
+        "room1404": "north"
+      }
+    },
+    {
+      "link": {
+        "room1403": "west",
+        "room1628": "east"
+      }
+    },
+    {
+      "link": {
+        "room1403": "east",
+        "room1630": "west"
+      }
+    },
+    {
+      "link": {
+        "room1404": "south",
+        "room1405": "north"
+      }
+    },
+    {
+      "link": {
+        "room1404": "west",
+        "room1626": "east"
+      }
+    },
+    {
+      "link": {
+        "room1404": "east",
+        "room1627": "west"
+      }
+    },
+    {
+      "link": {
+        "room1405": "south",
+        "room1406": "north"
+      }
+    },
+    {
+      "link": {
+        "room1405": "west",
+        "room1625": "east"
+      }
+    },
+    {
+      "link": {
+        "room1406": "west",
+        "room1407": "east"
+      }
+    },
+    {
+      "link": {
+        "room1406": "east",
+        "room1508": "west"
+      }
+    },
+    {
+      "link": {
+        "room1406": "south",
+        "room1584": "north"
+      }
+    },
+    {
+      "link": {
+        "room1407": "west",
+        "room1408": "east"
+      }
+    },
+    {
+      "link": {
+        "room1408": "west",
+        "room1409": "east"
+      }
+    },
+    {
+      "link": {
+        "room1408": "south",
+        "room1589": "north"
+      }
+    },
+    {
+      "link": {
+        "room1409": "west",
+        "room1410": "east"
+      }
+    },
+    {
+      "link": {
+        "room1409": "south",
+        "room1590": "north"
+      }
+    },
+    {
+      "link": {
+        "room1410": "west",
+        "room1411": "east"
+      }
+    },
+    {
+      "link": {
+        "room1411": "west",
+        "room1412": "east"
+      }
+    },
+    {
+      "link": {
+        "room1412": "west",
+        "room1413": "east"
+      }
+    },
+    {
+      "link": {
+        "room1413": "west",
+        "room1414": "east"
+      }
+    },
+    {
+      "link": {
+        "room1414": "west",
+        "room1415": "east"
+      }
+    },
+    {
+      "link": {
+        "room1415": "west",
+        "room1416": "east"
+      }
+    },
+    {
+      "link": {
+        "room1416": "west",
+        "room1417": "east"
+      }
+    },
+    {
+      "link": {
+        "room1417": "west",
+        "room1418": "east"
+      }
+    },
+    {
+      "link": {
+        "room1418": "south",
+        "room1419": "north"
+      }
+    },
+    {
+      "link": {
+        "room1418": "north",
+        "room1448": "south"
+      }
+    },
+    {
+      "link": {
+        "room1419": "south",
+        "room1420": "north"
+      }
+    },
+    {
+      "link": {
+        "room1420": "south",
+        "room1421": "north"
+      }
+    },
+    {
+      "link": {
+        "room1421": "south",
+        "room1422": "north"
+      }
+    },
+    {
+      "link": {
+        "room1422": "south",
+        "room1423": "north"
+      }
+    },
+    {
+      "link": {
+        "room1423": "south",
+        "room1424": "north"
+      }
+    },
+    {
+      "link": {
+        "room1424": "south",
+        "room1425": "north"
+      }
+    },
+    {
+      "link": {
+        "room1425": "south",
+        "room1426": "north"
+      }
+    },
+    {
+      "link": {
+        "room1426": "south",
+        "room1427": "north"
+      }
+    },
+    {
+      "link": {
+        "room1427": "south",
+        "room1428": "north"
+      }
+    },
+    {
+      "link": {
+        "room1428": "south",
+        "room1429": "north"
+      }
+    },
+    {
+      "link": {
+        "room1429": "south",
+        "room1430": "north"
+      }
+    },
+    {
+      "link": {
+        "room1430": "south",
+        "room1431": "north"
+      }
+    },
+    {
+      "link": {
+        "room1431": "south",
+        "room1432": "north"
+      }
+    },
+    {
+      "link": {
+        "room1432": "south",
+        "room1433": "north"
+      }
+    },
+    {
+      "link": {
+        "room1433": "south",
+        "room1434": "north"
+      }
+    },
+    {
+      "link": {
+        "room1434": "south",
+        "room1435": "north"
+      }
+    },
+    {
+      "link": {
+        "room1434": "east",
+        "room1545": "west"
+      }
+    },
+    {
+      "link": {
+        "room1435": "south",
+        "room1436": "north"
+      }
+    },
+    {
+      "link": {
+        "room1436": "south",
+        "room1437": "north"
+      }
+    },
+    {
+      "link": {
+        "room1437": "south",
+        "room1438": "north"
+      }
+    },
+    {
+      "link": {
+        "room1438": "south",
+        "room1439": "north"
+      }
+    },
+    {
+      "link": {
+        "room1448": "north",
+        "room1507": "south"
+      }
+    },
+    {
+      "link": {
+        "room1508": "east",
+        "room1509": "west"
+      }
+    },
+    {
+      "link": {
+        "room1509": "east",
+        "room1510": "west"
+      }
+    },
+    {
+      "link": {
+        "room1509": "north",
+        "room1624": "south"
+      }
+    },
+    {
+      "link": {
+        "room1510": "east",
+        "room1511": "west"
+      }
+    },
+    {
+      "link": {
+        "room1510": "north",
+        "room1623": "south"
+      }
+    },
+    {
+      "link": {
+        "room1511": "east",
+        "room1512": "west"
+      }
+    },
+    {
+      "link": {
+        "room1511": "north",
+        "room1622": "south"
+      }
+    },
+    {
+      "link": {
+        "room1512": "east",
+        "room1513": "west"
+      }
+    },
+    {
+      "link": {
+        "room1513": "east",
+        "room1514": "west"
+      }
+    },
+    {
+      "link": {
+        "room1514": "east",
+        "room1515": "west"
+      }
+    },
+    {
+      "link": {
+        "room1514": "north",
+        "room1621": "south"
+      }
+    },
+    {
+      "link": {
+        "room1515": "east",
+        "room1516": "west"
+      }
+    },
+    {
+      "link": {
+        "room1516": "east",
+        "room1517": "west"
+      }
+    },
+    {
+      "link": {
+        "room1516": "south",
+        "room1520": "north"
+      }
+    },
+    {
+      "link": {
+        "room1517": "east",
+        "room1518": "west"
+      }
+    },
+    {
+      "link": {
+        "room1518": "east",
+        "room1519": "west"
+      }
+    },
+    {
+      "link": {
+        "room1520": "south",
+        "room1521": "north"
+      }
+    },
+    {
+      "link": {
+        "room1521": "south",
+        "room1522": "north"
+      }
+    },
+    {
+      "link": {
+        "room1522": "south",
+        "room1523": "north"
+      }
+    },
+    {
+      "link": {
+        "room1523": "south",
+        "room1524": "north"
+      }
+    },
+    {
+      "link": {
+        "room1524": "south",
+        "room1525": "north"
+      }
+    },
+    {
+      "link": {
+        "room1525": "south",
+        "room1526": "north"
+      }
+    },
+    {
+      "link": {
+        "room1526": "south",
+        "room1527": "north"
+      }
+    },
+    {
+      "link": {
+        "room1527": "south",
+        "room1528": "north"
+      }
+    },
+    {
+      "link": {
+        "room1528": "south",
+        "room1529": "north"
+      }
+    },
+    {
+      "link": {
+        "room1529": "south",
+        "room1530": "north"
+      }
+    },
+    {
+      "link": {
+        "room1530": "south",
+        "room1531": "north"
+      }
+    },
+    {
+      "link": {
+        "room1531": "south",
+        "room1532": "north"
+      }
+    },
+    {
+      "link": {
+        "room1532": "south",
+        "room1533": "north"
+      }
+    },
+    {
+      "link": {
+        "room1533": "south",
+        "room1534": "north"
+      }
+    },
+    {
+      "link": {
+        "room1533": "east",
+        "room1597": "west"
+      }
+    },
+    {
+      "link": {
+        "room1534": "south",
+        "room1542": "north"
+      }
+    },
+    {
+      "link": {
+        "room1535": "east",
+        "room1536": "west"
+      }
+    },
+    {
+      "link": {
+        "room1535": "west",
+        "room1557": "east"
+      }
+    },
+    {
+      "link": {
+        "room1536": "east",
+        "room1537": "west"
+      }
+    },
+    {
+      "link": {
+        "room1537": "east",
+        "room1538": "west"
+      }
+    },
+    {
+      "link": {
+        "room1538": "east",
+        "room1539": "west"
+      }
+    },
+    {
+      "link": {
+        "room1539": "east",
+        "room1540": "west"
+      }
+    },
+    {
+      "link": {
+        "room1540": "east",
+        "room1541": "west"
+      }
+    },
+    {
+      "link": {
+        "room1541": "east",
+        "room1542": "west"
+      }
+    },
+    {
+      "link": {
+        "room1542": "east",
+        "room1591": "west"
+      }
+    },
+    {
+      "link": {
+        "room1543": "north",
+        "room1544": "south"
+      }
+    },
+    {
+      "link": {
+        "room1543": "south",
+        "room1546": "north"
+      }
+    },
+    {
+      "link": {
+        "room1544": "north",
+        "room1558": "south"
+      }
+    },
+    {
+      "link": {
+        "room1545": "east",
+        "room1546": "west"
+      }
+    },
+    {
+      "link": {
+        "room1546": "east",
+        "room1547": "west"
+      }
+    },
+    {
+      "link": {
+        "room1547": "east",
+        "room1548": "west"
+      }
+    },
+    {
+      "link": {
+        "room1548": "east",
+        "room1549": "west"
+      }
+    },
+    {
+      "link": {
+        "room1549": "east",
+        "room1550": "west"
+      }
+    },
+    {
+      "link": {
+        "room1550": "east",
+        "room1551": "west"
+      }
+    },
+    {
+      "link": {
+        "room1551": "east",
+        "room1552": "west"
+      }
+    },
+    {
+      "link": {
+        "room1552": "east",
+        "room1553": "west"
+      }
+    },
+    {
+      "link": {
+        "room1553": "east",
+        "room1554": "west"
+      }
+    },
+    {
+      "link": {
+        "room1554": "east",
+        "room1555": "west"
+      }
+    },
+    {
+      "link": {
+        "room1555": "east",
+        "room1556": "west"
+      }
+    },
+    {
+      "link": {
+        "room1556": "east",
+        "room1557": "west"
+      }
+    },
+    {
+      "link": {
+        "room1558": "north",
+        "room1559": "south"
+      }
+    },
+    {
+      "link": {
+        "room1559": "north",
+        "room1560": "south"
+      }
+    },
+    {
+      "link": {
+        "room1560": "north",
+        "room1561": "south"
+      }
+    },
+    {
+      "link": {
+        "room1561": "north",
+        "room1562": "south"
+      }
+    },
+    {
+      "link": {
+        "room1562": "north",
+        "room1563": "south"
+      }
+    },
+    {
+      "link": {
+        "room1563": "north",
+        "room1564": "south"
+      }
+    },
+    {
+      "link": {
+        "room1564": "north",
+        "room1565": "south"
+      }
+    },
+    {
+      "link": {
+        "room1565": "north",
+        "room1566": "south"
+      }
+    },
+    {
+      "link": {
+        "room1566": "north",
+        "room1567": "south"
+      }
+    },
+    {
+      "link": {
+        "room1567": "north",
+        "room1568": "south"
+      }
+    },
+    {
+      "link": {
+        "room1568": "north",
+        "room1569": "south"
+      }
+    },
+    {
+      "link": {
+        "room1569": "east",
+        "room1570": "west"
+      }
+    },
+    {
+      "link": {
+        "room1570": "east",
+        "room1571": "west"
+      }
+    },
+    {
+      "link": {
+        "room1571": "east",
+        "room1572": "west"
+      }
+    },
+    {
+      "link": {
+        "room1572": "east",
+        "room1573": "west"
+      }
+    },
+    {
+      "link": {
+        "room1573": "east",
+        "room1574": "west"
+      }
+    },
+    {
+      "link": {
+        "room1574": "east",
+        "room1575": "west"
+      }
+    },
+    {
+      "link": {
+        "room1575": "east",
+        "room1576": "west"
+      }
+    },
+    {
+      "link": {
+        "room1576": "east",
+        "room1577": "west"
+      }
+    },
+    {
+      "link": {
+        "room1577": "east",
+        "room1578": "west"
+      }
+    },
+    {
+      "link": {
+        "room1578": "east",
+        "room1579": "west"
+      }
+    },
+    {
+      "link": {
+        "room1579": "east",
+        "room1580": "west"
+      }
+    },
+    {
+      "link": {
+        "room1579": "north",
+        "room1584": "south"
+      }
+    },
+    {
+      "link": {
+        "room1579": "south",
+        "room1585": "north"
+      }
+    },
+    {
+      "link": {
+        "room1580": "east",
+        "room1581": "west"
+      }
+    },
+    {
+      "link": {
+        "room1581": "east",
+        "room1582": "west"
+      }
+    },
+    {
+      "link": {
+        "room1582": "east",
+        "room1583": "west"
+      }
+    },
+    {
+      "link": {
+        "room1583": "down",
+        "room1653": "up"
+      }
+    },
+    {
+      "link": {
+        "room1584": "east",
+        "room1587": "west"
+      }
+    },
+    {
+      "link": {
+        "room1584": "west",
+        "room1588": "east"
+      }
+    },
+    {
+      "link": {
+        "room1585": "south",
+        "room1586": "north"
+      }
+    },
+    {
+      "link": {
+        "room1588": "west",
+        "room1589": "east"
+      }
+    },
+    {
+      "link": {
+        "room1589": "west",
+        "room1590": "east"
+      }
+    },
+    {
+      "link": {
+        "room1591": "east",
+        "room1592": "west"
+      }
+    },
+    {
+      "link": {
+        "room1592": "east",
+        "room1593": "west"
+      }
+    },
+    {
+      "link": {
+        "room1593": "north",
+        "room1594": "south"
+      }
+    },
+    {
+      "link": {
+        "room1594": "west",
+        "room1595": "east"
+      }
+    },
+    {
+      "link": {
+        "room1595": "west",
+        "room1596": "east"
+      }
+    },
+    {
+      "link": {
+        "room1596": "north",
+        "room1597": "south"
+      }
+    },
+    {
+      "link": {
+        "room1597": "north",
+        "room1598": "south"
+      }
+    },
+    {
+      "link": {
+        "room1598": "north",
+        "room1599": "south"
+      }
+    },
+    {
+      "link": {
+        "room1598": "east",
+        "room1600": "west"
+      }
+    },
+    {
+      "link": {
+        "room1600": "east",
+        "room1601": "west"
+      }
+    },
+    {
+      "link": {
+        "room1600": "south",
+        "room1602": "north"
+      }
+    },
+    {
+      "link": {
+        "room1600": "north",
+        "room1603": "south"
+      }
+    },
+    {
+      "link": {
+        "room1602": "east",
+        "room1605": "west"
+      }
+    },
+    {
+      "link": {
+        "room1603": "east",
+        "room1604": "west"
+      }
+    },
+    {
+      "link": {
+        "room1627": "south",
+        "room1637": "north"
+      }
+    },
+    {
+      "link": {
+        "room1628": "down",
+        "room1629": "up"
+      }
+    },
+    {
+      "link": {
+        "room1631": "west",
+        "room1632": "east"
+      }
+    },
+    {
+      "link": {
+        "room1633": "east",
+        "room1634": "west"
+      }
+    }
+  ]
+}

--- a/chapter/prologue/area/dead/room1401.c
+++ b/chapter/prologue/area/dead/room1401.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Broken Bleached Crossing";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1402",
     "east" : "/chapter/prologue/area/dead/room1636",
     "west" : "/chapter/prologue/area/dead/room1635",
     "exit" : "/chapter/prologue/area/dead/entrance",
   ]);
+  */
 }

--- a/chapter/prologue/area/dead/room1402.c
+++ b/chapter/prologue/area/dead/room1402.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Cracked Crossing";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1401",
     "south" : "/chapter/prologue/area/dead/room1403",
     "east" : "/chapter/prologue/area/dead/room1633",
     "west" : "/chapter/prologue/area/dead/room1631",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1403.c
+++ b/chapter/prologue/area/dead/room1403.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Bleached Crossing";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1402",
     "south" : "/chapter/prologue/area/dead/room1404",
     "east" : "/chapter/prologue/area/dead/room1630",
     "west" : "/chapter/prologue/area/dead/room1628",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1404.c
+++ b/chapter/prologue/area/dead/room1404.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Mossy Bleached Crossing";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1403",
     "south" : "/chapter/prologue/area/dead/room1405",
     "east" : "/chapter/prologue/area/dead/room1627",
     "west" : "/chapter/prologue/area/dead/room1626",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1405.c
+++ b/chapter/prologue/area/dead/room1405.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Choked Split Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1404",
     "south" : "/chapter/prologue/area/dead/room1406",
     "west" : "/chapter/prologue/area/dead/room1625",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1406.c
+++ b/chapter/prologue/area/dead/room1406.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Bleached Crossing";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way opens into a broad break where several ruined lines meet in silence. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1405",
     "south" : "/chapter/prologue/area/dead/room1584",
     "east" : "/chapter/prologue/area/dead/room1508",
     "west" : "/chapter/prologue/area/dead/room1407",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1407.c
+++ b/chapter/prologue/area/dead/room1407.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Charred Bleached Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1406",
     "west" : "/chapter/prologue/area/dead/room1408",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1408.c
+++ b/chapter/prologue/area/dead/room1408.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Rubble Split Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1589",
     "east" : "/chapter/prologue/area/dead/room1407",
     "west" : "/chapter/prologue/area/dead/room1409",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1409.c
+++ b/chapter/prologue/area/dead/room1409.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Bleached Split Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1590",
     "east" : "/chapter/prologue/area/dead/room1408",
     "west" : "/chapter/prologue/area/dead/room1410",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1410.c
+++ b/chapter/prologue/area/dead/room1410.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Jagged Bleached Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1409",
     "west" : "/chapter/prologue/area/dead/room1411",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1411.c
+++ b/chapter/prologue/area/dead/room1411.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Ashen Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1410",
     "west" : "/chapter/prologue/area/dead/room1412",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1412.c
+++ b/chapter/prologue/area/dead/room1412.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1411",
     "west" : "/chapter/prologue/area/dead/room1413",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1413.c
+++ b/chapter/prologue/area/dead/room1413.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sagging Bleached Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1412",
     "west" : "/chapter/prologue/area/dead/room1414",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1414.c
+++ b/chapter/prologue/area/dead/room1414.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Eroded Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1413",
     "west" : "/chapter/prologue/area/dead/room1415",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1415.c
+++ b/chapter/prologue/area/dead/room1415.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1414",
     "west" : "/chapter/prologue/area/dead/room1416",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1416.c
+++ b/chapter/prologue/area/dead/room1416.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Shattered Bleached Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1415",
     "west" : "/chapter/prologue/area/dead/room1417",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1417.c
+++ b/chapter/prologue/area/dead/room1417.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Lichen Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1416",
     "west" : "/chapter/prologue/area/dead/room1418",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1418.c
+++ b/chapter/prologue/area/dead/room1418.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Bleached Split Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1448",
     "south" : "/chapter/prologue/area/dead/room1419",
     "east" : "/chapter/prologue/area/dead/room1417",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1419.c
+++ b/chapter/prologue/area/dead/room1419.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Pitted Bleached Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1418",
     "south" : "/chapter/prologue/area/dead/room1420",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1420.c
+++ b/chapter/prologue/area/dead/room1420.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Stained Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1419",
     "south" : "/chapter/prologue/area/dead/room1421",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1421.c
+++ b/chapter/prologue/area/dead/room1421.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1420",
     "south" : "/chapter/prologue/area/dead/room1422",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1422.c
+++ b/chapter/prologue/area/dead/room1422.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Seamed Bleached Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1421",
     "south" : "/chapter/prologue/area/dead/room1423",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1423.c
+++ b/chapter/prologue/area/dead/room1423.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Leaning Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1422",
     "south" : "/chapter/prologue/area/dead/room1424",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1424.c
+++ b/chapter/prologue/area/dead/room1424.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1423",
     "south" : "/chapter/prologue/area/dead/room1425",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1425.c
+++ b/chapter/prologue/area/dead/room1425.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Silted Bleached Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1424",
     "south" : "/chapter/prologue/area/dead/room1426",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1426.c
+++ b/chapter/prologue/area/dead/room1426.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Slick Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1425",
     "south" : "/chapter/prologue/area/dead/room1427",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1427.c
+++ b/chapter/prologue/area/dead/room1427.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1426",
     "south" : "/chapter/prologue/area/dead/room1428",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1428.c
+++ b/chapter/prologue/area/dead/room1428.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Ruined Bleached Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1427",
     "south" : "/chapter/prologue/area/dead/room1429",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1429.c
+++ b/chapter/prologue/area/dead/room1429.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Spalled Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1428",
     "south" : "/chapter/prologue/area/dead/room1430",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1430.c
+++ b/chapter/prologue/area/dead/room1430.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1429",
     "south" : "/chapter/prologue/area/dead/room1431",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1431.c
+++ b/chapter/prologue/area/dead/room1431.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Split Bleached Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1430",
     "south" : "/chapter/prologue/area/dead/room1432",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1432.c
+++ b/chapter/prologue/area/dead/room1432.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1431",
     "south" : "/chapter/prologue/area/dead/room1433",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1433.c
+++ b/chapter/prologue/area/dead/room1433.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1432",
     "south" : "/chapter/prologue/area/dead/room1434",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1434.c
+++ b/chapter/prologue/area/dead/room1434.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Smeared Bleached Split Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1433",
     "south" : "/chapter/prologue/area/dead/room1435",
     "east" : "/chapter/prologue/area/dead/room1545",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1435.c
+++ b/chapter/prologue/area/dead/room1435.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Worn Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1434",
     "south" : "/chapter/prologue/area/dead/room1436",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1436.c
+++ b/chapter/prologue/area/dead/room1436.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1435",
     "south" : "/chapter/prologue/area/dead/room1437",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1437.c
+++ b/chapter/prologue/area/dead/room1437.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cracked Faded Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1436",
     "south" : "/chapter/prologue/area/dead/room1438",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1438.c
+++ b/chapter/prologue/area/dead/room1438.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sundered Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1437",
     "south" : "/chapter/prologue/area/dead/room1439",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1439.c
+++ b/chapter/prologue/area/dead/room1439.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Faded Choked End";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1438",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1448.c
+++ b/chapter/prologue/area/dead/room1448.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Choked Faded Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1507",
     "south" : "/chapter/prologue/area/dead/room1418",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1507.c
+++ b/chapter/prologue/area/dead/room1507.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Scorched Choked End";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1448",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1508.c
+++ b/chapter/prologue/area/dead/room1508.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1509",
     "west" : "/chapter/prologue/area/dead/room1406",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1509.c
+++ b/chapter/prologue/area/dead/room1509.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Rubble Faded Split Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1624",
     "east" : "/chapter/prologue/area/dead/room1510",
     "west" : "/chapter/prologue/area/dead/room1508",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1510.c
+++ b/chapter/prologue/area/dead/room1510.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Collapsed Split Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1623",
     "east" : "/chapter/prologue/area/dead/room1511",
     "west" : "/chapter/prologue/area/dead/room1509",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1511.c
+++ b/chapter/prologue/area/dead/room1511.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Faded Split Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1622",
     "east" : "/chapter/prologue/area/dead/room1512",
     "west" : "/chapter/prologue/area/dead/room1510",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1512.c
+++ b/chapter/prologue/area/dead/room1512.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Ashen Faded Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1513",
     "west" : "/chapter/prologue/area/dead/room1511",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1513.c
+++ b/chapter/prologue/area/dead/room1513.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Blasted Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1514",
     "west" : "/chapter/prologue/area/dead/room1512",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1514.c
+++ b/chapter/prologue/area/dead/room1514.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Faded Split Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1621",
     "east" : "/chapter/prologue/area/dead/room1515",
     "west" : "/chapter/prologue/area/dead/room1513",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1515.c
+++ b/chapter/prologue/area/dead/room1515.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Eroded Faded Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1516",
     "west" : "/chapter/prologue/area/dead/room1514",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1516.c
+++ b/chapter/prologue/area/dead/room1516.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Splintered Split Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1520",
     "east" : "/chapter/prologue/area/dead/room1517",
     "west" : "/chapter/prologue/area/dead/room1515",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1517.c
+++ b/chapter/prologue/area/dead/room1517.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1518",
     "west" : "/chapter/prologue/area/dead/room1516",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1518.c
+++ b/chapter/prologue/area/dead/room1518.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Lichen Faded Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1519",
     "west" : "/chapter/prologue/area/dead/room1517",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1519.c
+++ b/chapter/prologue/area/dead/room1519.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Gritted Choked End";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1518",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1520.c
+++ b/chapter/prologue/area/dead/room1520.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1516",
     "south" : "/chapter/prologue/area/dead/room1521",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1521.c
+++ b/chapter/prologue/area/dead/room1521.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Stained Faded Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1520",
     "south" : "/chapter/prologue/area/dead/room1522",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1522.c
+++ b/chapter/prologue/area/dead/room1522.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Fractured Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1521",
     "south" : "/chapter/prologue/area/dead/room1523",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1523.c
+++ b/chapter/prologue/area/dead/room1523.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1522",
     "south" : "/chapter/prologue/area/dead/room1524",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1524.c
+++ b/chapter/prologue/area/dead/room1524.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Leaning Faded Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1523",
     "south" : "/chapter/prologue/area/dead/room1525",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1525.c
+++ b/chapter/prologue/area/dead/room1525.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Hollow Split Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1524",
     "south" : "/chapter/prologue/area/dead/room1526",
     "east" : "/chapter/prologue/area/dead/room1606",
   ]);
+  */
 }

--- a/chapter/prologue/area/dead/room1526.c
+++ b/chapter/prologue/area/dead/room1526.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1525",
     "south" : "/chapter/prologue/area/dead/room1527",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1527.c
+++ b/chapter/prologue/area/dead/room1527.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Slick Faded Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1526",
     "south" : "/chapter/prologue/area/dead/room1528",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1528.c
+++ b/chapter/prologue/area/dead/room1528.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Fallen Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1527",
     "south" : "/chapter/prologue/area/dead/room1529",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1529.c
+++ b/chapter/prologue/area/dead/room1529.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1528",
     "south" : "/chapter/prologue/area/dead/room1530",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1530.c
+++ b/chapter/prologue/area/dead/room1530.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Spalled Faded Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1529",
     "south" : "/chapter/prologue/area/dead/room1531",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1531.c
+++ b/chapter/prologue/area/dead/room1531.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Dusted Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1530",
     "south" : "/chapter/prologue/area/dead/room1532",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1532.c
+++ b/chapter/prologue/area/dead/room1532.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1531",
     "south" : "/chapter/prologue/area/dead/room1533",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1533.c
+++ b/chapter/prologue/area/dead/room1533.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Bleached Faded Split Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1532",
     "south" : "/chapter/prologue/area/dead/room1534",
     "east" : "/chapter/prologue/area/dead/room1597",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1534.c
+++ b/chapter/prologue/area/dead/room1534.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Dulled Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1533",
     "south" : "/chapter/prologue/area/dead/room1542",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1535.c
+++ b/chapter/prologue/area/dead/room1535.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Faded Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1536",
     "west" : "/chapter/prologue/area/dead/room1557",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1536.c
+++ b/chapter/prologue/area/dead/room1536.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Worn Faded Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The stonework is torn open, exposing fill and roots, with scorch marks in the cracks. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1537",
     "west" : "/chapter/prologue/area/dead/room1535",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1537.c
+++ b/chapter/prologue/area/dead/room1537.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Broken Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1538",
     "west" : "/chapter/prologue/area/dead/room1536",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1538.c
+++ b/chapter/prologue/area/dead/room1538.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1539",
     "west" : "/chapter/prologue/area/dead/room1537",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1539.c
+++ b/chapter/prologue/area/dead/room1539.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sundered Sunk Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1540",
     "west" : "/chapter/prologue/area/dead/room1538",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1540.c
+++ b/chapter/prologue/area/dead/room1540.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Mossy Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1541",
     "west" : "/chapter/prologue/area/dead/room1539",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1541.c
+++ b/chapter/prologue/area/dead/room1541.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1542",
     "west" : "/chapter/prologue/area/dead/room1540",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1542.c
+++ b/chapter/prologue/area/dead/room1542.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Scorched Sunk Split Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Chunks of wall have been scooped away, leaving raw ribs of stone. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1534",
     "east" : "/chapter/prologue/area/dead/room1591",
     "west" : "/chapter/prologue/area/dead/room1541",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1543.c
+++ b/chapter/prologue/area/dead/room1543.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Charred Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1544",
     "south" : "/chapter/prologue/area/dead/room1546",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1544.c
+++ b/chapter/prologue/area/dead/room1544.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1558",
     "south" : "/chapter/prologue/area/dead/room1543",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1545.c
+++ b/chapter/prologue/area/dead/room1545.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Collapsed Sunk Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Chunks of wall have been scooped away, leaving raw ribs of stone. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1546",
     "west" : "/chapter/prologue/area/dead/room1434",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1546.c
+++ b/chapter/prologue/area/dead/room1546.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Jagged Split Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Chunks of wall have been scooped away, leaving raw ribs of stone. The path splits around a heap of fallen blocks, offering lines gone to ruin. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1543",
     "east" : "/chapter/prologue/area/dead/room1547",
     "west" : "/chapter/prologue/area/dead/room1545",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1547.c
+++ b/chapter/prologue/area/dead/room1547.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1548",
     "west" : "/chapter/prologue/area/dead/room1546",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1548.c
+++ b/chapter/prologue/area/dead/room1548.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Blasted Sunk Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1549",
     "west" : "/chapter/prologue/area/dead/room1547",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1549.c
+++ b/chapter/prologue/area/dead/room1549.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sagging Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1550",
     "west" : "/chapter/prologue/area/dead/room1548",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1550.c
+++ b/chapter/prologue/area/dead/room1550.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1551",
     "west" : "/chapter/prologue/area/dead/room1549",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1551.c
+++ b/chapter/prologue/area/dead/room1551.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Splintered Sunk Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1552",
     "west" : "/chapter/prologue/area/dead/room1550",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1552.c
+++ b/chapter/prologue/area/dead/room1552.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Shattered Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1553",
     "west" : "/chapter/prologue/area/dead/room1551",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1553.c
+++ b/chapter/prologue/area/dead/room1553.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1554",
     "west" : "/chapter/prologue/area/dead/room1552",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1554.c
+++ b/chapter/prologue/area/dead/room1554.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Gritted Sunk Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1555",
     "west" : "/chapter/prologue/area/dead/room1553",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1555.c
+++ b/chapter/prologue/area/dead/room1555.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Pitted Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1556",
     "west" : "/chapter/prologue/area/dead/room1554",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1556.c
+++ b/chapter/prologue/area/dead/room1556.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Masonry slumps inward, its edges scored and melted in places. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1557",
     "west" : "/chapter/prologue/area/dead/room1555",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1557.c
+++ b/chapter/prologue/area/dead/room1557.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Fractured Sunk Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1535",
     "west" : "/chapter/prologue/area/dead/room1556",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1558.c
+++ b/chapter/prologue/area/dead/room1558.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Seamed Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1559",
     "south" : "/chapter/prologue/area/dead/room1544",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1559.c
+++ b/chapter/prologue/area/dead/room1559.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1560",
     "south" : "/chapter/prologue/area/dead/room1558",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1560.c
+++ b/chapter/prologue/area/dead/room1560.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Hollow Sunk Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1561",
     "south" : "/chapter/prologue/area/dead/room1559",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1561.c
+++ b/chapter/prologue/area/dead/room1561.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Silted Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1562",
     "south" : "/chapter/prologue/area/dead/room1560",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1562.c
+++ b/chapter/prologue/area/dead/room1562.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1563",
     "south" : "/chapter/prologue/area/dead/room1561",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1563.c
+++ b/chapter/prologue/area/dead/room1563.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Fallen Sunk Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1564",
     "south" : "/chapter/prologue/area/dead/room1562",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1564.c
+++ b/chapter/prologue/area/dead/room1564.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Ruined Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1565",
     "south" : "/chapter/prologue/area/dead/room1563",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1565.c
+++ b/chapter/prologue/area/dead/room1565.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1566",
     "south" : "/chapter/prologue/area/dead/room1564",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1566.c
+++ b/chapter/prologue/area/dead/room1566.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Dusted Sunk Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Jagged ribs of stone show cuts and pitting, some edges glassed by heat. The way runs on in a narrow line, hemmed by broken walls left to weather. Moss and pale mold cling to the damp pockets, and nothing moves except drifting grit.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1567",
     "south" : "/chapter/prologue/area/dead/room1565",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1567.c
+++ b/chapter/prologue/area/dead/room1567.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Split Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1568",
     "south" : "/chapter/prologue/area/dead/room1566",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1568.c
+++ b/chapter/prologue/area/dead/room1568.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1569",
     "south" : "/chapter/prologue/area/dead/room1567",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1569.c
+++ b/chapter/prologue/area/dead/room1569.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Dulled Sunk Broken Bend";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1568",
     "east" : "/chapter/prologue/area/dead/room1570",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1570.c
+++ b/chapter/prologue/area/dead/room1570.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Smeared Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1571",
     "west" : "/chapter/prologue/area/dead/room1569",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1571.c
+++ b/chapter/prologue/area/dead/room1571.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Sunk Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1572",
     "west" : "/chapter/prologue/area/dead/room1570",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1572.c
+++ b/chapter/prologue/area/dead/room1572.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Broken Cold Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1573",
     "west" : "/chapter/prologue/area/dead/room1571",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1573.c
+++ b/chapter/prologue/area/dead/room1573.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cracked Narrow Way";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1574",
     "west" : "/chapter/prologue/area/dead/room1572",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1574.c
+++ b/chapter/prologue/area/dead/room1574.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Narrow Way";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1575",
     "west" : "/chapter/prologue/area/dead/room1573",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1575.c
+++ b/chapter/prologue/area/dead/room1575.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Mossy Cold Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1576",
     "west" : "/chapter/prologue/area/dead/room1574",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1576.c
+++ b/chapter/prologue/area/dead/room1576.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Choked Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Walls to either side are chewed by blasts and blade scars, their faces peeled away. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1577",
     "west" : "/chapter/prologue/area/dead/room1575",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1577.c
+++ b/chapter/prologue/area/dead/room1577.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Narrow Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1578",
     "west" : "/chapter/prologue/area/dead/room1576",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1578.c
+++ b/chapter/prologue/area/dead/room1578.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Charred Cold Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1579",
     "west" : "/chapter/prologue/area/dead/room1577",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1579.c
+++ b/chapter/prologue/area/dead/room1579.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Rubble Crossing";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1584",
     "south" : "/chapter/prologue/area/dead/room1585",
     "east" : "/chapter/prologue/area/dead/room1580",
     "west" : "/chapter/prologue/area/dead/room1578",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1580.c
+++ b/chapter/prologue/area/dead/room1580.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Narrow Way";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1581",
     "west" : "/chapter/prologue/area/dead/room1579",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1581.c
+++ b/chapter/prologue/area/dead/room1581.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Jagged Cold Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1582",
     "west" : "/chapter/prologue/area/dead/room1580",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1582.c
+++ b/chapter/prologue/area/dead/room1582.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Ashen Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1583",
     "west" : "/chapter/prologue/area/dead/room1581",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1583.c
+++ b/chapter/prologue/area/dead/room1583.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Broken Bend";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1582",
     "down" : "/chapter/prologue/area/dead/room1653",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1584.c
+++ b/chapter/prologue/area/dead/room1584.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Sagging Cold Crossing";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1406",
     "south" : "/chapter/prologue/area/dead/room1579",
     "east" : "/chapter/prologue/area/dead/room1587",
     "west" : "/chapter/prologue/area/dead/room1588",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1585.c
+++ b/chapter/prologue/area/dead/room1585.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Eroded Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1579",
     "south" : "/chapter/prologue/area/dead/room1586",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1586.c
+++ b/chapter/prologue/area/dead/room1586.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Cold Choked End";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Leaning walls show long cuts and scorch trails, as if steel and heat worried them for hours. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1585",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1587.c
+++ b/chapter/prologue/area/dead/room1587.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Shattered Cold Choked End";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Blackened streaks and gouges run along the masonry, breaking any clean line. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1584",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1588.c
+++ b/chapter/prologue/area/dead/room1588.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Lichen Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1584",
     "west" : "/chapter/prologue/area/dead/room1589",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1589.c
+++ b/chapter/prologue/area/dead/room1589.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Cold Split Way";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Blackened streaks and gouges run along the masonry, breaking any clean line. The path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1408",
     "east" : "/chapter/prologue/area/dead/room1588",
     "west" : "/chapter/prologue/area/dead/room1590",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1590.c
+++ b/chapter/prologue/area/dead/room1590.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Pitted Cold Broken Bend";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1409",
     "east" : "/chapter/prologue/area/dead/room1589",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1591.c
+++ b/chapter/prologue/area/dead/room1591.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Stained Narrow Way";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1592",
     "west" : "/chapter/prologue/area/dead/room1542",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1592.c
+++ b/chapter/prologue/area/dead/room1592.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Narrow Way";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1593",
     "west" : "/chapter/prologue/area/dead/room1591",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1593.c
+++ b/chapter/prologue/area/dead/room1593.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Seamed Cold Broken Bend";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1594",
     "west" : "/chapter/prologue/area/dead/room1592",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1594.c
+++ b/chapter/prologue/area/dead/room1594.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Leaning Broken Bend";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1593",
     "west" : "/chapter/prologue/area/dead/room1595",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1595.c
+++ b/chapter/prologue/area/dead/room1595.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Cold Narrow Way";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Blackened streaks and gouges run along the masonry, breaking any clean line. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1594",
     "west" : "/chapter/prologue/area/dead/room1596",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1596.c
+++ b/chapter/prologue/area/dead/room1596.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Silted Cold Broken Bend";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Blackened streaks and gouges run along the masonry, breaking any clean line. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1597",
     "east" : "/chapter/prologue/area/dead/room1595",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1597.c
+++ b/chapter/prologue/area/dead/room1597.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Slick Split Way";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1598",
     "south" : "/chapter/prologue/area/dead/room1596",
     "west" : "/chapter/prologue/area/dead/room1533",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1598.c
+++ b/chapter/prologue/area/dead/room1598.c
@@ -5,11 +5,13 @@ void create() {
 
   short_desc = "Cold Split Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Fragments of arches and lintels hang at odd angles, cut and burned through. The path splits around a heap of fallen blocks, offering lines gone to ruin. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1599",
     "south" : "/chapter/prologue/area/dead/room1597",
     "east" : "/chapter/prologue/area/dead/room1600",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1599.c
+++ b/chapter/prologue/area/dead/room1599.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Ruined Cold Choked End";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1598",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1600.c
+++ b/chapter/prologue/area/dead/room1600.c
@@ -5,12 +5,14 @@ void create() {
 
   short_desc = "Spalled Crossing";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Fragments of arches and lintels hang at odd angles, cut and burned through. The way opens into a broad break where several ruined lines meet in silence. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1603",
     "south" : "/chapter/prologue/area/dead/room1602",
     "east" : "/chapter/prologue/area/dead/room1601",
     "west" : "/chapter/prologue/area/dead/room1598",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1601.c
+++ b/chapter/prologue/area/dead/room1601.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Cold Choked End";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1600",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1602.c
+++ b/chapter/prologue/area/dead/room1602.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Split Cold Broken Bend";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Fragments of arches and lintels hang at odd angles, cut and burned through. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1600",
     "east" : "/chapter/prologue/area/dead/room1605",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1603.c
+++ b/chapter/prologue/area/dead/room1603.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Bleached Broken Bend";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Fragments of arches and lintels hang at odd angles, cut and burned through. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1600",
     "east" : "/chapter/prologue/area/dead/room1604",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1604.c
+++ b/chapter/prologue/area/dead/room1604.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Cold Choked End";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1603",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1605.c
+++ b/chapter/prologue/area/dead/room1605.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Smeared Cold Choked End";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1602",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1621.c
+++ b/chapter/prologue/area/dead/room1621.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Worn Choked End";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. Fragments of arches and lintels hang at odd angles, cut and burned through. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1514",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1622.c
+++ b/chapter/prologue/area/dead/room1622.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Silted Choked End";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1511",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1623.c
+++ b/chapter/prologue/area/dead/room1623.c
@@ -5,8 +5,10 @@ void create() {
 
   short_desc = "Cracked Silted Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1643",
     "south" : "/chapter/prologue/area/dead/room1510",
   ]);
+  */
 }

--- a/chapter/prologue/area/dead/room1624.c
+++ b/chapter/prologue/area/dead/room1624.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Sundered Choked End";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1509",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1625.c
+++ b/chapter/prologue/area/dead/room1625.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Silted Choked End";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1405",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1626.c
+++ b/chapter/prologue/area/dead/room1626.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Choked Silted Choked End";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1404",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1627.c
+++ b/chapter/prologue/area/dead/room1627.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Scorched Broken Bend";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. The remains of pillars stand jagged, split and fused by old force. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "south" : "/chapter/prologue/area/dead/room1637",
     "west" : "/chapter/prologue/area/dead/room1404",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1628.c
+++ b/chapter/prologue/area/dead/room1628.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Silted Broken Bend";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. The remains of pillars stand jagged, split and fused by old force. The passage angles hard here, squeezed between stone left to lean and settle. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1403",
     "down" : "/chapter/prologue/area/dead/room1629",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1629.c
+++ b/chapter/prologue/area/dead/room1629.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Rubble Silted Choked End";
   long_desc = "Split slabs tilt against each other, their edges worn to chalk. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "up" : "/chapter/prologue/area/dead/room1628",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1630.c
+++ b/chapter/prologue/area/dead/room1630.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Collapsed Choked End";
   long_desc = "Pitted stone stretches ahead, littered with chips and fragments. The remains of pillars stand jagged, split and fused by old force. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1403",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1631.c
+++ b/chapter/prologue/area/dead/room1631.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Silted Narrow Way";
   long_desc = "Grit and broken tiles lie in drifts, the ground uneven and tired. The remains of pillars stand jagged, split and fused by old force. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1402",
     "west" : "/chapter/prologue/area/dead/room1632",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1632.c
+++ b/chapter/prologue/area/dead/room1632.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Ashen Silted Choked End";
   long_desc = "Stone underfoot is split into plates, with grit and ash packed into the seams. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1631",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1633.c
+++ b/chapter/prologue/area/dead/room1633.c
@@ -5,10 +5,12 @@ void create() {
 
   short_desc = "Blasted Narrow Way";
   long_desc = "The ground is a mosaic of cracked slabs and loose grit, dulled by age. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. The way runs on in a narrow line, hemmed by broken walls left to weather. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1634",
     "west" : "/chapter/prologue/area/dead/room1402",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1634.c
+++ b/chapter/prologue/area/dead/room1634.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Silted Choked End";
   long_desc = "Broken paving lies in uneven ridges, with fine dust caked between. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1633",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1635.c
+++ b/chapter/prologue/area/dead/room1635.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Eroded Silted Choked End";
   long_desc = "The floor is a churn of fractured stone and rubble, pressed flat by time. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "east" : "/chapter/prologue/area/dead/room1401",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1636.c
+++ b/chapter/prologue/area/dead/room1636.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Splintered Choked End";
   long_desc = "Rubble and crushed mortar blanket the surface, slick in places with old damp. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "west" : "/chapter/prologue/area/dead/room1401",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1637.c
+++ b/chapter/prologue/area/dead/room1637.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Silted Choked End";
   long_desc = "The surface dips and rises where blocks have settled, leaving sharp lips and hollows. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "north" : "/chapter/prologue/area/dead/room1627",
   ]);
+  */
 
   set_light(1);
 }

--- a/chapter/prologue/area/dead/room1653.c
+++ b/chapter/prologue/area/dead/room1653.c
@@ -5,9 +5,11 @@ void create() {
 
   short_desc = "Lichen Silted Choked End";
   long_desc = "Loose stones shift underfoot, buried in silt and powdered mortar. Carved blocks are shattered and glazed in places, a mix of chisel scars and burn pits. A collapsed heap chokes the line, the passage left to cave in. Thin lichen mats the shaded edges, and the air tastes of wet dust.";
+  /*
   dest_dir = ([
     "up" : "/chapter/prologue/area/dead/room1583",
   ]);
+  */
 
   set_light(1);
 }

--- a/daemon/link_d.c
+++ b/daemon/link_d.c
@@ -49,6 +49,7 @@ void create() {
   _dir_claims    = ([]);
 
   link_files = ({
+    "/chapter/prologue/area/dead/links.json",
     "/chapter/prologue/area/ruined/links.json",
     "/chapter/prologue/area/silent/links.json",
     "/chapter/prologue/area/sunken/links.json",


### PR DESCRIPTION
### Motivation
- Centralize room-to-room exit definitions for the `dead` area into a JSON topology file to match the existing pattern used by other areas. 
- Disable legacy per-room `dest_dir`/`exits` blocks so room code no longer carries duplicated exit topology. 
- Ensure the new `/chapter/prologue/area/dead/links.json` is picked up by the link registry daemon so links are available at runtime. 

### Description
- Created `/chapter/prologue/area/dead/links.json` containing reciprocal link objects for the `dead` area (area_prefix set to `/chapter/prologue/area/dead`).
- Commented out the legacy `dest_dir` / `exits` mapping blocks in the room files under `/chapter/prologue/area/dead/*.c` (including `entrance.c` and ~160 room files) without deleting any room data or descriptions.
- Updated `daemon/link_d.c` to include `"/chapter/prologue/area/dead/links.json"` in the list of link files loaded by the daemon.

### Testing
- Ran a Python script to parse room files and generate `links.json`; the script completed successfully and produced `162` reciprocal link entries. 
- Ran an automated script to wrap the legacy `dest_dir`/`exits` blocks in comment markers across the `dead` area room files; the script completed successfully and the files were updated. 
- Verified file changes with `git status` and committed the updates; the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f911eab08327abccd0971324548a)